### PR TITLE
feat: user profile — avatar upload + name edit

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -1,11 +1,15 @@
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
+import { useState } from 'react'
+import { View, Text, StyleSheet, TouchableOpacity, TextInput, Alert, ActivityIndicator } from 'react-native'
 import { useRouter } from 'expo-router'
 import { Image } from 'expo-image'
 import { Ionicons } from '@expo/vector-icons'
+// Lazy-loaded — requires native build
+let ImagePicker: typeof import('expo-image-picker') | null = null
+try { ImagePicker = require('expo-image-picker') } catch {}
 import { useAuth } from '../../src/context/AuthContext'
 import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
-import { supportedLanguages, type Language } from '@textstack/shared'
+import { supportedLanguages, type Language, authApi, getStorageUrl } from '@textstack/shared'
 import { fonts } from '../../src/theme/typography'
 
 const MENU_ITEMS = [
@@ -22,10 +26,52 @@ const BROWSE_ITEMS = [
 ]
 
 export default function ProfileScreen() {
-  const { user, isAuthenticated, signOut } = useAuth()
+  const { user, isAuthenticated, signOut, updateUser, getAccessToken } = useAuth()
   const { colors, themeMode, setThemeMode } = useTheme()
   const { language, switchLanguage } = useLanguage()
   const router = useRouter()
+  const [editing, setEditing] = useState(false)
+  const [editName, setEditName] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const startEdit = () => { setEditName(user?.name || ''); setEditing(true) }
+
+  const saveProfile = async () => {
+    setSaving(true)
+    try {
+      const token = await getAccessToken()
+      if (!token) return
+      const res = await authApi.updateProfile(editName.trim() || null, token)
+      await updateUser(res.user)
+      setEditing(false)
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const pickAvatar = async () => {
+    if (!ImagePicker) { Alert.alert('Not available', 'Image picker requires a native build'); return }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
+    })
+    if (result.canceled || !result.assets[0]) return
+    setSaving(true)
+    try {
+      const token = await getAccessToken()
+      if (!token) return
+      const res = await authApi.uploadAvatar(result.assets[0].uri, token)
+      await updateUser(res.user)
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Upload failed')
+    } finally {
+      setSaving(false)
+    }
+  }
 
   if (!isAuthenticated) {
     return (
@@ -46,16 +92,41 @@ export default function ProfileScreen() {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.header}>
-        <View style={[styles.avatarWrapper, { backgroundColor: colors.primary }]}>
+        <TouchableOpacity style={[styles.avatarWrapper, { backgroundColor: colors.primary }]} onPress={pickAvatar} activeOpacity={0.7}>
           {user?.picture ? (
-            <Image source={user.picture} style={styles.avatar} contentFit="cover" />
+            <Image source={user.picture.startsWith('http') ? user.picture : getStorageUrl(user.picture)} style={styles.avatar} contentFit="cover" />
           ) : (
             <Text style={styles.avatarLetter}>
               {(user?.name || user?.email || '?').charAt(0).toUpperCase()}
             </Text>
           )}
-        </View>
-        <Text style={[styles.name, { color: colors.text }]}>{user?.name || user?.email}</Text>
+          <View style={styles.avatarBadge}>
+            <Ionicons name="camera" size={14} color="#fff" />
+          </View>
+        </TouchableOpacity>
+        {editing ? (
+          <View style={styles.editRow}>
+            <TextInput
+              style={[styles.editInput, { color: colors.text, borderColor: colors.border, fontFamily: fonts.sans }]}
+              value={editName}
+              onChangeText={setEditName}
+              placeholder="Name"
+              placeholderTextColor={colors.textSecondary}
+              autoFocus
+            />
+            <TouchableOpacity onPress={saveProfile} disabled={saving} style={[styles.saveBtn, { backgroundColor: colors.primary }]}>
+              {saving ? <ActivityIndicator size="small" color="#fff" /> : <Text style={{ color: '#fff', fontFamily: fonts.sansMedium }}>Save</Text>}
+            </TouchableOpacity>
+            <TouchableOpacity onPress={() => setEditing(false)}>
+              <Text style={{ color: colors.textSecondary, fontFamily: fonts.sans }}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <TouchableOpacity onPress={startEdit} activeOpacity={0.7} style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+            <Text style={[styles.name, { color: colors.text }]}>{user?.name || user?.email}</Text>
+            <Ionicons name="pencil" size={14} color={colors.textSecondary} />
+          </TouchableOpacity>
+        )}
         <Text style={[styles.email, { color: colors.textSecondary }]}>{user?.email}</Text>
       </View>
 
@@ -211,4 +282,30 @@ const styles = StyleSheet.create({
   menuIcon: { marginRight: 12 },
   menuText: { flex: 1, fontFamily: fonts.sans, fontSize: 16 },
   sectionLabel: { fontFamily: fonts.sansMedium, fontSize: 12, textTransform: 'uppercase', letterSpacing: 1, marginTop: 20, marginBottom: 4 },
+  avatarBadge: {
+    position: 'absolute',
+    bottom: 0,
+    right: 0,
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  editRow: { alignItems: 'center', gap: 8, width: '80%' },
+  editInput: {
+    width: '100%',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  saveBtn: {
+    paddingHorizontal: 24,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
 })

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -12,21 +12,22 @@
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-google-signin/google-signin": "^16.1.1",
         "expo": "~55.0.9",
-        "expo-apple-authentication": "~55.0.8",
+        "expo-apple-authentication": "~55.0.9",
         "expo-asset": "^55.0.10",
         "expo-clipboard": "~55.0.9",
         "expo-constants": "~55.0.7",
-        "expo-dev-client": "~55.0.9",
-        "expo-document-picker": "~55.0.8",
+        "expo-dev-client": "~55.0.19",
+        "expo-document-picker": "~55.0.9",
         "expo-font": "~55.0.4",
-        "expo-image": "~55.0.5",
-        "expo-linking": "~55.0.7",
-        "expo-notifications": "~55.0.10",
-        "expo-router": "~55.0.2",
-        "expo-secure-store": "~55.0.8",
+        "expo-image": "~55.0.6",
+        "expo-image-picker": "~55.0.14",
+        "expo-linking": "~55.0.9",
+        "expo-notifications": "~55.0.14",
+        "expo-router": "~55.0.8",
+        "expo-secure-store": "~55.0.9",
         "expo-speech": "~55.0.9",
-        "expo-splash-screen": "~55.0.9",
-        "expo-sqlite": "~55.0.10",
+        "expo-splash-screen": "~55.0.13",
+        "expo-sqlite": "~55.0.11",
         "expo-status-bar": "~55.0.4",
         "react": "19.2.0",
         "react-dom": "^19.2.0",
@@ -1479,9 +1480,9 @@
       }
     },
     "node_modules/@expo-google-fonts/material-symbols": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/@expo-google-fonts/material-symbols/-/material-symbols-0.4.24.tgz",
-      "integrity": "sha512-1bJ63Yv2Bn8SN2MjrlbwLwUhnC8COOeejd15H88WjCtw5iNErqEPaBnpvmYyqciVYwudGo5drUIdY9C/5yPGbg==",
+      "version": "0.4.27",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/material-symbols/-/material-symbols-0.4.27.tgz",
+      "integrity": "sha512-cnb3DZnWUWpezGFkJ8y4MT5f/lw6FcgDzeJzic+T+vpQHLHG1cg3SC3i1w1i8Bk4xKR4HPY3t9iIRNvtr5ml8A==",
       "license": "MIT AND Apache-2.0"
     },
     "node_modules/@expo/code-signing-certificates": {
@@ -1662,9 +1663,9 @@
       }
     },
     "node_modules/@expo/log-box": {
-      "version": "55.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.7.tgz",
-      "integrity": "sha512-m7V1k2vlMp4NOj3fopjOg4zl/ANXyTRF3HMTMep2GZAKsPiDzgOQ41nm8CaU50/HlDIGXlCObss07gOn20UpHQ==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.8.tgz",
+      "integrity": "sha512-WVEuW1XcntUdOpQk8k9cUymM5FHKmEcPr6QO9SVIin3WYk5FbbwHRYr1T6GfwWF0UA2s9w9heeYolesq99vFIw==",
       "license": "MIT",
       "dependencies": {
         "@expo/dom-webview": "^55.0.3",
@@ -1745,6 +1746,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@expo/metro-runtime": {
+      "version": "55.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-55.0.7.tgz",
+      "integrity": "sha512-fV+DYvJ+A3fKEwkpJiXUhrpsWy4HjjbdapwJi/QmnGLFKYrzGvGqsWG+xf3mmUDwP413t6GL9162bnyMReYOaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/log-box": "55.0.8",
+        "anser": "^1.4.9",
+        "pretty-format": "^29.7.0",
+        "stacktrace-parser": "^0.1.10",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-dom": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@expo/osascript": {
@@ -2928,50 +2953,27 @@
       "license": "MIT"
     },
     "node_modules/@react-navigation/bottom-tabs": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.10.1.tgz",
-      "integrity": "sha512-MirOzKEe/rRwPSE9HMrS4niIo0LyUhewlvd01TpzQ1ipuXjH2wJbzAM9gS/r62zriB6HMHz2OY6oIRduwQJtTw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.15.8.tgz",
+      "integrity": "sha512-Fz/AAPE6Be0CimOXvon75RNgpFCbZvzF2RPcNeZOdOxIYyHDGxDdtsfTxLHB0tOp9HHXkT0xXOX8Rk001jdpbg==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/elements": "^2.9.5",
+        "@react-navigation/elements": "^2.9.13",
         "color": "^4.2.3",
         "sf-symbols-typescript": "^2.1.0"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.1.28",
+        "@react-navigation/native": "^7.2.1",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
         "react-native-screens": ">= 4.0.0"
       }
     },
-    "node_modules/@react-navigation/bottom-tabs/node_modules/@react-navigation/elements": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.8.tgz",
-      "integrity": "sha512-3gpwUmVnDJYvK9nFmAA/YXw0hmT/C/lZx8RkRMK+ux9l1T+32EWnQFnn34Wa1BMDX8HN2r64yrlW93DIzKI7Uw==",
-      "license": "MIT",
-      "dependencies": {
-        "color": "^4.2.3",
-        "use-latest-callback": "^0.2.4",
-        "use-sync-external-store": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.31",
-        "react": ">= 18.2.0",
-        "react-native": "*",
-        "react-native-safe-area-context": ">= 4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@react-native-masked-view/masked-view": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@react-navigation/core": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.15.1.tgz",
-      "integrity": "sha512-Fqr6qxfZJIC4ewho7LtTa9zz6hcOzohX7D1lcDfrkGaYkS5xBwEZViGNxCJK/czUc74ua8NThyrObQFjB6Q/RQ==",
+      "version": "7.17.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.17.1.tgz",
+      "integrity": "sha512-P1kL4FVTVYEf9Cvmb+WFxQ2UkbaXc9psj6OE0BsZ+hutPqZVbmiN6v/TI5QPf4qtg40a02yYo3vo+Mob9vJKtg==",
       "license": "MIT",
       "dependencies": {
         "@react-navigation/routers": "^7.5.3",
@@ -2993,13 +2995,36 @@
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT"
     },
-    "node_modules/@react-navigation/native": {
-      "version": "7.1.28",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.28.tgz",
-      "integrity": "sha512-d1QDn+KNHfHGt3UIwOZvupvdsDdiHYZBEj7+wL2yDVo3tMezamYy60H9s3EnNVE1Ae1ty0trc7F2OKqo/RmsdQ==",
+    "node_modules/@react-navigation/elements": {
+      "version": "2.9.13",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.13.tgz",
+      "integrity": "sha512-ZD8fPwhujgs3SwgaPRse+shLCFkeLhlfk9BHtQ604Qa7/p0/sRQV9HkTfREP8gtbt6nwk6WE+0vWfX2iqxOCKA==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/core": "^7.14.0",
+        "color": "^4.2.3",
+        "use-latest-callback": "^0.2.4",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@react-native-masked-view/masked-view": ">= 0.2.0",
+        "@react-navigation/native": "^7.2.1",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-masked-view/masked-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-navigation/native": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.1.tgz",
+      "integrity": "sha512-ohiGfR5kX585aADiYt+nfwdqmJjj5W/1eXN9CQ/njhQNi/sMmjaxYppS+e0E0zW+z5b4gaLFBvqLrJcvOdtLUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/core": "^7.17.1",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
@@ -3011,45 +3036,22 @@
       }
     },
     "node_modules/@react-navigation/native-stack": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.10.1.tgz",
-      "integrity": "sha512-8jt7olKysn07HuKKSjT/ahZZTV+WaZa96o9RI7gAwh7ATlUDY02rIRttwvCyjovhSjD9KCiuJ+Hd4kwLidHwJw==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.9.tgz",
+      "integrity": "sha512-s76NyRr/VSPRqXaLtaKUj9Q1qZ5ym0831QZFFXJcRyom6QYpo9eESB9/dfeN+tTEnH7kP77CwoCuR0THKMuk3w==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/elements": "^2.9.5",
+        "@react-navigation/elements": "^2.9.13",
         "color": "^4.2.3",
         "sf-symbols-typescript": "^2.1.0",
         "warn-once": "^0.1.1"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.1.28",
+        "@react-navigation/native": "^7.2.1",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
         "react-native-screens": ">= 4.0.0"
-      }
-    },
-    "node_modules/@react-navigation/native-stack/node_modules/@react-navigation/elements": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.8.tgz",
-      "integrity": "sha512-3gpwUmVnDJYvK9nFmAA/YXw0hmT/C/lZx8RkRMK+ux9l1T+32EWnQFnn34Wa1BMDX8HN2r64yrlW93DIzKI7Uw==",
-      "license": "MIT",
-      "dependencies": {
-        "color": "^4.2.3",
-        "use-latest-callback": "^0.2.4",
-        "use-sync-external-store": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.31",
-        "react": ">= 18.2.0",
-        "react-native": "*",
-        "react-native-safe-area-context": ">= 4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@react-native-masked-view/masked-view": {
-          "optional": true
-        }
       }
     },
     "node_modules/@react-navigation/routers": {
@@ -3188,7 +3190,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4242,7 +4244,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4545,9 +4547,9 @@
       }
     },
     "node_modules/expo-apple-authentication": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-55.0.8.tgz",
