### PR TITLE
chore(pdf-quality): Makefile targets for quality-poller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down restart logs status backup restore backup-list backup-verify rebuild-ssg clean-ssg deploy nginx-setup build rebuild fix-permissions test lint reindex-search seo-publish-setup seo-publish-status seo-publish-logs seo-publish-restart seo-publish-stop
+.PHONY: up down restart logs status backup restore backup-list backup-verify rebuild-ssg clean-ssg deploy nginx-setup build rebuild fix-permissions test lint reindex-search seo-publish-setup seo-publish-status seo-publish-logs seo-publish-restart seo-publish-stop quality-poll-setup quality-poll-status quality-poll-logs quality-poll-restart quality-poll-stop
 
 # ============================================================
 # Docker Services
@@ -174,6 +174,31 @@ seo-publish-restart:
 
 seo-publish-stop:
 	@systemctl --user stop seo-publish-poller
+
+# ============================================================
+# Book Quality Poller (Phase 1-2 structure fixes + Phase 3 content cleanup)
+# ============================================================
+
+quality-poll-setup:
+	@mkdir -p ~/.config/systemd/user
+	@cp infra/systemd/quality-poller.service ~/.config/systemd/user/
+	@systemctl --user daemon-reload
+	@systemctl --user enable quality-poller
+	@systemctl --user start quality-poller
+	@loginctl enable-linger $$(whoami)
+	@echo "Book Quality poller installed and started."
+
+quality-poll-status:
+	@systemctl --user status quality-poller
+
+quality-poll-logs:
+	@journalctl --user -u quality-poller -f
+
+quality-poll-restart:
+	@systemctl --user restart quality-poller
+
+quality-poll-stop:
+	@systemctl --user stop quality-poller
 
 # ============================================================
 # SEO Backfill (template-driven SEO generation for Authors/Editions/Genres/Blog)

--- a/infra/systemd/quality-poller.service
+++ b/infra/systemd/quality-poller.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=TextStack Book Quality Poller
 After=docker.service
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple
@@ -8,8 +10,6 @@ WorkingDirectory=/home/vasyl/projects/onlinelib/textstack
 ExecStart=/home/vasyl/projects/onlinelib/textstack/infra/scripts/quality-poll.sh
 Restart=on-failure
 RestartSec=10
-StartLimitBurst=5
-StartLimitIntervalSec=300
 Environment=HOME=/home/vasyl
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
 


### PR DESCRIPTION
## Summary

Mirror the `seo-publish` pattern for the Book Quality poller:
`make quality-poll-setup` / `-status` / `-logs` / `-restart` / `-stop`.
Without these, installing the poller required manual systemctl invocations
(which I just did on prod ad-hoc — this codifies the same steps).

Also: the unit had `StartLimitBurst` / `StartLimitIntervalSec` in `[Service]`,
where systemd expects them in `[Unit]` — moved. Was emitting a "Unknown key"
warning at startup; cosmetic, the poller worked anyway.

## Changes

- `Makefile` — 5 new targets + `.PHONY`.
- `infra/systemd/quality-poller.service` — StartLimit keys in `[Unit]`.

## Tests

`make -n quality-poll-setup` produces the expected commands. The poller is
already running on prod (installed manually); a follow-up `make quality-poll-restart`
will pick up the unit fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)