### PR TITLE
refactor: technical audit — security, dedup, CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,11 @@ jobs:
           ASPNETCORE_ENVIRONMENT=Development
           EOF
 
+      - name: Create volume dirs for non-root containers
+        run: |
+          mkdir -p data/storage data/textstack data/postgres-prod
+          chmod 777 data/storage data/textstack
+
       - name: Build containers
         run: docker compose build
 
@@ -139,6 +144,11 @@ jobs:
           ADMIN_EMAIL=admin@textstack.app
           ADMIN_PASSWORD=admin
           EOF
+
+      - name: Create volume dirs for non-root containers
+        run: |
+          mkdir -p data/storage data/textstack data/postgres-prod
+          chmod 777 data/storage data/textstack
 
       - name: Build & start services
         run: docker compose up -d --build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
 
+      - name: Lint (format check)
+        run: dotnet format --no-restore --verify-no-changes
+
       - name: Install EF Core tools
         run: dotnet tool install --global dotnet-ef
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,14 @@ jobs:
           mv dist/ssg-new dist/ssg
           rm -rf dist/ssg-old
 
+          # Validate SSG output
+          SSG_COUNT=$(find dist/ssg -name '*.html' | wc -l)
+          echo "SSG pages: $SSG_COUNT"
+          if [ "$SSG_COUNT" -lt 10 ]; then
+            echo "ERROR: SSG produced too few pages ($SSG_COUNT). Aborting."
+            exit 1
+          fi
+
           echo "SSG atomic swap completed"
 
       # nginx config update requires sudo - run manually via `make deploy` when config changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ make up                       # Start services
 
 # Docker
 make up / down / restart / logs / status
+make build                    # docker compose up -d --build
+make rebuild                  # full rebuild --no-cache
+make clean-ssg                # remove dist/ssg*
 
 # Deploy
 make deploy                   # Full deploy (pull, build, restart, SSG)
@@ -50,8 +53,13 @@ pnpm -C apps/web test:e2e                   # Playwright E2E (headless)
 pnpm -C apps/web test:e2e:ui                # Playwright E2E (UI mode)
 
 # Lint
-dotnet format backend/TextStack.sln         # Backend
+dotnet format textstack.sln                  # Backend
 pnpm -C apps/web lint                       # Frontend
+
+# CLI commands (via dotnet run --project backend/src/Api --)
+# create-admin <email> <password> [role]
+# optimize-images [--dry-run]
+# import-textstack <book-path>
 
 # Local dev (no Docker)
 dotnet run --project backend/src/Api
@@ -120,7 +128,11 @@ Context files: `apps/web/src/context/{Site,Auth,Download,Language}Context.tsx`
 
 **API client**: `useApi()` hook → `createApi(language)` → methods like `getBooks()`, `getBook(slug)`. Uses `fetchJsonWithRetry()`.
 
-**Admin panel**: Separate React app (English-only, no i18n). JWT auth, sidebar layout.
+**API client layer**: `apps/web/src/api/` — separate modules per domain: `client.ts` (base), `auth.ts`, `readingTracking.ts`, `userData.ts`, `userBooks.ts`, `dictionary.ts`, `translation.ts`. `useApi()` hook wraps these.
+
+**Reader hooks** (`apps/web/src/hooks/`): Reading session tracking (`useReadingSession`), progress sync (`useReadingProgress`), fullscreen (`useFullscreen`, `useImmersiveMode`), keyboard nav (`useReaderKeyboard`), in-book search (`useInBookSearch`), text selection (`useTextSelection`, `useDictionary`, `useTextTranslation`), dark mode (`useReaderSettings`, `useDarkMode`).
+
+**Admin panel**: Separate React app (`apps/admin/`), English-only, JWT auth. Pages: Dashboard, Upload, Jobs queue, Editions list/edit, Authors CRUD, Genres CRUD, Chapter editor, SSG rebuild, SEO crawl, Tools, Settings.
 
 ## Key Concepts
 