-      "integrity": "sha512-Cq3cdW6iCRnwkUEMdayfrZCo4DDKHXqJJHFGWNOIYiRrt7xE3vTM9JCvBuh9T9ToCeVg7hskovjAZyBrA7mFeg==",
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-55.0.9.tgz",
+      "integrity": "sha512-0+RKdvrNOfi262klXjvFqsFI/OkWZ7b46fNOjrJFhiI33Qi/c2DC2vuM/XR/sy0Ssa1wGnLdImcN4TJCBJwQ1w==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -4555,9 +4557,9 @@
       }
     },
     "node_modules/expo-application": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-55.0.8.tgz",
-      "integrity": "sha512-PeZk4Zj8LlzRcRtK3J4ouSPBoi9lroYsRbbz/0HEvx+uB6HIaM1qfzgpcctvjkdJJfnidBQNyieW5BVO/qUQ6w==",
+      "version": "55.0.10",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-55.0.10.tgz",
+      "integrity": "sha512-5ccf+S6hsQz+doi907TOJxKzV5AKgAgw004z4FoDWSoGhfab0LUPg6uyvOspuU4cbNvqw8EAy08hZbVO8nKc9Q==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -4604,15 +4606,15 @@
       }
     },
     "node_modules/expo-dev-client": {
-      "version": "55.0.9",
-      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-55.0.9.tgz",
-      "integrity": "sha512-cBPQ3l0kp429kTFgqC+qkqywFT+KJ8y1bDpwdQEGOzDe11mIE4lIShvQ7wAHsP9AL/iN14RGVTP969kRZsiVHQ==",
+      "version": "55.0.19",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-55.0.19.tgz",
+      "integrity": "sha512-NViuWgo1oqcKPei/M+FwwFC93cAsVhX7yT1/8pYPjMzPeZjV0DO82eur4H1ZwcmyxqSGjlae5R+MGXW88NeYEA==",
       "license": "MIT",
       "dependencies": {
-        "expo-dev-launcher": "55.0.10",
-        "expo-dev-menu": "55.0.9",
+        "expo-dev-launcher": "55.0.20",
+        "expo-dev-menu": "55.0.17",
         "expo-dev-menu-interface": "55.0.1",
-        "expo-manifests": "~55.0.9",
+        "expo-manifests": "~55.0.11",
         "expo-updates-interface": "~55.1.3"
       },
       "peerDependencies": {
@@ -4620,23 +4622,23 @@
       }
     },
     "node_modules/expo-dev-launcher": {
-      "version": "55.0.10",
-      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-55.0.10.tgz",
-      "integrity": "sha512-ZTdHzswVF4lK3CHqyKgYhv72X+CRsKmh5vdNl1e7J+rmm3oOT592WfCF20h2sPohm6aqTsfi7YFX1WpqYlVGNg==",
+      "version": "55.0.20",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-55.0.20.tgz",
+      "integrity": "sha512-vnIUk4k3ZyXSrSA7O4MVkWAIlErbSMEW8KexDGRVhEJkkAYZA2Yq5EcqJTrukvDC6/Jomx3Rpti+UfpLMIUk/g==",
       "license": "MIT",
       "dependencies": {
         "@expo/schema-utils": "^55.0.2",
-        "expo-dev-menu": "55.0.9",
-        "expo-manifests": "~55.0.9"
+        "expo-dev-menu": "55.0.17",
+        "expo-manifests": "~55.0.11"
       },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-dev-menu": {
-      "version": "55.0.9",
-      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-55.0.9.tgz",
-      "integrity": "sha512-pkb4kwznFu8w7+k8+QEkXI+brn/XFMDsAhFpuJhTsB/m2Yog4OIWLbLciKaH2N/MoovCOLe7D1y66BB7oo9zjQ==",
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-55.0.17.tgz",
+      "integrity": "sha512-UhYYHzNEy2imyPf0CFn4+2cIypqJ8D+pNBh9LxSVJaC4c3sARcGm+n52W4JA492KKiSyRrmwcWcbCMPLNj6sKQ==",
       "license": "MIT",
       "dependencies": {
         "expo-dev-menu-interface": "55.0.1"
@@ -4655,9 +4657,9 @@
       }
     },
     "node_modules/expo-document-picker": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-55.0.8.tgz",
