### PR TITLE
test(simplify): SrsEngine Theory + visible integration skips (phase 2)

### DIFF
--- a/tests/TextStack.IntegrationTests/BookStatsEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/BookStatsEndpointTests.cs
@@ -14,9 +14,6 @@ public class BookStatsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtu
         _auth = auth;
     }
 
-    private static bool ShouldSkip(HttpResponseMessage r) =>
-        r.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.InternalServerError;
-
     #region Unauthenticated
 
     [Fact]
@@ -37,7 +34,7 @@ public class BookStatsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtu
         var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/book-stats");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var stats = await response.Content.ReadFromJsonAsync<BookStatsResponse>(cancellationToken: TestContext.Current.CancellationToken);
@@ -59,7 +56,7 @@ public class BookStatsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtu
         var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/book-stats?year=2025");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -69,7 +66,7 @@ public class BookStatsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtu
         var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/book-stats");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
 
         var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         // Verify all expected fields are present in JSON

--- a/tests/TextStack.IntegrationTests/IntegrationSkip.cs
+++ b/tests/TextStack.IntegrationTests/IntegrationSkip.cs
@@ -1,0 +1,17 @@
+using System.Net;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Shared skip predicate for live-server integration tests. Replaces the
+/// per-file <c>ShouldSkip</c> copies + silent <c>return;</c> guards: callers
+/// pair this with <c>Assert.SkipWhen(...)</c> so an unreachable endpoint shows
+/// up as a SKIPPED test in the report instead of a green pass with no asserts.
+/// </summary>
+internal static class IntegrationSkip
+{
+    /// <summary>404/500 from the live API = endpoint not deployed or erroring;
+    /// the test can't meaningfully assert, so skip rather than false-pass.</summary>
+    public static bool Unavailable(HttpResponseMessage r) =>
+        r.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.InternalServerError;
+}

--- a/tests/TextStack.IntegrationTests/SearchEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/SearchEndpointTests.cs
@@ -17,9 +17,6 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
     }
 
     // Skip if site not configured (CI empty DB)
-    private static bool ShouldSkip(HttpResponseMessage r) =>
-        r.StatusCode == HttpStatusCode.NotFound || r.StatusCode == HttpStatusCode.InternalServerError;
-
     #region Search Endpoint
 
     [Fact]
@@ -28,7 +25,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=test");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -38,7 +35,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=author");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -48,7 +45,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=a");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
@@ -58,7 +55,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
@@ -68,7 +65,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=test&highlight=true");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -78,7 +75,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=test&limit=10&offset=0");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -92,7 +89,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search/suggest?q=the");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -102,7 +99,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search/suggest?q=a");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("[]", content);
@@ -118,7 +115,7 @@ public class SearchEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/search?q=book");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (ShouldSkip(response)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
 
         var result = await response.Content.ReadFromJsonAsync<SearchResponse>(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(result);

--- a/tests/TextStack.IntegrationTests/UserBookEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/UserBookEndpointTests.cs
@@ -39,7 +39,7 @@ public class UserBookEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtur
     [Fact]
     public async Task GetUserBooks_Authenticated_Returns200()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
 
         var request = _auth.CreateRequest(HttpMethod.Get, "/me/books");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
@@ -49,12 +49,12 @@ public class UserBookEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtur
     [Fact]
     public async Task GetUserBooks_ResponseShape_HasNewMetadataFields()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
 
         var request = _auth.CreateRequest(HttpMethod.Get, "/me/books");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        if (response.StatusCode != HttpStatusCode.OK) return;
+        Assert.SkipWhen(response.StatusCode != HttpStatusCode.OK, "list endpoint unavailable");
 
         var books = await response.Content.ReadFromJsonAsync<UserBookListItem[]>(
             cancellationToken: TestContext.Current.CancellationToken);
@@ -77,7 +77,7 @@ public class UserBookEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtur
     [Fact]
     public async Task GetUserBookQuota_Authenticated_Returns200()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
 
         var request = _auth.CreateRequest(HttpMethod.Get, "/me/books/quota");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
@@ -96,7 +96,7 @@ public class UserBookEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtur
     [Fact]
     public async Task GetUserBook_NonExistent_Returns404()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
 
         var request = _auth.CreateRequest(HttpMethod.Get, $"/me/books/{Guid.NewGuid()}");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);

