### PR TITLE
fix(mobile): word save failed — send nativeLanguage; drop redundant + button

### DIFF
--- a/apps/mobile/src/components/SelectionActionBar.tsx
+++ b/apps/mobile/src/components/SelectionActionBar.tsx
@@ -222,21 +222,13 @@ export function SelectionActionBar({
                 <Ionicons name="checkmark-done" size={20} color="#22c55e" />
               </TouchableOpacity>
             )}
-            {!stage && (
-              <TouchableOpacity
-                style={[styles.btn, wordSaved && { opacity: 0.5 }]}
-                onPress={onSaveWord}
-                disabled={wordSaved}
-                accessibilityRole="button"
-                accessibilityLabel={wordSaved ? 'Word saved' : 'Save word to vocabulary'}
-                accessibilityState={{ disabled: !!wordSaved }}
-              >
-                <Ionicons
-                  name={wordSaved ? 'checkmark-circle' : 'add-circle-outline'}
-                  size={20}
-                  color={wordSaved ? colors.success : colors.text}
-                />
-              </TouchableOpacity>
+            {/* No manual save button — single-word tap auto-saves to vocab
+                (PWA parity). Once the save lands we show a non-interactive
+                ✓ indicator; the stage badge above takes over on next open. */}
+            {!stage && wordSaved && (
+              <View style={styles.btn} accessibilityLabel="Saved to vocabulary">
+                <Ionicons name="checkmark-circle" size={20} color={colors.success} />
+              </View>
             )}
           </>
         )}

--- a/apps/mobile/src/hooks/useReaderVocabActions.ts
+++ b/apps/mobile/src/hooks/useReaderVocabActions.ts
@@ -122,6 +122,7 @@ export function useReaderVocabActions({
       const resp = await vocabularyApi.saveWord({
         word: selection.text,
         language,
+        nativeLanguage,
         sentence: selection.sentence || null,
         bookTitle: bookTitleRef.current || null,
         ...bookFields(),
@@ -220,6 +221,7 @@ export function useReaderVocabActions({
       const resp = await vocabularyApi.saveWord({
         word: selection.text,
         language,
+        nativeLanguage,
         sentence: selection.sentence || null,
         bookTitle: bookTitleRef.current || null,
         ...bookFields(),

--- a/packages/shared/src/api/vocabulary.ts
+++ b/packages/shared/src/api/vocabulary.ts
@@ -19,6 +19,9 @@ export function saveWord(data: {
   editionId?: string | null
   chapterId?: string | null
   userBookId?: string | null
+  // Required by the backend (native_language_required → 400). Web's local
+  // client already sends it; shared/mobile must too or every save fails.
+  nativeLanguage?: string | null
 }) {
   return authFetch<SaveWordResponseDto>('/me/vocabulary/words', jsonBody('POST', data))
 }


### PR DESCRIPTION
## Symptom
Reader word save on mobile fails with **"Could not save word. Try again."** (red toast), even though the inline translation shows. No underline, nothing added to vocab. (vc11/vc12 on device.)

## Root cause (architect)
Backend hard-requires `nativeLanguage` on save (`native_language_required → 400`). The **shared** `vocabularyApi.saveWord` type — mobile's only client — **omitted the field**, so mobile never sent it → every save 400'd. Web works because it has its *own* `apps/web/src/api/vocabulary.ts` that already includes `nativeLanguage`. Classic duplicated-client drift (flagged in the `/init` pass).

## Fix (developer)
- **shared** `packages/shared/src/api/vocabulary.ts`: add `nativeLanguage?: string | null` to the `saveWord` request type.
- **mobile** `useReaderVocabActions.ts`: pass `nativeLanguage` (from `NativeLanguageContext`, default `'en'`) in both `saveWord` + `autoSaveWord` bodies. Covers edition reader + user-book reader (same hook).
- **mobile** `SelectionActionBar.tsx`: remove the manual **`+`** save button — tapping a word already auto-saves (PWA parity: web's `WordPopup` has no manual save, only a saved indicator). Replaced with a non-interactive ✓ shown once the save lands.

## Why the "+" was redundant
Single-word tap fires auto-save (`autoSaveWord`). The `+` duplicated that and, while save was broken, looked like the only (failing) way to save. PWA = auto-save + saved-status indicator, no button. Now matched.

## Verification (tester)
- `tsc --noEmit` clean: mobile ✅, web ✅.
- Backend already validated (`native_language_required`); integration tests send `nativeLanguage` so they were green but couldn't catch the *client* omission — a client-contract gap noted for later, not worth a trivial wrapper test.

## Ship notes
- Web/shared change ships via normal frontend deploy.
- **Mobile needs a new EAS build** (next vc) to reach the device — the device fix is in RN code, not OTA-config.

## Rollback
Revert the commit. Additive shared field + mobile-only UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)