-      "integrity": "sha512-p6rYEQ1/h3UqGl3+hzTjv51fsNxoOVfMGSYjHX2/e3cvcy02MWWE+bpj4QEGo9MBwU4RyyIbuv/SCxGtAtG+eA==",
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-55.0.9.tgz",
+      "integrity": "sha512-XtkhmZ9alOj1n2Ok782lK9qtfk9TbaBoOJotSDK0pvq5oa+3UyHlLLTUmnC5UPMmFKoLGLJC3R2fLBFEiN5jCQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -4688,9 +4690,9 @@
       }
     },
     "node_modules/expo-glass-effect": {
-      "version": "55.0.7",
-      "resolved": "https://registry.npmjs.org/expo-glass-effect/-/expo-glass-effect-55.0.7.tgz",
-      "integrity": "sha512-G7Q9rUaEY0YC36fGE6irDljfsfvzz/y49zagARAKvSJSyQMUSrhR25WOr5LK5Cw7gQNNBEy9U1ctlr7yCay/fQ==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/expo-glass-effect/-/expo-glass-effect-55.0.8.tgz",
+      "integrity": "sha512-IvUjHb/4t6r2H/LXDjcQ4uDoHrmO2cLOvEb9leLavQ4HX5+P4LRtQrMDMlkWAn5Wo5DkLcG8+1CrQU2nqgogTA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -4699,9 +4701,9 @@
       }
     },
     "node_modules/expo-image": {
-      "version": "55.0.5",
-      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-55.0.5.tgz",
-      "integrity": "sha512-oejmMwy5O9EtC8po9NxkcurWHqND6p8xuJaj9FGNo8NXLt9e+w3cKWx7HuPzkH5y3qFXQ9Od+z+I/wxEci36fw==",
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-55.0.6.tgz",
+      "integrity": "sha512-TKuu0uBmgTZlhd91Glv+V4vSBMlfl0bdQxfl97oKKZUo3OBC13l3eLik7v3VNLJN7PZbiwOAiXkZkqSOBx/Xsw==",
       "license": "MIT",
       "dependencies": {
         "sf-symbols-typescript": "^2.2.0"
@@ -4718,6 +4720,27 @@
         }
       }
     },
