### PR TITLE
fix(mobile): faster word translation + reliable vocab auto-save

### DIFF
--- a/apps/mobile/src/components/SelectionActionBar.tsx
+++ b/apps/mobile/src/components/SelectionActionBar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native'
 import * as Clipboard from 'expo-clipboard'
 import { Ionicons } from '@expo/vector-icons'
-import { translationApi } from '@textstack/shared'
+import { cachedTranslate, peekTranslation } from '../lib/translateCache'
 import { useTheme } from '../context/ThemeContext'
 import { useTargetLanguage } from '../hooks/useTargetLanguage'
 import { fonts } from '../theme/typography'
@@ -98,20 +98,20 @@ export function SelectionActionBar({
       setTranslating(false)
       return
     }
+    // Instant render on a cache hit (re-tap of a seen word) — no spinner.
+    const cached = peekTranslation(selectedText, fromLang, toLang)
+    if (cached !== undefined) {
+      setTranslation(cached)
+      setTranslating(false)
+      return
+    }
     let cancelled = false
     setTranslation('')
     setTranslating(true)
-    translationApi.translate(selectedText, fromLang, toLang)
-      .then((res: { translatedText?: string; translation?: string }) => {
-        if (cancelled) return
-        setTranslation(res.translatedText || res.translation || '')
-      })
-      .catch(() => {
-        if (!cancelled) setTranslation('')
-      })
-      .finally(() => {
-        if (!cancelled) setTranslating(false)
-      })
+    cachedTranslate(selectedText, fromLang, toLang)
+      .then((t) => { if (!cancelled) setTranslation(t) })
+      .catch(() => { if (!cancelled) setTranslation('') })
+      .finally(() => { if (!cancelled) setTranslating(false) })
     return () => { cancelled = true }
   }, [selectedText, isMultiWord, fromLang, toLang, isSameLang])
 

--- a/apps/mobile/src/hooks/useReaderVocabActions.ts
+++ b/apps/mobile/src/hooks/useReaderVocabActions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, MutableRefObject } from 'react'
-import { vocabularyApi, translationApi, t } from '@textstack/shared'
+import { vocabularyApi, t } from '@textstack/shared'
+import { cachedTranslate } from '../lib/translateCache'
 import type { Chapter, VocabularyWordDto, Language } from '@textstack/shared'
 import { trackVocabSaved, trackTranslationUsed } from '../lib/analytics'
 import type { VocabMap } from './useReaderVocabMap'