@@ -141,9 +153,22 @@ Upload EPUB/PDF/FB2 → BookFile (stored) → IngestionJob (queued)
      → Worker polls → Extraction → Chapters created → search_vector indexed
 ```
 
+**Reading Stats**: Full reading analytics system.
+- ReadingSession — tracks duration, words read, start/end percent per reading session
+- ReadingGoal — daily_minutes or books_per_year targets with streak tracking
+- UserAchievement — 20 achievements across milestone/streak/time/special categories
+- AchievementChecker (`Application/ReadingTracking/AchievementChecker.cs`) runs after each session
+- Frontend: StatsPage with heatmap calendar, weekly chart, goals, achievements grid
+- Session tracking: 30s heartbeat, 3min idle threshold, 5min auto-end, localStorage queue, sendBeacon submit
+
+**Dictionary**: `GET /dictionary/{lang}/{word}` — proxies Free Dictionary API.
+
+**Translation**: `POST /translate` via LibreTranslate container. Config: `LibreTranslate:BaseUrl`, `LibreTranslate:TimeoutSeconds`, `LibreTranslate:MaxTextLength`.
+
 **SSG**: Puppeteer prerenders SEO pages to static HTML
 - nginx serves SSG first, falls back to SPA
 - Run `make rebuild-ssg` after content changes
+- SSG worker: separate always-running container polling DB every 5s. Supports IndexNow (Bing/Yandex) via `INDEXNOW_KEY`
 
 **When to rebuild SSG**:
 - After adding/publishing new books
@@ -153,15 +178,17 @@ Upload EPUB/PDF/FB2 → BookFile (stored) → IngestionJob (queued)
 
 ## API Endpoints
 
-**Public**: `GET /books`, `/books/{slug}`, `/authors`, `/genres`, `/search?q=`, `/seo/*`
+**Public**: `GET /books`, `/books/{slug}`, `/authors`, `/genres`, `/search?q=`, `/seo/*`, `/dictionary/{lang}/{word}`, `POST /translate`
 
 **Auth**: `POST /auth/login`, `/auth/refresh`, `/auth/logout`
 
-**User**: `GET/POST /me/library`, `/me/progress`, `/me/bookmarks`, `/me/highlights`, `/me/reading-tracking`
+**User**: `GET/POST /me/library`, `/me/progress/{editionId}` (GET/PUT/DELETE), `/me/bookmarks`, `/me/highlights/{editionId}`
 
-**User Books**: `POST /me/books/upload`, `GET /me/books`, `GET /me/books/{id}/chapters`
+**Reading Tracking**: `POST /me/reading/sessions`, `GET /me/reading/sessions`, `GET /me/reading/stats`, `GET /me/reading/stats/daily`, `GET/POST /me/reading/goals`, `DELETE /me/reading/goals/{id}`, `GET /me/reading/achievements`
 
-**Admin**: `POST /admin/books/upload`, `GET /admin/ingestion/jobs`, `/admin/settings`, `/admin/ssg-rebuild`, `/admin/seo-crawl`, `/admin/lint`
+**User Books**: `POST /me/books/upload`, `GET /me/books`, `GET /me/books/quota`, `GET /me/books/{id}`, `GET /me/books/{id}/chapters/{slug}`, `GET/PUT /me/books/{id}/progress`, `GET/POST/DELETE /me/books/{id}/bookmarks`, `POST /me/books/{id}/retry`, `DELETE /me/books/{id}`
+
+**Admin**: `POST /admin/books/upload`, `/admin/import/textstack`, `/admin/reimport/textstack`, `/admin/sync/standardebooks`, `/admin/reprocess/{editionId}`, `/admin/reprocess/all`, `GET /admin/ingestion/jobs`, `/admin/ingestion/jobs/{id}/retry`, `/admin/ingestion/jobs/{id}/preview`, `/admin/chapters/{id}` (GET/PUT/DELETE), `/admin/settings`, `/admin/ssg-rebuild`, `/admin/seo-crawl`, `/admin/lint`, CRUD for `/admin/authors`, `/admin/genres`
 
 ## Key Files
 
@@ -183,6 +210,9 @@ Upload EPUB/PDF/FB2 → BookFile (stored) → IngestionJob (queued)
 | API Hook | `apps/web/src/hooks/useApi.ts` |
 | i18n | `apps/web/src/locales/{en,uk}.json` |
 | Admin | `apps/admin/src/pages/` |
+| Stats | `apps/web/src/pages/StatsPage.tsx` |
+| Reading Hooks | `apps/web/src/hooks/useReadingSession.ts` |
+| Achievements | `backend/src/Application/ReadingTracking/AchievementChecker.cs` |
 | SSG | `apps/web/scripts/prerender.mjs` |
 | nginx config | `infra/nginx/textstack.conf` |
 
@@ -198,7 +228,7 @@ Search uses raw SQL (Dapper). After schema changes:
 ```
 tests/
 ├── TextStack.UnitTests/           # Pure logic, no DB
-├── TextStack.IntegrationTests/    # API + DB (Testcontainers)
+├── TextStack.IntegrationTests/    # API tests against running server (LiveApiFixture → localhost:8080, override via API_URL env)
 ├── TextStack.Extraction.Tests/    # Book parsing (EPUB/PDF/FB2)
 ├── TextStack.Search.Tests/        # Search logic
 apps/web/e2e/                      # Playwright E2E (chromium, mobile, admin projects)
@@ -207,6 +237,11 @@ apps/web/e2e/                      # Playwright E2E (chromium, mobile, admin pro
 Test naming convention: `{MethodName}_{Scenario}_{ExpectedResult}`
 
 **E2E setup**: Global setup authenticates test user + admin, discovers books from API → `.test-data.json`. Auth state stored in `apps/web/e2e/.auth/`. Page object helpers in `apps/web/e2e/helpers/`.
+
+**Test env vars**:
+- `ENABLE_TEST_AUTH=true` — enables test auth endpoints (needed for integration + E2E)
+- `ADMIN_EMAIL` / `ADMIN_PASSWORD` — needed for admin E2E
+- Integration tests set `Host` header: `general.localhost` (public), `textstack.dev` (admin)
 
 ## Deployment
 
@@ -217,6 +252,18 @@ Internet → Cloudflare (DNS+SSL) → Cloudflare Tunnel → nginx (port 80)
 ```
 
 Docker services: `db` (postgres:16), `migrator`, `api`, `worker`, `admin`, `ssg-worker`, `aspire-dashboard`, `libretranslate`. All localhost-only, no public ports except 80 via tunnel.
+
+## Extraction Pipeline
+
+Processing order: Spelling → Hyphenation → Typography → Semantic → Linter. Details in `backend/src/Extraction/RULES.md`. ARM64 caveat: uses compiled `Regex` not `[GeneratedRegex]` (SIGILL bug).
+
+## Telemetry
+
+OpenTelemetry → Aspire Dashboard (`localhost:18888`). OTLP: `:18889`. Services: `textstack-api`, `textstack-worker`.
+
+## Package Management
+
+Central versioning via `Directory.Packages.props` — don't add `<Version>` in individual csproj files. Target: `net10.0` (set in `Directory.Build.props`).
 
 ## Verifying SSG
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down restart logs status backup restore rebuild-ssg clean-ssg deploy nginx-setup build rebuild fix-permissions
+.PHONY: up down restart logs status backup restore rebuild-ssg clean-ssg deploy nginx-setup build rebuild fix-permissions test lint
 
 # ============================================================
 # Docker Services
@@ -75,6 +75,17 @@ rebuild-ssg:
 clean-ssg:
 	rm -rf apps/web/dist/ssg apps/web/dist/ssg-new apps/web/dist/ssg-old
 	@echo "SSG cleaned"
+
+# ============================================================
+# Testing & Linting
+# ============================================================
+
+test:
+	dotnet test
+	pnpm -C apps/web test
+
+lint:
+	dotnet format --verify-no-changes
 
 # ============================================================
 # Nginx Setup (one-time)

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,12 +1,44 @@
+import { refreshToken } from './auth'
 import { fetchJsonWithRetry, type FetchOptions } from '../lib/fetchWithRetry'
 
-const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080'
+export const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080'
 const STORAGE_BASE = import.meta.env.VITE_STORAGE_URL || API_BASE
 
 /** Build full URL for storage files (covers, photos) */
 export function getStorageUrl(path: string | null | undefined): string | undefined {
   if (!path) return undefined
   return `${STORAGE_BASE}/storage/${path}`
+}
+
+/** Authenticated fetch w/ auto token refresh on 401, error message parsing */
+export async function authFetch<T>(path: string, options?: RequestInit, retry = true): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    credentials: 'include',
+  })
+
+  if (!res.ok) {
+    if (res.status === 401 && retry) {
+      try {
+        await refreshToken()
+        return authFetch<T>(path, options, false)
+      } catch {
+        throw new Error('Unauthorized')
+      }
+    }
+    if (res.status === 401) throw new Error('Unauthorized')
+    const text = await res.text()
+    let error = `API error: ${res.status}`
+    try {
+      const json = JSON.parse(text)
+      if (json.error) error = json.error
+    } catch {}
+    throw new Error(error)
+  }
+
+  const text = await res.text()
+  if (!text) return {} as T
+  return JSON.parse(text)
 }
 
 async function fetchJson<T>(path: string, options?: FetchOptions): Promise<T> {

--- a/apps/web/src/api/readingTracking.ts
+++ b/apps/web/src/api/readingTracking.ts
@@ -1,24 +1,4 @@
-const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080'
-
-async function authFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
-    ...options,
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...options?.headers,
-    },
-  })
-
-  if (!res.ok) {
-    if (res.status === 401) throw new Error('Unauthorized')
-    throw new Error(`API error: ${res.status}`)
-  }
-
-  const text = await res.text()
-  if (!text) return {} as T
-  return JSON.parse(text)
-}
+import { authFetch } from './client'
 
 // --- Types ---
 