--- a/tests/TextStack.IntegrationTests/VocabularyAntiSpiralEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/VocabularyAntiSpiralEndpointTests.cs
@@ -22,9 +22,6 @@ public class VocabularyAntiSpiralEndpointTests : IClassFixture<LiveApiFixture>, 
         _auth = auth;
     }
 
-    private static bool ShouldSkip(HttpResponseMessage r) =>
-        r.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.InternalServerError;
-
     #region Unauthenticated → 401
 
     [Fact]
@@ -61,7 +58,8 @@ public class VocabularyAntiSpiralEndpointTests : IClassFixture<LiveApiFixture>, 
     {
         var request = _auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/settings");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
-        if (ShouldSkip(response) || !_auth.IsAuthenticated) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: TestContext.Current.CancellationToken);
@@ -77,7 +75,8 @@ public class VocabularyAntiSpiralEndpointTests : IClassFixture<LiveApiFixture>, 
     {
         var request = _auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/review");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
-        if (ShouldSkip(response) || !_auth.IsAuthenticated) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: TestContext.Current.CancellationToken);
@@ -93,7 +92,8 @@ public class VocabularyAntiSpiralEndpointTests : IClassFixture<LiveApiFixture>, 
     {
         var request = _auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/stats");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
-        if (ShouldSkip(response) || !_auth.IsAuthenticated) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: TestContext.Current.CancellationToken);
@@ -109,7 +109,8 @@ public class VocabularyAntiSpiralEndpointTests : IClassFixture<LiveApiFixture>, 
         var request = _auth.CreateRequest(HttpMethod.Put, "/me/vocabulary/settings");
         request.Content = JsonContent.Create(payload);
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
-        if (ShouldSkip(response) || !_auth.IsAuthenticated) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: TestContext.Current.CancellationToken);
@@ -129,7 +130,8 @@ public class VocabularyAntiSpiralEndpointTests : IClassFixture<LiveApiFixture>, 
     {
         var request = _auth.CreateRequest(HttpMethod.Post, $"/me/vocabulary/words/{Guid.NewGuid()}/unretire");
         var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
-        if (ShouldSkip(response) || !_auth.IsAuthenticated) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }

--- a/tests/TextStack.IntegrationTests/VocabularyPracticeTests.cs
+++ b/tests/TextStack.IntegrationTests/VocabularyPracticeTests.cs
@@ -24,9 +24,6 @@ public class VocabularyPracticeTests : IClassFixture<AuthenticatedApiFixture>
 
     private const string SrsLang = "de";
 
-    private static bool ShouldSkip(HttpResponseMessage r) =>
-        r.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.InternalServerError;
-
     private string UniqueWord(string prefix) => $"{prefix}{Guid.NewGuid():N}"[..16];
 
     private async Task<HttpResponseMessage> SaveWordAsync(string word, string language, CancellationToken ct)
@@ -58,12 +55,12 @@ public class VocabularyPracticeTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task GetReviewQueue_PracticeFlag_ReturnsNullWeeklyProgress()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         var resp = await _auth.Client.SendAsync(
             _auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/review?practice=true"), ct);
-        if (ShouldSkip(resp)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(resp), "endpoint unavailable (404/500)");
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
@@ -76,15 +73,15 @@ public class VocabularyPracticeTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task SubmitReview_PracticeMode_DoesNotMutateSrsState()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         // Need a real SRS-eligible word. "de" bypasses the EN frequency filter.
         var save = await SaveWordAsync(UniqueWord("zzpract"), SrsLang, ct);
-        if (ShouldSkip(save)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(save), "endpoint unavailable (404/500)");
         save.EnsureSuccessStatusCode();
         var saveBody = await save.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
-        if (saveBody.GetProperty("outcome").GetString() != "srs") return; // pending/lookup — skip
+        Assert.SkipWhen(saveBody.GetProperty("outcome").GetString() != "srs", "word not SRS-eligible (pending/lookup)");
         var wordId = saveBody.GetProperty("word").GetProperty("id").GetString()!;
 
         try
@@ -105,7 +102,7 @@ public class VocabularyPracticeTests : IClassFixture<AuthenticatedApiFixture>
                 isPractice = true,
             });
             var submitResp = await _auth.Client.SendAsync(submit, ct);
