### PR TITLE
fix(ai): /ai-quality Summary 500 (SqlQuery private row types)

### DIFF
--- a/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
@@ -203,8 +203,17 @@ public static class AdminAiQualityEndpoints
                     .ToList());
 
         // Latest eval score per feature (small table → fetch recent + group in memory).
-        var evalRows = await db.EvalRuns.OrderByDescending(r => r.CreatedAt).Take(500).ToListAsync(ct);
-        var latestEval = evalRows.GroupBy(r => r.Feature).ToDictionary(g => g.Key, g => g.First().Score);
+        // Resilient: a missing/empty eval_runs must never break the trace summary.
+        Dictionary<string, decimal> latestEval;
+        try
+        {
+            var evalRows = await db.EvalRuns.OrderByDescending(r => r.CreatedAt).Take(500).ToListAsync(ct);
+            latestEval = evalRows.GroupBy(r => r.Feature).ToDictionary(g => g.Key, g => g.First().Score);
+        }
+        catch
+        {
+            latestEval = [];
+        }
 
         var features = rows.Select(r => new FeatureSummaryDto(
             FeatureTag: r.FeatureTag,
@@ -231,7 +240,9 @@ public static class AdminAiQualityEndpoints
     }
 
     // Raw-SQL row shapes (mutable props + parameterless ctor for EF SqlQuery materialization).
-    private sealed class FeatureRow
+    // MUST be public: EF's SqlQuery materializer can't construct private nested types
+    // (fails only once rows exist), which 500'd the Summary on prod.
+    public sealed class FeatureRow
     {
         public string FeatureTag { get; set; } = "";
         public long Calls { get; set; }
@@ -243,7 +254,7 @@ public static class AdminAiQualityEndpoints
         public double P95 { get; set; }
     }
 
-    private sealed class DailyRow
+    public sealed class DailyRow
     {
         public string FeatureTag { get; set; } = "";
         public DateTime Day { get; set; }


### PR DESCRIPTION
**Bug:** `/ai-quality` Summary tab returns `INTERNAL_ERROR` (500) on prod.

**Root cause:** `GetSummary` runs raw SQL via EF Core `Database.SqlQuery<T>` mapping to `FeatureRow`/`DailyRow`, which were **`private` nested classes**. EF's materializer can't construct private nested types — it throws *only once rows exist* (an empty `llm_traces` returns zero rows → no materialization → looked fine; prod has sampled traces → 500). Latent since AI-008.

**Fix:**
- Make `FeatureRow`/`DailyRow` `public`.
- Harden the AI-010 latest-eval-score lookup (try/catch → empty) so a missing/empty `eval_runs` can never break the trace summary.

**Verification:** `dotnet build` 0/0. Couldn't repro locally (dev DB port not exposed to host), but the failure mode (works empty / 500 with rows) is the textbook private-SqlQuery-type limitation; deploy #270 succeeded so migrations (incl. eval_runs) are applied. Will confirm on prod after redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)