@@ -98,6 +78,7 @@ export interface AchievementDto {
 export async function submitSession(data: SubmitSessionRequest): Promise<SubmitSessionResponse> {
   return authFetch<SubmitSessionResponse>('/me/reading/sessions', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
 }
@@ -131,6 +112,7 @@ export async function getGoals(): Promise<GoalDto[]> {
 export async function createGoal(data: CreateGoalRequest): Promise<GoalDto> {
   return authFetch<GoalDto>('/me/reading/goals', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
 }

--- a/apps/web/src/api/userBooks.ts
+++ b/apps/web/src/api/userBooks.ts
@@ -1,6 +1,4 @@
-import { refreshToken } from './auth'
-
-const API_BASE = import.meta.env.VITE_API_URL ?? ''
+import { authFetch, API_BASE } from './client'
 
 export interface UserBook {
   id: string
@@ -65,37 +63,6 @@ export interface StorageQuota {
   usedBytes: number
   limitBytes: number
   usedPercent: number
-}
-
-async function authFetch<T>(path: string, options?: RequestInit, retry = true): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
-    ...options,
-    credentials: 'include',
-  })
-
-  if (!res.ok) {
-    if (res.status === 401 && retry) {
-      // Try refresh token and retry once
-      try {
-        await refreshToken()
-        return authFetch<T>(path, options, false)
-      } catch {
-        throw new Error('Unauthorized')
-      }
-    }
-    if (res.status === 401) throw new Error('Unauthorized')
-    const text = await res.text()
-    let error = `API error: ${res.status}`
-    try {
-      const json = JSON.parse(text)
-      if (json.error) error = json.error
-    } catch {}
-    throw new Error(error)
-  }
-
-  const text = await res.text()
-  if (!text) return {} as T
-  return JSON.parse(text)
 }
 
 export async function uploadUserBook(

--- a/apps/web/src/api/userData.ts
+++ b/apps/web/src/api/userData.ts
@@ -1,36 +1,4 @@
-import { refreshToken } from './auth'
-
-const API_BASE = import.meta.env.VITE_API_URL ?? ''
-
-async function authFetch<T>(path: string, options?: RequestInit, retry = true): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
-    ...options,
-    credentials: 'include',
-  })
-
-  if (!res.ok) {
-    if (res.status === 401 && retry) {
-      try {
-        await refreshToken()
-        return authFetch<T>(path, options, false)
-      } catch {
-        throw new Error('Unauthorized')
-      }
-    }
-    if (res.status === 401) throw new Error('Unauthorized')
-    const text = await res.text()
-    let error = `API error: ${res.status}`
-    try {
-      const json = JSON.parse(text)
-      if (json.error) error = json.error
-    } catch {}
-    throw new Error(error)
-  }
-
-  const text = await res.text()
-  if (!text) return {} as T
-  return JSON.parse(text)
-}
+import { authFetch } from './client'
 
 // Bookmark types
 export interface PublicBookmark {

--- a/backend/Docker/Api.Dockerfile
+++ b/backend/Docker/Api.Dockerfile
@@ -19,6 +19,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS runtime
 RUN apk add --no-cache git \
     && deluser app 2>/dev/null; delgroup app 2>/dev/null; \
        addgroup -g 1000 app && adduser -D -u 1000 -G app app
+RUN mkdir -p /storage /data/textstack && chown -R app:app /storage /data/textstack
 WORKDIR /app
 COPY --from=build /app/publish .
 USER app

--- a/backend/Docker/Api.Dockerfile
+++ b/backend/Docker/Api.Dockerfile
@@ -16,7 +16,9 @@ COPY backend/src/ backend/src/
 RUN dotnet publish backend/src/Api/Api.csproj -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS runtime
-RUN apk add --no-cache git
+RUN apk add --no-cache git \
+    && deluser app 2>/dev/null; delgroup app 2>/dev/null; \
+       addgroup -g 1000 app && adduser -D -u 1000 -G app app
 WORKDIR /app
 COPY --from=build /app/publish .
 USER app

--- a/backend/Docker/Api.Dockerfile
+++ b/backend/Docker/Api.Dockerfile
@@ -19,6 +19,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS runtime
 RUN apk add --no-cache git
 WORKDIR /app
 COPY --from=build /app/publish .
+USER app
 ENV ASPNETCORE_URLS=http://+:8080
 EXPOSE 8080
 ENTRYPOINT ["dotnet", "Api.dll"]

--- a/backend/Docker/Worker.Dockerfile
+++ b/backend/Docker/Worker.Dockerfile
@@ -59,6 +59,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Puppeteer cache location (scripts mounted via docker-compose volume)
 ENV PUPPETEER_CACHE_DIR=/app/.cache/puppeteer
 
+RUN userdel -r app 2>/dev/null; userdel -r ubuntu 2>/dev/null; \
+    groupadd -g 1000 app && useradd -u 1000 -g app -m app
+
 WORKDIR /app
 COPY --from=build /app/publish .
 

--- a/backend/Docker/Worker.Dockerfile
+++ b/backend/Docker/Worker.Dockerfile
@@ -66,6 +66,8 @@ COPY --from=build /app/publish .
 RUN mkdir -p /app/apps/web && \
     cd /app/apps/web && \
     npm init -y --silent && \
-    npm install --silent puppeteer
+    npm install --silent puppeteer && \
+    chown -R app:app /app
 
+USER app
 ENTRYPOINT ["dotnet", "Worker.dll"]

--- a/backend/Docker/Worker.Dockerfile
+++ b/backend/Docker/Worker.Dockerfile
@@ -62,6 +62,7 @@ ENV PUPPETEER_CACHE_DIR=/app/.cache/puppeteer
 RUN userdel -r app 2>/dev/null; userdel -r ubuntu 2>/dev/null; \
     groupadd -g 1000 app && useradd -u 1000 -g app -m app
 
+RUN mkdir -p /storage && chown app:app /storage
 WORKDIR /app
 COPY --from=build /app/publish .
 

--- a/backend/src/Api/Endpoints/HighlightsEndpoints.cs
+++ b/backend/src/Api/Endpoints/HighlightsEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.Extensions;
 using Api.Sites;
 using Application.Auth;
 using Application.Common.Interfaces;
@@ -19,13 +20,6 @@ public static class HighlightsEndpoints
         group.MapDelete("/{id:guid}", DeleteHighlight).WithName("DeleteHighlight");
     }
 
-    private static Guid? GetUserId(HttpContext httpContext, AuthService authService)
-    {
-        var accessToken = httpContext.Request.Cookies["access_token"];
-        if (string.IsNullOrEmpty(accessToken)) return null;
-        return authService.ValidateAccessToken(accessToken);
-    }
-
     private static async Task<IResult> GetHighlights(
         Guid editionId,
         HttpContext httpContext,
@@ -33,7 +27,7 @@ public static class HighlightsEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var siteId = httpContext.GetSiteId();
@@ -65,7 +59,7 @@ public static class HighlightsEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var siteId = httpContext.GetSiteId();
@@ -126,7 +120,7 @@ public static class HighlightsEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var highlight = await db.Highlights
@@ -187,7 +181,7 @@ public static class HighlightsEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var highlight = await db.Highlights

--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.Extensions;
 using Api.Sites;
 using Application.Auth;
 using Application.Common.Interfaces;
@@ -24,13 +25,6 @@ public static class ReadingTrackingEndpoints
         group.MapGet("/achievements", GetAchievements).WithName("GetAchievements");
     }
 
-    private static Guid? GetUserId(HttpContext httpContext, AuthService authService)
-    {
-        var accessToken = httpContext.Request.Cookies["access_token"];
-        if (string.IsNullOrEmpty(accessToken)) return null;
-        return authService.ValidateAccessToken(accessToken);
-    }
-
     // --- Sessions ---
 
     private static async Task<IResult> SubmitSession(
@@ -40,7 +34,7 @@ public static class ReadingTrackingEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
         var siteId = httpContext.GetSiteId();
 
@@ -104,7 +98,7 @@ public static class ReadingTrackingEndpoints
         [FromQuery] int? limit,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
         var siteId = httpContext.GetSiteId();
 
@@ -135,7 +129,7 @@ public static class ReadingTrackingEndpoints
         [FromQuery] string? tz,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
         var siteId = httpContext.GetSiteId();
 
@@ -236,7 +230,7 @@ public static class ReadingTrackingEndpoints
         [FromQuery] string? tz,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
         var siteId = httpContext.GetSiteId();
 
@@ -274,7 +268,7 @@ public static class ReadingTrackingEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
         var siteId = httpContext.GetSiteId();
 
@@ -293,7 +287,7 @@ public static class ReadingTrackingEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
         var siteId = httpContext.GetSiteId();
 
@@ -346,7 +340,7 @@ public static class ReadingTrackingEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var goal = await db.ReadingGoals
@@ -367,7 +361,7 @@ public static class ReadingTrackingEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
         var siteId = httpContext.GetSiteId();
 

--- a/backend/src/Api/Endpoints/SearchEndpoints.cs
+++ b/backend/src/Api/Endpoints/SearchEndpoints.cs
@@ -52,6 +52,9 @@ public static class SearchEndpoints
         if (string.IsNullOrWhiteSpace(q) || q.Length < 2)
             return Results.BadRequest(new { error = "Query must be at least 2 characters" });
 
+        if (q.Length > 200)
+            return Results.BadRequest(new { error = "Query too long (max 200 characters)" });
+
         // ─── Extract Context ────────────────────────────────────
         // Site and language from request context (multitenancy)
         var siteId = httpContext.GetSiteId();

--- a/backend/src/Api/Endpoints/UserBooksEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserBooksEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.Extensions;
 using Application.Auth;
 using Application.Common.Interfaces;
 using Application.UserBooks;
@@ -31,13 +32,6 @@ public static class UserBooksEndpoints
         group.MapDelete("/{id:guid}", DeleteBook).WithName("DeleteUserBook");
     }
 