-            if (ShouldSkip(submitResp)) return;
+            Assert.SkipWhen(IntegrationSkip.Unavailable(submitResp), "endpoint unavailable (404/500)");
             submitResp.EnsureSuccessStatusCode();
 
             // Backend response echoes "no movement" — same stage in/out, same interval.
@@ -132,14 +129,14 @@ public class VocabularyPracticeTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task SubmitReview_PracticeMode_DoesNotConsumeWeeklyBudget()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         var save = await SaveWordAsync(UniqueWord("zzbud"), SrsLang, ct);
-        if (ShouldSkip(save)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(save), "endpoint unavailable (404/500)");
         save.EnsureSuccessStatusCode();
         var saveBody = await save.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
-        if (saveBody.GetProperty("outcome").GetString() != "srs") return;
+        Assert.SkipWhen(saveBody.GetProperty("outcome").GetString() != "srs", "word not SRS-eligible (pending/lookup)");
         var wordId = saveBody.GetProperty("word").GetProperty("id").GetString()!;
 
         try
@@ -162,7 +159,7 @@ public class VocabularyPracticeTests : IClassFixture<AuthenticatedApiFixture>
                     isPractice = true,
                 });
                 var submitResp = await _auth.Client.SendAsync(submit, ct);
-                if (ShouldSkip(submitResp)) return;
+                Assert.SkipWhen(IntegrationSkip.Unavailable(submitResp), "endpoint unavailable (404/500)");
                 submitResp.EnsureSuccessStatusCode();
             }
 

--- a/tests/TextStack.IntegrationTests/VocabularySpiralTests.cs
+++ b/tests/TextStack.IntegrationTests/VocabularySpiralTests.cs
@@ -30,9 +30,6 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
     // without guessing which English words are in top-5k.
     private const string SrsLang = "de";
 
-    private static bool ShouldSkip(HttpResponseMessage r) =>
-        r.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.InternalServerError;
-
     private string UniqueWord(string prefix) => $"{prefix}{Guid.NewGuid():N}"[..16];
 
     private async Task<HttpResponseMessage> SaveWordAsync(string word, string language, CancellationToken ct)
@@ -90,7 +87,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task SaveWord_OovEnglishWord_ReturnsLookupOutcome()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         // Frequency filter now defaults OFF (every tap → SRS), so this test must
@@ -101,7 +98,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
         // LookupOnly and land in WordLookup, never in the SRS queue.
         var word = UniqueWord("zzoov");
         var resp = await SaveWordAsync(word, "en", ct);
-        if (ShouldSkip(resp)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(resp), "endpoint unavailable (404/500)");
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
@@ -116,7 +113,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task SaveWord_OverDailyCap_GoesToPending()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         // Cap floor is 5, so fill the cap with N unique SRS-eligible saves then expect
@@ -131,7 +128,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
             for (var i = 0; i < MinDailyCap; i++)
             {
                 var r = await SaveWordAsync(UniqueWord($"zzfill{i}"), SrsLang, ct);
-                if (ShouldSkip(r)) return;
+                Assert.SkipWhen(IntegrationSkip.Unavailable(r), "endpoint unavailable (404/500)");
                 r.EnsureSuccessStatusCode();
                 var j = await r.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
                 if (j.GetProperty("outcome").GetString() == "srs")
@@ -139,7 +136,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
             }
 
             var resp = await SaveWordAsync(UniqueWord("zzcap"), SrsLang, ct);
-            if (ShouldSkip(resp)) return;
+            Assert.SkipWhen(IntegrationSkip.Unavailable(resp), "endpoint unavailable (404/500)");
 
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
             var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
