### PR TITLE
AI-003: TracingDecorator + LlmTrace persistence

### DIFF
--- a/backend/src/Ai/TextStack.Ai.Llm/TextStack.Ai.Llm.csproj
+++ b/backend/src/Ai/TextStack.Ai.Llm/TextStack.Ai.Llm.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 </Project>

--- a/backend/src/Ai/TextStack.Ai.Llm/TracingDecorator.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/TracingDecorator.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TextStack.Ai.Core;
+
+namespace TextStack.Ai.Llm;
+
+/// <summary>
+/// Wraps any <see cref="ILlmService"/> and records a sampled <see cref="LlmTrace"/>
+/// per call (cost/latency/tokens/error). Singleton: the trace write is
+/// fire-and-forget on a fresh DI scope (IServiceScopeFactory → scoped
+/// ILlmTraceWriter), so persistence never adds latency to the LLM call.
+///
+/// Cost is taken from <c>response.Usage.CostUsd</c> (computed by the provider via
+/// ModelPricing in AI-002) — the decorator does not recompute it.
+/// </summary>
+public sealed class TracingDecorator(
+    ILlmService inner,
+    IServiceScopeFactory scopeFactory,
+    TracingOptions options,
+    ILogger<TracingDecorator> logger) : ILlmService
+{
+    public async Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var response = await inner.CompleteAsync(request, ct);
+            sw.Stop();
+            TryPersist(BuildTrace(request, response, sw.ElapsedMilliseconds, error: null), isError: false);
+            return response;
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            TryPersist(BuildTrace(request, response: null, sw.ElapsedMilliseconds, error: ex.Message), isError: true);
+            throw;
+        }
+    }
+
+    // TODO(AI-028): trace streamed calls once real token streaming exists. The
+    // current StreamAsync is a single-delta placeholder, so pass through untraced.
+    public IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, CancellationToken ct)
+        => inner.StreamAsync(request, ct);
+
+    private void TryPersist(LlmTrace trace, bool isError)
+    {
+        if (!ShouldSample(trace.FeatureTag, isError, options))
+            return;
+
+        // Fire-and-forget on its own scope — the decorator is a singleton but
+        // ILlmTraceWriter (and its DbContext) is scoped.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var writer = scope.ServiceProvider.GetRequiredService<ILlmTraceWriter>();
+                await writer.WriteAsync(trace, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to persist LLM trace {TraceId} ({Feature})", trace.Id, trace.FeatureTag);
+            }
+        });
+    }
+
+    // ---- pure, deterministic helpers (unit-tested directly) ----
+
+    /// <summary>Build a trace from a request/response (response null on error).</summary>
+    public static LlmTrace BuildTrace(LlmRequest request, LlmResponse? response, long latencyMs, string? error)
+    {
+        var messagesJson = JsonSerializer.Serialize(request.Messages);
+        var toolCallsJson = response is { ToolCalls.Count: > 0 }
+            ? JsonSerializer.Serialize(response.ToolCalls)
+            : null;
+
+        return new LlmTrace(
+            Id: response?.TraceId ?? Guid.NewGuid(),
+            FeatureTag: string.IsNullOrWhiteSpace(request.FeatureTag) ? "unknown" : request.FeatureTag,
+            ModelId: response?.ModelId ?? "unknown",
+            PromptHash: ComputePromptHash(request.SystemPrompt, messagesJson),
+            SystemPrompt: TraceRedactor.Redact(request.SystemPrompt),
+            MessagesJson: TraceRedactor.Redact(messagesJson) ?? "[]",
+            ResponseText: TraceRedactor.Redact(response?.Text),
+            ToolCallsJson: toolCallsJson,
+            TokensIn: response?.Usage.InputTokens ?? 0,
+            TokensOut: response?.Usage.OutputTokens ?? 0,
+            CostUsd: response?.Usage.CostUsd ?? 0m,
+            LatencyMs: (int)Math.Min(latencyMs, int.MaxValue),
+            UserId: null,
+            TraceParentId: request.TraceParentId,
+            Error: error,
+            CreatedAt: DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>Errors are always sampled; otherwise by the per-feature rate.</summary>
+    public static bool ShouldSample(string featureTag, bool isError, TracingOptions options)
+    {
+        if (isError) return true;
+        var rate = options.RateFor(featureTag);
+        if (rate >= 1.0) return true;
+        if (rate <= 0.0) return false;
+        return Random.Shared.NextDouble() < rate;
+    }
+
+    private static string ComputePromptHash(string systemPrompt, string messagesJson)
+    {
+        var bytes = Encoding.UTF8.GetBytes($"{systemPrompt}\n{messagesJson}");
+        return Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+    }
+}
+
+/// <summary>
+/// Strips obvious PII (email, phone) before a prompt/response is persisted —
+/// the playbook PII rule for LlmTrace. Compiled (not [GeneratedRegex]) per the
+/// repo's ARM64 SIGILL caveat.
+/// </summary>
+public static class TraceRedactor
+{
+    private static readonly Regex Email =
+        new(@"[\w.+-]+@[\w-]+\.[\w.-]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // Conservative: 8+ digits with optional separators / leading +.
+    private static readonly Regex Phone =
+        new(@"\+?\d[\d\s().-]{7,}\d", RegexOptions.Compiled);
+
+    public static string? Redact(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+        text = Email.Replace(text, "[redacted-email]");
+        text = Phone.Replace(text, "[redacted-phone]");
+        return text;
+    }
+}

--- a/backend/src/Ai/TextStack.Ai.Llm/TracingOptions.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/TracingOptions.cs
@@ -1,0 +1,18 @@
+namespace TextStack.Ai.Llm;
+
+/// <summary>
+/// Trace sampling policy (ADR-AI-011). Errors are always sampled regardless of
+/// these rates. <paramref name="PerFeatureRates"/> overrides the default for a
+/// given <c>FeatureTag</c> (e.g. high-volume "explain"/"translate" → 0.1).
+/// Built from appsettings (<c>Ai:Tracing:Sampling</c>) in AI-005.
+/// </summary>
+public sealed record TracingOptions(
+    double DefaultSampleRate = 1.0,
+    IReadOnlyDictionary<string, double>? PerFeatureRates = null)
+{
+    /// <summary>Effective sample rate (0..1) for a feature tag.</summary>
+    public double RateFor(string featureTag) =>
+        PerFeatureRates is not null && PerFeatureRates.TryGetValue(featureTag, out var r)
+            ? r
+            : DefaultSampleRate;
+}

--- a/backend/src/Application/Ai/DbLlmTraceWriter.cs
+++ b/backend/src/Application/Ai/DbLlmTraceWriter.cs
@@ -1,0 +1,38 @@
+using Application.Common.Interfaces;
+using Domain.Entities;
+
+namespace Application.Ai;
+
+/// <summary>
+/// Persists AI Core.LlmTrace records to Postgres via <see cref="IAppDbContext"/>.
+/// Scoped (owns a per-request DbContext) — the singleton TracingDecorator
+/// resolves it inside a fresh DI scope per write. Core types are written as
+/// global:: to avoid the namespace clash (Application.* vs TextStack.*) and the
+/// type-name clash with the EF entity <see cref="LlmTrace"/>.
+/// </summary>
+public sealed class DbLlmTraceWriter(IAppDbContext db) : global::TextStack.Ai.Core.ILlmTraceWriter
+{
+    public async Task WriteAsync(global::TextStack.Ai.Core.LlmTrace trace, CancellationToken ct)
+    {
+        db.LlmTraces.Add(new LlmTrace
+        {
+            Id = trace.Id,
+            FeatureTag = trace.FeatureTag,
+            ModelId = trace.ModelId,
+            PromptHash = trace.PromptHash,
+            SystemPrompt = trace.SystemPrompt,
+            MessagesJson = trace.MessagesJson,
+            ResponseText = trace.ResponseText,
+            ToolCallsJson = trace.ToolCallsJson,
+            TokensIn = trace.TokensIn,
+            TokensOut = trace.TokensOut,
+            CostUsd = trace.CostUsd,
+            LatencyMs = trace.LatencyMs,
+            UserId = trace.UserId,
+            TraceParentId = trace.TraceParentId,
+            Error = trace.Error,
+            CreatedAt = trace.CreatedAt,
+        });
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/backend/src/Application/Application.csproj
+++ b/backend/src/Application/Application.csproj
@@ -20,5 +20,6 @@
     <ProjectReference Include="..\Search\TextStack.Search\TextStack.Search.csproj" />
     <ProjectReference Include="..\Epub\TextStack.Epub\TextStack.Epub.csproj" />
     <ProjectReference Include="..\Vocabulary\TextStack.Vocabulary\TextStack.Vocabulary.csproj" />
+    <ProjectReference Include="..\Ai\TextStack.Ai.Core\TextStack.Ai.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/backend/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/backend/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -57,6 +57,7 @@ public interface IAppDbContext
     DbSet<SeoBackfillSettings> SeoBackfillSettings { get; }
     DbSet<Collection> Collections { get; }
     DbSet<BookCollection> BookCollections { get; }
+    DbSet<LlmTrace> LlmTraces { get; }
 
     Task<int> SaveChangesAsync(CancellationToken ct = default);
 

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -48,6 +48,11 @@ public static class DependencyInjection
         services.AddKeyedSingleton<Domain.LLM.ILlmService, OllamaLlmService>("ollama");
         services.AddSingleton<Domain.LLM.ILlmServiceFactory, LlmServiceFactory>();
 
+        // AI platform (Ai.* libs). Leaf only — the singleton TracingDecorator
+        // resolves this per-write via a fresh scope. Full Gateway→Tracing→Provider
+        // composition is wired in AI-005.
+        services.AddScoped<global::TextStack.Ai.Core.ILlmTraceWriter, Ai.DbLlmTraceWriter>();
+
         // SSG Rebuild - interfaces for SOLID compliance
         services.AddScoped<ISsgRouteProvider, SsgRouteProvider>();
         services.AddScoped<ISsgJobService, SsgRebuildService>();

--- a/backend/src/Domain/Entities/LlmTrace.cs
+++ b/backend/src/Domain/Entities/LlmTrace.cs
@@ -1,0 +1,29 @@
+namespace Domain.Entities;
+
+/// <summary>
+/// Persisted trace of a single LLM call (table <c>llm_trace</c>). Written —
+/// sampled — by the AI <c>TracingDecorator</c> for cost/latency/quality
+/// observability. Plain POCO; EF mapping lives in AppDbContext.Ai.cs.
+/// </summary>
+public class LlmTrace
+{
+    public Guid Id { get; set; }
+    public required string FeatureTag { get; set; }
+    public required string ModelId { get; set; }
+    public required string PromptHash { get; set; }
+    public string? SystemPrompt { get; set; }
+    public required string MessagesJson { get; set; }
+    public string? ResponseText { get; set; }
+    public string? ToolCallsJson { get; set; }
+    public int TokensIn { get; set; }
+    public int TokensOut { get; set; }
+    public decimal CostUsd { get; set; }
+    public int LatencyMs { get; set; }
+    public Guid? UserId { get; set; }
+    public Guid? TraceParentId { get; set; }
+    public string? Error { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+
+    // Optional FK → users; ON DELETE SET NULL (a deleted user shouldn't erase traces).
+    public User? User { get; set; }
+}

--- a/backend/src/Infrastructure/Migrations/20260604034703_AddLlmTrace.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260604034703_AddLlmTrace.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604034703_AddLlmTrace")]
+    partial class AddLlmTrace
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260604034703_AddLlmTrace.cs
+++ b/backend/src/Infrastructure/Migrations/20260604034703_AddLlmTrace.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLlmTrace : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "llm_traces",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    feature_tag = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    model_id = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    prompt_hash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    system_prompt = table.Column<string>(type: "text", nullable: true),
+                    messages_json = table.Column<string>(type: "jsonb", nullable: false),
+                    response_text = table.Column<string>(type: "text", nullable: true),
+                    tool_calls_json = table.Column<string>(type: "jsonb", nullable: true),
+                    tokens_in = table.Column<int>(type: "integer", nullable: false),
+                    tokens_out = table.Column<int>(type: "integer", nullable: false),
+                    cost_usd = table.Column<decimal>(type: "numeric(10,6)", nullable: false),
+                    latency_ms = table.Column<int>(type: "integer", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    trace_parent_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    error = table.Column<string>(type: "text", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_llm_traces", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_llm_traces_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_llm_traces_feature_tag_created_at",
+                table: "llm_traces",
+                columns: new[] { "feature_tag", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_llm_traces_user_id",
+                table: "llm_traces",
+                column: "user_id",
+                filter: "user_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "llm_traces");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Ai.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Ai.cs
@@ -1,0 +1,37 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Persistence;
+
+/// <summary>
+/// AI observability entities. <see cref="LlmTrace"/> (table <c>llm_trace</c>) —
+/// sampled per-call traces written by the AI TracingDecorator for
+/// cost/latency/quality analysis. snake_case names come from the global
+/// convention (OnConfiguring).
+/// </summary>
+public partial class AppDbContext
+{
+    private static void ConfigureAi(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<LlmTrace>(e =>
+        {
+            // Hot query: recent traces for a feature (admin dashboards).
+            e.HasIndex(x => new { x.FeatureTag, x.CreatedAt });
+            // Per-user lookups; partial index keeps it small (most traces have no user).
+            e.HasIndex(x => x.UserId).HasFilter("user_id IS NOT NULL");
+
+            e.Property(x => x.FeatureTag).HasMaxLength(64);
+            e.Property(x => x.ModelId).HasMaxLength(128);
+            e.Property(x => x.PromptHash).HasMaxLength(64);
+            e.Property(x => x.MessagesJson).HasColumnType("jsonb");
+            e.Property(x => x.ToolCallsJson).HasColumnType("jsonb");
+            e.Property(x => x.CostUsd).HasColumnType("numeric(10,6)");
+
+            // Optional FK → users; a deleted user nulls the column but keeps the trace.
+            e.HasOne(x => x.User)
+                .WithMany()
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.SetNull);
+        });
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -78,6 +78,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
     public DbSet<SeoBackfillSettings> SeoBackfillSettings => Set<SeoBackfillSettings>();
     public DbSet<Collection> Collections => Set<Collection>();
     public DbSet<BookCollection> BookCollections => Set<BookCollection>();
+    public DbSet<LlmTrace> LlmTraces => Set<LlmTrace>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -94,6 +95,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
         ConfigureOps(modelBuilder);
         ConfigureSeo(modelBuilder);
         ConfigureCollections(modelBuilder);
+        ConfigureAi(modelBuilder);
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/tests/TextStack.UnitTests/TextStack.UnitTests.csproj
+++ b/tests/TextStack.UnitTests/TextStack.UnitTests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\backend\src\Worker\Worker.csproj" />
     <ProjectReference Include="..\..\backend\src\Tts\TextStack.Tts\TextStack.Tts.csproj" />
     <ProjectReference Include="..\..\backend\src\Vocabulary\TextStack.Vocabulary\TextStack.Vocabulary.csproj" />
+    <ProjectReference Include="..\..\backend\src\Ai\TextStack.Ai.Llm\TextStack.Ai.Llm.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/TextStack.UnitTests/TracingDecoratorTests.cs
+++ b/tests/TextStack.UnitTests/TracingDecoratorTests.cs
@@ -1,0 +1,142 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TextStack.Ai.Core;
+using TextStack.Ai.Llm;
+
+namespace TextStack.UnitTests;
+
+public class TracingDecoratorTests
+{
+    private static LlmRequest Req(string? feature = "explain") =>
+        new("system prompt", new[] { new LlmMessage("user", "hello") }, 100, FeatureTag: feature);
+
+    private static LlmResponse Resp() =>
+        new("the answer", Array.Empty<ToolCall>(), new LlmUsage(10, 5, 0.0001m), "gpt-4.1-nano", Guid.NewGuid());
+
+    // ---- ShouldSample ----
+
+    [Fact]
+    public void ShouldSample_Error_AlwaysTrue_EvenAtZeroRate()
+    {
+        var opts = new TracingOptions(DefaultSampleRate: 0.0);
+        Assert.True(TracingDecorator.ShouldSample("explain", isError: true, opts));
+    }
+
+    [Theory]
+    [InlineData(1.0, true)]
+    [InlineData(0.0, false)]
+    public void ShouldSample_NonError_HonorsDeterministicRate(double rate, bool expected)
+    {
+        var opts = new TracingOptions(DefaultSampleRate: rate);
+        Assert.Equal(expected, TracingDecorator.ShouldSample("translate", isError: false, opts));
+    }
+
+    [Fact]
+    public void ShouldSample_PerFeatureOverride_BeatsDefault()
+    {
+        var opts = new TracingOptions(
+            DefaultSampleRate: 1.0,
+            PerFeatureRates: new Dictionary<string, double> { ["explain"] = 0.0 });
+        Assert.False(TracingDecorator.ShouldSample("explain", isError: false, opts)); // overridden to 0
+        Assert.True(TracingDecorator.ShouldSample("rag", isError: false, opts));       // default 1.0
+    }
+
+    // ---- BuildTrace ----
+
+    [Fact]
+    public void BuildTrace_Success_PopulatesFromResponse()
+    {
+        var resp = Resp();
+        var trace = TracingDecorator.BuildTrace(Req(), resp, latencyMs: 42, error: null);
+
+        Assert.Equal(resp.TraceId, trace.Id);
+        Assert.Equal("explain", trace.FeatureTag);
+        Assert.Equal("gpt-4.1-nano", trace.ModelId);
+        Assert.Equal(10, trace.TokensIn);
+        Assert.Equal(5, trace.TokensOut);
+        Assert.Equal(0.0001m, trace.CostUsd);
+        Assert.Equal(42, trace.LatencyMs);
+        Assert.Null(trace.Error);
+        Assert.False(string.IsNullOrEmpty(trace.PromptHash));
+        Assert.Contains("hello", trace.MessagesJson);
+    }
+
+    [Fact]
+    public void BuildTrace_Error_NoResponse_DefaultsAndZeros()
+    {
+        var trace = TracingDecorator.BuildTrace(Req(), response: null, latencyMs: 5, error: "boom");
+
+        Assert.Equal("unknown", trace.ModelId);
+        Assert.Equal("boom", trace.Error);
+        Assert.Equal(0, trace.TokensIn);
+        Assert.Equal(0m, trace.CostUsd);
+        Assert.NotEqual(Guid.Empty, trace.Id);
+    }
+
+    [Fact]
+    public void BuildTrace_NullFeatureTag_DefaultsToUnknown()
+    {
+        var trace = TracingDecorator.BuildTrace(Req(feature: null), Resp(), 1, null);
+        Assert.Equal("unknown", trace.FeatureTag);
+    }
+
+    // ---- TraceRedactor ----
+
+    [Fact]
+    public void Redact_MasksEmailAndPhone()
+    {
+        var red = TraceRedactor.Redact("reach me at john.doe@example.com or +1 (415) 555-2671 today");
+        Assert.DoesNotContain("john.doe@example.com", red);
+        Assert.DoesNotContain("555-2671", red);
+        Assert.Contains("[redacted-email]", red);
+        Assert.Contains("[redacted-phone]", red);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Redact_NullOrEmpty_PassesThrough(string? input)
+    {
+        Assert.Equal(input, TraceRedactor.Redact(input));
+    }
+
+    // ---- pass-through (response unchanged; trace write is fire-and-forget) ----
+
+    [Fact]
+    public async Task CompleteAsync_ReturnsInnerResponseUnchanged()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<ILlmTraceWriter, NoOpWriter>();
+        using var sp = services.BuildServiceProvider();
+
+        var resp = Resp();
+        var decorator = new TracingDecorator(
+            new StubLlm(resp),
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            new TracingOptions(),
+            NullLogger<TracingDecorator>.Instance);
+
+        var result = await decorator.CompleteAsync(Req(), CancellationToken.None);
+
+        Assert.Equal(resp.Text, result.Text);
+        Assert.Equal(resp.ModelId, result.ModelId);
+        Assert.Equal(resp.Usage.InputTokens, result.Usage.InputTokens);
+    }
+
+    private sealed class StubLlm(LlmResponse resp) : ILlmService
+    {
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct) => Task.FromResult(resp);
+
+        public async IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, [EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.CompletedTask;
+            yield return new LlmDelta(TextDelta: resp.Text);
+        }
+    }
+
+    private sealed class NoOpWriter : ILlmTraceWriter
+    {
+        public Task WriteAsync(LlmTrace trace, CancellationToken ct) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Observability seam for LLM calls (playbook Phase 2). `TracingDecorator` wraps any `ILlmService` and records a **sampled** `LlmTrace` per call — without adding latency. Builds on AI-001/AI-002.

## What
- **`TextStack.Ai.Llm/TracingDecorator`** (singleton): times the call, builds an `LlmTrace`, samples, and **fire-and-forgets** the write on a fresh DI scope (`IServiceScopeFactory` → scoped `ILlmTraceWriter`). Cost is taken from `response.Usage.CostUsd` (computed by the provider via `ModelPricing` in AI-002) — not recomputed.
- **Sampling** (ADR-AI-011): errors always; per-feature rate via `TracingOptions` (defaults 1.0; `explain`/`translate` → 0.1 wired in AI-005).
- **`TraceRedactor`**: strips email/phone before persisting (playbook PII rule).
- **Persistence**: `Domain.Entities.LlmTrace` + `AppDbContext.Ai` config + migration `AddLlmTrace` (table `llm_traces`: `jsonb` messages/tool_calls, `numeric(10,6)` cost, indexes on `feature_tag+created_at` and partial `user_id`, FK `user_id` ON DELETE SET NULL). `Application/Ai/DbLlmTraceWriter` implements `Core.ILlmTraceWriter` via `IAppDbContext`.
- **DI**: only the leaf `ILlmTraceWriter` is registered. Full `Gateway→Tracing→Provider` composition stays in **AI-005**.
- **Tests**: 11 unit tests (BuildTrace, ShouldSample, redaction, pass-through).

## Decisions (per your calls)
- Decorator **singleton + fire-and-forget** write (non-blocking).
- Scope = **machinery + migration only**; composition deferred to AI-005.

## Deviations / review
1. **Table is `llm_traces`** (EF/repo plural convention) vs playbook's `llm_trace` (singular). Kept repo consistency.
2. **Streamed calls untraced** — `StreamAsync` passes through (placeholder stream from AI-002); real stream tracing is `TODO(AI-028)`.
3. **`UserId` always null** for now — a plain `LlmRequest` carries no user; populated later when called within user/agent context.
4. Cost persisted from `LlmUsage` (AI-002), not recomputed in the decorator (diverges from ADR-AI-012's letter, consistent with AI-002's accepted decision).
5. Index is `feature_tag, created_at` ascending (EF) — Postgres scans backward for `ORDER BY created_at DESC`, so the playbook's DESC optimization is effectively covered.

## Constraints honored
Legacy `Application/LLM/*` + `Domain/LLM/*` + the 6 callers untouched. No decorator composition wired. Only new migration `AddLlmTrace`.

## Verify
`dotnet build textstack.sln` → 0/0. `dotnet test --filter TracingDecorator` → 11 pass. Migration applies via migrator on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)