-    private static Guid? GetUserId(HttpContext httpContext, AuthService authService)
-    {
-        var accessToken = httpContext.Request.Cookies["access_token"];
-        if (string.IsNullOrEmpty(accessToken)) return null;
-        return authService.ValidateAccessToken(accessToken);
-    }
-
     private static async Task<IResult> UploadBook(
         HttpContext httpContext,
         AuthService authService,
@@ -47,7 +41,7 @@ public static class UserBooksEndpoints
         [FromForm] string? language,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         if (file == null || file.Length == 0)
@@ -69,7 +63,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var books = await userBookService.GetBooksAsync(userId.Value, ct);
@@ -82,7 +76,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var quota = await userBookService.GetStorageQuotaAsync(userId.Value, ct);
@@ -96,7 +90,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var book = await userBookService.GetBookAsync(userId.Value, id, ct);
@@ -113,7 +107,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var chapter = await userBookService.GetChapterBySlugAsync(userId.Value, id, slug, ct);
@@ -129,7 +123,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var progress = await userBookService.GetProgressAsync(userId.Value, id, ct);
@@ -146,7 +140,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var (success, error) = await userBookService.UpsertProgressAsync(userId.Value, id, request, ct);
@@ -163,7 +157,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var bookmarks = await userBookService.GetBookmarksAsync(userId.Value, id, ct);
@@ -178,7 +172,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var (bookmark, error) = await userBookService.CreateBookmarkAsync(userId.Value, id, request, ct);
@@ -196,7 +190,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var (success, error) = await userBookService.DeleteBookmarkAsync(userId.Value, id, bookmarkId, ct);
@@ -215,7 +209,7 @@ public static class UserBooksEndpoints
         IFileStorageService storage,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         // Build expected path pattern
@@ -258,7 +252,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var (success, error) = await userBookService.RetryAsync(userId.Value, id, ct);
@@ -275,7 +269,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var (success, error) = await userBookService.CancelAsync(userId.Value, id, ct);
@@ -292,7 +286,7 @@ public static class UserBooksEndpoints
         UserBookService userBookService,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var (success, error) = await userBookService.DeleteAsync(userId.Value, id, ct);

--- a/backend/src/Api/Endpoints/UserDataEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserDataEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.Extensions;
 using Api.Sites;
 using Application.Auth;
 using Application.Common.Interfaces;
@@ -31,13 +32,6 @@ public static class UserDataEndpoints
         group.MapDelete("/library/{editionId:guid}", RemoveFromLibrary).WithName("RemoveFromLibrary");
     }
 
-    private static Guid? GetUserId(HttpContext httpContext, AuthService authService)
-    {
-        var accessToken = httpContext.Request.Cookies["access_token"];
-        if (string.IsNullOrEmpty(accessToken)) return null;
-        return authService.ValidateAccessToken(accessToken);
-    }
-
     // Reading Progress Endpoints
 
     private static async Task<IResult> GetAllProgress(
@@ -48,7 +42,7 @@ public static class UserDataEndpoints
         [FromQuery] int? offset,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var siteId = httpContext.GetSiteId();
@@ -82,7 +76,7 @@ public static class UserDataEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var siteId = httpContext.GetSiteId();
@@ -111,7 +105,7 @@ public static class UserDataEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var siteId = httpContext.GetSiteId();
@@ -192,7 +186,7 @@ public static class UserDataEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var siteId = httpContext.GetSiteId();
@@ -219,7 +213,7 @@ public static class UserDataEndpoints
         [FromQuery] int? offset,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var siteId = httpContext.GetSiteId();
@@ -252,7 +246,7 @@ public static class UserDataEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var siteId = httpContext.GetSiteId();
@@ -280,7 +274,7 @@ public static class UserDataEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var siteId = httpContext.GetSiteId();
@@ -331,7 +325,7 @@ public static class UserDataEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var bookmark = await db.Bookmarks
@@ -356,7 +350,7 @@ public static class UserDataEndpoints
         [FromQuery] int? offset,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var query = db.UserLibraries
@@ -388,7 +382,7 @@ public static class UserDataEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         // Check if edition exists
@@ -437,7 +431,7 @@ public static class UserDataEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var userId = GetUserId(httpContext, authService);
+        var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
         var libraryItem = await db.UserLibraries

--- a/backend/src/Api/Extensions/ClaimsPrincipalExtensions.cs
+++ b/backend/src/Api/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,13 @@
+using Application.Auth;
+
+namespace Api.Extensions;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static Guid? GetUserId(this HttpContext httpContext, AuthService authService)
+    {
+        var accessToken = httpContext.Request.Cookies["access_token"];
+        if (string.IsNullOrEmpty(accessToken)) return null;
+        return authService.ValidateAccessToken(accessToken);
+    }
+}

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -40,24 +40,17 @@ builder.Services.AddTextStackTelemetry(
         .AddHttpClientInstrumentation());
 builder.Logging.AddTelemetryLogging(builder.Configuration, "textstack-api");
 
+var corsOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+    ?? [
+        "http://localhost:5173", "http://general.localhost", "http://general.localhost:5173",
+        "http://localhost:81", "http://admin.localhost", "http://admin.localhost:81",
+        "https://textstack.app", "https://textstack.dev"
+    ];
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        policy.WithOrigins(
-                // Dev: public site
-                "http://localhost:5173",
-                "http://general.localhost",
-                "http://general.localhost:5173",
-                // Dev: admin panel
-                "http://localhost:81",
-                "http://admin.localhost",
-                "http://admin.localhost:81",
-                // Prod: public site
-                "https://textstack.app",
-                // Prod: admin panel
-                "https://textstack.dev"
-            )
+        policy.WithOrigins(corsOrigins)
             .AllowAnyHeader()
             .AllowAnyMethod()
             .AllowCredentials();
@@ -71,7 +64,7 @@ builder.Services.AddApplication();
 builder.Services.AddAuthSettings(builder.Configuration);
 
 var connectionString = builder.Configuration.GetConnectionString("Default")
-    ?? "Host=localhost;Port=5432;Database=books;Username=app;Password=changeme";
+    ?? throw new InvalidOperationException("ConnectionStrings:Default is required");
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(connectionString)
@@ -123,6 +116,18 @@ builder.Services.AddRateLimiter(options =>
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 });
 