@@ -158,7 +155,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task GetReviewQueue_ReflectsWeeklyBudgetSetting_AndClampsCards()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         // Floor the budget so we can assert the queue is clamped. Can't set to 0
@@ -167,7 +164,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
         try
         {
             var resp = await _auth.Client.SendAsync(_auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/review"), ct);
-            if (ShouldSkip(resp)) return;
+            Assert.SkipWhen(IntegrationSkip.Unavailable(resp), "endpoint unavailable (404/500)");
 
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
             var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
@@ -191,7 +188,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task PromoteLookup_BypassesDailyCap_CreatesSrsWord()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         // Floor the cap; then fill it so the very next SrsEligible save would be
@@ -207,7 +204,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
             for (var i = 0; i < MinDailyCap; i++)
             {
                 var r = await SaveWordAsync(UniqueWord($"zzfiller{i}"), SrsLang, ct);
-                if (ShouldSkip(r)) return;
+                Assert.SkipWhen(IntegrationSkip.Unavailable(r), "endpoint unavailable (404/500)");
                 r.EnsureSuccessStatusCode();
                 var j = await r.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
                 if (j.GetProperty("outcome").GetString() == "srs")
@@ -216,7 +213,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
 
             // Seed a rare word → WordLookup
             var saveResp = await SaveWordAsync(UniqueWord("zzrare"), "en", ct);
-            if (ShouldSkip(saveResp)) return;
+            Assert.SkipWhen(IntegrationSkip.Unavailable(saveResp), "endpoint unavailable (404/500)");
             saveResp.EnsureSuccessStatusCode();
             var saveBody = await saveResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
             Assert.Equal("lookup", saveBody.GetProperty("outcome").GetString());
@@ -242,7 +239,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task PromotePending_CreatesSrsWord()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         await SetSettingsAsync(dailyCap: MinDailyCap, weeklyBudget: 70, ct);
@@ -257,7 +254,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
             for (var i = 0; i < MinDailyCap; i++)
             {
                 var r = await SaveWordAsync(UniqueWord($"zzpfill{i}"), SrsLang, ct);
-                if (ShouldSkip(r)) return;
+                Assert.SkipWhen(IntegrationSkip.Unavailable(r), "endpoint unavailable (404/500)");
                 r.EnsureSuccessStatusCode();
                 var j = await r.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
                 if (j.GetProperty("outcome").GetString() == "srs")
@@ -265,7 +262,7 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
             }
 
             var saveResp = await SaveWordAsync(UniqueWord("zzpend"), SrsLang, ct);
-            if (ShouldSkip(saveResp)) return;
+            Assert.SkipWhen(IntegrationSkip.Unavailable(saveResp), "endpoint unavailable (404/500)");
             saveResp.EnsureSuccessStatusCode();
             var saveBody = await saveResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
             Assert.Equal("pending", saveBody.GetProperty("outcome").GetString());
@@ -304,11 +301,11 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task GetLookups_ReturnsListShape()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         var resp = await _auth.Client.SendAsync(_auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/lookups"), ct);
-        if (ShouldSkip(resp)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(resp), "endpoint unavailable (404/500)");
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
@@ -320,11 +317,11 @@ public class VocabularySpiralTests : IClassFixture<AuthenticatedApiFixture>
     [Fact]
     public async Task GetStats_IncludesLookupCount()
     {
-        if (!_auth.IsAuthenticated) return;
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
         var ct = TestContext.Current.CancellationToken;
 
         var resp = await _auth.Client.SendAsync(_auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/stats"), ct);
-        if (ShouldSkip(resp)) return;
+        Assert.SkipWhen(IntegrationSkip.Unavailable(resp), "endpoint unavailable (404/500)");
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);

--- a/tests/TextStack.UnitTests/SrsEngineTests.cs
+++ b/tests/TextStack.UnitTests/SrsEngineTests.cs
@@ -6,160 +6,36 @@ public class SrsEngineTests
 {
     private readonly ISrsEngine _srs = new SrsEngine();
 
-    // === Correct answers: stage progression ===
-
-    [Fact]
-    public void Calculate_Stage0_OneCorrect_AdvancesToStage1()
+    // Calculate(stage, consecutiveCorrect, currentInterval, isCorrect)
+    //   → (newStage, newInterval, newConsecutive)
+    [Theory]
+    // Correct → stage progression
+    [InlineData(0, 0, 0, true, 1, 1, 0)]    // New → Recognition (1 correct advances)
+    [InlineData(1, 0, 1, true, 1, 1, 1)]    // Recognition needs 2 → stays, consec++
+    [InlineData(1, 1, 1, true, 2, 3, 0)]    // 2nd correct → Recall
+    [InlineData(2, 1, 3, true, 3, 7, 0)]    // → Context
+    [InlineData(3, 1, 7, true, 4, 14, 0)]   // → Mastered
+    [InlineData(2, 0, 3, true, 2, 3, 1)]    // first correct in stage → consec++, stays
+    // Mastered → interval growth (×2, capped 60)
+    [InlineData(4, 0, 14, true, 4, 28, 1)]  // doubles
+    [InlineData(4, 0, 50, true, 4, 60, 1)]  // caps at 60
+    [InlineData(4, 0, 60, true, 4, 60, 1)]  // already at cap → stays
+    // Incorrect → demotion
+    [InlineData(0, 0, 0, false, 0, 0.5, 0)] // stays at 0, retry interval
+    [InlineData(1, 1, 1, false, 1, 0.5, 0)] // stays at 1
+    [InlineData(2, 1, 3, false, 1, 1, 0)]   // → Recognition
+    [InlineData(3, 0, 7, false, 2, 1, 0)]   // → Recall
+    [InlineData(4, 3, 28, false, 2, 1, 0)]  // Mastered drops to Recall, not Context
+    public void Calculate_ReturnsExpectedStageIntervalConsecutive(
+        int stage, int consecutive, double interval, bool isCorrect,
+        int expectedStage, double expectedInterval, int expectedConsecutive)
     {
-        var (stage, interval, consecutive) = _srs.Calculate(0, 0, 0, true);
+        var (newStage, newInterval, newConsecutive) = _srs.Calculate(stage, consecutive, interval, isCorrect);
 
-        Assert.Equal(1, stage);
-        Assert.Equal(1, interval);
-        Assert.Equal(0, consecutive);
+        Assert.Equal(expectedStage, newStage);
+        Assert.Equal(expectedInterval, newInterval);
+        Assert.Equal(expectedConsecutive, newConsecutive);
     }
-
-    [Fact]
-    public void Calculate_Stage1_OneCorrect_StaysAtStage1()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(1, 0, 1, true);
-
-        Assert.Equal(1, stage);
-        Assert.Equal(1, interval);
-        Assert.Equal(1, consecutive);
-    }
-
-    [Fact]
-    public void Calculate_Stage1_TwoCorrect_AdvancesToStage2()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(1, 1, 1, true);
-
-        Assert.Equal(2, stage);
-        Assert.Equal(3, interval);
-        Assert.Equal(0, consecutive);
-    }
-
-    [Fact]
-    public void Calculate_Stage2_TwoCorrect_AdvancesToStage3()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(2, 1, 3, true);
-
-        Assert.Equal(3, stage);
-        Assert.Equal(7, interval);
-        Assert.Equal(0, consecutive);
-    }
-
-    [Fact]
-    public void Calculate_Stage3_TwoCorrect_AdvancesToStage4()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(3, 1, 7, true);
-
-        Assert.Equal(4, stage);
-        Assert.Equal(14, interval);
-        Assert.Equal(0, consecutive);
-    }
-
-    // === Mastered stage: interval growth ===
-
-    [Fact]
-    public void Calculate_Stage4_Correct_DoublesInterval()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(4, 0, 14, true);
-
-        Assert.Equal(4, stage);
-        Assert.Equal(28, interval);
-        Assert.Equal(1, consecutive);
-    }
-
-    [Fact]
-    public void Calculate_Stage4_Correct_CapsAt60Days()
-    {
-        var (stage, interval, _) = _srs.Calculate(4, 0, 50, true);
-
-        Assert.Equal(4, stage);
-        Assert.Equal(60, interval);
-    }
-
-    [Fact]
-    public void Calculate_Stage4_Correct_AlreadyAtCap_StaysAt60()
-    {
-        var (stage, interval, _) = _srs.Calculate(4, 0, 60, true);
-
-        Assert.Equal(4, stage);
-        Assert.Equal(60, interval);
-    }
-
-    // === Incorrect answers: demotion ===
-
-    [Fact]
-    public void Calculate_Stage0_Incorrect_StaysAtStage0()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(0, 0, 0, false);
-
-        Assert.Equal(0, stage);
-        Assert.Equal(0.5, interval);
-        Assert.Equal(0, consecutive);
-    }
-
-    [Fact]
-    public void Calculate_Stage1_Incorrect_StaysAtStage1()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(1, 1, 1, false);
-
-        Assert.Equal(1, stage);
-        Assert.Equal(0.5, interval);
-        Assert.Equal(0, consecutive);
-    }
-
-    [Fact]
-    public void Calculate_Stage2_Incorrect_DemotesToStage1()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(2, 1, 3, false);
-
-        Assert.Equal(1, stage);
-        Assert.Equal(1, interval);
-        Assert.Equal(0, consecutive);
-    }
-
-    [Fact]
-    public void Calculate_Stage3_Incorrect_DemotesToStage2()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(3, 0, 7, false);
-
-        Assert.Equal(2, stage);
-        Assert.Equal(1, interval);
-        Assert.Equal(0, consecutive);
-    }
-
-    [Fact]
-    public void Calculate_Stage4_Incorrect_DemotesToStage2()
-    {
-        var (stage, interval, consecutive) = _srs.Calculate(4, 3, 28, false);
-
-        Assert.Equal(2, stage);
-        Assert.Equal(1, interval);
-        Assert.Equal(0, consecutive);
-    }
-
-    // === ConsecutiveCorrect tracking ===
-
-    [Fact]
-    public void Calculate_Stage2_FirstCorrect_IncrementsConsecutive()
-    {
-        var (stage, _, consecutive) = _srs.Calculate(2, 0, 3, true);
-
-        Assert.Equal(2, stage);
-        Assert.Equal(1, consecutive);
-    }
-
-    [Fact]
-    public void Calculate_Stage0_Correct_ResetsConsecutiveOnAdvance()
-    {
-        var (_, _, consecutive) = _srs.Calculate(0, 0, 0, true);
-
-        Assert.Equal(0, consecutive);
-    }
-
-    // === GetReviewMode ===
 
     [Theory]
     [InlineData(0, false, "multiple_choice")]
