### PR TITLE
fix(library): move delete button into UserBookDetailPage action row

### DIFF
--- a/apps/web/src/pages/UserBookDetailPage.tsx
+++ b/apps/web/src/pages/UserBookDetailPage.tsx
@@ -275,6 +275,24 @@ export function UserBookDetailPage() {
                 linkOnly
               />
             )}
+
+            {isReady && (
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting}
+                className="user-book-detail__delete-icon"
+                aria-label={deleting ? 'Deleting…' : 'Delete this book'}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                  <path d="M10 11v6" />
+                  <path d="M14 11v6" />
+                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                </svg>
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -308,25 +326,6 @@ export function UserBookDetailPage() {
         </div>
       )}
 
-      {isReady && (
-        <div className="user-book-detail__danger-zone">
-          <button
-            type="button"
-            onClick={handleDelete}
-            disabled={deleting}
-            className="user-book-detail__delete-icon"
-            aria-label={deleting ? 'Deleting…' : 'Delete this book'}
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <polyline points="3 6 5 6 21 6" />
-              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-              <path d="M10 11v6" />
-              <path d="M14 11v6" />
-              <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-            </svg>
-          </button>
-        </div>
-      )}
     </div>
     <Footer />
     </>

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -4662,16 +4662,8 @@ html.dark .add-to-collection-button--icon[aria-label]::after {
   background: rgba(0, 0, 0, 0.04);
 }
 
-/* Danger zone — destructive actions live below the chapters list, not
-   in the primary action row. Apple HIG: distance + understatement
-   reduce accidental clicks. Trash icon + custom hover tooltip. */
-.user-book-detail__danger-zone {
-  margin-top: 48px;
-  padding-top: 24px;
-  border-top: 1px solid var(--color-border, #E8E2D9);
-  display: flex;
-  justify-content: center;
-}
+/* Trash icon now lives in the primary action row next to Share/Add-to-collection.
+   Custom hover tooltip via aria-label ::after. */
 .user-book-detail__delete-icon {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

The trash icon on the user-book detail page lived alone in a "danger zone"
block below the chapter list — visually orphaned from every other book
action (Continue Reading, Mark as read, Add to collection, Share).

Moves it into the same action row, keeping the destructive styling
(red-bordered round icon button, hover tooltip via aria-label).
Removed the now-unused `.user-book-detail__danger-zone` CSS.

## Tests

`pnpm -C apps/web build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)