### PR TITLE
AI-004: ModelGateway v0 + DI composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### AI platform — observable LLM layer (foundation) (2026-06-04)
+
+Building a unified, observable LLM layer so every AI call (Explain, Translate,
+Distractor, BookMetadata, TagSuggestion, …) routes through one seam and is
+logged for cost/latency/quality. Shipped as small, self-contained PRs; the new
+stack runs in parallel with the legacy `ILlmServiceFactory` path — callers
+migrate later (AI-005), so behavior is unchanged so far.
+
+- **AI-001 — `TextStack.Ai.Core`** ([`dc7b28e`](https://github.com/mrviduus/textstack/commit/dc7b28e)) — new class library with the AI contracts: `ILlmService` (LlmRequest/LlmResponse/LlmUsage/LlmMessage/LlmDelta), `ITool`, `IEmbeddingService`, `IAgent`, `ILlmTraceWriter` + supporting records. Pure interfaces, zero implementations.
+- **AI-002 — `TextStack.Ai.Llm` providers** ([`bff1523`](https://github.com/mrviduus/textstack/commit/bff1523)) — `OpenAiLlmClient` + `OllamaLlmClient` ported 1:1 from the legacy services onto the new `ILlmService` (production quirks preserved verbatim: OpenAI reasoning-budget `+512` padding, Ollama `think=false`). `ModelPricing` is the single source of per-model USD cost, surfaced on `LlmResponse.Usage`.
+- **AI-003 — TracingDecorator + `llm_traces`** ([`54d2598`](https://github.com/mrviduus/textstack/commit/54d2598)) — singleton decorator wraps any provider and records a **sampled** trace (cost/tokens/latency/error) **fire-and-forget** on a fresh DI scope, so persistence adds no latency. New Postgres table `llm_traces` (jsonb messages, `numeric(10,6)` cost, FK user ON DELETE SET NULL) + `DbLlmTraceWriter`. Email/phone redacted before persist; errors always sampled, high-volume features sampled at 10% (ADR-AI-011).
+- **AI-004 — `ModelGateway` v0 + DI composition** (this PR) — `ModelGateway` (a composite `ILlmService`) routes each call to a provider by `FeatureTag` via `Ai:Routes` config, then the full stack is wired in DI: keyed providers → `TracingDecorator` → gateway as the default `ILlmService`. Routing mirrors the existing per-feature mapping (explain/translate → OpenAI, distractor/bookmeta/tagsuggestion → Ollama) so nothing changes until callers migrate. Cost-cap / shadow / escalate are deferred to a later phase.
+
 ### Web header — restore search icon on non-home pages (2026-05-24)
 
 - **Search icon back in the header** ([`4eb1986`](https://github.com/mrviduus/textstack/commit/4eb1986)) — was removed in [`3e53e3e`](https://github.com/mrviduus/textstack/commit/3e53e3e) on the assumption that the hero search on home was enough. It wasn't: on every other page (library, discover, vocabulary, reader, …) the hero is gone and users had nowhere to launch a search from. Icon now shows on all routes except home (where the hero input still owns the affordance), opens the existing `MobileSearchOverlay`, and ships with 10 new `Header.test.tsx` cases pinning visibility per route + open/close flow.

--- a/backend/src/Ai/TextStack.Ai.Llm/ModelGateway.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/ModelGateway.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TextStack.Ai.Core;
+
+namespace TextStack.Ai.Llm;
+
+/// <summary>
+/// Composite <see cref="ILlmService"/> that routes each call to a provider by
+/// <c>FeatureTag</c> (config <c>Ai:Routes:{featureTag}</c> → provider key, falling
+/// back to <c>Ai:DefaultProvider</c>). Resolves the *decorated* keyed instance, so
+/// tracing already wraps the provider. Callers never know which model answered.
+///
+/// v0: routing only. Shadow / escalate / cost-cap are later phases.
+/// </summary>
+public sealed class ModelGateway(
+    IServiceProvider serviceProvider,
+    IConfiguration config,
+    ILogger<ModelGateway> logger) : ILlmService
+{
+    public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
+        => Route(request.FeatureTag).CompleteAsync(request, ct);
+
+    public IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, CancellationToken ct)
+        => Route(request.FeatureTag).StreamAsync(request, ct);
+
+    private ILlmService Route(string? featureTag)
+    {
+        string? key = null;
+        if (!string.IsNullOrWhiteSpace(featureTag))
+        {
+            key = config[$"Ai:Routes:{featureTag}"];
+            if (key is null)
+                logger.LogDebug("No Ai:Routes entry for feature '{Feature}'; using default provider", featureTag);
+        }
+        key ??= config["Ai:DefaultProvider"] ?? "openai";
+        return serviceProvider.GetRequiredKeyedService<ILlmService>(key);
+    }
+}

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -57,6 +57,25 @@
       "TagSuggestion": "ollama"
     }
   },
+  "Ai": {
+    "DefaultProvider": "openai",
+    "Routes": {
+      "explain": "openai",
+      "translate": "openai",
+      "distractor": "ollama",
+      "bookmeta": "ollama",
+      "tagsuggestion": "ollama"
+    },
+    "Tracing": {
+      "Sampling": {
+        "Default": 1.0,
+        "PerFeature": {
+          "explain": 0.1,
+          "translate": 0.1
+        }
+      }
+    }
+  },
   "FileUpload": {
     "MaxBookSizeMb": 100,
     "MaxCoverSizeMb": 5,

--- a/backend/src/Application/Application.csproj
+++ b/backend/src/Application/Application.csproj
@@ -21,5 +21,6 @@
     <ProjectReference Include="..\Epub\TextStack.Epub\TextStack.Epub.csproj" />
     <ProjectReference Include="..\Vocabulary\TextStack.Vocabulary\TextStack.Vocabulary.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.Core\TextStack.Ai.Core.csproj" />
+    <ProjectReference Include="..\Ai\TextStack.Ai.Llm\TextStack.Ai.Llm.csproj" />
   </ItemGroup>
 </Project>

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -12,6 +12,7 @@ using Application.Export;
 using Application.SsgRebuild;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Application;
 
@@ -48,10 +49,38 @@ public static class DependencyInjection
         services.AddKeyedSingleton<Domain.LLM.ILlmService, OllamaLlmService>("ollama");
         services.AddSingleton<Domain.LLM.ILlmServiceFactory, LlmServiceFactory>();
 
-        // AI platform (Ai.* libs). Leaf only — the singleton TracingDecorator
-        // resolves this per-write via a fresh scope. Full Gateway→Tracing→Provider
-        // composition is wired in AI-005.
+        // AI platform (Ai.* libs) — new ILlmService stack. The legacy keyed
+        // Domain.LLM providers above stay until callers migrate (AI-005).
+        // Trace writer: scoped (per-request DbContext); the singleton
+        // TracingDecorator resolves it per-write via a fresh scope.
         services.AddScoped<global::TextStack.Ai.Core.ILlmTraceWriter, Ai.DbLlmTraceWriter>();
+
+        // Sampling policy (Ai:Tracing:Sampling). Errors always sampled regardless.
+        services.AddSingleton(sp =>
+        {
+            var c = sp.GetRequiredService<IConfiguration>();
+            return new global::TextStack.Ai.Llm.TracingOptions(
+                c.GetValue("Ai:Tracing:Sampling:Default", 1.0),
+                c.GetSection("Ai:Tracing:Sampling:PerFeature").Get<Dictionary<string, double>>());
+        });
+
+        // Raw providers (keyed) on Core.ILlmService.
+        services.AddKeyedSingleton<global::TextStack.Ai.Core.ILlmService, global::TextStack.Ai.Llm.OpenAiLlmClient>("openai-raw");
+        services.AddKeyedSingleton<global::TextStack.Ai.Core.ILlmService, global::TextStack.Ai.Llm.OllamaLlmClient>("ollama-raw");
+
+        // Decorated providers (keyed): TracingDecorator wraps each raw provider.
+        foreach (var providerKey in new[] { "openai", "ollama" })
+        {
+            services.AddKeyedSingleton<global::TextStack.Ai.Core.ILlmService>(providerKey, (sp, key) =>
+                new global::TextStack.Ai.Llm.TracingDecorator(
+                    sp.GetRequiredKeyedService<global::TextStack.Ai.Core.ILlmService>($"{key}-raw"),
+                    sp.GetRequiredService<IServiceScopeFactory>(),
+                    sp.GetRequiredService<global::TextStack.Ai.Llm.TracingOptions>(),
+                    sp.GetRequiredService<ILogger<global::TextStack.Ai.Llm.TracingDecorator>>()));
+        }
+
+        // Default Core.ILlmService = the gateway (routes FeatureTag → decorated provider).
+        services.AddSingleton<global::TextStack.Ai.Core.ILlmService, global::TextStack.Ai.Llm.ModelGateway>();
 
         // SSG Rebuild - interfaces for SOLID compliance
         services.AddScoped<ISsgRouteProvider, SsgRouteProvider>();

--- a/backend/src/Worker/appsettings.json
+++ b/backend/src/Worker/appsettings.json
@@ -21,5 +21,18 @@
       "BookMetadata": "ollama",
       "TagSuggestion": "ollama"
     }
+  },
+  "Ai": {
+    "DefaultProvider": "ollama",
+    "Routes": {
+      "distractor": "ollama",
+      "bookmeta": "ollama",
+      "tagsuggestion": "ollama"
+    },
+    "Tracing": {
+      "Sampling": {
+        "Default": 1.0
+      }
+    }
   }
 }

--- a/tests/TextStack.UnitTests/ModelGatewayTests.cs
+++ b/tests/TextStack.UnitTests/ModelGatewayTests.cs
@@ -1,0 +1,62 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TextStack.Ai.Core;
+using TextStack.Ai.Llm;
+
+namespace TextStack.UnitTests;
+
+public class ModelGatewayTests
+{
+    // Routing config mirrors the appsettings shape.
+    private static ModelGateway BuildGateway()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ai:DefaultProvider"] = "openai",
+                ["Ai:Routes:explain"] = "openai",
+                ["Ai:Routes:translate"] = "openai",
+                ["Ai:Routes:distractor"] = "ollama",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        // Stub providers keyed like the real decorated registrations; each echoes
+        // its key back as ModelId so we can assert which provider answered.
+        services.AddKeyedSingleton<ILlmService>("openai", new KeyEchoLlm("openai"));
+        services.AddKeyedSingleton<ILlmService>("ollama", new KeyEchoLlm("ollama"));
+        var sp = services.BuildServiceProvider();
+
+        return new ModelGateway(sp, cfg, NullLogger<ModelGateway>.Instance);
+    }
+
+    [Theory]
+    [InlineData("explain", "openai")]
+    [InlineData("translate", "openai")]
+    [InlineData("distractor", "ollama")]
+    [InlineData("no-such-feature", "openai")] // unmapped → default
+    [InlineData(null, "openai")]               // no tag → default
+    public async Task CompleteAsync_RoutesByFeatureTag(string? feature, string expectedProvider)
+    {
+        var gateway = BuildGateway();
+        var request = new LlmRequest("system", Array.Empty<LlmMessage>(), 10, FeatureTag: feature);
+
+        var response = await gateway.CompleteAsync(request, CancellationToken.None);
+
+        Assert.Equal(expectedProvider, response.ModelId);
+    }
+
+    private sealed class KeyEchoLlm(string key) : ILlmService
+    {
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct) =>
+            Task.FromResult(new LlmResponse("", Array.Empty<ToolCall>(), new LlmUsage(0, 0, 0m), key, Guid.NewGuid()));
+
+        public async IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, [EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.CompletedTask;
+            yield return new LlmDelta(TextDelta: key);
+        }
+    }
+}


### PR DESCRIPTION
Wires the new `ILlmService` stack into DI so it's live — but **unused until callers migrate (AI-005)**, so zero behavior change.

## What
- **`ModelGateway`** (`Core.ILlmService`, in `Ai.Llm`): routes each call by `FeatureTag` via `Ai:Routes` config → resolves the *decorated* keyed provider (tracing already inside). v0 = routing only.
- **DI composition** (`AddApplication`): keyed raw providers (`openai-raw`/`ollama-raw`) → `TracingDecorator` (singleton, `TracingOptions` from `Ai:Tracing:Sampling`) → keyed decorated (`openai`/`ollama`) → `ModelGateway` registered as the default `Core.ILlmService`. `Application` now references `TextStack.Ai.Llm` (consistent with legacy LLM impls already living in Application).
- **appsettings** (Api + Worker): `Ai:{DefaultProvider,Routes,Tracing.Sampling}` — mirrors the current `LLM:Providers` map (explain/translate→OpenAI, distractor/bookmeta/tagsuggestion→Ollama), tags lowercase.
- **Tests**: 5 routing unit tests (FeatureTag → provider, default fallback, null tag).
- **CHANGELOG**: new "AI platform — observable LLM layer" section covering AI-001→004 (for the upcoming writeup).

## Constraints honored
Legacy `Application/LLM/*`, `Domain/LLM/*`, the 6 callers, and Api/Worker `Program.cs` untouched. No caller migration (AI-005). No cost-cap / shadow / escalate (later phase).

## Verify
`dotnet build textstack.sln` → 0/0. `dotnet test --filter ModelGateway` → 5 pass. Container resolves `Core.ILlmService` → `ModelGateway`; keyed `openai`/`ollama` → `TracingDecorator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)