@@ -169,66 +45,25 @@ public class SrsEngineTests
     [InlineData(2, false, "multiple_choice")]
     [InlineData(2, true, "multiple_choice")]
     [InlineData(3, false, "multiple_choice")]
+    [InlineData(3, true, "context")]              // Context stage with a sentence
     [InlineData(4, false, "multiple_choice")]
+    [InlineData(4, true, "context")]              // Mastered with a sentence
+    [InlineData(99, false, "multiple_choice")]    // invalid stage → default
     public void GetReviewMode_ReturnsExpected(int stage, bool hasSentence, string expected)
     {
         Assert.Equal(expected, _srs.GetReviewMode(stage, hasSentence));
     }
 
-    [Fact]
-    public void GetReviewMode_Stage3_WithSentence_ReturnsContext()
+    // F4 anti-spiral: retire only Mastered (stage 4) with ≥3 consecutive correct
+    // AND interval ≥ 14 days.
+    [Theory]
+    [InlineData(4, 3, 14, true)]    // boundary: interval == 14 retires
+    [InlineData(4, 5, 60, true)]
+    [InlineData(3, 10, 60, false)]  // not Mastered
+    [InlineData(4, 2, 60, false)]   // only 2 consecutive
+    [InlineData(4, 5, 13, false)]   // interval below 14
+    public void ShouldAutoRetire_ReturnsExpected(int stage, int consecutiveCorrect, double intervalDays, bool expected)
     {
-        Assert.Equal("context", _srs.GetReviewMode(3, true));
-    }
-
-    [Fact]
-    public void GetReviewMode_Stage4_WithSentence_ReturnsContext()
-    {
-        Assert.Equal("context", _srs.GetReviewMode(4, true));
-    }
-
-    [Fact]
-    public void GetReviewMode_InvalidStage_ReturnsMultipleChoice()
-    {
-        Assert.Equal("multiple_choice", _srs.GetReviewMode(99, false));
-    }
-
-    // === ShouldAutoRetire (F4 anti-spiral) ===
-
-    [Fact]
-    public void ShouldAutoRetire_Mastered_3Correct_14Day_True()
-    {
-        Assert.True(_srs.ShouldAutoRetire(stage: 4, consecutiveCorrect: 3, intervalDays: 14));
-    }
-
-    [Fact]
-    public void ShouldAutoRetire_Mastered_3Correct_LongerInterval_True()
-    {
-        Assert.True(_srs.ShouldAutoRetire(stage: 4, consecutiveCorrect: 5, intervalDays: 60));
-    }
-
-    [Fact]
-    public void ShouldAutoRetire_NotMastered_False()
-    {
-        Assert.False(_srs.ShouldAutoRetire(stage: 3, consecutiveCorrect: 10, intervalDays: 60));
-    }
-
-    [Fact]
-    public void ShouldAutoRetire_Mastered_OnlyTwoCorrect_False()
-    {
-        Assert.False(_srs.ShouldAutoRetire(stage: 4, consecutiveCorrect: 2, intervalDays: 60));
-    }
-
-    [Fact]
-    public void ShouldAutoRetire_Mastered_IntervalBelow14_False()
-    {
-        Assert.False(_srs.ShouldAutoRetire(stage: 4, consecutiveCorrect: 5, intervalDays: 13));
-    }
-
-    [Fact]
-    public void ShouldAutoRetire_Mastered_IntervalExactly14_True()
-    {
-        // Boundary: interval == 14 is the promotion threshold (>= 14 per plan).
-        Assert.True(_srs.ShouldAutoRetire(stage: 4, consecutiveCorrect: 3, intervalDays: 14.0));
+        Assert.Equal(expected, _srs.ShouldAutoRetire(stage, consecutiveCorrect, intervalDays));
     }
 }