+    "node_modules/expo-image-loader": {
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.0.tgz",
+      "integrity": "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.14.tgz",
+      "integrity": "sha512-qiloh0DY2JiS86wVT0f7Oe8n2Js65wZMQb0X5lJK1mH1wk8UqWlfqgMSF75ZKODtJAkYwO7m+fy5drGt0cEQng==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~55.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-json-utils": {
       "version": "55.0.0",
       "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-55.0.0.tgz",
@@ -4725,12 +4748,12 @@
       "license": "MIT"
     },
     "node_modules/expo-linking": {
-      "version": "55.0.7",
-      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-55.0.7.tgz",
-      "integrity": "sha512-MiGCedere1vzQTEi2aGrkzd7eh/rPSz4w6F3GMBuAJzYl+/0VhIuyhozpEGrueyDIXWfzaUVOcn3SfxVi+kwQQ==",
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-55.0.9.tgz",
+      "integrity": "sha512-QWEefQZUu7PuJzye19Hr6msqpO4VB4TiY4T/6AkISJzZnoZGxWg16s3JTZS7D/b3VMm8VQfhw9I5NF/7f8EPcA==",
       "license": "MIT",
       "dependencies": {
-        "expo-constants": "~55.0.7",
+        "expo-constants": "~55.0.9",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
@@ -4739,12 +4762,12 @@
       }
     },
     "node_modules/expo-manifests": {
-      "version": "55.0.9",
-      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-55.0.9.tgz",
-      "integrity": "sha512-i82j3X4hbxYDe6kxUw4u8WfvbvTj2w+9BD9WKuL0mFRy+MjvdzdyaqAjEViWCKo/alquP/hTApDTQBb3UmWhkg==",
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-55.0.11.tgz",
+      "integrity": "sha512-3+pFun4C9F/eFMVpwZgOBrBWq5sfu7rS1uxTrcg9G7jUFatNe5W6hr+M7z7aQPDf0J1afaSudUZPawx1LLf15w==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~55.0.8",
+        "@expo/config": "~55.0.10",
         "expo-json-utils": "~55.0.0"
       },
       "peerDependencies": {
@@ -4780,16 +4803,16 @@
       }
     },
     "node_modules/expo-notifications": {
-      "version": "55.0.10",
-      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-55.0.10.tgz",
-      "integrity": "sha512-F+ozrVFthKCwfqz2cXmcqrqwzBMTAwoNBqTZERuFtgc+6I++mweVzLLTtbAy8kBDZ33MA13GKyeq7mw13/rDgw==",
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-55.0.14.tgz",
+      "integrity": "sha512-fwWTd0OK82Yj2MLJJK0cIgaRtAu8OUcjGuucdtsp/dOsErqBsGQQWpotoEXoRPrDrCL4sHwSvg9QzGdeouJ/jQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.8.12",
         "abort-controller": "^3.0.0",
         "badgin": "^1.1.5",
-        "expo-application": "~55.0.8",
-        "expo-constants": "~55.0.7"
+        "expo-application": "~55.0.10",
+        "expo-constants": "~55.0.9"
       },
       "peerDependencies": {
         "expo": "*",
@@ -4798,25 +4821,25 @@
       }
     },
     "node_modules/expo-router": {
-      "version": "55.0.2",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-55.0.2.tgz",
-      "integrity": "sha512-KREcI1l89no0KEC/t3/eBOBNWqSMQ8X4TyekqLVGpotflEVPyloWP9TnrwyDF13ThrzTqB1SDLycrkAhitHtpQ==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-55.0.8.tgz",
+      "integrity": "sha512-SG51cnmH84Htxa+vXJPw4xl10rDCrWkC/3m38Sn51Bg+9N2nPPJMhCYifAcR9ZYK6mlb2BPG1GiHVjZw78DSxQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/metro-runtime": "^55.0.6",
+        "@expo/metro-runtime": "^55.0.7",
         "@expo/schema-utils": "^55.0.2",
-        "@radix-ui/react-slot": "1.2.0",
+        "@radix-ui/react-slot": "^1.2.0",
         "@radix-ui/react-tabs": "^1.1.12",
-        "@react-navigation/bottom-tabs": "7.10.1",
-        "@react-navigation/native": "7.1.28",
-        "@react-navigation/native-stack": "7.10.1",
+        "@react-navigation/bottom-tabs": "^7.15.5",
+        "@react-navigation/native": "^7.1.33",
+        "@react-navigation/native-stack": "^7.14.5",
         "client-only": "^0.0.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
-        "expo-glass-effect": "^55.0.7",
-        "expo-image": "^55.0.5",
-        "expo-server": "^55.0.5",
-        "expo-symbols": "^55.0.4",
+        "expo-glass-effect": "^55.0.8",
+        "expo-image": "^55.0.6",
+        "expo-server": "^55.0.6",
+        "expo-symbols": "^55.0.5",
         "fast-deep-equal": "^3.1.3",
         "invariant": "^2.2.4",
         "nanoid": "^3.3.8",
@@ -4831,13 +4854,13 @@
         "vaul": "^1.1.2"
       },
       "peerDependencies": {
-        "@expo/log-box": "55.0.7",
-        "@expo/metro-runtime": "^55.0.6",
-        "@react-navigation/drawer": "^7.7.2",
+        "@expo/log-box": "55.0.8",
+        "@expo/metro-runtime": "^55.0.7",
+        "@react-navigation/drawer": "^7.9.4",
         "@testing-library/react-native": ">= 13.2.0",
         "expo": "*",
-        "expo-constants": "^55.0.7",
-        "expo-linking": "^55.0.7",
+        "expo-constants": "^55.0.9",
+        "expo-linking": "^55.0.9",
         "react": "*",
         "react-dom": "*",
         "react-native": "*",
@@ -4868,30 +4891,6 @@
           "optional": true
         },
         "react-server-dom-webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/expo-router/node_modules/@expo/metro-runtime": {
-      "version": "55.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-55.0.6.tgz",
-      "integrity": "sha512-l8VvgKN9md+URjeQDB+DnHVmvpcWI6zFLH6yv7GTv4sfRDKyaZ5zDXYjTP1phYdgW6ea2NrRtCGNIxylWhsgtg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/log-box": "55.0.7",
-        "anser": "^1.4.9",
-        "pretty-format": "^29.7.0",
-        "stacktrace-parser": "^0.1.10",
-        "whatwg-fetch": "^3.0.0"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-dom": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
           "optional": true
         }
       }
