### PR TITLE
feat(reader): peek on tap, explicit manual save, frequency hint

### DIFF
--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -437,12 +437,9 @@ export default function UserBookReaderScreen() {
         const mode: 'tap' | 'drag' = data.mode === 'tap' ? 'tap' : 'drag'
         const nextId = openSelection(data.text ? { ...data, mode } : null)
         if (nextId !== null && !data.text.includes(' ')) {
-          // Auto-TTS + auto-save on single-word tap, mirrors public reader.
+          // Single-word tap = "peek": auto-TTS + translation only. Saving is an
+          // explicit tap now (no auto-save), mirrors public reader.
           toggleTts(data.text, { rate: settings.ttsSpeed, lang: language })
-          void vocabActions.autoSaveWord(
-            { text: data.text, sentence: data.sentence || '', anchor: data.anchor || null, selectionId: nextId },
-            autoSavedRef,
-          )
         }
       }
     } catch (err) {
@@ -458,6 +455,11 @@ export default function UserBookReaderScreen() {
   const handleMarkKnown = () => {
     if (!selection) return
     void vocabActions.markKnown(selection)
+  }
+
+  const handleRemoveWord = () => {
+    if (!selection) return
+    void vocabActions.removeWord(selection)
   }
 
   const handleHighlight = async (color: string) => {
@@ -627,6 +629,7 @@ export default function UserBookReaderScreen() {
             onHighlight={handleHighlight}
             highlightColor={settings.lastHighlightColor}
             onMarkKnown={handleMarkKnown}
+            onRemove={handleRemoveWord}
             isSpeaking={isSpeaking}
             wordSaved={wordSaved}
             vocabStage={selection ? (vocabMapRef.current[selection.text.toLowerCase()]?.stage ?? null) : null}

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -301,13 +301,11 @@ export default function ReaderScreen() {
         // Default to 'drag' for any legacy payload that doesn't include mode.
         const mode: 'tap' | 'drag' = data.mode === 'tap' ? 'tap' : 'drag'
         const nextId = openSelection(data.text ? { ...data, mode } : null)
-        // Single word: auto-TTS + auto-save to vocabulary (matches web behavior)
+        // Single-word tap = "peek": auto-TTS + show translation only. Saving is
+        // now an explicit tap on the Save button (no auto-save) so a word looked
+        // up by accident isn't added to vocabulary.
         if (nextId !== null && !data.text.includes(' ')) {
           toggleTts(data.text, { rate: settings.ttsSpeed, lang: language })
-          vocabActions.autoSaveWord(
-            { text: data.text, sentence: data.sentence || '', anchor: data.anchor || null, selectionId: nextId },
-            autoSavedRef,
-          )
         }
       }
     } catch (err) {
@@ -640,6 +638,7 @@ export default function ReaderScreen() {
             onHighlight={handleHighlight}
             highlightColor={settings.lastHighlightColor}
             onMarkKnown={handleMarkKnown}
+            onRemove={handleRemoveWord}
             isSpeaking={isSpeaking}
             wordSaved={wordSaved}
             vocabStage={vocabMapRef.current[selection.text.toLowerCase()]?.stage ?? null}

--- a/apps/mobile/src/components/SelectionActionBar.tsx
+++ b/apps/mobile/src/components/SelectionActionBar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native'
 import * as Clipboard from 'expo-clipboard'
 import { Ionicons } from '@expo/vector-icons'
-import { cachedTranslate, peekTranslation } from '../lib/translateCache'
+import { cachedTranslate, peekTranslation, type SaveCategory } from '../lib/translateCache'
 import { useTheme } from '../context/ThemeContext'
 import { useTargetLanguage } from '../hooks/useTargetLanguage'
 import { fonts } from '../theme/typography'
@@ -39,6 +39,8 @@ interface SelectionActionBarProps {
    *  fill. Tapping commits this color; change via HighlightNoteModal after. */
   highlightColor?: HighlightColorKey
   onMarkKnown?: () => void
+  /** Remove the word from vocabulary — lets the user undo an accidental save. */
+  onRemove?: () => void
   isSpeaking?: boolean
   wordSaved?: boolean
   vocabStage?: number | null
@@ -76,6 +78,7 @@ export function SelectionActionBar({
   onHighlight,
   highlightColor = 'yellow',
   onMarkKnown,
+  onRemove,
   isSpeaking,
   wordSaved,
   vocabStage,
@@ -92,24 +95,29 @@ export function SelectionActionBar({
   // user re-taps mid-fetch.
   const [translation, setTranslation] = useState('')
   const [translating, setTranslating] = useState(false)
+  // Backend frequency hint for the tapped word — drives Save-button emphasis.
+  const [category, setCategory] = useState<SaveCategory | undefined>(undefined)
   useEffect(() => {
     if (isMultiWord || !selectedText || isSameLang) {
       setTranslation('')
       setTranslating(false)
+      setCategory(undefined)
       return
     }
     // Instant render on a cache hit (re-tap of a seen word) — no spinner.
     const cached = peekTranslation(selectedText, fromLang, toLang)
     if (cached !== undefined) {
-      setTranslation(cached)
+      setTranslation(cached.translation)
+      setCategory(cached.category)
       setTranslating(false)
       return
     }
     let cancelled = false
     setTranslation('')
+    setCategory(undefined)
     setTranslating(true)
     cachedTranslate(selectedText, fromLang, toLang)
-      .then((t) => { if (!cancelled) setTranslation(t) })
+      .then((r) => { if (!cancelled) { setTranslation(r.translation); setCategory(r.category) } })
       .catch(() => { if (!cancelled) setTranslation('') })
       .finally(() => { if (!cancelled) setTranslating(false) })
     return () => { cancelled = true }
@@ -222,13 +230,40 @@ export function SelectionActionBar({
                 <Ionicons name="checkmark-done" size={20} color="#22c55e" />
               </TouchableOpacity>
             )}
-            {/* No manual save button — single-word tap auto-saves to vocab
-                (PWA parity). Once the save lands we show a non-interactive
-                ✓ indicator; the stage badge above takes over on next open. */}
+            {/* Transient ✓ right after a save lands (before the stage badge
+                takes over on next render). */}
             {!stage && wordSaved && (
               <View style={styles.btn} accessibilityLabel="Saved to vocabulary">
                 <Ionicons name="checkmark-circle" size={20} color={colors.success} />
               </View>
+            )}
+            {/* Manual save — tap = look, this commits. Tint is a frequency
+                RECOMMENDATION (learnable/rare = accent, common = muted), never
+                a gate: any word can still be saved. */}
+            {!stage && !wordSaved && onSaveWord && (
+              <TouchableOpacity
+                style={styles.btn}
+                onPress={onSaveWord}
+                accessibilityRole="button"
+                accessibilityLabel={category === 'rare' ? 'Save word to vocabulary (rare word)' : 'Save word to vocabulary'}
+              >
+                <Ionicons
+                  name="add-circle"
+                  size={24}
+                  color={category === 'common' ? colors.textSecondary : (category ? colors.success : colors.text)}
+                />
+              </TouchableOpacity>
+            )}
+            {/* Remove — undo an accidental save. */}
+            {(stage || wordSaved) && onRemove && (
+              <TouchableOpacity
+                style={styles.btn}
+                onPress={onRemove}
+                accessibilityRole="button"
+                accessibilityLabel="Remove word from vocabulary"
+              >
+                <Ionicons name="trash-outline" size={20} color={colors.textSecondary} />
+              </TouchableOpacity>
             )}
           </>
         )}

--- a/apps/mobile/src/hooks/useReaderVocabActions.ts
+++ b/apps/mobile/src/hooks/useReaderVocabActions.ts
@@ -170,11 +170,10 @@ export function useReaderVocabActions({
       const saved = resp.word
       if (!saved) return
       onWordSaved(saved, selection.text)
-      // Dismiss the selection toolbar after a successful save — matches
-      // markKnown / removeWord, and mirrors web's behavior (PWA closes the
-      // word popup after save). Previously left the toolbar visible with
-      // wordSaved=true, which read as "stuck".
-      setSelection(null)
+      // Keep the toolbar OPEN after a manual save: in the peek-on-tap model the
+      // save is explicit, so the user should see the saved state (stage badge)
+      // and be able to immediately undo an accidental save via Remove. The ✕
+      // closes it. (Auto-close made the new Remove affordance unreachable.)
     } catch (e) {
       console.warn('Save word failed:', e)
       showToast({ message: 'Could not save word. Try again.', variant: 'error' })

--- a/apps/mobile/src/hooks/useReaderVocabActions.ts
+++ b/apps/mobile/src/hooks/useReaderVocabActions.ts
@@ -109,7 +109,7 @@ export function useReaderVocabActions({
     // cachedTranslate (not translationApi) so this reuses the gloss the
     // selection toolbar just fetched for the same word — no 2nd round-trip.
     cachedTranslate(sourceText, language, targetLang)
-      .then(translation => {
+      .then(({ translation }) => {
         if (translation && saved.id) {
           vocabularyApi.updateWord(saved.id, { translation }).catch(() => {})
           vocabMapRef.current[key] = { ...vocabMapRef.current[key], translation }

--- a/apps/mobile/src/hooks/useReaderVocabMap.ts
+++ b/apps/mobile/src/hooks/useReaderVocabMap.ts
@@ -115,7 +115,7 @@ export function useReaderVocabMap({
         try {
           // cachedTranslate de-dupes against the toolbar/save path and
           // memoizes, so re-opening the chapter is free.
-          const translation = await cachedTranslate(key, bookLanguage, nativeLanguage)
+          const { translation } = await cachedTranslate(key, bookLanguage, nativeLanguage)
           if (!translation) continue
           vocabMapRef.current[key] = { ...vocabMapRef.current[key], translation }
           // Persist server-side so re-opens skip the round-trip.

--- a/apps/mobile/src/lib/translateCache.ts
+++ b/apps/mobile/src/lib/translateCache.ts
@@ -1,32 +1,32 @@
 import { translationApi } from '@textstack/shared'
 
-// In-memory translation cache shared by the reader's selection toolbar and the
-// vocab auto-save path. Two wins:
+export type SaveCategory = 'common' | 'learnable' | 'rare'
+export type CachedTranslation = { translation: string; category?: SaveCategory }
+
+// In-memory translation cache shared by the reader's selection toolbar, the
+// vocab save path, and the gloss backfill. Wins:
 //   1. Re-tapping a word is instant (no network round-trip).
-//   2. De-dupes the double translate per tap — the toolbar fetches the gloss,
-//      then auto-save reuses the same cached result instead of a 2nd call.
-// Session-scoped (cleared on app restart); the backend file cache covers
-// cross-session reuse.
-const cache = new Map<string, string>()
+//   2. De-dupes the double translate per tap.
+//   3. Carries the backend's single-word frequency "category" so the toolbar
+//      can recommend (not gate) saving.
+// Session-scoped; the backend file cache covers cross-session reuse.
+const cache = new Map<string, CachedTranslation>()
 
 const keyOf = (text: string, from: string, to: string) =>
   `${from}|${to}|${text.trim().toLowerCase()}`
 
-/** Synchronous peek — lets the toolbar render instantly on a cache hit
- *  (no spinner) instead of awaiting a resolved promise. */
-export function peekTranslation(text: string, from: string, to: string): string | undefined {
+/** Synchronous peek — lets the toolbar render instantly on a cache hit. */
+export function peekTranslation(text: string, from: string, to: string): CachedTranslation | undefined {
   return cache.get(keyOf(text, from, to))
 }
 
-/** Cached translate. On miss, hits the API once and memoizes a non-empty
- *  result. Concurrent callers for the same key each fetch, but the backend
- *  file cache absorbs that — the win here is re-taps + cross-call de-dupe. */
-export async function cachedTranslate(text: string, from: string, to: string): Promise<string> {
+/** Cached translate. On miss, hits the API once and memoizes a non-empty result. */
+export async function cachedTranslate(text: string, from: string, to: string): Promise<CachedTranslation> {
   const k = keyOf(text, from, to)
   const hit = cache.get(k)
   if (hit !== undefined) return hit
-  const res = await translationApi.translate(text, from, to) as { translatedText?: string; translation?: string }
-  const t = res.translatedText || res.translation || ''
-  if (t) cache.set(k, t)
-  return t
+  const res = await translationApi.translate(text, from, to) as { translatedText?: string; translation?: string; category?: SaveCategory }
+  const out: CachedTranslation = { translation: res.translatedText || res.translation || '', category: res.category }
+  if (out.translation) cache.set(k, out)
+  return out
 }

--- a/backend/src/Api/Endpoints/TranslationEndpoints.cs
+++ b/backend/src/Api/Endpoints/TranslationEndpoints.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Application.Common.Interfaces;
+using Application.Vocabulary;
 using Domain.LLM;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -26,6 +27,7 @@ public static class TranslationEndpoints
         IConfiguration config,
         ILlmServiceFactory llmFactory,
         IAppDbContext db,
+        IFrequencyFilter freqFilter,
         ILogger<Program> logger,
         CancellationToken ct)
     {
@@ -54,6 +56,31 @@ public static class TranslationEndpoints
 
         var srcLang = request.SourceLang.Split('-')[0];
         var tgtLang = request.TargetLang.Split('-')[0];
+
+        // Peek-time "save recommendation" hint for the reader toolbar: classify a
+        // single word by frequency so the client can emphasize Save for words worth
+        // learning and de-emphasize ones the reader already knows. Dataset is
+        // en-only, so only hint for English source; null = no recommendation.
+        // This does NOT gate saving — manual save always commits.
+        string? category = null;
+        var trimmedText = request.Text.Trim();
+        if (srcLang == "en" && trimmedText.Length > 0 && !trimmedText.Contains(' '))
+        {
+            try
+            {
+                var cls = await freqFilter.ClassifyAsync(trimmedText.ToLowerInvariant(), srcLang, 0, ct);
+                category = cls.Kind switch
+                {
+                    FrequencyClassKind.SrsEligible => "common",      // top ~5k — likely known
+                    FrequencyClassKind.RequiresRetap => "learnable", // mid-tier — worth learning
+                    _ => "rare",                                     // rare / OOV / proper noun
+                };
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Translate frequency-classify failed; no save hint");
+            }
+        }
 
         // Resolve genre from request → Editions (catalog book) → UserBooks (user
         // upload). Mirrors ExplainEndpoints. Fail-soft: a lookup error logs and
@@ -96,7 +123,9 @@ public static class TranslationEndpoints
                     var cached = await File.ReadAllTextAsync(cacheFile, ct);
                     var cachedResp = JsonSerializer.Deserialize<TranslateResponse>(cached);
                     if (cachedResp != null && !string.IsNullOrWhiteSpace(cachedResp.TranslatedText))
-                        return Results.Ok(cachedResp);
+                        // Re-attach a fresh category — it's word-only (cache key
+                        // also varies by sentence/genre, so don't trust the stored one).
+                        return Results.Ok(cachedResp with { Category = category });
                 }
             }
         }
@@ -119,7 +148,7 @@ public static class TranslationEndpoints
             if (string.IsNullOrWhiteSpace(translated))
                 return Results.Problem("Translation returned empty result", statusCode: 502);
 
-            var resp = new TranslateResponse(translated, request.SourceLang, request.TargetLang);
+            var resp = new TranslateResponse(translated, request.SourceLang, request.TargetLang, category);
 
             try
             {
@@ -240,7 +269,10 @@ public record TranslateRequest(
 public record TranslateResponse(
     string TranslatedText,
     string SourceLang,
-    string TargetLang
+    string TargetLang,
+    // Frequency "save recommendation" for a single word: "common" | "learnable" |
+    // "rare" | null (phrase / non-en / unknown). Informational only — never gates save.
+    string? Category = null
 );
 
 public record LanguageInfo(string Code, string Name);

--- a/packages/shared/src/api/translation.ts
+++ b/packages/shared/src/api/translation.ts
@@ -2,6 +2,10 @@ import { publicFetch, jsonBody } from './client'
 
 export interface TranslationResult {
   translatedText: string
+  /** Single-word save recommendation from the backend frequency filter:
+   *  'common' (likely known) | 'learnable' (worth saving) | 'rare' | undefined
+   *  (phrase / non-English / unknown). Informational only — never gates save. */
+  category?: 'common' | 'learnable' | 'rare'
 }
 
 export function translate(text: string, source: string, target: string, signal?: AbortSignal) {

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -517,7 +517,7 @@
     "toastWordAddedCount": "Added · {count} this session",
     "toastTapToReview": "Tap to review",
     "coachmarkTitle": "Tap any word",
-    "coachmarkSubtitle": "Tap a word to save it to your vocabulary.",
+    "coachmarkSubtitle": "Tap a word to see its translation, then tap Save to add it to your vocabulary.",
     "coachmarkDismiss": "Got it",
     "vocab": {
       "queuedForTomorrow": "Daily cap reached — queued for tomorrow",


### PR DESCRIPTION
## Why
User feedback + UX research. Restore **"look without saving"**: a single-word tap should show the translation (peek), and saving should be an **explicit, intentional** action — not an auto-save on every tap (which pollutes the SRS queue and means you can't check a word without committing it).

Research (Kindle Word Wise/Vocabulary Builder, LingQ, Readlang): the proven pattern separates **peek** (zero commitment) from **save** (a distinct act). Auto-save apps lean on heavy downstream cleanup — at odds with TextStack's "don't interrupt reading; vocab depth = real progress" thesis.

Model chosen by the user: **frequency-smart manual** — tap = peek; one tap saves; the word-frequency category is a *recommendation*, never a silent gate.

## Changes
**Mobile**
- **Tap = peek only**: removed `autoSaveWord` from both readers' `handleMessage` (`app/reader/.../[chapterSlug].tsx`, `app/my-books/.../[chapterSlug].tsx`). Auto-TTS + translation still fire.
- **Explicit Save button** in `SelectionActionBar` (one tap, always commits). Tint is a frequency *recommendation*: `learnable`/`rare` → accent, `common` → muted. Any word can still be saved.
- **Remove (trash)** on saved words — undo an accidental save (`onRemove` → `vocabActions.removeWord`).
- `translateCache` now carries the backend `category`.

**Backend**
- `/translate` returns optional `category` (`common`|`learnable`|`rare`) for single English words via `IFrequencyFilter` (in-memory, cheap; en-only dataset → null otherwise). **Informational only** — does not gate saving; the frequency filter stays OFF.

**Copy**: coachmark → "Tap a word to see its translation, then tap Save…".

## Out of scope
- Translation over *every* word (full-text Word Wise) — separate large feature.
- "Always-on translation over saved words" — already exists (`showInlineTranslations`).

## Verification
- `tsc --noEmit`: mobile ✅, web ✅. Backend `dotnet build` ✅.
- Manual (next EAS build): tap new word → translation, **nothing saved**; tap **Save** → underline + ✓ + in Vocabulary; common word → Save muted; saved word → badge + mark-known + **remove**; toggle inline translations → gloss over saved words.
- Mobile needs a new EAS build to reach the device.

## Rollback
Revert the commit. Additive backend field + mobile UI/flow change; web reader untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)