### PR TITLE
AI-011: PodcastGenerationJob entity + migration (Phase 3 start)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### AI platform — Phase 3: Podcast MVP (2026-06-06)
+
+Two-voice "podcast" (NotebookLM-style dialogue) generated per catalog edition: LLM builds a script, Edge TTS voices each line, ffmpeg stitches an mp3 the reader can play. Shipped in small PRs.
+
+- **AI-011 — `PodcastGenerationJob` entity + migration** (this PR) — foundation only (no behavior). New `PodcastGenerationJob` (edition-scoped: `EditionId` FK cascade, `Lang`, `Status`, `ScriptJson` jsonb, `AudioPath`, `DurationSeconds`, `CostUsd`, `Error`, timestamps) + `PodcastJobStatus` enum (Queued/Running/Succeeded/Failed), mirroring the `BookQualityJob` job pattern. DbSet on `IAppDbContext`/`AppDbContext`, EF config in `AppDbContext.Podcasts.cs` (indexes on status + edition), migration `AddPodcastGenerationJob` (table `podcast_generation_jobs`). Script builder will use the gateway (`gpt-4.1-nano`, FeatureTag `podcast.script`); TTS reuses the free Edge TTS. ScriptBuilder/AudioAssembler/Worker/endpoints/UI follow in AI-012→017.
+
 ### AI platform — observable LLM layer (foundation) (2026-06-04)
 
 Building a unified, observable LLM layer so every AI call (Explain, Translate,

--- a/backend/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/backend/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -59,6 +59,7 @@ public interface IAppDbContext
     DbSet<BookCollection> BookCollections { get; }
     DbSet<LlmTrace> LlmTraces { get; }
     DbSet<EvalRun> EvalRuns { get; }
+    DbSet<PodcastGenerationJob> PodcastGenerationJobs { get; }
 
     Task<int> SaveChangesAsync(CancellationToken ct = default);
 

--- a/backend/src/Domain/Entities/PodcastGenerationJob.cs
+++ b/backend/src/Domain/Entities/PodcastGenerationJob.cs
@@ -1,0 +1,33 @@
+using Domain.Enums;
+
+namespace Domain.Entities;
+
+/// <summary>
+/// A request to generate a 2-voice "podcast" (NotebookLM-style dialogue) for a catalog
+/// edition (Phase 3). Processed by the Worker: LLM builds a script, Edge TTS voices each
+/// line, ffmpeg stitches them into one mp3 stored under the edition. Mirrors the
+/// <see cref="BookQualityJob"/> job pattern. EF mapping in AppDbContext.Podcasts.cs.
+/// </summary>
+public class PodcastGenerationJob
+{
+    public Guid Id { get; set; }
+    public Guid EditionId { get; set; }
+    public string Lang { get; set; } = "en";
+    public PodcastJobStatus Status { get; set; } = PodcastJobStatus.Queued;
+
+    /// <summary>Structured script: array of <c>{"speaker","line"}</c> turns (jsonb).</summary>
+    public string? ScriptJson { get; set; }
+
+    /// <summary>Storage-relative path to the generated mp3 (served under /storage).</summary>
+    public string? AudioPath { get; set; }
+
+    public int? DurationSeconds { get; set; }
+    public decimal? CostUsd { get; set; }
+    public string? Error { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? StartedAt { get; set; }
+    public DateTimeOffset? FinishedAt { get; set; }
+
+    public Edition? Edition { get; set; }
+}

--- a/backend/src/Domain/Enums/PodcastJobStatus.cs
+++ b/backend/src/Domain/Enums/PodcastJobStatus.cs
@@ -1,0 +1,10 @@
+namespace Domain.Enums;
+
+/// <summary>Lifecycle of a <c>PodcastGenerationJob</c> (Phase 3 — Podcast MVP).</summary>
+public enum PodcastJobStatus
+{
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+}

--- a/backend/src/Infrastructure/Migrations/20260606154538_AddPodcastGenerationJob.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260606154538_AddPodcastGenerationJob.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260606154538_AddPodcastGenerationJob")]
+    partial class AddPodcastGenerationJob
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260606154538_AddPodcastGenerationJob.cs
+++ b/backend/src/Infrastructure/Migrations/20260606154538_AddPodcastGenerationJob.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPodcastGenerationJob : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "podcast_generation_jobs",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    edition_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    lang = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    script_json = table.Column<string>(type: "jsonb", nullable: true),
+                    audio_path = table.Column<string>(type: "text", nullable: true),
+                    duration_seconds = table.Column<int>(type: "integer", nullable: true),
+                    cost_usd = table.Column<decimal>(type: "numeric(10,6)", nullable: true),
+                    error = table.Column<string>(type: "text", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    started_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    finished_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_podcast_generation_jobs", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_podcast_generation_jobs_editions_edition_id",
+                        column: x => x.edition_id,
+                        principalTable: "editions",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_podcast_generation_jobs_edition_id",
+                table: "podcast_generation_jobs",
+                column: "edition_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_podcast_generation_jobs_status",
+                table: "podcast_generation_jobs",
+                column: "status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "podcast_generation_jobs");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Podcasts.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Podcasts.cs
@@ -1,0 +1,25 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Persistence;
+
+/// <summary>EF mapping for Phase 3 podcast generation (<see cref="PodcastGenerationJob"/>).</summary>
+public partial class AppDbContext
+{
+    private static void ConfigurePodcasts(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<PodcastGenerationJob>(e =>
+        {
+            e.HasIndex(x => x.Status);          // worker polls queued jobs
+            e.HasIndex(x => x.EditionId);       // "latest podcast for this edition"
+            e.Property(x => x.Lang).HasMaxLength(16);
+            e.Property(x => x.ScriptJson).HasColumnType("jsonb");
+            e.Property(x => x.CostUsd).HasColumnType("numeric(10,6)");
+
+            e.HasOne(x => x.Edition)
+                .WithMany()
+                .HasForeignKey(x => x.EditionId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -80,6 +80,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
     public DbSet<BookCollection> BookCollections => Set<BookCollection>();
     public DbSet<LlmTrace> LlmTraces => Set<LlmTrace>();
     public DbSet<EvalRun> EvalRuns => Set<EvalRun>();
+    public DbSet<PodcastGenerationJob> PodcastGenerationJobs => Set<PodcastGenerationJob>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -97,6 +98,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
         ConfigureSeo(modelBuilder);
         ConfigureCollections(modelBuilder);
         ConfigureAi(modelBuilder);
+        ConfigurePodcasts(modelBuilder);
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)


### PR DESCRIPTION
Starts **Phase 3 — Podcast MVP** (2-voice NotebookLM-style dialogue per catalog edition: LLM script → Edge TTS → ffmpeg mp3 → reader plays). This PR is **foundation only — no behavior**.

### Added
- `Domain/Entities/PodcastGenerationJob.cs` — edition-scoped: `EditionId` (FK editions, cascade), `Lang`, `Status`, `ScriptJson` (jsonb), `AudioPath`, `DurationSeconds`, `CostUsd` (numeric(10,6)), `Error`, `CreatedAt/StartedAt/FinishedAt`. Mirrors the `BookQualityJob` job pattern.
- `Domain/Enums/PodcastJobStatus.cs` — Queued/Running/Succeeded/Failed.
- DbSet on `IAppDbContext` + `AppDbContext`; EF config `AppDbContext.Podcasts.cs` (indexes on Status + EditionId, jsonb, FK cascade).
- Migration `AddPodcastGenerationJob` → table `podcast_generation_jobs`.

### Phase 3 decisions (applied in later PRs)
- ScriptBuilder uses the gateway (`gpt-4.1-nano`, FeatureTag `podcast.script`) — not gpt-5-mini (we don't run it).
- 2 voices via the free **Edge TTS** (`TextStack.Tts`): Aria + Guy.
- ffmpeg concat (added to Worker image in AI-013); mp3 stored via `IFileStorageService`, served at `/storage`.
- Catalog editions only for MVP (user-book podcasts deferred).

### Verification
- `dotnet build textstack.sln` → 0/0 · `dotnet test tests/TextStack.UnitTests` → 113 passed. Entity-only; not referenced anywhere yet.

Next: AI-012 ScriptBuilder · AI-013 AudioAssembler+ffmpeg · AI-014 PodcastWorker · AI-015 endpoints+nginx · AI-016 reader button · AI-017 goldens+cost check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)