### PR TITLE
feat: FB2 format extraction support

### DIFF
--- a/apps/admin/src/pages/UploadPage.tsx
+++ b/apps/admin/src/pages/UploadPage.tsx
@@ -83,7 +83,7 @@ export function UploadPage() {
   return (
     <div className="upload-page">
       <h1>Upload Book</h1>
-      <p className="upload-page__subtitle">Upload an EPUB or PDF file to add to the library.</p>
+      <p className="upload-page__subtitle">Upload an EPUB, PDF or FB2 file to add to the library.</p>
 
       <form onSubmit={handleSubmit} className="upload-form">
         <div className="form-group">
@@ -91,7 +91,7 @@ export function UploadPage() {
           <input
             type="file"
             id="file"
-            accept=".epub,.pdf"
+            accept=".epub,.pdf,.fb2"
             onChange={(e) => setFile(e.target.files?.[0] || null)}
             required
           />

--- a/apps/web/src/components/library/UploadSection.tsx
+++ b/apps/web/src/components/library/UploadSection.tsx
@@ -84,7 +84,7 @@ export function UploadSection({ onUploadComplete }: UploadSectionProps) {
       >
         <input
           type="file"
-          accept=".epub,.pdf"
+          accept=".epub,.pdf,.fb2"
           onChange={handleFileSelect}
           disabled={isUploading}
           style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', opacity: 0, cursor: 'pointer', zIndex: 2 }}
@@ -108,7 +108,7 @@ export function UploadSection({ onUploadComplete }: UploadSectionProps) {
               <line x1="12" y1="3" x2="12" y2="15" />
             </svg>
             <p className="upload-section__text">
-              Drop EPUB or PDF here
+              Drop EPUB, PDF or FB2 here
             </p>
             <p className="upload-section__subtext">
               or click to browse

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -91,7 +91,7 @@
     "processing": "Processing...",
     "failed": "Failed",
     "noUploads": "No uploaded books yet.",
-    "uploadHint": "Click the + button to upload EPUB files.",
+    "uploadHint": "Click the + button to upload EPUB, PDF or FB2 files.",
     "timeJustNow": "just now",
     "timeMinAgo": "min ago",
     "timeHoursAgo": "hours ago",

--- a/apps/web/src/locales/uk.json
+++ b/apps/web/src/locales/uk.json
@@ -91,7 +91,7 @@
     "processing": "Обробка...",
     "failed": "Помилка",
     "noUploads": "Завантажених книг поки немає.",
-    "uploadHint": "Натисніть кнопку +, щоб завантажити EPUB файли.",
+    "uploadHint": "Натисніть кнопку +, щоб завантажити EPUB, PDF або FB2 файли.",
     "timeJustNow": "щойно",
     "timeMinAgo": "хв тому",
     "timeHoursAgo": "год тому",

--- a/backend/src/Extraction/TextStack.Extraction/Enums/SourceFormat.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Enums/SourceFormat.cs
@@ -4,5 +4,6 @@ public enum SourceFormat
 {
     Unknown = 0,
     Epub = 1,
-    Pdf = 2
+    Pdf = 2,
+    Fb2 = 3
 }

--- a/backend/src/Extraction/TextStack.Extraction/Extractors/Fb2TextExtractor.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Extractors/Fb2TextExtractor.cs
@@ -1,0 +1,368 @@
+using System.Net;
+using System.Text;
+using System.Xml.Linq;
+using TextStack.Extraction.Contracts;
+using TextStack.Extraction.Enums;
+using TextStack.Extraction.TextProcessing.Processors;
+using TextStack.Extraction.Toc;
+using TextStack.Extraction.Utilities;
+
+namespace TextStack.Extraction.Extractors;
+
+public sealed class Fb2TextExtractor : ITextExtractor
+{
+    public SourceFormat SupportedFormat => SourceFormat.Fb2;
+
+    private static readonly XNamespace Fb2Ns = "http://www.gribuser.ru/xml/fictionbook/2.0";
+    private static readonly XNamespace XlinkNs = "http://www.w3.org/1999/xlink";
+
+    public async Task<ExtractionResult> ExtractAsync(ExtractionRequest request, CancellationToken ct = default)
+    {
+        var warnings = new List<ExtractionWarning>();
+
+        XDocument doc;
+        try
+        {
+            doc = await XDocument.LoadAsync(request.Content, LoadOptions.None, ct);
+        }
+        catch (Exception ex)
+        {
+            warnings.Add(new ExtractionWarning(
+                ExtractionWarningCode.ParseError,
+                $"Failed to parse FB2: {ex.Message}"));
+
+            return new ExtractionResult(
+                SourceFormat.Fb2,
+                new ExtractionMetadata(null, null, null, null),
+                [], [], new ExtractionDiagnostics(TextSource.None, null, warnings));
+        }
+
+        var root = doc.Root;
+        if (root == null)
+        {
+            warnings.Add(new ExtractionWarning(ExtractionWarningCode.EmptyContent, "Empty FB2 document"));
+            return new ExtractionResult(
+                SourceFormat.Fb2,
+                new ExtractionMetadata(null, null, null, null),
+                [], [], new ExtractionDiagnostics(TextSource.None, null, warnings));
+        }
+
+        // Detect namespace — some FB2 files omit xmlns
+        var ns = root.Name.Namespace != XNamespace.None ? root.Name.Namespace : Fb2Ns;
+
+        // --- Metadata ---
+        var titleInfo = root.Element(ns + "description")?.Element(ns + "title-info");
+
+        var title = titleInfo?.Element(ns + "book-title")?.Value?.Trim();
+
+        var authors = titleInfo?.Elements(ns + "author")
+            .Select(a => string.Join(" ",
+                new[] { a.Element(ns + "first-name")?.Value, a.Element(ns + "middle-name")?.Value, a.Element(ns + "last-name")?.Value }
+                    .Where(s => !string.IsNullOrWhiteSpace(s))))
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToList();
+        var authorsStr = authors?.Count > 0 ? string.Join(", ", authors) : null;
+
+        var lang = titleInfo?.Element(ns + "lang")?.Value?.Trim();
+
+        var annotation = titleInfo?.Element(ns + "annotation");
+        var description = annotation != null ? GetPlainText(annotation) : null;
+
+        // --- Binary images ---
+        var binaryMap = new Dictionary<string, (byte[] Data, string MimeType)>(StringComparer.OrdinalIgnoreCase);
+        var images = new List<ExtractedImage>();
+
+        foreach (var binary in root.Elements(ns + "binary"))
+        {
+            try
+            {
+                var id = binary.Attribute("id")?.Value;
+                if (string.IsNullOrEmpty(id)) continue;
+
+                var base64 = binary.Value.Trim();
+                if (string.IsNullOrEmpty(base64)) continue;
+
+                var data = Convert.FromBase64String(base64);
+                if (data.Length == 0) continue;
+
+                var mimeType = ImageUtils.DetectMimeType(data);
+                binaryMap[id] = (data, mimeType);
+                images.Add(new ExtractedImage(id, data, mimeType, IsCover: false));
+            }
+            catch (Exception ex)
+            {
+                warnings.Add(new ExtractionWarning(
+                    ExtractionWarningCode.ChapterParseError,
+                    $"Failed to decode binary '{binary.Attribute("id")?.Value}': {ex.Message}"));
+            }
+        }
+
+        // --- Cover ---
+        byte[]? coverImage = null;
+        string? coverMimeType = null;
+
+        try
+        {
+            var coverpage = titleInfo?.Element(ns + "coverpage");
+            var coverImageEl = coverpage?.Element(ns + "image");
+            if (coverImageEl != null)
+            {
+                var href = coverImageEl.Attribute(XlinkNs + "href")?.Value
+                        ?? coverImageEl.Attribute("href")?.Value;
+                if (href != null)
+                {
+                    var coverId = href.TrimStart('#');
+                    if (binaryMap.TryGetValue(coverId, out var coverData))
+                    {
+                        coverImage = coverData.Data;
+                        coverMimeType = coverData.MimeType;
+                        var idx = images.FindIndex(i => i.OriginalPath == coverId);
+                        if (idx >= 0) images[idx] = images[idx] with { IsCover = true };
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            warnings.Add(new ExtractionWarning(
+                ExtractionWarningCode.CoverExtractionFailed,
+                $"Failed to extract cover: {ex.Message}"));
+        }
+
+        // --- Chapters ---
+        var mainBody = root.Elements(ns + "body")
+            .FirstOrDefault(b => b.Attribute("name") == null);
+
+        var units = new List<ContentUnit>();
+        var tocChapters = new List<(int ChapterNumber, string Html)>();
+
+        if (mainBody != null)
+        {
+            var flatSections = FlattenSections(mainBody, ns);
+            var order = 0;
+
+            foreach (var (sectionTitle, rawHtml) in flatSections)
+            {
+                if (ct.IsCancellationRequested) break;
+
+                try
+                {
+                    var (cleanHtml, plainText) = HtmlCleaner.Clean(rawHtml);
+                    if (string.IsNullOrWhiteSpace(plainText)) continue;
+
+                    try
+                    {
+                        if (PiracyWatermarkProcessor.IsPiracyWatermark(cleanHtml))
+                        {
+                            warnings.Add(new ExtractionWarning(
+                                ExtractionWarningCode.ContentFiltered,
+                                "Skipped piracy watermark chapter"));
+                            continue;
+                        }
+                    }
+                    catch { }
+
+                    var chapterNumber = order + 1;
+                    var chapterTitle = sectionTitle ?? $"Section {chapterNumber}";
+                    var wordCount = HtmlCleaner.CountWords(plainText);
+
+                    cleanHtml = TocGenerator.InjectAnchorIds(cleanHtml, chapterNumber);
+                    tocChapters.Add((chapterNumber, cleanHtml));
+
+                    units.Add(new ContentUnit(
+                        Type: ContentUnitType.Chapter,
+                        Title: chapterTitle,
+                        Html: cleanHtml,
+                        PlainText: plainText,
+                        OrderIndex: order++,
+                        WordCount: wordCount));
+                }
+                catch (Exception ex)
+                {
+                    warnings.Add(new ExtractionWarning(
+                        ExtractionWarningCode.ChapterParseError,
+                        $"Failed to parse section: {ex.Message}"));
+                }
+            }
+        }
+
+        if (units.Count == 0 && mainBody != null)
+        {
+            warnings.Add(new ExtractionWarning(ExtractionWarningCode.EmptyContent, "No content extracted from FB2"));
+        }
+
+        var toc = TocGenerator.GenerateToc(tocChapters);
+        var metadata = new ExtractionMetadata(title, authorsStr, lang, description, coverImage, coverMimeType);
+        var textSource = units.Count > 0 ? TextSource.NativeText : TextSource.None;
+        var diagnostics = new ExtractionDiagnostics(textSource, null, warnings);
+
+        return new ExtractionResult(SourceFormat.Fb2, metadata, units, images, diagnostics, toc);
+    }
+
+    /// <summary>
+    /// Recursively flattens nested &lt;section&gt; elements into a flat list of (title, html) pairs.
+    /// </summary>
+    private static List<(string? Title, string Html)> FlattenSections(XElement parent, XNamespace ns, string? parentTitle = null)
+    {
+        var result = new List<(string?, string)>();
+        var sections = parent.Elements(ns + "section").ToList();
+
+        if (sections.Count == 0)
+        {
+            // Leaf — convert content directly
+            var sectionTitle = ExtractSectionTitle(parent, ns) ?? parentTitle;
+            var html = ConvertSectionToHtml(parent, ns);
+            if (!string.IsNullOrWhiteSpace(html))
+                result.Add((sectionTitle, html));
+            return result;
+        }
+
+        // Has child sections — check for own content before first section
+        var ownContent = GetOwnContentElements(parent, ns);
+        if (ownContent.Count > 0)
+        {
+            var sectionTitle = ExtractSectionTitle(parent, ns) ?? parentTitle;
+            var html = ConvertElementsToHtml(ownContent, ns);
+            if (!string.IsNullOrWhiteSpace(html))
+                result.Add((sectionTitle, html));
+        }
+
+        var currentTitle = ExtractSectionTitle(parent, ns);
+        foreach (var section in sections)
+        {
+            var childTitle = ExtractSectionTitle(section, ns);
+            var effectiveParent = childTitle == null ? (currentTitle ?? parentTitle) : null;
+            result.AddRange(FlattenSections(section, ns, effectiveParent));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Converts a section's content elements (excluding nested sections and title) to HTML.
+    /// </summary>
+    private static string ConvertSectionToHtml(XElement section, XNamespace ns)
+    {
+        var elements = section.Elements()
+            .Where(e => e.Name.LocalName != "section" && e.Name.LocalName != "title")
+            .ToList();
+        return ConvertElementsToHtml(elements, ns);
+    }
+
+    private static string ConvertElementsToHtml(IEnumerable<XElement> elements, XNamespace ns)
+    {
+        var sb = new StringBuilder();
+        foreach (var el in elements)
+            sb.Append(ConvertElement(el, ns));
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Recursively converts an FB2 XML element to HTML.
+    /// </summary>
+    private static string ConvertElement(XElement element, XNamespace ns)
+    {
+        var sb = new StringBuilder();
+        var localName = element.Name.LocalName;
+
+        var (openTag, closeTag) = localName switch
+        {
+            "p" => ("<p>", "</p>"),
+            "emphasis" => ("<em>", "</em>"),
+            "strong" => ("<strong>", "</strong>"),
+            "strikethrough" => ("<del>", "</del>"),
+            "code" => ("<code>", "</code>"),
+            "sup" => ("<sup>", "</sup>"),
+            "sub" => ("<sub>", "</sub>"),
+            "subtitle" => ("<h3>", "</h3>"),
+            "epigraph" => ("<blockquote class=\"epigraph\">", "</blockquote>"),
+            "cite" => ("<blockquote>", "</blockquote>"),
+            "poem" => ("<div class=\"poem\">", "</div>"),
+            "stanza" => ("<div class=\"stanza\">", "</div>"),
+            "v" => ("<p class=\"verse\">", "</p>"),
+            "text-author" => ("<p class=\"text-author\">", "</p>"),
+            "title" => ("<h2>", "</h2>"),
+            "table" => ("<table>", "</table>"),
+            "tr" => ("<tr>", "</tr>"),
+            "td" => ("<td>", "</td>"),
+            "th" => ("<th>", "</th>"),
+            _ => ("", "")
+        };
+
+        if (localName == "empty-line")
+        {
+            sb.Append("<br/>");
+        }
+        else if (localName == "image")
+        {
+            var href = element.Attribute(XlinkNs + "href")?.Value
+                    ?? element.Attribute("href")?.Value;
+            if (href != null)
+            {
+                var imgId = href.TrimStart('#');
+                sb.Append($"<img src=\"{WebUtility.HtmlEncode(imgId)}\"/>");
+            }
+        }
+        else if (localName == "a")
+        {
+            var href = element.Attribute(XlinkNs + "href")?.Value
+                    ?? element.Attribute("href")?.Value ?? "#";
+            // Internal note links → dead link, external links kept
+            if (href.StartsWith('#')) href = "#";
+            sb.Append($"<a href=\"{WebUtility.HtmlEncode(href)}\">");
+            AppendChildNodes(sb, element, ns);
+            sb.Append("</a>");
+        }
+        else if (localName == "section")
+        {
+            // Skip nested sections — handled by FlattenSections
+        }
+        else if (!string.IsNullOrEmpty(openTag))
+        {
+            sb.Append(openTag);
+            AppendChildNodes(sb, element, ns);
+            sb.Append(closeTag);
+        }
+        else
+        {
+            // Unknown tag — just render children
+            AppendChildNodes(sb, element, ns);
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendChildNodes(StringBuilder sb, XElement element, XNamespace ns)
+    {
+        foreach (var node in element.Nodes())
+        {
+            if (node is XText text)
+                sb.Append(WebUtility.HtmlEncode(text.Value));
+            else if (node is XElement child)
+                sb.Append(ConvertElement(child, ns));
+        }
+    }
+
+    private static string? ExtractSectionTitle(XElement section, XNamespace ns)
+    {
+        var titleEl = section.Element(ns + "title");
+        if (titleEl == null) return null;
+
+        var text = string.Join(" ", titleEl.Elements(ns + "p").Select(p => p.Value.Trim()))
+            .Trim();
+        return string.IsNullOrWhiteSpace(text) ? null : text;
+    }
+
+    private static string GetPlainText(XElement element)
+    {
+        return string.Join(" ", element.DescendantNodes().OfType<XText>().Select(t => t.Value.Trim())
+            .Where(t => !string.IsNullOrEmpty(t))).Trim();
+    }
+
+    private static List<XElement> GetOwnContentElements(XElement element, XNamespace ns)
+    {
+        return element.Elements()
+            .Where(e => e.Name.LocalName != "section" && e.Name.LocalName != "title")
+            .ToList();
+    }
+}

--- a/backend/src/Extraction/TextStack.Extraction/Registry/ExtractorRegistry.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Registry/ExtractorRegistry.cs
@@ -9,7 +9,8 @@ public sealed class ExtractorRegistry : IExtractorRegistry
     private static readonly Dictionary<string, SourceFormat> ExtensionMap = new(StringComparer.OrdinalIgnoreCase)
     {
         [".epub"] = SourceFormat.Epub,
-        [".pdf"] = SourceFormat.Pdf
+        [".pdf"] = SourceFormat.Pdf,
+        [".fb2"] = SourceFormat.Fb2
     };
 
     private readonly Dictionary<SourceFormat, ITextExtractor> _extractors;

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -49,6 +49,7 @@ else
 // Extraction
 builder.Services.AddSingleton<ITextExtractor, EpubTextExtractor>();
 builder.Services.AddSingleton<ITextExtractor, PdfTextExtractor>();
+builder.Services.AddSingleton<ITextExtractor, Fb2TextExtractor>();
 builder.Services.AddSingleton<IExtractorRegistry, ExtractorRegistry>();
 
 // Image optimization

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -91,7 +91,7 @@
     "processing": "Processing...",
     "failed": "Failed",
     "noUploads": "No uploaded books yet.",
-    "uploadHint": "Click the + button to upload EPUB files.",
+    "uploadHint": "Click the + button to upload EPUB, PDF or FB2 files.",
     "timeJustNow": "just now",
     "timeMinAgo": "min ago",
     "timeHoursAgo": "hours ago",

--- a/packages/shared/src/i18n/uk.json
+++ b/packages/shared/src/i18n/uk.json
@@ -91,7 +91,7 @@
     "processing": "Обробка...",
     "failed": "Помилка",
     "noUploads": "Завантажених книг поки немає.",
-    "uploadHint": "Натисніть кнопку +, щоб завантажити EPUB файли.",
+    "uploadHint": "Натисніть кнопку +, щоб завантажити EPUB, PDF або FB2 файли.",
     "timeJustNow": "щойно",
     "timeMinAgo": "хв тому",
     "timeHoursAgo": "год тому",

--- a/tests/TextStack.Extraction.Tests/Fb2ExtractorTests.cs
+++ b/tests/TextStack.Extraction.Tests/Fb2ExtractorTests.cs
@@ -1,0 +1,472 @@
+using System.Text;
+using TextStack.Extraction.Contracts;
+using TextStack.Extraction.Enums;
+using TextStack.Extraction.Extractors;
+
+namespace TextStack.Extraction.Tests;
+
+public class Fb2ExtractorTests
+{
+    private static string FixturePath => Path.Combine(
+        AppContext.BaseDirectory, "Fixtures", "minimal.fb2");
+
+    [Fact]
+    public async Task ExtractAsync_ValidFb2_ReturnsUnitsWithMetadata()
+    {
+        var extractor = new Fb2TextExtractor();
+        await using var stream = File.OpenRead(FixturePath);
+        var request = new ExtractionRequest { Content = stream, FileName = "minimal.fb2" };
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.NotEmpty(result.Units);
+        Assert.Equal("Minimal Test Book", result.Metadata.Title);
+        Assert.Equal("Test Author", result.Metadata.Authors);
+        Assert.Equal("en", result.Metadata.Language);
+        Assert.Equal(SourceFormat.Fb2, result.SourceFormat);
+        Assert.Equal(TextSource.NativeText, result.Diagnostics.TextSource);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ValidFb2_ExtractsChapterTitles()
+    {
+        var extractor = new Fb2TextExtractor();
+        await using var stream = File.OpenRead(FixturePath);
+        var request = new ExtractionRequest { Content = stream, FileName = "minimal.fb2" };
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.Equal(2, result.Units.Count);
+        Assert.Equal("Chapter 1", result.Units[0].Title);
+        Assert.Equal("Chapter 2", result.Units[1].Title);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ValidFb2_ExtractsCoverImage()
+    {
+        var extractor = new Fb2TextExtractor();
+        await using var stream = File.OpenRead(FixturePath);
+        var request = new ExtractionRequest { Content = stream, FileName = "minimal.fb2" };
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.NotNull(result.Metadata.CoverImage);
+        Assert.True(result.Metadata.CoverImage.Length > 0);
+        Assert.Equal("image/jpeg", result.Metadata.CoverMimeType);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ValidFb2_WordCountsPositive()
+    {
+        var extractor = new Fb2TextExtractor();
+        await using var stream = File.OpenRead(FixturePath);
+        var request = new ExtractionRequest { Content = stream, FileName = "minimal.fb2" };
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.All(result.Units, u => Assert.True(u.WordCount > 0));
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ValidFb2_GeneratesToc()
+    {
+        var extractor = new Fb2TextExtractor();
+        await using var stream = File.OpenRead(FixturePath);
+        var request = new ExtractionRequest { Content = stream, FileName = "minimal.fb2" };
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.NotNull(result.Toc);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_InvalidXml_NeverThrows()
+    {
+        var extractor = new Fb2TextExtractor();
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("not valid xml at all"));
+        var request = new ExtractionRequest { Content = stream, FileName = "invalid.fb2" };
+
+        var exception = await Record.ExceptionAsync(() => extractor.ExtractAsync(request));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptySections_Skipped()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description><title-info><book-title>Empty</book-title></title-info></description>
+              <body>
+                <section><title><p>Empty Chapter</p></title></section>
+                <section><title><p>Real Chapter</p></title><p>Some actual content here for testing.</p></section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "empty-sections.fb2" };
+        var extractor = new Fb2TextExtractor();
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.Single(result.Units);
+        Assert.Equal("Real Chapter", result.Units[0].Title);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NestedSections_Flattened()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description><title-info><book-title>Nested</book-title></title-info></description>
+              <body>
+                <section>
+                  <title><p>Part 1</p></title>
+                  <section>
+                    <title><p>Chapter 1</p></title>
+                    <p>Content of chapter one with enough words.</p>
+                  </section>
+                  <section>
+                    <title><p>Chapter 2</p></title>
+                    <p>Content of chapter two with enough words.</p>
+                  </section>
+                </section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "nested.fb2" };
+        var extractor = new Fb2TextExtractor();
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.Equal(2, result.Units.Count);
+        Assert.Equal("Chapter 1", result.Units[0].Title);
+        Assert.Equal("Chapter 2", result.Units[1].Title);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NoCover_NoCrash()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description><title-info><book-title>No Cover</book-title></title-info></description>
+              <body>
+                <section><title><p>Chapter 1</p></title><p>Some content for the chapter.</p></section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "no-cover.fb2" };
+        var extractor = new Fb2TextExtractor();
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.Null(result.Metadata.CoverImage);
+        Assert.NotEmpty(result.Units);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MultipleAuthors_JoinedWithComma()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description>
+                <title-info>
+                  <author><first-name>John</first-name><last-name>Doe</last-name></author>
+                  <author><first-name>Jane</first-name><middle-name>M</middle-name><last-name>Smith</last-name></author>
+                  <book-title>Co-authored Book</book-title>
+                </title-info>
+              </description>
+              <body>
+                <section><title><p>Ch1</p></title><p>Some text content here.</p></section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "multi-author.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.Equal("John Doe, Jane M Smith", result.Metadata.Authors);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_FormattingTags_ConvertedToHtml()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description><title-info><book-title>Fmt</book-title></title-info></description>
+              <body>
+                <section>
+                  <title><p>Formatted</p></title>
+                  <p>Normal <emphasis>italic</emphasis> and <strong>bold</strong> and <strikethrough>deleted</strikethrough> text.</p>
+                </section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "fmt.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.Single(result.Units);
+        Assert.Contains("italic", result.Units[0].PlainText);
+        Assert.Contains("bold", result.Units[0].PlainText);
+        Assert.Contains("deleted", result.Units[0].PlainText);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_PoemAndEpigraph_ConvertedToHtml()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description><title-info><book-title>Poetry</book-title></title-info></description>
+              <body>
+                <section>
+                  <title><p>Poem Chapter</p></title>
+                  <epigraph><p>Some wise quote here.</p><text-author>Wise Person</text-author></epigraph>
+                  <poem>
+                    <stanza>
+                      <v>Roses are red,</v>
+                      <v>Violets are blue.</v>
+                    </stanza>
+                  </poem>
+                  <p>After the poem there is more content.</p>
+                </section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "poem.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.Single(result.Units);
+        Assert.Contains("Roses are red", result.Units[0].PlainText);
+        Assert.Contains("Wise Person", result.Units[0].PlainText);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NotesBody_Skipped()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description><title-info><book-title>Notes</book-title></title-info></description>
+              <body>
+                <section><title><p>Chapter 1</p></title><p>Main content text here.</p></section>
+              </body>
+              <body name="notes">
+                <section id="n1"><title><p>1</p></title><p>This is a footnote that should not appear.</p></section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "notes.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.Single(result.Units);
+        Assert.Equal("Chapter 1", result.Units[0].Title);
+        Assert.DoesNotContain("footnote", result.Units[0].PlainText);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NoBody_ReturnsEmptyUnits()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description><title-info><book-title>No Body</book-title></title-info></description>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "nobody.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.Empty(result.Units);
+        Assert.Equal("No Body", result.Metadata.Title);
+        Assert.Equal(TextSource.None, result.Diagnostics.TextSource);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_AnnotationDescription_Extracted()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description>
+                <title-info>
+                  <book-title>Desc Book</book-title>
+                  <annotation><p>This is a book about adventures.</p><p>It is very exciting.</p></annotation>
+                </title-info>
+              </description>
+              <body>
+                <section><title><p>Ch</p></title><p>Content here for the chapter.</p></section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "desc.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.NotNull(result.Metadata.Description);
+        Assert.Contains("adventures", result.Metadata.Description);
+        Assert.Contains("exciting", result.Metadata.Description);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_InvalidXml_ReturnsDiagnosticsParseError()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("<broken xml"));
+        var request = new ExtractionRequest { Content = stream, FileName = "broken.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.Equal(SourceFormat.Fb2, result.SourceFormat);
+        Assert.Equal(TextSource.None, result.Diagnostics.TextSource);
+        Assert.Contains(result.Diagnostics.Warnings,
+            w => w.Code == ExtractionWarningCode.ParseError);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_UntitledSection_GetsFallbackTitle()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description><title-info><book-title>Untitled</book-title></title-info></description>
+              <body>
+                <section>
+                  <p>Content without any title element for this section.</p>
+                </section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "untitled.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.Single(result.Units);
+        Assert.Equal("Section 1", result.Units[0].Title);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_InlineImages_ConvertedToImgTags()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
+              <description><title-info><book-title>Images</book-title></title-info></description>
+              <body>
+                <section>
+                  <title><p>With Image</p></title>
+                  <p>Before image text.</p>
+                  <image l:href="#pic1.png"/>
+                  <p>After image text.</p>
+                </section>
+              </body>
+              <binary id="pic1.png" content-type="image/png">iVBORw0KGgo=</binary>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "images.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.Single(result.Units);
+        Assert.NotEmpty(result.Images);
+        Assert.Contains("Before image", result.Units[0].PlainText);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NestedWithOwnContent_SplitCorrectly()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+              <description><title-info><book-title>Mixed</book-title></title-info></description>
+              <body>
+                <section>
+                  <title><p>Part 1</p></title>
+                  <p>Introduction to part one with some text.</p>
+                  <section>
+                    <title><p>Chapter 1</p></title>
+                    <p>Chapter one content text here.</p>
+                  </section>
+                </section>
+              </body>
+            </FictionBook>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = new ExtractionRequest { Content = stream, FileName = "mixed.fb2" };
+
+        var result = await new Fb2TextExtractor().ExtractAsync(request);
+
+        Assert.Equal(2, result.Units.Count);
+        Assert.Equal("Part 1", result.Units[0].Title);
+        Assert.Contains("Introduction", result.Units[0].PlainText);
+        Assert.Equal("Chapter 1", result.Units[1].Title);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_CoverMarkedInImagesList()
+    {
+        var extractor = new Fb2TextExtractor();
+        await using var stream = File.OpenRead(FixturePath);
+        var request = new ExtractionRequest { Content = stream, FileName = "minimal.fb2" };
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.Single(result.Images);
+        Assert.True(result.Images[0].IsCover);
+        Assert.Equal("cover.jpg", result.Images[0].OriginalPath);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptyStream_NeverThrows()
+    {
+        using var stream = new MemoryStream([]);
+        var request = new ExtractionRequest { Content = stream, FileName = "empty.fb2" };
+
+        var exception = await Record.ExceptionAsync(
+            () => new Fb2TextExtractor().ExtractAsync(request));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_OrderIndexSequential()
+    {
+        var extractor = new Fb2TextExtractor();
+        await using var stream = File.OpenRead(FixturePath);
+        var request = new ExtractionRequest { Content = stream, FileName = "minimal.fb2" };
+
+        var result = await extractor.ExtractAsync(request);
+
+        for (var i = 0; i < result.Units.Count; i++)
+            Assert.Equal(i, result.Units[i].OrderIndex);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_AllUnitsAreChapterType()
+    {
+        var extractor = new Fb2TextExtractor();
+        await using var stream = File.OpenRead(FixturePath);
+        var request = new ExtractionRequest { Content = stream, FileName = "minimal.fb2" };
+
+        var result = await extractor.ExtractAsync(request);
+
+        Assert.All(result.Units, u => Assert.Equal(ContentUnitType.Chapter, u.Type));
+    }
+}

--- a/tests/TextStack.Extraction.Tests/Fixtures/minimal.fb2
+++ b/tests/TextStack.Extraction.Tests/Fixtures/minimal.fb2
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
+  <description>
+    <title-info>
+      <genre>fiction</genre>
+      <author>
+        <first-name>Test</first-name>
+        <last-name>Author</last-name>
+      </author>
+      <book-title>Minimal Test Book</book-title>
+      <annotation><p>A test book for extraction testing.</p></annotation>
+      <coverpage><image l:href="#cover.jpg"/></coverpage>
+      <lang>en</lang>
+    </title-info>
+  </description>
+  <body>
+    <section>
+      <title><p>Chapter 1</p></title>
+      <p>This is the first chapter with enough words to pass validation and extraction tests properly.</p>
+      <p>It contains <emphasis>emphasized text</emphasis> and <strong>bold text</strong> for formatting tests.</p>
+    </section>
+    <section>
+      <title><p>Chapter 2</p></title>
+      <p>This is the second chapter with some more content for testing purposes and verification.</p>
+    </section>
+  </body>
+  <binary id="cover.jpg" content-type="image/jpeg">/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/9oACAEBAAA/AHtA/9k=</binary>
+</FictionBook>


### PR DESCRIPTION
## Summary
- **Fb2TextExtractor** — full FB2 parser using `System.Xml.Linq` (no new NuGet deps)
- Extracts metadata (title, authors, language, description), cover image, chapters, inline images, ToC
- Flattens nested `<section>` hierarchy, skips `<body name="notes">`
- FB2→HTML tag conversion (emphasis, poem, epigraph, cite, etc.)
- Registered in `SourceFormat` enum, `ExtractorRegistry`, Worker DI
- Frontend accepts `.fb2` in upload UI (web + admin) with updated i18n hints

## Test plan
- [x] 23 unit tests (`Fb2ExtractorTests`) — all pass
- [x] 169/169 full extraction suite — 0 regressions
- [x] Docker worker image builds clean
- [ ] Upload real `.fb2` file via user library → verify chapters render
- [ ] Upload via admin panel → verify ingestion job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)