+// Validate required config at startup
+if (!builder.Environment.IsEnvironment("Test"))
+{
+    var jwtSecret = builder.Configuration["Jwt:SecretKey"];
+    if (string.IsNullOrEmpty(jwtSecret))
+        throw new InvalidOperationException("Jwt:SecretKey is required. Set JWT_SECRET env var.");
+
+    var googleClientId = builder.Configuration["Google:ClientId"];
+    if (string.IsNullOrEmpty(googleClientId))
+        throw new InvalidOperationException("Google:ClientId is required. Set GOOGLE_CLIENT_ID env var.");
+}
+
 var app = builder.Build();
 
 // Skip migrations in Test environment (uses InMemory DB)
@@ -165,7 +170,18 @@ app.UseStaticFiles(new StaticFileOptions
 });
 
 // Health check before site resolution (for infra probes)
-app.MapGet("/health", () => Results.Ok("healthy"));
+app.MapGet("/health", async (AppDbContext db) =>
+{
+    try
+    {
+        await db.Database.ExecuteSqlRawAsync("SELECT 1");
+        return Results.Ok("healthy");
+    }
+    catch
+    {
+        return Results.StatusCode(503);
+    }
+});
 
 // Site resolution middleware
 app.UseSiteContext();

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -23,5 +23,22 @@
     "BaseUrl": "http://localhost:5000",
     "MaxTextLength": 500,
     "TimeoutSeconds": 30
+  },
+  "FileUpload": {
+    "MaxBookSizeMb": 100,
+    "MaxCoverSizeMb": 5,
+    "MaxPhotoSizeMb": 2
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:5173",
+      "http://general.localhost",
+      "http://general.localhost:5173",
+      "http://localhost:81",
+      "http://admin.localhost",
+      "http://admin.localhost:81",
+      "https://textstack.app",
+      "https://textstack.dev"
+    ]
   }
 }

--- a/backend/src/Application/Books/BookService.cs
+++ b/backend/src/Application/Books/BookService.cs
@@ -107,10 +107,7 @@ public class BookService(IAppDbContext db)
         {
             try
             {
-                toc = JsonSerializer.Deserialize<List<TocEntryDto>>(result.TocJson, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                });
+                toc = JsonSerializer.Deserialize<List<TocEntryDto>>(result.TocJson, Common.JsonDefaults.Options);
             }
             catch
             {

--- a/backend/src/Application/Common/ImageProcessingHelper.cs
+++ b/backend/src/Application/Common/ImageProcessingHelper.cs
@@ -1,0 +1,65 @@
+using HtmlAgilityPack;
+
+namespace Application.Common;
+
+public static class ImageProcessingHelper
+{
+    public static string RewriteImageSrcs(string html, Dictionary<string, string> imageMap)
+    {
+        if (string.IsNullOrEmpty(html) || imageMap.Count == 0)
+            return html;
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var imgNodes = doc.DocumentNode.SelectNodes("//img[@src]");
+        if (imgNodes == null)
+            return html;
+
+        foreach (var img in imgNodes)
+        {
+            var src = img.GetAttributeValue("src", "");
+            if (string.IsNullOrEmpty(src))
+                continue;
+
+            var normalizedSrc = NormalizeImagePath(src);
+
+            foreach (var (originalPath, newUrl) in imageMap)
+            {
+                var normalizedOriginal = NormalizeImagePath(originalPath);
+                if (normalizedSrc.Equals(normalizedOriginal, StringComparison.OrdinalIgnoreCase) ||
+                    normalizedSrc.EndsWith(normalizedOriginal, StringComparison.OrdinalIgnoreCase) ||
+                    normalizedOriginal.EndsWith(normalizedSrc, StringComparison.OrdinalIgnoreCase))
+                {
+                    img.SetAttributeValue("src", newUrl);
+                    break;
+                }
+            }
+        }
+
+        return doc.DocumentNode.InnerHtml;
+    }
+
+    public static string NormalizeImagePath(string path)
+    {
+        var result = path;
+        while (result.StartsWith("../"))
+            result = result[3..];
+        while (result.StartsWith("./"))
+            result = result[2..];
+        result = result.TrimStart('/');
+        return result;
+    }
+
+    public static string GetExtensionFromMimeType(string mimeType)
+    {
+        return mimeType switch
+        {
+            "image/png" => ".png",
+            "image/gif" => ".gif",
+            "image/webp" => ".webp",
+            "image/svg+xml" => ".svg",
+            _ => ".jpg"
+        };
+    }
+}

--- a/backend/src/Application/Common/JsonDefaults.cs
+++ b/backend/src/Application/Common/JsonDefaults.cs
@@ -1,0 +1,11 @@
+using System.Text.Json;
+
+namespace Application.Common;
+
+public static class JsonDefaults
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+}

--- a/backend/src/Application/Common/Result.cs
+++ b/backend/src/Application/Common/Result.cs
@@ -1,0 +1,9 @@
+namespace Application.Common;
+
+public record Result<T>(T? Data, string? Error)
+{
+    public bool IsSuccess => Error == null;
+
+    public static Result<T> Success(T data) => new(data, null);
+    public static Result<T> Failure(string error) => new(default, error);
+}

--- a/backend/src/Application/UserBooks/UserBookService.cs
+++ b/backend/src/Application/UserBooks/UserBookService.cs
@@ -162,12 +162,12 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
         {
             try
             {
-                toc = JsonSerializer.Deserialize<List<TocEntryDto>>(book.TocJson, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                });
+                toc = JsonSerializer.Deserialize<List<TocEntryDto>>(book.TocJson, Common.JsonDefaults.Options);
             }
