### PR TITLE
fix(mobile): inline vocab translation gloss shows on first load

### DIFF
--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -889,7 +889,13 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
     var VHL_MANAGED_NAMES = ['vocab-new','vocab-recognition','vocab-recall','vocab-context','vocab-mastered','vocab-active'];
     var VHL_WORD_RE = /[\\p{L}\\p{N}'-]+/gu;
 
-    var _showInlineTranslations = false;
+    // Default ON to match the React default (useReaderSettings.showInlineTranslations: true).
+    // Initialising false caused a race: markVocabWords (vocab paint) often ran before the
+    // setShowInlineTranslations(true) injection landed, so vhlRenderOverlay bailed and the
+    // gloss never drew on first load — only a settings toggle forced a re-paint. Starting
+    // true makes the gloss draw from the first paint; the off-injection still hides it for
+    // users who disabled it.
+    var _showInlineTranslations = true;
     var _currentVocabMap = {};
     var _vhlSupport = null;
 


### PR DESCRIPTION
## Problem
On Android (WebView reader), the grey translation gloss above saved vocabulary words — the same feature working in the web/PWA — did not appear on chapter load. Underlines drew, but no gloss. Users only saw it after toggling the inline-translation setting off→on. Reported as missing for ~2 months.

## Root cause
The WebView reader initialised `_showInlineTranslations = false` (`apps/mobile/src/lib/readerHtml.ts`) while the React setting `useReaderSettings.showInlineTranslations` defaults to `true`. On chapter load `markVocabWords` (the vocab paint) frequently ran **before** the `setShowInlineTranslations(true)` injection landed, so `vhlRenderOverlay` bailed on `if (!_showInlineTranslations) return` and never drew the gloss. Toggling the setting forced a re-paint, which is why it "worked" only after a manual toggle.

Data + wiring were already correct: `getReaderVocab` returns `translation`, the setting defaults on, native≠book language, and tapping the word shows the translation.

## Fix
Initialise the WebView flag `_showInlineTranslations = true` (parity with the React default) so the gloss draws from the first paint, with no dependence on injection ordering. The `setShowInlineTranslations(false)` injection still hides it for users who disabled it.

One-line change + explanatory comment.

## Verification
- `npx tsc --noEmit` (apps/mobile): clean.
- Logic: gloss no longer races the settings injection; default-on path renders on first vocab paint.
- On-device confirmation pending the OTA/build (cannot run the user's Android here).

## Rollback
Revert this commit — restores `_showInlineTranslations = false`. No data/schema impact (pure WebView UI default).

## Ship
Mobile JS bundle change → ships via expo-updates OTA after merge (no Store rebuild required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)