### PR DESCRIPTION
## Why
Phase 2 of the test triage (#251 did the deletions). This is the SIMPLIFY pass — reduce repetition + kill false-confidence silent skips, on the **kept** core tests.

## Changes
**1. `SrsEngineTests` → table-driven**
~22 sequential `[Fact]` cases (stage progression / interval growth / demotion / consecutive / auto-retire) collapsed into **3 `[Theory]`** (`Calculate`, `GetReviewMode`, `ShouldAutoRetire`). Same coverage (30 cases), −250 LOC of repetition. Verified locally: 30 pass.

**2. Integration silent-skip fix (the #1 quality finding)**
- 5 duplicated `private static bool ShouldSkip(...)` → one shared `IntegrationSkip.Unavailable(resp)`.
- ~50 silent `if (...) return;` guards → `Assert.SkipWhen(...)` / `Assert.SkipUnless(...)`.
- **Effect:** an unreachable endpoint (404/500) or disabled test-auth now reports as **SKIPPED** instead of a green pass with zero assertions. In healthy CI nothing changes (conditions false → tests run + assert as before).

## Deliberately NOT done (senior-dev judgment)
- `TextProcessingTests` / `DistractorGeneratorTests` consolidation: each `[Fact]` asserts a **distinct rule via a distinct API** (instance vs static, contains/absent/null/dedupe/lowercase…). A `[Theory]` would add indirection without reducing real complexity — that's churn, not simplification.
- Shared `SaveWordAsync`/`CreateRequest` fixture helpers: low-value, deferred.

## Verification
Unit suite green (96). IntegrationTests compiles clean (live-server tests run in CI docker job). Build clean.

## Rollback
Revert the commit. Pure test-only change, no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)