-            catch { }
+            catch (JsonException)
+            {
+                // Malformed ToC JSON — return null toc
+            }
         }
 
         return new UserBookDetailDto(

--- a/backend/src/Extraction/TextStack.Extraction/Extractors/PdfTextExtractor.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Extractors/PdfTextExtractor.cs
@@ -386,10 +386,10 @@ public sealed class PdfTextExtractor : ITextExtractor
         {
             using var pdfStream = new MemoryStream(pdfBytes);
             using var imageStream = new MemoryStream();
-            #pragma warning disable CA1416 // Platform compatibility — worker runs on Linux
+#pragma warning disable CA1416 // Platform compatibility — worker runs on Linux
             Conversion.SaveJpeg(imageStream, pdfStream, Index.FromStart(0),
                 options: new RenderOptions(Dpi: 150));
-            #pragma warning restore CA1416
+#pragma warning restore CA1416
             var result = imageStream.ToArray();
             return result.Length > 0 ? result : null;
         }

--- a/backend/src/Extraction/TextStack.Extraction/Typography/Fractions.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Typography/Fractions.cs
@@ -46,17 +46,31 @@ public static class Fractions
     // Superscript digits for custom fractions
     private static readonly Dictionary<char, char> SuperscriptMap = new()
     {
-        ['0'] = '\u2070', ['1'] = '\u00B9', ['2'] = '\u00B2', ['3'] = '\u00B3',
-        ['4'] = '\u2074', ['5'] = '\u2075', ['6'] = '\u2076', ['7'] = '\u2077',
-        ['8'] = '\u2078', ['9'] = '\u2079'
+        ['0'] = '\u2070',
+        ['1'] = '\u00B9',
+        ['2'] = '\u00B2',
+        ['3'] = '\u00B3',
+        ['4'] = '\u2074',
+        ['5'] = '\u2075',
+        ['6'] = '\u2076',
+        ['7'] = '\u2077',
+        ['8'] = '\u2078',
+        ['9'] = '\u2079'
     };
 
     // Subscript digits for custom fractions
     private static readonly Dictionary<char, char> SubscriptMap = new()
     {
-        ['0'] = '\u2080', ['1'] = '\u2081', ['2'] = '\u2082', ['3'] = '\u2083',
-        ['4'] = '\u2084', ['5'] = '\u2085', ['6'] = '\u2086', ['7'] = '\u2087',
-        ['8'] = '\u2088', ['9'] = '\u2089'
+        ['0'] = '\u2080',
+        ['1'] = '\u2081',
+        ['2'] = '\u2082',
+        ['3'] = '\u2083',
+        ['4'] = '\u2084',
+        ['5'] = '\u2085',
+        ['6'] = '\u2086',
+        ['7'] = '\u2087',
+        ['8'] = '\u2088',
+        ['9'] = '\u2089'
     };
 
     private const char FractionSlash = '\u2044'; // ⁄

--- a/backend/src/Worker/Services/IngestionService.cs
+++ b/backend/src/Worker/Services/IngestionService.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Application.Common.Interfaces;
 using Domain.Entities;
 using Domain.Enums;
-using HtmlAgilityPack;
 using Infrastructure.Persistence;
 using Infrastructure.Telemetry;
 using Microsoft.EntityFrameworkCore;
@@ -354,7 +353,9 @@ public class IngestionWorkerService
             .Select(u => new AppIngestion.ParsedChapter(
                 u.OrderIndex,
                 u.Title ?? $"Chapter {u.OrderIndex + 1}",
-                RewriteImageSrcs(u.Html ?? string.Empty, imageMap, editionId),
+                Application.Common.ImageProcessingHelper.RewriteImageSrcs(
+                    u.Html ?? string.Empty,
+                    imageMap.ToDictionary(kv => kv.Key, kv => $"/books/{editionId}/assets/{kv.Value}")),
                 u.PlainText,
                 u.WordCount ?? 0,
                 u.OriginalChapterNumber,
@@ -369,68 +370,6 @@ public class IngestionWorkerService
             chapters);
     }
 
-    private static string RewriteImageSrcs(string html, Dictionary<string, Guid> imageMap, Guid editionId)
-    {
-        if (string.IsNullOrEmpty(html) || imageMap.Count == 0)
-            return html;
-
-        var doc = new HtmlDocument();
-        doc.LoadHtml(html);
-
-        var imgNodes = doc.DocumentNode.SelectNodes("//img[@src]");
-        if (imgNodes == null)
-            return html;
-
-        foreach (var img in imgNodes)
-        {
-            var src = img.GetAttributeValue("src", "");
-            if (string.IsNullOrEmpty(src))
-                continue;
-
-            // Try to match the src to an image in our map
-            // Need to handle various path formats
-            var normalizedSrc = NormalizeImagePath(src);
-
-            foreach (var (originalPath, assetId) in imageMap)
-            {
-                var normalizedOriginal = NormalizeImagePath(originalPath);
-                if (normalizedSrc.Equals(normalizedOriginal, StringComparison.OrdinalIgnoreCase) ||
-                    normalizedSrc.EndsWith(normalizedOriginal, StringComparison.OrdinalIgnoreCase) ||
-                    normalizedOriginal.EndsWith(normalizedSrc, StringComparison.OrdinalIgnoreCase))
-                {
-                    img.SetAttributeValue("src", $"/books/{editionId}/assets/{assetId}");
-                    break;
-                }
-            }
-        }
-
-        return doc.DocumentNode.InnerHtml;
-    }
-
-    private static string NormalizeImagePath(string path)
-    {
-        // Remove leading ../ or ./
-        var result = path;
-        while (result.StartsWith("../"))
-            result = result[3..];
-        while (result.StartsWith("./"))
-            result = result[2..];
-        // Remove leading /
-        result = result.TrimStart('/');
-        return result;
-    }
-
-    private static string GetExtensionFromMimeType(string mimeType)
-    {
-        return mimeType switch
-        {
-            "image/png" => ".png",
-            "image/gif" => ".gif",
-            "image/webp" => ".webp",
-            "image/svg+xml" => ".svg",
-            _ => ".jpg"
-        };
-    }
 
     private static AppIngestion.ExtractionSummary MapToExtractionSummary(ExtractionResult result)
     {

--- a/backend/src/Worker/Services/UserIngestionService.cs
+++ b/backend/src/Worker/Services/UserIngestionService.cs
@@ -3,7 +3,6 @@ using Application.Common.Interfaces;
 using Domain.Entities;
 using Domain.Enums;
 using Domain.Utilities;
-using HtmlAgilityPack;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -183,7 +182,7 @@ public class UserIngestionService
             // Create chapters
             foreach (var unit in result.Units)
             {
-                var html = RewriteImageSrcs(unit.Html ?? string.Empty, imageMap);
+                var html = Application.Common.ImageProcessingHelper.RewriteImageSrcs(unit.Html ?? string.Empty, imageMap);
                 var chapterTitle = SanitizeText(unit.Title ?? $"Chapter {unit.OrderIndex + 1}");
                 var chapter = new UserChapter
                 {
@@ -251,64 +250,6 @@ public class UserIngestionService
         }
     }
 
-    private static string RewriteImageSrcs(string html, Dictionary<string, string> imageMap)
-    {
-        if (string.IsNullOrEmpty(html) || imageMap.Count == 0)
-            return html;
-
-        var doc = new HtmlDocument();
-        doc.LoadHtml(html);
-
-        var imgNodes = doc.DocumentNode.SelectNodes("//img[@src]");
-        if (imgNodes == null)
-            return html;
-
-        foreach (var img in imgNodes)
-        {
-            var src = img.GetAttributeValue("src", "");
-            if (string.IsNullOrEmpty(src))
-                continue;
-
-            var normalizedSrc = NormalizeImagePath(src);
-
-            foreach (var (originalPath, newUrl) in imageMap)
-            {
-                var normalizedOriginal = NormalizeImagePath(originalPath);
-                if (normalizedSrc.Equals(normalizedOriginal, StringComparison.OrdinalIgnoreCase) ||
-                    normalizedSrc.EndsWith(normalizedOriginal, StringComparison.OrdinalIgnoreCase) ||
-                    normalizedOriginal.EndsWith(normalizedSrc, StringComparison.OrdinalIgnoreCase))
-                {
-                    img.SetAttributeValue("src", newUrl);
-                    break;
-                }
-            }
-        }
-
-        return doc.DocumentNode.InnerHtml;
-    }
-
-    private static string NormalizeImagePath(string path)
-    {
-        var result = path;
-        while (result.StartsWith("../"))
-            result = result[3..];
-        while (result.StartsWith("./"))
-            result = result[2..];
-        result = result.TrimStart('/');
-        return result;
-    }
-
-    private static string GetExtensionFromMimeType(string mimeType)
-    {
-        return mimeType switch
-        {
-            "image/png" => ".png",
-            "image/gif" => ".gif",
-            "image/webp" => ".webp",
-            "image/svg+xml" => ".svg",
-            _ => ".jpg"
-        };
-    }
 
     private static string MapToFriendlyError(ExtractionWarningCode? code) => code switch
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,7 +186,7 @@ services:
   # ===========================================
 
   libretranslate:
-    image: libretranslate/libretranslate:latest
+    image: libretranslate/libretranslate:v1.6.4
     container_name: textstack_libretranslate
     environment:
       - LT_LOAD_ONLY=en,uk,ru,de,fr,es,pl

--- a/tests/TextStack.IntegrationTests/AuthorsEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/AuthorsEndpointTests.cs
@@ -26,7 +26,7 @@ public class AuthorsEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GetAuthors_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/authors");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -36,7 +36,7 @@ public class AuthorsEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GetAuthors_WithPagination_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/authors?limit=10&offset=0");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -46,7 +46,7 @@ public class AuthorsEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GetAuthors_WithLanguageFilter_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/authors?language=en");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -56,7 +56,7 @@ public class AuthorsEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GetAuthors_WithSortRecent_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/authors?sort=recent");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -66,11 +66,11 @@ public class AuthorsEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GetAuthors_ReturnsValidPaginatedResult()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/authors");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var result = await response.Content.ReadFromJsonAsync<AuthorsResponse>();
+        var result = await response.Content.ReadFromJsonAsync<AuthorsResponse>(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.True(result.Total >= 0);
         Assert.NotNull(result.Items);
@@ -84,7 +84,7 @@ public class AuthorsEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GetAuthor_NonExistent_Returns404()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/authors/non-existent-author-slug-12345");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // 404 expected, also accept if site not configured
         Assert.True(response.StatusCode == HttpStatusCode.NotFound ||

--- a/tests/TextStack.IntegrationTests/DictionaryEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/DictionaryEndpointTests.cs
@@ -22,7 +22,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     public async Task LookupWord_ValidEnglishWord_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/hello");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // External API might be unavailable
         if (response.StatusCode == HttpStatusCode.BadGateway ||
@@ -34,7 +34,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var result = await response.Content.ReadFromJsonAsync<DictionaryResponse>();
+        var result = await response.Content.ReadFromJsonAsync<DictionaryResponse>(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("hello", result.Word.ToLower());
         Assert.NotEmpty(result.Definitions);
@@ -44,7 +44,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     public async Task LookupWord_NonExistentWord_Returns404()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/asdfghjklzxcv");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // External API might be unavailable
         if (response.StatusCode == HttpStatusCode.BadGateway ||
@@ -61,7 +61,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     public async Task LookupWord_EmptyWord_Returns400()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Empty path segment might result in 404 from routing
         Assert.True(
@@ -75,7 +75,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     {
         var longWord = new string('a', 150);
         var request = _fixture.CreateRequest(HttpMethod.Get, $"/api/dictionary/en/{longWord}");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -84,14 +84,14 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     public async Task LookupWord_ReturnsPhonetic()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/book");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (response.StatusCode != HttpStatusCode.OK)
         {
             return; // Skip
         }
 
-        var result = await response.Content.ReadFromJsonAsync<DictionaryResponse>();
+        var result = await response.Content.ReadFromJsonAsync<DictionaryResponse>(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         // Phonetic might or might not be available depending on word
         // Just verify the structure is valid
@@ -102,14 +102,14 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     public async Task LookupWord_ReturnsPartOfSpeech()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/run");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (response.StatusCode != HttpStatusCode.OK)
         {
             return; // Skip
         }
 
-        var result = await response.Content.ReadFromJsonAsync<DictionaryResponse>();
+        var result = await response.Content.ReadFromJsonAsync<DictionaryResponse>(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.NotEmpty(result.Definitions);
         Assert.All(result.Definitions, d => Assert.NotNull(d.PartOfSpeech));
@@ -120,7 +120,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     {
         // German word
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/de/hallo");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // External API might not support all languages or be unavailable
         if (response.StatusCode == HttpStatusCode.BadGateway ||

--- a/tests/TextStack.IntegrationTests/HighlightsEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/HighlightsEndpointTests.cs
@@ -24,7 +24,7 @@ public class HighlightsEndpointTests : IClassFixture<LiveApiFixture>
     {
         var editionId = Guid.NewGuid();
         var request = _fixture.CreateRequest(HttpMethod.Get, $"/me/highlights/{editionId}");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -46,7 +46,7 @@ public class HighlightsEndpointTests : IClassFixture<LiveApiFixture>
             selectedText = "text"
         });
 
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -65,7 +65,7 @@ public class HighlightsEndpointTests : IClassFixture<LiveApiFixture>
             selectedText = "text"
         });
 
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Without auth, should still be 401
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -86,7 +86,7 @@ public class HighlightsEndpointTests : IClassFixture<LiveApiFixture>
             noteText = "Test note"
         });
 
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -100,7 +100,7 @@ public class HighlightsEndpointTests : IClassFixture<LiveApiFixture>
     {
         var highlightId = Guid.NewGuid();
         var request = _fixture.CreateRequest(HttpMethod.Delete, $"/me/highlights/{highlightId}");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }

--- a/tests/TextStack.IntegrationTests/SearchEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/SearchEndpointTests.cs
@@ -26,7 +26,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Search_TitleQuery_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=test");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -36,7 +36,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Search_AuthorQuery_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=author");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -46,7 +46,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Search_ShortQuery_ReturnsBadRequest()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=a");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -56,7 +56,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Search_EmptyQuery_ReturnsBadRequest()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -66,7 +66,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Search_WithHighlight_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=test&highlight=true");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -76,7 +76,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Search_WithPagination_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=test&limit=10&offset=0");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -90,7 +90,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Suggest_ValidPrefix_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search/suggest?q=the");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -100,11 +100,11 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Suggest_ShortPrefix_ReturnsEmptyArray()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search/suggest?q=a");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("[]", content);
     }
 
@@ -116,11 +116,11 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Search_ReturnsValidPaginatedResult()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=book");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var result = await response.Content.ReadFromJsonAsync<SearchResponse>();
+        var result = await response.Content.ReadFromJsonAsync<SearchResponse>(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.True(result.Total >= 0);
         Assert.NotNull(result.Items);

--- a/tests/TextStack.IntegrationTests/SitemapEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/SitemapEndpointTests.cs
@@ -33,7 +33,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task SitemapIndex_Returns200WithXmlContentType()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemap.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return; // CI: no site configured
 
@@ -45,11 +45,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task SitemapIndex_StartsWithXmlDeclaration()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemap.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.StartsWith("<?xml", content.TrimStart());
     }
 
@@ -57,11 +57,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task SitemapIndex_HasCorrectNamespace()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemap.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
 
         Assert.NotNull(doc.Root);
@@ -73,11 +73,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task SitemapIndex_DoesNotContainChapters()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemap.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.DoesNotContain("chapters", content, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -85,11 +85,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task SitemapIndex_ContainsRequiredSitemaps()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemap.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
 
         var locs = doc.Descendants(SitemapNs + "loc").Select(e => e.Value).ToList();
@@ -107,7 +107,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task BooksSitemap_Returns200WithXmlContentType()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/books.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
@@ -119,11 +119,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task BooksSitemap_HasCorrectUrlsetNamespace()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/books.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
 
         Assert.NotNull(doc.Root);
@@ -135,11 +135,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task BooksSitemap_AllLocsAreValidAbsoluteUrls()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/books.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
 
         var locs = doc.Descendants(SitemapNs + "loc").Select(e => e.Value).ToList();
@@ -157,11 +157,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task BooksSitemap_LastmodFormatIsValid()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/books.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
 
         var lastmods = doc.Descendants(SitemapNs + "lastmod").Select(e => e.Value).ToList();
@@ -177,11 +177,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task BooksSitemap_UrlsMatchBookPattern()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/books.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
 
         var locs = doc.Descendants(SitemapNs + "loc").Select(e => e.Value).ToList();
@@ -197,11 +197,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task BooksSitemap_NoChapterUrls()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/books.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
 
         var locs = doc.Descendants(SitemapNs + "loc").Select(e => e.Value).ToList();
@@ -226,7 +226,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task AuthorsSitemap_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/authors.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
@@ -237,11 +237,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task AuthorsSitemap_UrlsMatchAuthorPattern()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/authors.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
 
         var locs = doc.Descendants(SitemapNs + "loc").Select(e => e.Value).ToList();
@@ -261,7 +261,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GenresSitemap_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/genres.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
@@ -272,11 +272,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GenresSitemap_UrlsMatchGenrePattern()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/genres.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
 
         var locs = doc.Descendants(SitemapNs + "loc").Select(e => e.Value).ToList();
@@ -296,7 +296,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task ChaptersSitemap_Returns404()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/chapters-1.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // 404 expected, but also accept if site not configured
         Assert.True(response.StatusCode == HttpStatusCode.NotFound ||
@@ -311,7 +311,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task RobotsTxt_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/robots.txt");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
@@ -323,11 +323,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task RobotsTxt_ContainsSitemapReference()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/robots.txt");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         if (IsIndexingDisabled(content)) return; // Site has indexing disabled
 
         Assert.Contains("Sitemap:", content);
@@ -338,11 +338,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task RobotsTxt_DisallowsAdminAndApi()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/robots.txt");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         if (IsIndexingDisabled(content)) return; // Site has indexing disabled
 
         Assert.Contains("Disallow: /admin", content);
@@ -361,11 +361,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task Sitemaps_AreValidXml(string path)
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, path);
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
         Assert.NotNull(doc.Root);
     }
@@ -378,11 +378,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task BooksSitemap_FirstUrlReturns200()
     {
         var sitemapRequest = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/books.xml");
-        var sitemapResponse = await _fixture.Client.SendAsync(sitemapRequest);
+        var sitemapResponse = await _fixture.Client.SendAsync(sitemapRequest, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(sitemapResponse)) return;
 
-        var content = await sitemapResponse.Content.ReadAsStringAsync();
+        var content = await sitemapResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
         var firstLoc = doc.Descendants(SitemapNs + "loc").FirstOrDefault()?.Value;
 
@@ -390,7 +390,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
 
         var uri = new Uri(firstLoc);
         var pageRequest = _fixture.CreateRequest(HttpMethod.Get, uri.AbsolutePath);
-        var pageResponse = await _fixture.Client.SendAsync(pageRequest);
+        var pageResponse = await _fixture.Client.SendAsync(pageRequest, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, pageResponse.StatusCode);
     }
@@ -399,11 +399,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task AuthorsSitemap_FirstUrlReturns200()
     {
         var sitemapRequest = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/authors.xml");
-        var sitemapResponse = await _fixture.Client.SendAsync(sitemapRequest);
+        var sitemapResponse = await _fixture.Client.SendAsync(sitemapRequest, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(sitemapResponse)) return;
 
-        var content = await sitemapResponse.Content.ReadAsStringAsync();
+        var content = await sitemapResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
         var firstLoc = doc.Descendants(SitemapNs + "loc").FirstOrDefault()?.Value;
 
@@ -411,7 +411,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
 
         var uri = new Uri(firstLoc);
         var pageRequest = _fixture.CreateRequest(HttpMethod.Get, uri.AbsolutePath);
-        var pageResponse = await _fixture.Client.SendAsync(pageRequest);
+        var pageResponse = await _fixture.Client.SendAsync(pageRequest, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, pageResponse.StatusCode);
     }
@@ -420,11 +420,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GenresSitemap_FirstUrlReturns200()
     {
         var sitemapRequest = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/genres.xml");
-        var sitemapResponse = await _fixture.Client.SendAsync(sitemapRequest);
+        var sitemapResponse = await _fixture.Client.SendAsync(sitemapRequest, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(sitemapResponse)) return;
 
-        var content = await sitemapResponse.Content.ReadAsStringAsync();
+        var content = await sitemapResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
         var firstLoc = doc.Descendants(SitemapNs + "loc").FirstOrDefault()?.Value;
 
@@ -432,7 +432,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
 
         var uri = new Uri(firstLoc);
         var pageRequest = _fixture.CreateRequest(HttpMethod.Get, uri.AbsolutePath);
-        var pageResponse = await _fixture.Client.SendAsync(pageRequest);
+        var pageResponse = await _fixture.Client.SendAsync(pageRequest, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, pageResponse.StatusCode);
     }
@@ -441,7 +441,7 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task PagesSitemap_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/pages.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
@@ -452,11 +452,11 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
     public async Task PagesSitemap_ContainsHomepages()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/sitemaps/pages.xml");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (ShouldSkip(response)) return;
 
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var doc = XDocument.Parse(content);
         var locs = doc.Descendants(SitemapNs + "loc").Select(e => e.Value).ToList();
 

--- a/tests/TextStack.IntegrationTests/TranslationEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/TranslationEndpointTests.cs
@@ -29,7 +29,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
             targetLang = "uk"
         });
 
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // LibreTranslate might not be running, so accept 502/503
         if (response.StatusCode == HttpStatusCode.BadGateway ||
@@ -40,7 +40,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var result = await response.Content.ReadFromJsonAsync<TranslateResponse>();
+        var result = await response.Content.ReadFromJsonAsync<TranslateResponse>(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.NotNull(result.TranslatedText);
         Assert.Equal("en", result.SourceLang);
@@ -58,7 +58,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
             targetLang = "uk"
         });
 
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -74,7 +74,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
             targetLang = "uk"
         });
 
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -90,7 +90,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
             targetLang = ""
         });
 
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -107,7 +107,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
             targetLang = "uk"
         });
 
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -120,7 +120,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GetLanguages_Returns200()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/translate/languages");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // LibreTranslate might not be running, so accept 502/503
         if (response.StatusCode == HttpStatusCode.BadGateway ||
@@ -131,7 +131,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var languages = await response.Content.ReadFromJsonAsync<LanguageInfo[]>();
+        var languages = await response.Content.ReadFromJsonAsync<LanguageInfo[]>(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(languages);
         Assert.True(languages.Length > 0);
     }
@@ -140,7 +140,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
     public async Task GetLanguages_ContainsEnglishAndUkrainian()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/translate/languages");
-        var response = await _fixture.Client.SendAsync(request);
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // LibreTranslate might not be running
         if (response.StatusCode != HttpStatusCode.OK)
@@ -148,7 +148,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
             return;
         }
 
-        var languages = await response.Content.ReadFromJsonAsync<LanguageInfo[]>();
+        var languages = await response.Content.ReadFromJsonAsync<LanguageInfo[]>(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(languages);
         Assert.Contains(languages, l => l.Code == "en");
         Assert.Contains(languages, l => l.Code == "uk");


### PR DESCRIPTION
## Summary
- **Security**: non-root Docker users, config validation at startup, search query length limit, pinned LibreTranslate, removed default DB password, CORS from config, health check w/ DB
- **Dedup**: extracted `ImageProcessingHelper` (2 services), `GetUserId` extension (4 endpoints), consolidated `authFetch` (4 frontend modules)
- **Quality**: `Result<T>`, `JsonDefaults` shared JSON options, `FileUpload` size limits in config
- **CI/CD**: `dotnet format` lint in CI, SSG page count validation in deploy, `make test`/`make lint` targets

## Test plan
- [x] `docker compose build` — all 5 services build
- [x] `docker compose up -d` — all containers healthy
- [x] `dotnet test` — search (21), unit (48), integration (62) pass
- [x] `pnpm test:e2e` — 61 Playwright tests pass
- [x] `pnpm -C apps/web build` — frontend builds
- [x] API health endpoint returns "healthy"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)