### PR TITLE
docs+fix: correct model id to gpt-4.1-nano

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,9 +191,9 @@ Upload EPUB/PDF/FB2 → BookFile (stored) → IngestionJob (queued)
 
 **Dictionary**: `GET /dictionary/{lang}/{word}` — proxies Free Dictionary API. Used by web reader (phonetic + first-meaning definition) and by mobile vocabulary review (SRS card feedback only). Mobile **reader** no longer calls it as of 2026-05-15 — phonetic + inline definition removed from `WordCard`/`DictionarySheet` (sheet deleted) in favor of OpenAI Explain for the technical-reader audience, and to shrink Play Store Data Safety third-party processor list to OpenAI + Edge TTS only.
 
-**Translation**: `POST /api/translate` via OpenAI (`gpt-5-mini`). Config: `OpenAI:ApiKey`, `OpenAI:Model`, `OpenAI:Translate:MaxTextLength`. LibreTranslate dropped 2026-04-22.
+**Translation**: `POST /api/translate` via OpenAI (`gpt-4.1-nano`). Config: `OpenAI:ApiKey`, `OpenAI:Model`, `OpenAI:Translate:MaxTextLength`. LibreTranslate dropped 2026-04-22.
 
-**Explain (contextual)**: `POST /api/explain` — LLM-powered 2-3 sentence explanation of a word in the sentence it appears in. Uses `ILlmService` (OpenAI `gpt-5-mini`). SHA256-keyed file cache at `data/explain-cache`, 30d TTL. Rate limited per-IP (20/min). Impl: `backend/src/Api/Endpoints/ExplainEndpoints.cs`.
+**Explain (contextual)**: `POST /api/explain` — LLM-powered 2-3 sentence explanation of a word in the sentence it appears in. Uses `ILlmService` (OpenAI `gpt-4.1-nano`). SHA256-keyed file cache at `data/explain-cache`, 30d TTL. Rate limited per-IP (20/min). Impl: `backend/src/Api/Endpoints/ExplainEndpoints.cs`.
 
 **TTS (Text-to-Speech)**: Edge TTS via direct WebSocket to `speech.platform.bing.com`. No API key, no deps.
 - **`TextStack.Tts`** class library: `EdgeTtsClient` (WebSocket protocol), `EdgeTtsService` (disk cache + `IHostedService` startup cleanup)

--- a/backend/src/Ai/TextStack.Ai.Llm/ModelPricing.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/ModelPricing.cs
@@ -16,7 +16,6 @@ public static class ModelPricing
         new Dictionary<string, (decimal, decimal)>(StringComparer.OrdinalIgnoreCase)
         {
             ["gpt-4.1-nano"] = (0.10m, 0.40m),
-            ["gpt-5-mini"] = (0.25m, 2.00m),
             ["gpt-4o-mini"] = (0.15m, 0.60m),
         };
 


### PR DESCRIPTION
CLAUDE.md said `gpt-5-mini` for translate/explain — wrong. The project uses **`gpt-4.1-nano`** everywhere (`OpenAI:Model` in appsettings; confirmed by a live prod `llm_traces` row). Fixed the two CLAUDE.md refs and removed the unused `gpt-5-mini` entry from `ModelPricing` (gpt-4.1-nano is the real model, already priced $0.10/$0.40). Build 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)