@@ -4939,9 +4938,9 @@
       }
     },
     "node_modules/expo-secure-store": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-55.0.8.tgz",
-      "integrity": "sha512-8w9tQe8U6oRo5YIzqCqVhRrOnfoODNDoitBtLXEx+zS6WLUnkRq5kH7ViJuOgiM7PzLr9pvAliRiDOKyvFbTuQ==",
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-55.0.9.tgz",
+      "integrity": "sha512-TIPGjM73LKlebpXwgAu/yL7lNWr6RQYmFw3vgYHOqLFYQMpsBqkQmopovbNX3c/0+RCE9KZlLAkcz8r6detILQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -4966,21 +4965,21 @@
       }
     },
     "node_modules/expo-splash-screen": {
-      "version": "55.0.9",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-55.0.9.tgz",
-      "integrity": "sha512-FWAHLg5w6aesnrU1RtNoVNIA3FN11lFQCiWafPHpneqNtI6Wzkxxz3vu+4JTWlSkMIbylZ85F0qJe0CCNI9Eig==",
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-55.0.13.tgz",
+      "integrity": "sha512-dEainzjUZbqdmcQjO7tIqoh432jloxOGzHJHErGIMxg1QlahKj0e5D/4CY1Xd6qIOs1rRBlG63mPxx7iGBWbHQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/prebuild-config": "^55.0.7"
+        "@expo/prebuild-config": "^55.0.11"
       },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-sqlite": {