@@ -42,6 +43,24 @@ type Options = {
  * screen — it shares state plumbing with selection lifecycle that's hard
  * to lift cleanly. This hook covers the four user-initiated handlers.
  */
+const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
+
+/** Save with up to 3 attempts + backoff. Absorbs transient network/5xx blips
+ *  that previously dropped a tapped word silently (no underline, no retry).
+ *  Deterministic 4xx just exhausts the 3 attempts quickly, then rethrows. */
+async function saveWordWithRetry(body: Parameters<typeof vocabularyApi.saveWord>[0]) {
+  let lastErr: unknown
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      return await vocabularyApi.saveWord(body)
+    } catch (e) {
+      lastErr = e
+      if (attempt < 2) await delay(350 * (attempt + 1))
+    }
+  }
+  throw lastErr
+}
+
 export function useReaderVocabActions({
   vocabMapRef,
   bookTitleRef,
@@ -87,11 +106,13 @@ export function useReaderVocabActions({
 
     const targetLang = nativeLanguage !== language ? nativeLanguage : 'en'
     trackTranslationUsed({ fromLang: language, toLang: targetLang, kind: 'word' })
-    translationApi.translate(sourceText, language, targetLang)
-      .then(res => {
-        if (res.translatedText && saved.id) {
-          vocabularyApi.updateWord(saved.id, { translation: res.translatedText }).catch(() => {})
-          vocabMapRef.current[key] = { ...vocabMapRef.current[key], translation: res.translatedText }
+    // cachedTranslate (not translationApi) so this reuses the gloss the
+    // selection toolbar just fetched for the same word — no 2nd round-trip.
+    cachedTranslate(sourceText, language, targetLang)
+      .then(translation => {
+        if (translation && saved.id) {
+          vocabularyApi.updateWord(saved.id, { translation }).catch(() => {})
+          vocabMapRef.current[key] = { ...vocabMapRef.current[key], translation }
           // Push full map so the inline-translation span renders above the underline.
           // addVocabWord alone only carries {stage}, wiping any prior translation.
           injectJs(`markVocabWords(${JSON.stringify(vocabMapRef.current)})`)
@@ -119,7 +140,7 @@ export function useReaderVocabActions({
     if (savingRef.current.has(keyLc)) return
     savingRef.current.add(keyLc)
     try {
-      const resp = await vocabularyApi.saveWord({
+      const resp = await saveWordWithRetry({
         word: selection.text,
         language,
         nativeLanguage,
@@ -218,7 +239,7 @@ export function useReaderVocabActions({
     if (autoSavedRef.current.has(keyLc)) return
     autoSavedRef.current.add(keyLc)
     try {
-      const resp = await vocabularyApi.saveWord({
+      const resp = await saveWordWithRetry({
         word: selection.text,
         language,
         nativeLanguage,

--- a/apps/mobile/src/hooks/useReaderVocabMap.ts
+++ b/apps/mobile/src/hooks/useReaderVocabMap.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { vocabularyApi, translationApi } from '@textstack/shared'
+import { vocabularyApi } from '@textstack/shared'
 import { vocabMapCache } from '../lib/readerOfflineCache'
+import { cachedTranslate } from '../lib/translateCache'
 
 export type VocabMapEntry = { stage: number; id: string; translation?: string }
 export type VocabMap = Record<string, VocabMapEntry>
@@ -112,20 +113,22 @@ export function useReaderVocabMap({
       for (const { key, id } of missing) {
         if (cancelled) return
         try {
-          const res = await translationApi.translate(key, bookLanguage, nativeLanguage)
-          const translation = res.translatedText
+          // cachedTranslate de-dupes against the toolbar/save path and
+          // memoizes, so re-opening the chapter is free.
+          const translation = await cachedTranslate(key, bookLanguage, nativeLanguage)
           if (!translation) continue
           vocabMapRef.current[key] = { ...vocabMapRef.current[key], translation }
           // Persist server-side so re-opens skip the round-trip.
           vocabularyApi.updateWord(id, { translation }).catch(() => {})
+          // Progressive paint: each gloss appears the moment its word
+          // resolves, instead of all-at-once after the whole loop (which on
+          // a page of N missing words felt like "glosses never show"). The
+          // 100ms-debounced paint effect coalesces bursts.
+          if (!cancelled) bumpVocab()
         } catch {
           // Skip a single word's failure — keep going.
         }
       }
-      if (cancelled) return
-      // Single re-paint at the end coalesces N translation results into
-      // one markVocabWords injection (vs flickering per-word).
-      bumpVocab()
     })()
     return () => { cancelled = true }
   }, [isAuthenticated, chapterId, bookLanguage, nativeLanguage, vocabVersion, bumpVocab])

--- a/apps/mobile/src/lib/translateCache.ts
+++ b/apps/mobile/src/lib/translateCache.ts
@@ -1,0 +1,32 @@
+import { translationApi } from '@textstack/shared'
+
+// In-memory translation cache shared by the reader's selection toolbar and the
+// vocab auto-save path. Two wins:
+//   1. Re-tapping a word is instant (no network round-trip).
+//   2. De-dupes the double translate per tap — the toolbar fetches the gloss,
+//      then auto-save reuses the same cached result instead of a 2nd call.
+// Session-scoped (cleared on app restart); the backend file cache covers
+// cross-session reuse.
+const cache = new Map<string, string>()
+
+const keyOf = (text: string, from: string, to: string) =>
+  `${from}|${to}|${text.trim().toLowerCase()}`
+
+/** Synchronous peek — lets the toolbar render instantly on a cache hit
+ *  (no spinner) instead of awaiting a resolved promise. */
+export function peekTranslation(text: string, from: string, to: string): string | undefined {
+  return cache.get(keyOf(text, from, to))
+}
+
+/** Cached translate. On miss, hits the API once and memoizes a non-empty
+ *  result. Concurrent callers for the same key each fetch, but the backend
+ *  file cache absorbs that — the win here is re-taps + cross-call de-dupe. */
+export async function cachedTranslate(text: string, from: string, to: string): Promise<string> {
+  const k = keyOf(text, from, to)
+  const hit = cache.get(k)
+  if (hit !== undefined) return hit
+  const res = await translationApi.translate(text, from, to) as { translatedText?: string; translation?: string }
+  const t = res.translatedText || res.translation || ''
+  if (t) cache.set(k, t)
+  return t
+}


### PR DESCRIPTION
## Symptoms (vc12, on device)
1. **Translation too slow** on tap.
2. **Not all tapped words save** (no underline).
3. **Gray inline gloss missing** on some saved words.

## Root cause
- Each tap did a **live OpenAI translate** with **no client cache** → re-taps re-hit the network. Worse, each tap fired **two** translates: the toolbar gloss + a separate save-side translate (`onWordSaved`). Backend file-cache made the 2nd a hit, but it's still two round-trips.
- `autoSaveWord` **swallowed transient failures silently** (network/5xx) with no retry → a tapped word vanished with no underline and no feedback. Dedup cleared only on selection close.
- The gray inline gloss is the per-word *stored* translation, set asynchronously after save by that same flaky translate call — so it inherits the flakiness.

## Fix (cache + dedupe + retry; gpt-5-mini kept)
- **`translateCache.ts`** (new): shared in-memory cache. `peekTranslation` lets the toolbar render **instantly** on a re-tap (no spinner); `cachedTranslate` memoizes.
- **SelectionActionBar**: toolbar gloss goes through the cache.
- **useReaderVocabActions**: `onWordSaved` uses `cachedTranslate` → **reuses the toolbar's result** (no 2nd round-trip). Save POST wrapped in **`saveWordWithRetry`** (3 attempts + backoff) so transient blips no longer drop a word; deterministic 4xx exhausts quickly then gives up silently (PWA-style).

## Not included (follow-up)
Old words saved *before* translation worked (or where it returned empty) have no stored gloss and there's **no mobile backfill** (web has one). This PR makes *new* saves reliable; retroactively glossing old words is a separate change — flag if you want it.

## Verification
`tsc --noEmit` mobile: clean ✅. Needs a new EAS build (next vc) to reach the device.

## Rollback
Revert the commit. Mobile-only, additive cache + retry wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)