### PR TITLE
fix(vocab): add every tapped word to SRS by default

### DIFF
--- a/backend/src/Api/Endpoints/VocabularyEndpoints.Settings.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.Settings.cs
@@ -30,7 +30,7 @@ public static partial class VocabularyEndpoints
         return Results.Ok(new VocabSettingsDto(
             DailyNewCap: settings?.DailyNewCap ?? 15,
             WeeklyReviewBudget: settings?.WeeklyReviewBudget ?? 70,
-            FrequencyFilterEnabled: settings?.FrequencyFilterEnabled ?? true,
+            FrequencyFilterEnabled: settings?.FrequencyFilterEnabled ?? false,
             ClusteringEnabled: settings?.ClusteringEnabled ?? true,
             AutoRetireEnabled: settings?.AutoRetireEnabled ?? true));
     }

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.cs
@@ -135,10 +135,13 @@ public static partial class VocabularyEndpoints
         // Anti-spiral F1: frequency gate. Rare/OOV words go to WordLookup and
         // never touch SRS. Mid-tier words need 2 taps before joining SRS. The
         // user's FrequencyFilterEnabled setting lets them opt out entirely.
+        // Default OFF when the user has no settings row — matches the entity
+        // default. Every tapped word goes straight to SRS unless the user has
+        // explicitly turned the frequency filter back on.
         var filterEnabled = await db.UserVocabularySettings
             .Where(s => s.UserId == userId && s.SiteId == siteId)
             .Select(s => (bool?)s.FrequencyFilterEnabled)
-            .FirstOrDefaultAsync(ct) ?? true;
+            .FirstOrDefaultAsync(ct) ?? false;
 
         // Query unconditionally so a user who flips the filter off doesn't leave
         // orphan lookups behind when the same word is next saved to SRS.

--- a/backend/src/Application/Vocabulary/DailyCapService.cs
+++ b/backend/src/Application/Vocabulary/DailyCapService.cs
@@ -16,7 +16,11 @@ public record DailyCapStatus(int Used, int Cap, int Remaining);
 
 public class DailyCapService(IAppDbContext db)
 {
-    public const int DefaultDailyCap = 15;
+    // Default = the per-user vocabulary ceiling (5000), i.e. effectively no
+    // daily limit: every tapped word enters SRS immediately and you only ever
+    // hit the absolute MaxWordsPerUser gate. Users can still opt into a real
+    // daily cap (5–100) via vocab settings.
+    public const int DefaultDailyCap = 5000;
 
     public async Task<DailyCapStatus> GetStatusAsync(Guid userId, Guid siteId, CancellationToken ct)
     {

--- a/backend/src/Domain/Entities/UserVocabularySettings.cs
+++ b/backend/src/Domain/Entities/UserVocabularySettings.cs
@@ -8,7 +8,9 @@ public class UserVocabularySettings
     public int DailyNewCap { get; set; } = 15;
     public int WeeklyReviewBudget { get; set; } = 70;
 
-    public bool FrequencyFilterEnabled { get; set; } = true;
+    // Default OFF: every tapped word goes straight to SRS (+ underline), no
+    // frequency gating. Users can opt back in via vocab settings.
+    public bool FrequencyFilterEnabled { get; set; } = false;
     public bool ClusteringEnabled { get; set; } = true;
     public bool AutoRetireEnabled { get; set; } = true;
 

--- a/tests/TextStack.IntegrationTests/VocabularySpiralTests.cs
+++ b/tests/TextStack.IntegrationTests/VocabularySpiralTests.cs
@@ -93,6 +93,10 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
         if (!_auth.IsAuthenticated) return;
         var ct = TestContext.Current.CancellationToken;
 
+        // Frequency filter now defaults OFF (every tap → SRS), so this test must
+        // opt the filter back ON to exercise the LookupOnly classification path.
+        await SetSettingsAsync(dailyCap: 15, weeklyBudget: 70, ct);
+
         // Guid-suffixed word can't exist in the wordfreq dataset — must classify as
         // LookupOnly and land in WordLookup, never in the SRS queue.
         var word = UniqueWord("zzoov");

--- a/tests/TextStack.UnitTests/DailyCapServiceTests.cs
+++ b/tests/TextStack.UnitTests/DailyCapServiceTests.cs
@@ -42,10 +42,12 @@ public class DailyCapServiceTests
     }
 
     [Fact]
-    public void DefaultDailyCap_Is15()
+    public void DefaultDailyCap_EqualsVocabularyCeiling_NoEffectiveDailyLimit()
     {
-        // Anti-spiral plan default. If this changes, update shared TS constant
-        // and the UserVocabularySettings default too.
-        Assert.Equal(15, DailyCapService.DefaultDailyCap);
+        // Daily cap is now opt-in: with no settings row the enforcement default
+        // equals the per-user vocabulary ceiling (5000), so the daily gate never
+        // binds before MaxWordsPerUser. The settings modal still SUGGESTS 15
+        // (shared TS DEFAULT_DAILY_CAP) for users who choose to opt into a cap.
+        Assert.Equal(5000, DailyCapService.DefaultDailyCap);
     }
 }


### PR DESCRIPTION
## What

Tapping a word in the reader now always saves it to SRS (and underlines it), regardless of word frequency or how many words were saved today. Matches the web PWA save flow.

Root cause of the reported mobile bug ("no underline / no auto-add"): two anti-spiral gates intercepted saves before they reached the SRS table.

## Changes
- **FrequencyFilter → opt-in (default OFF)**: `UserVocabularySettings.FrequencyFilterEnabled` default + both `?? true` endpoint fallbacks flipped to `false`. Rare / mid-tier / proper-noun words no longer routed to lookup-only.
- **Daily cap → effectively removed**: `DailyCapService.DefaultDailyCap` = vocab ceiling (5000), so the daily gate never binds before `MaxWordsPerUser`. Still opt-in (5–100) via vocab settings.

## Tests
- `VocabularySpiralTests.SaveWord_OovEnglishWord_ReturnsLookupOutcome` now explicitly enables the filter (it tests that path).
- `DailyCapServiceTests` default assertion updated (15 → 5000).
- Backend builds clean; DailyCap unit tests pass.

## Notes / caveats
- **No client change needed** — mobile vc11 + web already auto-save on tap; this is purely backend behavior.
- **Existing users with a saved settings row** (`FrequencyFilterEnabled=true` or an explicit daily cap) keep their setting — default only affects users without a row.
- **Settings-modal footgun**: GET still suggests `dailyNewCap=15`; opening + saving vocab settings persists a real 15/day cap. Display ceiling unchanged (modal slider 5–100). Flag if you want the modal to represent "no cap".

## Rollback
Revert this commit — restores the old anti-spiral defaults (filter ON, 15/day cap). No migration involved (no DB-level default on the column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)