-      "version": "55.0.10",
-      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-55.0.10.tgz",
-      "integrity": "sha512-yLQXkwcA0OVSKuL4t+a6vv+H/Klh8147n7hH75AN0MkC48p3Go7+6GM+3SFENeaBUsmOnOS3XSFxMxxj6PIg4g==",
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-55.0.11.tgz",
+      "integrity": "sha512-lDGJrE0m1lw/3y1ZSsER2kfXnS+9WzgaKcIFp/RKbTfyhs0v8l86Ulqdr+6peRFOfzi0kdj4Ty0LzE2Adx93tg==",
       "license": "MIT",
       "dependencies": {
         "await-lock": "^2.2.2"
@@ -5005,9 +5004,9 @@
       }
     },
     "node_modules/expo-symbols": {
-      "version": "55.0.4",
-      "resolved": "https://registry.npmjs.org/expo-symbols/-/expo-symbols-55.0.4.tgz",
-      "integrity": "sha512-w9rxPlpta3gks0G4Tvpq/qQdiMp4R/XOeOzyjSruYUQakmsWbQBKA+Sd/fCVXs7qFJSvVTOGXiOhZm+YJRYZVg==",
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/expo-symbols/-/expo-symbols-55.0.5.tgz",
+      "integrity": "sha512-W/QYRvnYVes947ZYOHtuKL8Gobs7BUjeu9oknzbo4jGnou7Ks6bj1CwdT0ZWNBgaTopbS4/POXumJIkW4cTPSQ==",
       "license": "MIT",
       "dependencies": {
         "@expo-google-fonts/material-symbols": "^0.4.1",
@@ -5163,23 +5162,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/log-box": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.8.tgz",
-      "integrity": "sha512-WVEuW1XcntUdOpQk8k9cUymM5FHKmEcPr6QO9SVIin3WYk5FbbwHRYr1T6GfwWF0UA2s9w9heeYolesq99vFIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/dom-webview": "^55.0.3",
-        "anser": "^1.4.9",
-        "stacktrace-parser": "^0.1.10"
-      },
-      "peerDependencies": {
-        "@expo/dom-webview": "^55.0.3",
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo/node_modules/@react-native/debugger-frontend": {
@@ -9369,7 +9351,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -34,6 +34,7 @@
     "expo-document-picker": "~55.0.9",
     "expo-font": "~55.0.4",
     "expo-image": "~55.0.6",
+    "expo-image-picker": "~55.0.14",
     "expo-linking": "~55.0.9",
     "expo-notifications": "~55.0.14",
     "expo-router": "~55.0.8",

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -26,6 +26,8 @@ interface AuthState {
   isAuthenticated: boolean
   isLoading: boolean
   signInWithTokens: (accessToken: string, refreshToken: string, user: UserDto) => Promise<void>
+  updateUser: (user: UserDto) => Promise<void>
+  getAccessToken: () => Promise<string | null>
   signOut: () => Promise<void>
 }
 
@@ -34,6 +36,8 @@ const AuthContext = createContext<AuthState>({
   isAuthenticated: false,
   isLoading: true,
   signInWithTokens: async () => {},
+  updateUser: async () => {},
+  getAccessToken: async () => null,
   signOut: async () => {},
 })
 
@@ -71,6 +75,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [],
   )
 
+  const updateUser = useCallback(async (userData: UserDto) => {
+    await SecureStore.setItemAsync('user', JSON.stringify(userData))
+    setUser(userData)
+  }, [])
+
+  const getAccessToken = useCallback(async () => {
+    return SecureStore.getItemAsync('access_token')
+  }, [])
+
   const signOut = useCallback(async () => {
     await SecureStore.deleteItemAsync('access_token')
     await SecureStore.deleteItemAsync('refresh_token')
@@ -85,6 +98,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isAuthenticated: user !== null,
         isLoading,
         signInWithTokens,
+        updateUser,
+        getAccessToken,
         signOut,
       }}
     >

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -39,6 +39,7 @@ import './styles/reviews.css'
 import './styles/blog.css'
 import './styles/highlights.css'
 import './styles/auth.css'
+import './styles/profile.css'
 
 function LanguageRoutes() {
   const { lang } = useParams<{ lang: string }>()

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -94,6 +94,33 @@ export async function getCurrentUser(): Promise<AuthResponse> {
   return authFetch<AuthResponse>('/auth/me')
 }
 
+// Profile API
+export async function updateProfile(name: string | null): Promise<AuthResponse> {
+  return authFetch<AuthResponse>('/me/profile', {
+    method: 'PUT',
+    body: JSON.stringify({ name }),
+  })
+}
+
+export async function uploadAvatar(file: File): Promise<AuthResponse> {
+  const formData = new FormData()
+  formData.append('file', file)
+  const res = await fetch(`${API_BASE}/me/profile/avatar`, {
+    method: 'POST',
+    credentials: 'include',
+    body: formData,
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw new Error(data?.error || 'Upload failed')
+  }
+  return res.json()
+}
+
+export async function deleteAvatar(): Promise<void> {
+  await authFetch<void>('/me/profile/avatar', { method: 'DELETE' })
+}
+
 // Reading Progress API
 export interface ReadingProgressDto {
   editionId: string

--- a/apps/web/src/components/auth/ProfileModal.tsx
+++ b/apps/web/src/components/auth/ProfileModal.tsx
@@ -1,0 +1,112 @@
+import { useState, useRef, FormEvent } from 'react'
+import { useAuth } from '../../context/AuthContext'
+
+export function ProfileModal({ onClose }: { onClose: () => void }) {
+  const { user, updateProfile, updateAvatar, deleteAvatar } = useAuth()
+  const [name, setName] = useState(user?.name || '')
+  const [preview, setPreview] = useState<string | null>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  if (!user) return null
+
+  const avatarSrc = preview || (user.picture?.startsWith('http')
+    ? user.picture
+    : user.picture ? `/storage/${user.picture}` : null)
+
+  const initials = user.name
+    ? user.name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)
+    : user.email[0].toUpperCase()
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0]
+    if (!f) return
+    setFile(f)
+    setPreview(URL.createObjectURL(f))
+  }
+
+  const handleRemoveAvatar = () => {
+    setFile(null)
+    setPreview('__remove__')
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      const trimmedName = name.trim() || null
+      if (trimmedName !== user.name) {
+        await updateProfile(trimmedName)
+      }
+      if (file) {
+        await updateAvatar(file)
+      } else if (preview === '__remove__' && user.picture) {
+        await deleteAvatar()
+      }
+      onClose()
+    } catch (err: any) {
+      setError(err.message || 'Failed to update profile.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="profile-overlay" onClick={onClose}>
+      <div className="profile-modal" onClick={e => e.stopPropagation()}>
+        <button className="profile-modal__close" onClick={onClose}>&times;</button>
+        <div className="profile-modal__body">
+          <h2 className="profile-modal__title">Edit profile</h2>
+          <form onSubmit={handleSubmit}>
+            <div className="profile-modal__avatar-section">
+              <div className="profile-modal__avatar" onClick={() => fileRef.current?.click()}>
+                {avatarSrc && avatarSrc !== '__remove__' ? (
+                  <img src={avatarSrc} alt="" referrerPolicy="no-referrer" />
+                ) : (
+                  <span>{initials}</span>
+                )}
+                <div className="profile-modal__avatar-overlay">
+                  <span className="material-icons-outlined">photo_camera</span>
+                </div>
+              </div>
+              <input
+                ref={fileRef}
+                type="file"
+                accept="image/jpeg,image/png"
+                onChange={handleFileChange}
+                style={{ display: 'none' }}
+              />
+              {(avatarSrc && avatarSrc !== '__remove__') && (
+                <button type="button" className="profile-modal__remove-btn" onClick={handleRemoveAvatar}>
+                  Remove photo
+                </button>
+              )}
+            </div>
+            <label className="profile-modal__label">Name</label>
+            <input
+              type="text"
+              className="profile-modal__input"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Your name"
+            />
+            <label className="profile-modal__label">Email</label>
+            <input
+              type="email"
+              className="profile-modal__input profile-modal__input--disabled"
+              value={user.email}
+              disabled
+            />
+            {error && <p className="profile-modal__error">{error}</p>}
+            <button className="profile-modal__btn" type="submit" disabled={loading}>
+              {loading ? 'Saving...' : 'Save changes'}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -1,10 +1,12 @@
 import { useState, useRef, useEffect } from 'react'
 import { useAuth } from '../../context/AuthContext'
 import { LocalizedLink } from '../LocalizedLink'
+import { ProfileModal } from './ProfileModal'
 
 export function UserMenu() {
   const { user, logout } = useAuth()
   const [open, setOpen] = useState(false)
+  const [showProfile, setShowProfile] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
 
   // Close on outside click
@@ -27,68 +29,81 @@ export function UserMenu() {
     ? user.name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)
     : user.email[0].toUpperCase()
 
-  return (
-    <div className="user-menu" ref={menuRef}>
-      <button
-        className="user-menu__trigger"
-        onClick={() => setOpen(!open)}
-        aria-expanded={open}
-        aria-haspopup="true"
-      >
-        {user.picture ? (
-          <img src={user.picture} alt="" className="user-menu__avatar-img" referrerPolicy="no-referrer" />
-        ) : (
-          <span className="user-menu__avatar">{initials}</span>
-        )}
-      </button>
+  const avatarSrc = user.picture?.startsWith('http')
+    ? user.picture
+    : user.picture ? `/storage/${user.picture}` : null
 
-      {open && (
-        <div className="user-menu__dropdown">
-          <div className="user-menu__info">
-            <span className="user-menu__name">{user.name || 'User'}</span>
-            <span className="user-menu__email">{user.email}</span>
+  return (
+    <>
+      <div className="user-menu" ref={menuRef}>
+        <button
+          className="user-menu__trigger"
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+          aria-haspopup="true"
+        >
+          {avatarSrc ? (
+            <img src={avatarSrc} alt="" className="user-menu__avatar-img" referrerPolicy="no-referrer" />
+          ) : (
+            <span className="user-menu__avatar">{initials}</span>
+          )}
+        </button>
+
+        {open && (
+          <div className="user-menu__dropdown">
+            <div className="user-menu__info">
+              <span className="user-menu__name">{user.name || 'User'}</span>
+              <span className="user-menu__email">{user.email}</span>
+            </div>
+            <hr className="user-menu__divider" />
+            <button
+              className="user-menu__item"
+              onClick={() => { setOpen(false); setShowProfile(true) }}
+            >
+              Edit profile
+            </button>
+            <LocalizedLink
+              to="/library"
+              className="user-menu__item"
+              onClick={() => setOpen(false)}
+            >
+              My Library
+            </LocalizedLink>
+            <LocalizedLink
+              to="/vocabulary"
+              className="user-menu__item"
+              onClick={() => setOpen(false)}
+            >
+              Vocabulary
+            </LocalizedLink>
+            <LocalizedLink
+              to="/highlights"
+              className="user-menu__item"
+              onClick={() => setOpen(false)}
+            >
+              Highlights
+            </LocalizedLink>
+            <LocalizedLink
+              to="/stats"
+              className="user-menu__item"
+              onClick={() => setOpen(false)}
+            >
+              Stats
+            </LocalizedLink>
+            <hr className="user-menu__divider" />
+            <button
+              className="user-menu__item user-menu__item--danger"
+              onClick={() => {
+                setOpen(false)
+                logout()
+              }}
+            >
+              Sign out
+            </button>
           </div>
-          <hr className="user-menu__divider" />
-          <LocalizedLink
-            to="/library"
-            className="user-menu__item"
-            onClick={() => setOpen(false)}
-          >
-            My Library
-          </LocalizedLink>
-          <LocalizedLink
-            to="/vocabulary"
-            className="user-menu__item"
-            onClick={() => setOpen(false)}
-          >
-            Vocabulary
-          </LocalizedLink>
-          <LocalizedLink
-            to="/highlights"
-            className="user-menu__item"
-            onClick={() => setOpen(false)}
-          >
-            Highlights
-          </LocalizedLink>
-          <LocalizedLink
-            to="/stats"
-            className="user-menu__item"
-            onClick={() => setOpen(false)}
-          >
-            Stats
-          </LocalizedLink>
-          <hr className="user-menu__divider" />
-          <button
-            className="user-menu__item user-menu__item--danger"
-            onClick={() => {
-              setOpen(false)
-              logout()
-            }}
-          >
-            Sign out
-          </button>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+      {showProfile && <ProfileModal onClose={() => setShowProfile(false)} />}
+    </>
   )
 }

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, useCallback, ReactNode 
 import {
   User, getCurrentUser, loginWithGoogle, logout as logoutApi, refreshToken,
   loginWithEmail as loginWithEmailApi, registerWithEmail as registerWithEmailApi,
+  updateProfile as updateProfileApi, uploadAvatar as uploadAvatarApi, deleteAvatar as deleteAvatarApi,
 } from '../api/auth'
 
 interface AuthContextValue {
@@ -15,6 +16,9 @@ interface AuthContextValue {
   loginWithEmail: (email: string, password: string) => Promise<void>
   registerWithEmail: (email: string, password: string, name?: string) => Promise<void>
   logout: () => Promise<void>
+  updateProfile: (name: string | null) => Promise<void>
+  updateAvatar: (file: File) => Promise<void>
+  deleteAvatar: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue>({
@@ -28,6 +32,9 @@ const AuthContext = createContext<AuthContextValue>({
   loginWithEmail: async () => {},
   registerWithEmail: async () => {},
   logout: async () => {},
+  updateProfile: async () => {},
+  updateAvatar: async () => {},
+  deleteAvatar: async () => {},
 })
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID
@@ -131,6 +138,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [authenticateAndClose],
   )
 
+  const updateProfile = useCallback(async (name: string | null) => {
+    const response = await updateProfileApi(name)
+    setUser(response.user)
+  }, [])
+
+  const updateAvatar = useCallback(async (file: File) => {
+    const response = await uploadAvatarApi(file)
+    setUser(response.user)
+  }, [])
+
+  const deleteAvatar = useCallback(async () => {
+    await deleteAvatarApi()
+    setUser(prev => prev ? { ...prev, picture: null } : null)
+  }, [])
+
   const logout = useCallback(async () => {
     try {
       await logoutApi()
@@ -156,6 +178,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         loginWithEmail,
         registerWithEmail,
         logout,
+        updateProfile,
+        updateAvatar,
+        deleteAvatar,
       }}
     >
       {children}

--- a/apps/web/src/styles/profile.css
+++ b/apps/web/src/styles/profile.css
@@ -1,0 +1,183 @@
+/* Profile modal overlay */
+.profile-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  backdrop-filter: blur(4px);
+}
+
+.profile-modal {
+  background: var(--color-bg-card);
+  border-radius: 12px;
+  width: 100%;
+  max-width: 400px;
+  position: relative;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  animation: profile-modal-in 0.2s ease-out;
+}
+
+@keyframes profile-modal-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.profile-modal__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: background 0.15s;
+}
+
+.profile-modal__close:hover {
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+}
+
+.profile-modal__body {
+  padding: 2rem;
+}
+
+.profile-modal__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 1.5rem;
+  text-align: center;
+  color: var(--color-text);
+}
+
+.profile-modal__avatar-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1.25rem;
+  gap: 0.5rem;
+}
+
+.profile-modal__avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  overflow: hidden;
+  cursor: pointer;
+  position: relative;
+  background: var(--color-brand);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-modal__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-modal__avatar span {
+  color: #fff;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.profile-modal__avatar-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s;
+  color: #fff;
+}
+
+.profile-modal__avatar:hover .profile-modal__avatar-overlay {
+  opacity: 1;
+}
+
+.profile-modal__remove-btn {
+  background: none;
+  border: none;
+  color: #ef4444;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.profile-modal__remove-btn:hover {
+  text-decoration: underline;
+}
+
+.profile-modal__label {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin-bottom: 0.3rem;
+}
+
+.profile-modal__input {
+  width: 100%;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  outline: none;
+  margin-bottom: 0.75rem;
+  transition: border-color 0.15s;
+}
+
+.profile-modal__input:focus {
+  border-color: var(--color-brand);
+}
+
+.profile-modal__input--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.profile-modal__error {
+  color: #ef4444;
+  font-size: 0.82rem;
+  margin: 0 0 0.75rem;
+  text-align: center;
+}
+
+.profile-modal__btn {
+  width: 100%;
+  padding: 0.7rem;
+  background: var(--color-brand);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.profile-modal__btn:hover:not(:disabled) {
+  background: var(--color-brand-hover);
+}
+
+.profile-modal__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/backend/src/Api/Endpoints/ProfileEndpoints.cs
+++ b/backend/src/Api/Endpoints/ProfileEndpoints.cs
@@ -1,0 +1,112 @@
+using Api.Extensions;
+using Application.Auth;
+using Application.Common.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Endpoints;
+
+public static class ProfileEndpoints
+{
+    private static readonly string[] AllowedPhotoExtensions = [".jpg", ".jpeg", ".png"];
+    private const long MaxPhotoSize = 2 * 1024 * 1024; // 2MB
+
+    public static void MapProfileEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/me/profile").WithTags("Profile");
+
+        group.MapPut("/", UpdateProfile).WithName("UpdateProfile");
+        group.MapPost("/avatar", UploadAvatar).WithName("UploadAvatar").DisableAntiforgery();
+        group.MapDelete("/avatar", DeleteAvatar).WithName("DeleteAvatar");
+    }
+
+    private static async Task<IResult> UpdateProfile(
+        [FromBody] UpdateProfileRequest request,
+        AuthService authService,
+        IAppDbContext db,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var user = await authService.GetUserByIdAsync(userId.Value, ct);
+        if (user == null) return Results.Unauthorized();
+
+        user.Name = request.Name?.Trim();
+        await db.SaveChangesAsync(ct);
+
+        return Results.Ok(new AuthResponse(new UserDto(user.Id, user.Email, user.Name, user.Picture, user.CreatedAt)));
+    }
+
+    private static async Task<IResult> UploadAvatar(
+        IFormFile file,
+        AuthService authService,
+        IAppDbContext db,
+        IFileStorageService storage,
+        IImageOptimizer imageOptimizer,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var user = await authService.GetUserByIdAsync(userId.Value, ct);
+        if (user == null) return Results.Unauthorized();
+
+        if (file.Length == 0)
+            return Results.BadRequest(new { error = "File is empty" });
+
+        if (file.Length > MaxPhotoSize)
+            return Results.BadRequest(new { error = "File too large. Max 2MB allowed" });
+
+        var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
+        if (!AllowedPhotoExtensions.Contains(ext))
+            return Results.BadRequest(new { error = "Invalid file type. Only JPG and PNG allowed" });
+
+        // Delete old avatar if it's a local file (not external URL like Google)
+        if (!string.IsNullOrEmpty(user.Picture) && !user.Picture.StartsWith("http"))
+        {
+            await storage.DeleteFileAsync(user.Picture, ct);
+        }
+
+        using var ms = new MemoryStream();
+        await file.CopyToAsync(ms, ct);
+        var mimeType = file.ContentType ?? "image/jpeg";
+        var optimized = await imageOptimizer.OptimizeAsync(ms.ToArray(), mimeType, ct: ct);
+
+        using var optimizedStream = new MemoryStream(optimized.Data);
+        var fileName = $"avatar{optimized.Extension}";
+        var relativePath = await storage.SaveFileAsync(userId.Value, fileName, optimizedStream, ct);
+
+        user.Picture = relativePath;
+        await db.SaveChangesAsync(ct);
+
+        return Results.Ok(new AuthResponse(new UserDto(user.Id, user.Email, user.Name, user.Picture, user.CreatedAt)));
+    }
+
+    private static async Task<IResult> DeleteAvatar(
+        AuthService authService,
+        IAppDbContext db,
+        IFileStorageService storage,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var user = await authService.GetUserByIdAsync(userId.Value, ct);
+        if (user == null) return Results.Unauthorized();
+
+        if (!string.IsNullOrEmpty(user.Picture) && !user.Picture.StartsWith("http"))
+        {
+            await storage.DeleteFileAsync(user.Picture, ct);
+        }
+
+        user.Picture = null;
+        await db.SaveChangesAsync(ct);
+
+        return Results.Ok();
+    }
+}
+
+public record UpdateProfileRequest(string? Name);

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -260,6 +260,7 @@ app.MapSiteEndpoints();
 app.MapSeoEndpoints();
 app.MapSsgEndpoints();
 app.MapAuthEndpoints();
+app.MapProfileEndpoints();
 app.MapUserDataEndpoints();
 app.MapHighlightsEndpoints();
 app.MapTranslationEndpoints();

--- a/packages/shared/src/api/auth.ts
+++ b/packages/shared/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { getApiConfig } from './client'
-import type { MobileAuthResponse } from '../types/api'
+import type { MobileAuthResponse, AuthResponse } from '../types/api'
 
 async function mobilePost<T>(path: string, body: unknown): Promise<T> {
   const { baseUrl } = getApiConfig()
@@ -79,4 +79,44 @@ export async function logout(accessToken: string): Promise<void> {
     method: 'POST',
     headers: { Authorization: `Bearer ${accessToken}` },
   })
+}
+
+// Profile
+export async function updateProfile(name: string | null, accessToken: string): Promise<AuthResponse> {
+  const { baseUrl } = getApiConfig()
+  const res = await fetch(`${baseUrl}/me/profile`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+    body: JSON.stringify({ name }),
+  })
+  if (!res.ok) throw new Error('Failed to update profile')
+  return res.json()
+}
+
+export async function uploadAvatar(imageUri: string, accessToken: string): Promise<AuthResponse> {
+  const { baseUrl } = getApiConfig()
+  const formData = new FormData()
+  const filename = imageUri.split('/').pop() || 'avatar.jpg'
+  const ext = filename.split('.').pop()?.toLowerCase() || 'jpg'
+  const mimeType = ext === 'png' ? 'image/png' : 'image/jpeg'
+  formData.append('file', { uri: imageUri, name: filename, type: mimeType } as any)
+  const res = await fetch(`${baseUrl}/me/profile/avatar`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    body: formData,
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw new Error(data?.error || 'Upload failed')
+  }
+  return res.json()
+}
+
+export async function deleteAvatar(accessToken: string): Promise<void> {
+  const { baseUrl } = getApiConfig()
+  const res = await fetch(`${baseUrl}/me/profile/avatar`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  if (!res.ok) throw new Error('Failed to delete avatar')
 }


### PR DESCRIPTION
## Summary
- Backend: `PUT /me/profile` (name), `POST /me/profile/avatar` (upload, 2MB max, jpg/png), `DELETE /me/profile/avatar`
- Web: ProfileModal component in UserMenu — avatar preview, name edit, remove photo
- Mobile: inline name editing + camera badge on avatar, expo-image-picker (lazy-loaded for Expo Go compat)
- Shared: profile API functions in `@textstack/shared` for mobile

## Test plan
- [x] Backend endpoints verified via curl (name update, avatar upload, avatar delete)
- [x] Web: name change persists, avatar upload shows in menu, modal close on save
- [x] Mobile: edit mode renders, name input + save/cancel, camera badge visible
- [x] Mobile: graceful fallback when expo-image-picker native module unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)