### PR TITLE
fix(mobile): reader settings drawer not scrollable

### DIFF
--- a/apps/mobile/src/components/ReaderSettingsDrawer.tsx
+++ b/apps/mobile/src/components/ReaderSettingsDrawer.tsx
@@ -35,15 +35,20 @@ export function ReaderSettingsDrawer({ visible, onClose, settings, onUpdate }: P
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <Pressable
-        style={styles.overlay}
-        onPress={onClose}
-        accessibilityRole="button"
-        accessibilityLabel="Close reader settings"
-      >
-        <Pressable style={[styles.drawer, { backgroundColor: colors.background }]} onPress={e => e.stopPropagation()}>
+      <View style={styles.overlay}>
+        {/* Backdrop tap-to-close in its own absolute layer — must NOT wrap the
+            drawer/ScrollView. A Pressable ancestor steals the scroll gesture on
+            iOS, which made the settings list unscrollable (couldn't reach
+            Inline Translations / Reading Stats). */}
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close reader settings"
+        />
+        <View style={[styles.drawer, { backgroundColor: colors.background }]}>
           <View style={styles.handle} />
-          <ScrollView showsVerticalScrollIndicator={false}>
+          <ScrollView showsVerticalScrollIndicator={false} bounces={false}>
             <View style={styles.header}>
               <Text style={[styles.title, { color: colors.text }]} accessibilityRole="header">Reading Settings</Text>
               <TouchableOpacity
@@ -217,8 +222,8 @@ export function ReaderSettingsDrawer({ visible, onClose, settings, onUpdate }: P
               />
             </View>
           </ScrollView>
-        </Pressable>
-      </Pressable>
+        </View>
+      </View>
     </Modal>
   )
 }


### PR DESCRIPTION
## Symptom
The Reading Settings drawer can't scroll — you only see down to VOCABULARY; **Inline Translations** and Reading Stats below the fold are unreachable (so the user can't enable the inline-gloss toggle).

## Root cause
The drawer wrapped its `ScrollView` in a `Pressable` (used to stop taps inside from closing the sheet). On iOS a `Pressable` ancestor captures the scroll pan gesture → the `ScrollView` never scrolls.

## Fix
Backdrop tap-to-close moves into its own `StyleSheet.absoluteFill` Pressable layer *behind* the drawer. The drawer and its `ScrollView` are now plain `View`s with no `Pressable` ancestor → scrolling works. Tap-outside still closes (the backdrop layer); taps inside hit the drawer View (no close).

## Verification
`tsc --noEmit` clean. Manual: open reader settings → scroll to Inline Translations / Reading Stats → toggle reachable; tap outside still closes. Needs a new EAS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)