### PR TITLE
fix: admin blog INTERNAL_ERROR — siteId query param

### DIFF
--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -930,11 +930,11 @@ export const adminApi = {
   },
 
   getBlogPost: async (id: string): Promise<BlogPostDetail> => {
-    return fetchJson<BlogPostDetail>(`/admin/blog/${id}`)
+    return fetchJson<BlogPostDetail>(`/admin/blog/${id}?siteId=${DEFAULT_SITE_ID}`)
   },
 
   createBlogPost: async (data: { title: string; content: string; language: string; authorName: string; excerpt?: string; tags?: string; seoTitle?: string; seoDescription?: string }): Promise<BlogPostDetail> => {
-    return fetchJson<BlogPostDetail>('/admin/blog', {
+    return fetchJson<BlogPostDetail>(`/admin/blog?siteId=${DEFAULT_SITE_ID}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
@@ -942,7 +942,7 @@ export const adminApi = {
   },
 
   updateBlogPost: async (id: string, data: { title: string; content: string; language: string; authorName: string; excerpt?: string; tags?: string; seoTitle?: string; seoDescription?: string }): Promise<BlogPostDetail> => {
-    return fetchJson<BlogPostDetail>(`/admin/blog/${id}`, {
+    return fetchJson<BlogPostDetail>(`/admin/blog/${id}?siteId=${DEFAULT_SITE_ID}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
@@ -950,31 +950,31 @@ export const adminApi = {
   },
 
   deleteBlogPost: async (id: string): Promise<void> => {
-    await fetchVoid(`/admin/blog/${id}`, { method: 'DELETE' })
+    await fetchVoid(`/admin/blog/${id}?siteId=${DEFAULT_SITE_ID}`, { method: 'DELETE' })
   },
 
   publishBlogPost: async (id: string): Promise<void> => {
-    await fetchVoid(`/admin/blog/${id}/publish`, { method: 'POST' })
+    await fetchVoid(`/admin/blog/${id}/publish?siteId=${DEFAULT_SITE_ID}`, { method: 'POST' })
   },
 
   unpublishBlogPost: async (id: string): Promise<void> => {
-    await fetchVoid(`/admin/blog/${id}/unpublish`, { method: 'POST' })
+    await fetchVoid(`/admin/blog/${id}/unpublish?siteId=${DEFAULT_SITE_ID}`, { method: 'POST' })
   },
 
   uploadBlogCover: async (id: string, file: File): Promise<{ coverImagePath: string }> => {
     const formData = new FormData()
     formData.append('file', file)
-    return fetchJson<{ coverImagePath: string }>(`/admin/blog/${id}/cover`, {
+    return fetchJson<{ coverImagePath: string }>(`/admin/blog/${id}/cover?siteId=${DEFAULT_SITE_ID}`, {
       method: 'POST',
       body: formData,
     })
   },
 
   deleteBlogCover: async (id: string): Promise<void> => {
-    await fetchVoid(`/admin/blog/${id}/cover`, { method: 'DELETE' })
+    await fetchVoid(`/admin/blog/${id}/cover?siteId=${DEFAULT_SITE_ID}`, { method: 'DELETE' })
   },
 
   getBlogStats: async (): Promise<BlogStats> => {
-    return fetchJson<BlogStats>('/admin/blog/stats')
+    return fetchJson<BlogStats>(`/admin/blog/stats?siteId=${DEFAULT_SITE_ID}`)
   },
 }

--- a/apps/web/e2e/tests/admin/blog.spec.ts
+++ b/apps/web/e2e/tests/admin/blog.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '@playwright/test'
+import path from 'path'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const authFile = path.resolve(__dirname, '../../.auth/admin.json')
+
+const API_URL = process.env.API_URL ?? 'http://localhost:8080'
+const SITE_ID = '11111111-1111-1111-1111-111111111111'
+const ADMIN_HEADERS = { Host: 'textstack.dev', 'Content-Type': 'application/json' }
+
+function hasAdminAuth(): boolean {
+  try {
+    const data = JSON.parse(fs.readFileSync(authFile, 'utf-8'))
+    return data.cookies?.length > 0
+  } catch {
+    return false
+  }
+}
+
+test.use({ storageState: authFile })
+
+test.describe('Admin Blog endpoints with siteId query param', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let createdPostId: string
+
+  test.beforeEach(() => {
+    test.skip(!hasAdminAuth(), 'Admin auth not configured')
+  })
+
+  test('GET /admin/blog — list posts with siteId', async ({ request }) => {
+    const resp = await request.get(`${API_URL}/admin/blog?siteId=${SITE_ID}`, {
+      headers: ADMIN_HEADERS,
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    expect(body).toHaveProperty('total')
+    expect(body).toHaveProperty('items')
+  })
+
+  test('GET /admin/blog/stats — stats with siteId', async ({ request }) => {
+    const resp = await request.get(`${API_URL}/admin/blog/stats?siteId=${SITE_ID}`, {
+      headers: ADMIN_HEADERS,
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    expect(body).toHaveProperty('total')
+    expect(body).toHaveProperty('published')
+    expect(body).toHaveProperty('draft')
+  })
+
+  test('POST /admin/blog — create post with siteId', async ({ request }) => {
+    const resp = await request.post(`${API_URL}/admin/blog?siteId=${SITE_ID}`, {
+      headers: ADMIN_HEADERS,
+      data: {
+        title: 'E2E Test Blog Post',
+        content: '<p>Test content for E2E</p>',
+        language: 'en',
+        authorName: 'E2E Test',
+      },
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    expect(body.title).toBe('E2E Test Blog Post')
+    expect(body.id).toBeTruthy()
+    createdPostId = body.id
+  })
+
+  test('GET /admin/blog/:id — get post with siteId', async ({ request }) => {
+    test.skip(!createdPostId, 'No post created')
+    const resp = await request.get(`${API_URL}/admin/blog/${createdPostId}?siteId=${SITE_ID}`, {
+      headers: ADMIN_HEADERS,
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    expect(body.title).toBe('E2E Test Blog Post')
+  })
+
+  test('PUT /admin/blog/:id — update post with siteId', async ({ request }) => {
+    test.skip(!createdPostId, 'No post created')
+    const resp = await request.put(`${API_URL}/admin/blog/${createdPostId}?siteId=${SITE_ID}`, {
+      headers: ADMIN_HEADERS,
+      data: {
+        title: 'E2E Updated Blog Post',
+        content: '<p>Updated content</p>',
+        language: 'en',
+        authorName: 'E2E Test',
+      },
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    expect(body.title).toBe('E2E Updated Blog Post')
+  })
+
+  test('POST /admin/blog/:id/publish — publish with siteId', async ({ request }) => {
+    test.skip(!createdPostId, 'No post created')
+    const resp = await request.post(`${API_URL}/admin/blog/${createdPostId}/publish?siteId=${SITE_ID}`, {
+      headers: ADMIN_HEADERS,
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    expect(body.status).toBe('Published')
+  })
+
+  test('POST /admin/blog/:id/unpublish — unpublish with siteId', async ({ request }) => {
+    test.skip(!createdPostId, 'No post created')
+    const resp = await request.post(`${API_URL}/admin/blog/${createdPostId}/unpublish?siteId=${SITE_ID}`, {
+      headers: ADMIN_HEADERS,
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    expect(body.status).toBe('Draft')
+  })
+
+  test('DELETE /admin/blog/:id — delete post with siteId', async ({ request }) => {
+    test.skip(!createdPostId, 'No post created')
+    const resp = await request.delete(`${API_URL}/admin/blog/${createdPostId}?siteId=${SITE_ID}`, {
+      headers: ADMIN_HEADERS,
+    })
+    expect(resp.status()).toBe(204)
+  })
+
+  test('GET /admin/blog — without siteId returns 400', async ({ request }) => {
+    const resp = await request.get(`${API_URL}/admin/blog`, {
+      headers: ADMIN_HEADERS,
+    })
+    // Required param missing → 400
+    expect(resp.status()).toBe(400)
+  })
+
+  test('admin blog page loads', async ({ page }) => {
+    await page.goto('/blog')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('body')).not.toContainText('INTERNAL_ERROR')
+  })
+})

--- a/backend/src/Api/Endpoints/AdminBlogEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminBlogEndpoints.cs
@@ -5,7 +5,6 @@ using Domain.Enums;
 using Domain.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Api.Sites;
 
 namespace Api.Endpoints;
 
@@ -28,8 +27,8 @@ public static class AdminBlogEndpoints
     }
 
     private static async Task<IResult> GetAll(
-        HttpContext httpContext,
         IAppDbContext db,
+        [FromQuery] Guid siteId,
         [FromQuery] string? search,
         [FromQuery] string? status,
         [FromQuery] string? language,
@@ -37,7 +36,6 @@ public static class AdminBlogEndpoints
         [FromQuery] int limit = 20,
         CancellationToken ct = default)
     {
-        var siteId = httpContext.GetSiteId();
 
         var query = db.BlogPosts.Where(p => p.SiteId == siteId);
 
@@ -66,11 +64,10 @@ public static class AdminBlogEndpoints
     }
 
     private static async Task<IResult> GetStats(
-        HttpContext httpContext,
         IAppDbContext db,
+        [FromQuery] Guid siteId,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
 
         var posts = db.BlogPosts.Where(p => p.SiteId == siteId);
         var total = await posts.CountAsync(ct);
@@ -84,11 +81,10 @@ public static class AdminBlogEndpoints
 
     private static async Task<IResult> GetById(
         Guid id,
-        HttpContext httpContext,
         IAppDbContext db,
+        [FromQuery] Guid siteId,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
 
         var post = await db.BlogPosts
             .Where(p => p.Id == id && p.SiteId == siteId)
@@ -105,11 +101,10 @@ public static class AdminBlogEndpoints
 
     private static async Task<IResult> Create(
         [FromBody] CreateBlogPostRequest request,
-        HttpContext httpContext,
         IAppDbContext db,
+        [FromQuery] Guid siteId,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
 
         if (string.IsNullOrWhiteSpace(request.Title))
             return Results.BadRequest("Title is required");
@@ -161,11 +156,10 @@ public static class AdminBlogEndpoints
     private static async Task<IResult> Update(
         Guid id,
         [FromBody] UpdateBlogPostRequest request,
-        HttpContext httpContext,
         IAppDbContext db,
+        [FromQuery] Guid siteId,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
         var post = await db.BlogPosts.FirstOrDefaultAsync(p => p.Id == id && p.SiteId == siteId, ct);
         if (post is null) return Results.NotFound();
 
@@ -207,11 +201,10 @@ public static class AdminBlogEndpoints
 
     private static async Task<IResult> Delete(
         Guid id,
-        HttpContext httpContext,
         IAppDbContext db,
+        [FromQuery] Guid siteId,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
         var post = await db.BlogPosts.FirstOrDefaultAsync(p => p.Id == id && p.SiteId == siteId, ct);
         if (post is null) return Results.NotFound();
 
@@ -223,11 +216,10 @@ public static class AdminBlogEndpoints
 
     private static async Task<IResult> Publish(
         Guid id,
-        HttpContext httpContext,
         IAppDbContext db,
+        [FromQuery] Guid siteId,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
         var post = await db.BlogPosts.FirstOrDefaultAsync(p => p.Id == id && p.SiteId == siteId, ct);
         if (post is null) return Results.NotFound();
 
@@ -242,11 +234,10 @@ public static class AdminBlogEndpoints
 
     private static async Task<IResult> Unpublish(
         Guid id,
-        HttpContext httpContext,
         IAppDbContext db,
+        [FromQuery] Guid siteId,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
         var post = await db.BlogPosts.FirstOrDefaultAsync(p => p.Id == id && p.SiteId == siteId, ct);
         if (post is null) return Results.NotFound();
 
@@ -264,13 +255,12 @@ public static class AdminBlogEndpoints
     private static async Task<IResult> UploadCover(
         Guid id,
         IFormFile file,
-        HttpContext httpContext,
         IAppDbContext db,
         IFileStorageService storage,
         IImageOptimizer imageOptimizer,
+        [FromQuery] Guid siteId,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
         var post = await db.BlogPosts.FirstOrDefaultAsync(p => p.Id == id && p.SiteId == siteId, ct);
         if (post is null) return Results.NotFound();
 
@@ -303,12 +293,11 @@ public static class AdminBlogEndpoints
 
     private static async Task<IResult> DeleteCover(
         Guid id,
-        HttpContext httpContext,
         IAppDbContext db,
         IFileStorageService storage,
+        [FromQuery] Guid siteId,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
         var post = await db.BlogPosts.FirstOrDefaultAsync(p => p.Id == id && p.SiteId == siteId, ct);
         if (post is null) return Results.NotFound();
 


### PR DESCRIPTION
## Summary
- Admin blog endpoints used `httpContext.GetSiteId()` which throws because admin routes skip `SiteContextMiddleware`
- Changed all 10 endpoints to accept `[FromQuery] Guid siteId` (matching authors/genres pattern)
- Added `siteId` query param to all admin client blog API calls

## Test plan
- [ ] Open admin blog page — no INTERNAL_ERROR
- [ ] Create, edit, publish, unpublish, delete blog post
- [ ] E2E: `pnpm -C apps/web test:e2e -- --grep "Admin Blog"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)