### PR TITLE
refactor(mobile): unify the two readers behind one ReaderShell

### DIFF
--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -1,248 +1,61 @@
-import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, Linking } from 'react-native'
+import { useEffect, useState, useRef, useCallback } from 'react'
+import { View, StyleSheet, ActivityIndicator } from 'react-native'
 import { WebView } from 'react-native-webview'
-import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
-import { userBooksApi, t, parseScrollLocator } from '@textstack/shared'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { userBooksApi, parseScrollLocator } from '@textstack/shared'
 import type { UserBookChapterDto, BookmarkDto } from '@textstack/shared'
-import { buildReaderHtml } from '../../../../src/lib/readerHtml'
 import { useAuth } from '../../../../src/context/AuthContext'
-import { useReaderSettings } from '../../../../src/hooks/useReaderSettings'
-import { useReaderSelection } from '../../../../src/hooks/useReaderSelection'
-import { useReaderHighlights } from '../../../../src/hooks/useReaderHighlights'
-import { useReaderVocabMap } from '../../../../src/hooks/useReaderVocabMap'
-import { useReaderVocabActions } from '../../../../src/hooks/useReaderVocabActions'
-import { ReaderSettingsDrawer } from '../../../../src/components/ReaderSettingsDrawer'
-import { SelectionActionBar } from '../../../../src/components/SelectionActionBar'
-import { TranslationSheet } from '../../../../src/components/TranslationSheet'
-import { ExplanationSheet } from '../../../../src/components/ExplanationSheet'
-import { HighlightNoteModal } from '../../../../src/components/HighlightNoteModal'
-import { BookmarksSheet } from '../../../../src/components/BookmarksSheet'
-import { TocSheet } from '../../../../src/components/TocSheet'
-import { useTts } from '../../../../src/hooks/useTts'
-import { useReaderOverlayV2Active } from '../../../../src/hooks/useReaderOverlayV2Active'
-import { useReadingSession } from '../../../../src/hooks/useReadingSession'
-import { useQuickStats } from '../../../../src/hooks/useQuickStats'
-import { useHaptics } from '../../../../src/hooks/useHaptics'
-import { useToast } from '../../../../src/context/ToastContext'
-import { useLanguage } from '../../../../src/context/LanguageContext'
-import { useNativeLanguage } from '../../../../src/context/NativeLanguageContext'
-import { ReaderStatsWidget } from '../../../../src/components/ReaderStatsWidget'
-import { computeBookProgress } from '@textstack/shared'
 import { useUserBookProgress } from '../../../../src/hooks/useUserBookProgress'
-import { ReaderTapCoachmark } from '../../../../src/components/reader/ReaderTapCoachmark'
-import { Ionicons } from '@expo/vector-icons'
+import { ReaderShell } from '../../../../src/components/reader/ReaderShell'
+import { useToast } from '../../../../src/context/ToastContext'
 import { useTheme } from '../../../../src/context/ThemeContext'
-import { fonts } from '../../../../src/theme/typography'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { StatusBar } from 'expo-status-bar'
 import { trackBookOpened } from '../../../../src/lib/analytics'
 
-/** Lightweight {key} interpolation — shared `t()` returns raw keys. */
-function interpolate(template: string, vars: Record<string, string | number>): string {
-  return template.replace(/\{(\w+)\}/g, (_, k) => String(vars[k] ?? `{${k}}`))
-}
+/**
+ * User-uploaded book reader route. Thin wrapper around <ReaderShell>: owns the
+ * /me/books data hooks (chapter, chapter list, bookmarks, progress, infinite
+ * scroll) and hands the loaded chapter + a `kind: 'userbook'` source down. By
+ * sharing the shell it now matches the public reader exactly — including the
+ * inline-translation gloss + exit summary that used to be missing here.
+ */
+const bookmarkSlug = (b: BookmarkDto) => (b.locator.startsWith('chapter:') ? b.locator.slice(8) : b.locator)
 
 export default function UserBookReaderScreen() {
   const { bookId, chapterSlug } = useLocalSearchParams<{ bookId: string; chapterSlug: string }>()
   const router = useRouter()
-  const { isAuthenticated, user } = useAuth()
-  const { settings, update: updateSettings, resolvedFontFamily, resolvedTheme } = useReaderSettings()
-  const overlayV2 = useReaderOverlayV2Active()
+  const { isAuthenticated } = useAuth()
+  const { colors } = useTheme()
+  const { show: showToast } = useToast()
+
   const [chapter, setChapter] = useState<UserBookChapterDto | null>(null)
   const [loading, setLoading] = useState(true)
-  const [settingsOpen, setSettingsOpen] = useState(false)
-  const [translateOpen, setTranslateOpen] = useState(false)
-  const [explainOpen, setExplainOpen] = useState(false)
-  const [progress, setProgress] = useState(0)
-  const [bookmarksOpen, setBookmarksOpen] = useState(false)
-  const [tocOpen, setTocOpen] = useState(false)
   const [bookmarks, setBookmarks] = useState<BookmarkDto[]>([])
   const [chapters, setChapters] = useState<{ slug: string; title: string; chapterNumber?: number }[]>([])
-  // Distinguish "still fetching chapter list" from "extractor returned 0
-  // chapters" in TocSheet — without this both look like a blank sheet.
   const [chaptersLoading, setChaptersLoading] = useState(true)
-  // Σ wordCount of all chapters in the book — used for book-wide progress %.
-  const totalWordCountRef = useRef(0)
-  // Book-wide percent (0..1) — chapter progress folded into the full book
-  // length. Footer + saved progress use this; without it the bar reset to
-  // 0% on every chapter boundary. null until chapters/wordCount land so
-  // the footer doesn't flash a fake 0% before metadata arrives.
-  const bookProgressRef = useRef<number | null>(null)
-  const [bookProgress, setBookProgress] = useState<number | null>(null)
-  const { toggle: toggleTts, isSpeaking } = useTts()
-  const { colors } = useTheme()
-  const quickStats = useQuickStats(isAuthenticated)
-  const haptics = useHaptics()
-  const { show: showToast } = useToast()
-  const { language } = useLanguage()
-  const { nativeLanguage } = useNativeLanguage()
-  const sessionWordCountRef = useRef(0)
 
-  const notifyWordSaved = useCallback(() => {
-    sessionWordCountRef.current += 1
-    const count = sessionWordCountRef.current
-    haptics.play('complete')
-    showToast({
-      variant: 'success',
-      message:
-        count > 1
-          ? interpolate(t(language, 'reader.toastWordAddedCount'), { count })
-          : t(language, 'reader.toastWordAdded'),
-      actionLabel: t(language, 'reader.toastTapToReview'),
-      onPress: () => router.push('/vocabulary'),
-      duration: 2400,
-    })
-  }, [haptics, showToast, language, router])
-  const insets = useSafeAreaInsets()
-  const topBarHeight = 56 + insets.top
-  const footerHeight = 80 + insets.bottom
   const webViewRef = useRef<WebView>(null)
+  const injectJs = useCallback((js: string) => {
+    webViewRef.current?.injectJavaScript(`try{${js}}catch(e){console.error('[diag] injectJs failed:', e && e.message, ${JSON.stringify(js.slice(0, 80))});};true;`)
+  }, [])
+
   const progressRef = useRef(0)
-  // Pixel-accurate scrollY (apps/mobile/src/lib/readerHtml.ts reports it
-  // in 'progress' messages). Used to build the locator + restore on mount.
   const scrollOffsetRef = useRef(0)
-  // Saved offset from the previous session for one-shot restore on
-  // chapter mount. null means "no saved position" — start at top.
+  const currentChapterSlugRef = useRef<string | null>(null)
+  const bookProgressRef = useRef<number | null>(null)
+  const totalWordCountRef = useRef(0)
   const savedScrollOffsetRef = useRef<number | null>(null)
   const restoreScrolledRef = useRef(false)
   const nextChapterRef = useRef<{ slug: string; title: string } | null>(null)
   const wordCountRef = useRef(0)
-  const currentChapterSlugRef = useRef<string | null>(null)
-  const [visibleChapterSlug, setVisibleChapterSlug] = useState<string | null>(null)
-
-  // Sync ref so callbacks fired after a setState see the current bookId
-  // (mirrors editionIdRef in the public reader). Used by shared hooks
-  // below to build the per-book payload for the API.
-  const userBookIdRef = useRef<string | null>(null)
-  useEffect(() => { userBookIdRef.current = bookId || null }, [bookId])
   const bookTitleRef = useRef<string | null>(null)
 
-  // Hoisted ahead of the shared hooks so they can request WebView script
-  // injection (markVocabWords, renderHighlight, scroll restore).
-  const injectJs = useCallback((js: string) => {
-    webViewRef.current?.injectJavaScript(js + ';true;')
-  }, [])
+  // Sync ref so callbacks fired after a setState see the current bookId
+  // (mirrors editionIdRef in the public reader) — used by the shared
+  // highlights/vocab hooks inside ReaderShell.
+  const userBookIdRef = useRef<string | null>(null)
+  useEffect(() => { userBookIdRef.current = bookId || null }, [bookId])
 
-  const {
-    vocabMapRef,
-    flushToCache: flushVocabMap,
-    bumpVocab,
-  } = useReaderVocabMap({
-    user,
-    isAuthenticated,
-    chapterId: chapter?.id,
-    injectJs,
-    bookLanguage: language,
-    nativeLanguage,
-  })
-
-  const {
-    selection,
-    setSelection,
-    wordSaved,
-    setWordSaved,
-    lookupState,
-    setLookupState,
-    autoSavedRef,
-    openSelection,
-  } = useReaderSelection({ flushVocabMap })
-
-  const {
-    highlightsRef,
-    editingHighlight,
-    setEditingHighlight,
-    create: createHighlight,
-    saveNote: saveHighlightNote,
-    updateColor: updateHighlightColor,
-    remove: removeHighlight,
-  } = useReaderHighlights({
-    userBookId: bookId || null,
-    userBookIdRef,
-    user,
-    isAuthenticated,
-    chapterId: chapter?.id,
-    injectJs,
-    showToast,
-  })
-
-  const vocabActions = useReaderVocabActions({
-    vocabMapRef,
-    bookTitleRef,
-    userBookIdRef,
-    chapter: chapter ? { id: chapter.id } as unknown as Parameters<typeof useReaderVocabActions>[0]['chapter'] : null,
-    language,
-    nativeLanguage,
-    isAuthenticated,
-    injectJs,
-    bumpVocab,
-    notifyWordSaved: () => notifyWordSaved(),
-    setSessionWordCount: () => { /* user-book uses sessionWordCountRef inline */ },
-    setWordSaved,
-    setSelection,
-    setLookupState,
-    showToast,
-  })
-
-  // Immersive mode — bars hide on scroll down, reveal on scroll up.
-  // See `readerHtml.ts` for the scroll-direction detector that drives
-  // the `scrollDir` message handled below.
-  const [barsVisible, setBarsVisible] = useState(true)
-  const barsVisibleRef = useRef(true)
-  const barsAnim = useRef(new Animated.Value(1)).current
-  const topBarTranslateY = barsAnim.interpolate({ inputRange: [0, 1], outputRange: [-topBarHeight, 0] })
-  const footerTranslateY = barsAnim.interpolate({ inputRange: [0, 1], outputRange: [footerHeight, 0] })
-  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const hideBars = useCallback(() => {
-    if (hideTimerRef.current) {
-      clearTimeout(hideTimerRef.current)
-      hideTimerRef.current = null
-    }
-    if (!barsVisibleRef.current) return
-    barsVisibleRef.current = false
-    setBarsVisible(false)
-    Animated.timing(barsAnim, { toValue: 0, duration: 300, useNativeDriver: true }).start()
-  }, [barsAnim])
-
-  const showBars = useCallback(() => {
-    if (hideTimerRef.current) {
-      clearTimeout(hideTimerRef.current)
-      hideTimerRef.current = null
-    }
-    if (barsVisibleRef.current) return
-    barsVisibleRef.current = true
-    setBarsVisible(true)
-    Animated.timing(barsAnim, { toValue: 1, duration: 200, useNativeDriver: true }).start()
-  }, [barsAnim])
-
-  const startHideTimer = useCallback(() => {
-    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
-    hideTimerRef.current = setTimeout(() => {
-      hideBars()
-    }, 3000)
-  }, [hideBars])
-
-  const toggleBars = useCallback(() => {
-    if (barsVisibleRef.current) hideBars()
-    else showBars()
-  }, [hideBars, showBars])
-
-  useEffect(() => { if (chapter) startHideTimer() }, [chapter, startHideTimer])
-
-  // Clear pending hide-bars timer on unmount.
-  useEffect(() => () => { if (hideTimerRef.current) clearTimeout(hideTimerRef.current) }, [])
-
-  const { updateProgress: updateSessionProgress, sessionStartedAt } = useReadingSession({
-    editionId: null,
-    userBookId: bookId || null,
-    wordCount: wordCountRef.current,
-    isAuthenticated,
-  })
-
-  // Owns server PUT + local book-percent cache + AppState background
-  // flush. Was 30+ lines of inline logic — extracted to mirror the
-  // catalog reader's useReaderProgress contract (saveProgress / bumpProgress).
-  const { saveProgress: saveUserBookProgress, bumpProgress: bumpUserBookProgress } = useUserBookProgress({
+  const { saveProgress, bumpProgress } = useUserBookProgress({
     bookId: bookId || null,
     chapterSlug,
     currentChapterSlugRef,
@@ -251,6 +64,7 @@ export default function UserBookReaderScreen() {
     bookProgressRef,
   })
 
+  // Load the current chapter.
   useEffect(() => {
     if (!bookId || !chapterSlug) return
     let cancelled = false
@@ -261,16 +75,12 @@ export default function UserBookReaderScreen() {
         setChapter(ch)
         wordCountRef.current = ch.wordCount || 0
       })
-      .catch(e => {
-        if (!cancelled) console.warn('Failed to load user book chapter:', e)
-      })
+      .catch(e => { if (!cancelled) console.warn('Failed to load user book chapter:', e) })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [bookId, chapterSlug])
 
-  // Load saved scroll offset for this chapter so onLoadEnd can scroll
-  // there. Public reader does the same via getLocalProgress; user-books
-  // route through the server API (single source of truth).
+  // Load saved scroll offset for this chapter (server is the single source of truth).
   useEffect(() => {
     restoreScrolledRef.current = false
     savedScrollOffsetRef.current = null
@@ -278,10 +88,7 @@ export default function UserBookReaderScreen() {
     let cancelled = false
     userBooksApi.getUserBookProgress(bookId)
       .then(prog => {
-        if (cancelled) return
-        if (!prog || prog.chapterSlug !== chapterSlug) return
-        // Shared parser handles slug-with-colons + malformed input,
-        // returns null for anything we can't trust. See P1 in ADR-011.
+        if (cancelled || !prog || prog.chapterSlug !== chapterSlug) return
         const parsed = parseScrollLocator(prog.locator)
         if (parsed && parsed.slug === chapterSlug && parsed.offset > 0) {
           savedScrollOffsetRef.current = parsed.offset
@@ -291,21 +98,7 @@ export default function UserBookReaderScreen() {
     return () => { cancelled = true }
   }, [bookId, chapterSlug])
 
-  // Recompute book-wide progress when chapters/totalWordCount finally
-  // resolves — early 'progress' messages fire before the chapter list
-  // arrives, so without this the footer sits at 0% until the user
-  // scrolls again.
-  useEffect(() => {
-    if (chapters.length === 0) return
-    const slug = currentChapterSlugRef.current || chapterSlug || null
-    const bp = computeBookProgress(chapters, slug, progressRef.current, totalWordCountRef.current)
-    bookProgressRef.current = bp
-    setBookProgress(bp)
-  }, [chapters, chapterSlug])
-
-  // Flush handled by useUserBookProgress (unmount effect + AppState listener).
-
-  // Load bookmarks + chapter list for TOC
+  // Load bookmarks + chapter list for TOC + book-wide word count.
   const bookOpenedFiredRef = useRef(false)
   useEffect(() => {
     if (!bookId) return
@@ -313,9 +106,6 @@ export default function UserBookReaderScreen() {
       bookOpenedFiredRef.current = true
       trackBookOpened({ source: 'userbook', userBookId: bookId })
     }
-    // Failures here don't block reading — log so QA can see flaps, but
-    // we intentionally don't toast (the page is functional without TOC
-    // or bookmarks on first load).
     userBooksApi.getUserBookBookmarks(bookId).then(setBookmarks).catch(e => {
       console.warn('Failed to load user-book bookmarks:', e)
     })
@@ -329,35 +119,32 @@ export default function UserBookReaderScreen() {
         wordCount: typeof ch.wordCount === 'number' && ch.wordCount > 0 ? ch.wordCount : 0,
       }))
       setChapters(mapped)
-      // Sum wordCount with null-guard (some chapters may lack the field).
-      // Prefer `b.totalWordCount` if API provided it — that's the canonical
-      // book length and includes any chapter the per-chapter loop missed.
       const summed = mapped.reduce((s, c) => s + (c.wordCount || 0), 0)
-      totalWordCountRef.current = (typeof b.totalWordCount === 'number' && b.totalWordCount > 0)
-        ? b.totalWordCount
-        : summed
+      totalWordCountRef.current = (typeof b.totalWordCount === 'number' && b.totalWordCount > 0) ? b.totalWordCount : summed
     }).catch(e => {
       console.warn('Failed to load user-book chapter list:', e)
-    }).finally(() => {
-      setChaptersLoading(false)
-    })
+    }).finally(() => { setChaptersLoading(false) })
   }, [bookId])
 
-  const activeSlug = visibleChapterSlug ?? chapterSlug
-  const isCurrentBookmarked = bookmarks.some(b => {
-    const slug = b.locator.startsWith('chapter:') ? b.locator.slice(8) : b.locator
-    return slug === activeSlug
-  })
+  const loadNextChapter = async () => {
+    const next = nextChapterRef.current
+    if (!next || !bookId) return
+    try {
+      const ch = await userBooksApi.getUserBookChapter(bookId, next.slug)
+      injectJs(`appendChapter(${JSON.stringify({ html: ch.html, title: ch.title, slug: ch.slug })})`)
+      wordCountRef.current += ch.wordCount || 0
+      nextChapterRef.current = ch.next || null
+      if (!ch.next) injectJs('disableInfiniteScroll()')
+    } catch (e) {
+      console.warn('Failed to load next user-book chapter:', e)
+      injectJs('disableInfiniteScroll()')
+    }
+  }
 
-  const handleToggleBookmark = async () => {
-    if (!bookId || !activeSlug || !chapter) return
-    const existing = bookmarks.find(b => {
-      const slug = b.locator.startsWith('chapter:') ? b.locator.slice(8) : b.locator
-      return slug === activeSlug
-    })
+  const toggleBookmark = async (slug: string) => {
+    if (!bookId || !slug || !chapter) return
+    const existing = bookmarks.find(b => bookmarkSlug(b) === slug)
     if (existing) {
-      // Optimistic remove — restore + toast if the server rejects so the
-      // UI doesn't silently lie about state (mirrors B-29 on public reader).
       setBookmarks(prev => prev.filter(b => b.id !== existing.id))
       try {
         await userBooksApi.deleteUserBookBookmark(bookId, existing.id)
@@ -370,7 +157,7 @@ export default function UserBookReaderScreen() {
       try {
         const bm = await userBooksApi.createUserBookBookmark(bookId, {
           chapterId: chapter.id,
-          locator: `chapter:${activeSlug}`,
+          locator: `chapter:${slug}`,
           title: chapter.title,
         })
         setBookmarks(prev => [...prev, bm])
@@ -381,7 +168,7 @@ export default function UserBookReaderScreen() {
     }
   }
 
-  const handleDeleteBookmark = async (bmId: string) => {
+  const deleteBookmark = async (bmId: string) => {
     if (!bookId) return
     const snapshot = bookmarks.find(b => b.id === bmId) ?? null
     setBookmarks(prev => prev.filter(b => b.id !== bmId))
@@ -389,150 +176,10 @@ export default function UserBookReaderScreen() {
       await userBooksApi.deleteUserBookBookmark(bookId, bmId)
     } catch (e) {
       console.warn('Delete user-book bookmark (sheet) failed:', e)
-      if (snapshot) {
-        setBookmarks(prev => (prev.some(b => b.id === bmId) ? prev : [...prev, snapshot]))
-      }
+      if (snapshot) setBookmarks(prev => (prev.some(b => b.id === bmId) ? prev : [...prev, snapshot]))
       showToast({ message: 'Could not remove bookmark. Try again.', variant: 'error' })
     }
   }
-
-  const handleMessage = useCallback((event: any) => {
-    try {
-      const data = JSON.parse(event.nativeEvent.data)
-      if (data.type === 'tap') {
-        toggleBars()
-      } else if (data.type === 'scrollDir') {
-        if (data.dir === 'up') showBars()
-        else if (data.dir === 'down') hideBars()
-      } else if (data.type === 'progress') {
-        progressRef.current = data.progress
-        if (typeof data.scrollY === 'number') scrollOffsetRef.current = data.scrollY
-        setProgress(data.progress)
-        updateSessionProgress(data.progress)
-        if (data.chapterSlug) {
-          currentChapterSlugRef.current = data.chapterSlug
-          setVisibleChapterSlug(data.chapterSlug)
-        }
-        // Book-wide progress for the footer — keeps the user oriented
-        // across chapter boundaries instead of resetting to 0%.
-        const activeSlugForCalc = data.chapterSlug || currentChapterSlugRef.current || chapterSlug || null
-        const bp = computeBookProgress(chapters, activeSlugForCalc, data.progress, totalWordCountRef.current)
-        bookProgressRef.current = bp
-        setBookProgress(bp)
-        // Debounced save (server PUT + local book-% cache) — owned by
-        // useUserBookProgress so the AppState background flush + unmount
-        // flush + book-% cache live in one place.
-        bumpUserBookProgress()
-      } else if (data.type === 'loaded') {
-        if (chapter?.next) {
-          nextChapterRef.current = chapter.next
-          injectJs('enableInfiniteScroll()')
-        }
-      } else if (data.type === 'requestNextChapter') {
-        loadNextChapter()
-      } else if (data.type === 'highlightTap') {
-        const hl = highlightsRef.current.find(h => h.id === data.highlightId)
-        if (hl) setEditingHighlight(hl)
-      } else if (data.type === 'selection') {
-        const mode: 'tap' | 'drag' = data.mode === 'tap' ? 'tap' : 'drag'
-        const nextId = openSelection(data.text ? { ...data, mode } : null)
-        if (nextId !== null && !data.text.includes(' ')) {
-          // Single-word tap = "peek": auto-TTS + translation only. Saving is an
-          // explicit tap now (no auto-save), mirrors public reader.
-          toggleTts(data.text, { rate: settings.ttsSpeed, lang: language })
-        }
-      }
-    } catch (err) {
-      if (__DEV__) console.warn('[user-book-reader] postMessage handler threw', err, event?.nativeEvent?.data)
-    }
-  }, [chapter, chapters, bookId, chapterSlug, settings.ttsSpeed, isAuthenticated, language, toggleBars, showBars, hideBars, toggleTts, vocabActions, autoSavedRef, openSelection, setEditingHighlight, highlightsRef, updateSessionProgress, bumpUserBookProgress])
-
-  const handleSaveWord = () => {
-    if (!selection) return
-    void vocabActions.saveWord(selection)
-  }
-
-  const handleMarkKnown = () => {
-    if (!selection) return
-    void vocabActions.markKnown(selection)
-  }
-
-  const handleRemoveWord = () => {
-    if (!selection) return
-    void vocabActions.removeWord(selection)
-  }
-
-  const handleHighlight = async (color: string) => {
-    if (!selection || !chapter) return
-    await createHighlight({ color, selection, chapter: { id: chapter.id } })
-    if (color === 'yellow' || color === 'green' || color === 'pink' || color === 'blue') {
-      updateSettings({ lastHighlightColor: color })
-    }
-    setSelection(null)
-  }
-
-  // Mirror the public reader: tap = single-word layout of SelectionActionBar
-  // (translation row + per-word actions); drag = layout chosen by content.
-  const isMultiWord = !!(selection && selection.mode === 'drag' && selection.text.includes(' '))
-
-  const navigateChapter = (slug: string) => {
-    // Flush current chapter's tail before leaving — matches catalog
-    // reader, prevents losing the last few seconds of scroll on nav.
-    saveUserBookProgress()
-    // Eagerly seed book-progress for the new chapter (progress=0 at top).
-    // Without this the footer keeps the OLD chapter's % until the first
-    // scroll message lands.
-    progressRef.current = 0
-    scrollOffsetRef.current = 0
-    setProgress(0)
-    if (chapters.length > 0) {
-      const bp = computeBookProgress(chapters, slug, 0, totalWordCountRef.current)
-      bookProgressRef.current = bp
-      setBookProgress(bp)
-    }
-    router.replace(`/my-books/read/${bookId}/${slug}`)
-  }
-
-
-  const loadNextChapter = async () => {
-    const next = nextChapterRef.current
-    if (!next || !bookId) return
-    try {
-      const ch = await userBooksApi.getUserBookChapter(bookId, next.slug)
-      injectJs(`appendChapter(${JSON.stringify({ html: ch.html, title: ch.title, slug: ch.slug })})`)
-      wordCountRef.current += ch.wordCount || 0
-      nextChapterRef.current = ch.next || null
-      if (!ch.next) injectJs('disableInfiniteScroll()')
-    } catch (e) {
-      // If we can't load the next chapter, turn off infinite scroll so
-      // we don't retry-loop on every scroll gesture. A warn tells QA
-      // the network (not the content) dropped us.
-      console.warn('Failed to load next user-book chapter:', e)
-      injectJs('disableInfiniteScroll()')
-    }
-  }
-
-  const currentChapterIndex = chapters.findIndex(c => c.slug === chapterSlug)
-  const totalChapters = chapters.length
-
-  // Memoize HTML + WebView source — without this, every render (bars
-  // toggle, progress tick, selection set) rebuilt the full chapter HTML
-  // string AND created a new `{ html }` object, causing the WebView to
-  // throw away its DOM and re-render. Public reader fixed this in B-36;
-  // user-book reader was overlooked. Keep deps to actual style inputs.
-  const html = useMemo(() => {
-    if (!chapter) return ''
-    return buildReaderHtml(chapter.html, {
-      fontSize: settings.fontSize,
-      lineHeight: settings.lineHeight,
-      fontFamily: resolvedFontFamily,
-      textAlign: settings.textAlign,
-      backgroundColor: resolvedTheme.backgroundColor,
-      textColor: resolvedTheme.textColor,
-    }, undefined, { top: insets.top, bottom: insets.bottom }, { overlayV2 })
-  }, [chapter, settings.fontSize, settings.lineHeight, resolvedFontFamily, settings.textAlign, resolvedTheme.backgroundColor, resolvedTheme.textColor, insets.top, insets.bottom, overlayV2])
-
-  const webViewSource = useMemo(() => ({ html }), [html])
 
   if (loading || !chapter) {
     return (
@@ -542,301 +189,43 @@ export default function UserBookReaderScreen() {
     )
   }
 
-  const barBg = resolvedTheme.backgroundColor
-  const barText = resolvedTheme.textColor
-
   return (
-    <>
-      <Stack.Screen options={{ headerShown: false }} />
-      <StatusBar hidden={!barsVisible} style={settings.theme === 'dark' ? 'light' : 'dark'} />
-      <View style={[styles.container, { backgroundColor: barBg }]}>
-        {/* WebView first — overlay bars rendered after so they sit on top of native layer */}
-        <WebView
-          ref={webViewRef}
-          source={webViewSource}
-          style={[styles.webview, { backgroundColor: resolvedTheme.backgroundColor }]}
-          onMessage={handleMessage}
-          onLoadEnd={() => {
-            // `html` memo rebuilds on settings change → WebView reloads → JS state wiped.
-            // Re-apply highlights + vocab from refs so they survive font/theme tweaks.
-            for (const h of highlightsRef.current) {
-              injectJs(`renderHighlight(${JSON.stringify(h.id)}, ${JSON.stringify(h.anchorJson)}, ${JSON.stringify(h.color)}, ${JSON.stringify(h.selectedText)})`)
-            }
-            if (Object.keys(vocabMapRef.current).length > 0) {
-              injectJs(`markVocabWords(${JSON.stringify(vocabMapRef.current)})`)
-            }
-            // One-shot restore of saved scroll position. Settings changes
-            // re-fire onLoadEnd; the ref guard keeps us from yanking the
-            // user back to the original offset mid-read.
-            if (!restoreScrolledRef.current && savedScrollOffsetRef.current != null) {
-              const off = savedScrollOffsetRef.current
-              restoreScrolledRef.current = true
-              injectJs(`window.__textstackRestoreScroll && window.__textstackRestoreScroll(${off})`)
-            }
-          }}
-          originWhitelist={['*']}
-          scrollEnabled
-          showsVerticalScrollIndicator={false}
-          // GPU-composited page on Android — library reader parity.
-          androidLayerType="hardware"
-          overScrollMode="never"
-          bounces={false}
-          menuItems={[]}
-          cacheEnabled={false}
-          // Intercept in-book links; route external URLs out to the OS
-          // browser so the WebView keeps its injected script + DOM.
-          onShouldStartLoadWithRequest={(req) => {
-            const { url, navigationType } = req
-            if (url === 'about:blank' || url.startsWith('data:') || url.startsWith('file:')) return true
-            if (navigationType === 'click' && (url.startsWith('http://') || url.startsWith('https://'))) {
-              Linking.openURL(url).catch(() => {})
-              return false
-            }
-            return false
-          }}
-        />
-
-        {/* Top bar — after WebView so it renders on top */}
-        <Animated.View style={[styles.topBar, { backgroundColor: barBg, borderBottomColor: barText + '20', paddingTop: insets.top, opacity: barsAnim, transform: [{ translateY: topBarTranslateY }] }]} pointerEvents={barsVisible ? 'auto' : 'none'}>
-          <TouchableOpacity onPress={() => router.back()} style={styles.topBarBtn}>
-            <Ionicons name="chevron-back" size={24} color={colors.primary} />
-          </TouchableOpacity>
-          <Text style={[styles.chapterTitle, { color: barText }]} numberOfLines={1}>
-            {chapter.title}
-          </Text>
-          <View style={styles.topBarRight}>
-            <TouchableOpacity onPress={() => setTocOpen(true)} style={styles.iconBtn}>
-              <Ionicons name="list-outline" size={20} color={barText} />
-            </TouchableOpacity>
-            <TouchableOpacity onPress={handleToggleBookmark} style={styles.iconBtn}>
-              <Ionicons name={isCurrentBookmarked ? 'bookmark' : 'bookmark-outline'} size={20} color={isCurrentBookmarked ? colors.primary : barText} />
-            </TouchableOpacity>
-            <TouchableOpacity onPress={() => setSettingsOpen(true)} style={styles.iconBtn}>
-              <Ionicons name="text-outline" size={20} color={barText} />
-            </TouchableOpacity>
-          </View>
-        </Animated.View>
-
-        {selection && (
-          <SelectionActionBar
-            selectedText={selection.text}
-            isMultiWord={isMultiWord}
-            language={language}
-            onTranslate={() => setTranslateOpen(true)}
-            onExplain={() => setExplainOpen(true)}
-            onSpeak={() => toggleTts(selection.text, { rate: settings.ttsSpeed, lang: language })}
-            onSaveWord={handleSaveWord}
-            onHighlight={handleHighlight}
-            highlightColor={settings.lastHighlightColor}
-            onMarkKnown={handleMarkKnown}
-            onRemove={handleRemoveWord}
-            isSpeaking={isSpeaking}
-            wordSaved={wordSaved}
-            vocabStage={selection ? (vocabMapRef.current[selection.text.toLowerCase()]?.stage ?? null) : null}
-            isAuthenticated={isAuthenticated}
-            bottomOffset={footerHeight}
-            onClose={() => {
-              // Mirror catalog reader: drop the native WebView selection
-              // rectangle so the user doesn't see leftover highlighting
-              // after closing our overlay.
-              injectJs('try{window.getSelection&&window.getSelection().removeAllRanges()}catch(e){}')
-              setSelection(null)
-            }}
-          />
-        )}
-
-        {/* First-run tap-to-save hint — self-gated by AsyncStorage flag */}
-        <ReaderTapCoachmark />
-
-        {/* Reading stats widget */}
-        {settings.showReaderStats && isAuthenticated && quickStats && barsVisible && (
-          <ReaderStatsWidget
-            sessionStartedAt={sessionStartedAt}
-            todaySeconds={quickStats.todaySeconds}
-            dailyGoalMinutes={quickStats.dailyGoalMinutes}
-          />
-        )}
-
-        <Animated.View style={[styles.footerOverlay, { backgroundColor: barBg, paddingBottom: insets.bottom, opacity: barsAnim, transform: [{ translateY: footerTranslateY }] }]} pointerEvents={barsVisible ? 'auto' : 'none'}>
-          <View style={[styles.progressContainer, { borderTopColor: colors.border }]}>
-            <View style={[styles.progressBar, { backgroundColor: colors.border }]}>
-              {/* Book-wide percent — was chapter-only, which reset to ~0%
-                  on every new chapter and felt like no progress was being
-                  made through the book. Empty bar while loading instead of
-                  fake 0%. */}
-              <View style={[styles.progressFill, { width: `${bookProgress != null ? Math.round(bookProgress * 100) : 0}%`, backgroundColor: colors.primary }]} />
-            </View>
-            <View style={styles.footerRow}>
-              <TouchableOpacity
-                onPress={() => chapter?.prev && navigateChapter(chapter.prev.slug)}
-                disabled={!chapter?.prev}
-                style={styles.chevronBtn}
-                accessibilityLabel="Previous chapter"
-                accessibilityRole="button"
-              >
-                <Text style={[styles.chevron, { color: chapter?.prev ? colors.text : colors.textSecondary, opacity: chapter?.prev ? 1 : 0.3 }]}>‹</Text>
-              </TouchableOpacity>
-
-              <View style={styles.footerInfo}>
-                <Text style={[styles.footerChapter, { color: colors.text }]} numberOfLines={1}>
-                  {chapter?.title || ''}
-                </Text>
-                <View style={styles.footerMeta}>
-                  {totalChapters > 1 && currentChapterIndex >= 0 && (
-                    <Text style={[styles.footerCounter, { color: colors.textSecondary }]}>
-                      {currentChapterIndex + 1} / {totalChapters}
-                    </Text>
-                  )}
-                  <Text style={[styles.footerPercent, { color: colors.textSecondary }]}>
-                    {bookProgress != null ? `${Math.round(bookProgress * 100)}%` : '—'}
-                  </Text>
-                </View>
-              </View>
-
-              <TouchableOpacity
-                onPress={() => chapter?.next && navigateChapter(chapter.next.slug)}
-                disabled={!chapter?.next}
-                style={styles.chevronBtn}
-                accessibilityLabel="Next chapter"
-                accessibilityRole="button"
-              >
-                <Text style={[styles.chevron, { color: chapter?.next ? colors.text : colors.textSecondary, opacity: chapter?.next ? 1 : 0.3 }]}>›</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        </Animated.View>
-
-        <ReaderSettingsDrawer
-          visible={settingsOpen}
-          onClose={() => setSettingsOpen(false)}
-          settings={settings}
-          onUpdate={updateSettings}
-        />
-
-        <TranslationSheet
-          visible={translateOpen}
-          text={selection?.text || ''}
-          onClose={() => setTranslateOpen(false)}
-          onSpeak={(t) => toggleTts(t, { rate: settings.ttsSpeed, lang: language })}
-          fromLang={language}
-        />
-
-        <ExplanationSheet
-          visible={explainOpen}
-          word={selection?.text || ''}
-          sentence={selection?.sentence || selection?.text || ''}
-          fromLang={language}
-          onClose={() => setExplainOpen(false)}
-        />
-
-        <BookmarksSheet
-          visible={bookmarksOpen}
-          onClose={() => setBookmarksOpen(false)}
-          bookmarks={bookmarks}
-          currentChapterSlug={activeSlug || ''}
-          onNavigate={navigateChapter}
-          onDelete={handleDeleteBookmark}
-          onToggleCurrent={handleToggleBookmark}
-          isCurrentBookmarked={isCurrentBookmarked}
-        />
-
-        <TocSheet
-          visible={tocOpen}
-          chapters={chapters}
-          currentChapterSlug={activeSlug || ''}
-          bookmarks={bookmarks.map(b => ({
-            chapterSlug: b.locator.startsWith('chapter:') ? b.locator.slice(8) : b.locator,
-            title: b.title || undefined,
-          }))}
-          onNavigate={navigateChapter}
-          onClose={() => setTocOpen(false)}
-          loading={chaptersLoading}
-        />
-
-        {/* Highlight note editor — Android-safe replacement for Alert.prompt */}
-        <HighlightNoteModal
-          visible={!!editingHighlight}
-          snippet={editingHighlight
-            ? editingHighlight.selectedText.substring(0, 120) + (editingHighlight.selectedText.length > 120 ? '…' : '')
-            : ''}
-          initialNote={editingHighlight?.noteText || ''}
-          initialColor={(editingHighlight?.color ?? settings.lastHighlightColor) as 'yellow' | 'green' | 'pink' | 'blue'}
-          onCancel={() => setEditingHighlight(null)}
-          onColorChange={async (color) => {
-            const hl = editingHighlight
-            if (!hl) return
-            updateSettings({ lastHighlightColor: color })
-            await updateHighlightColor(hl.id, color)
-          }}
-          onSave={async (note) => {
-            const hl = editingHighlight
-            setEditingHighlight(null)
-            if (hl) await saveHighlightNote(hl.id, note)
-          }}
-          onDelete={async () => {
-            const hl = editingHighlight
-            setEditingHighlight(null)
-            if (hl) await removeHighlight(hl.id)
-          }}
-        />
-      </View>
-    </>
+    <ReaderShell
+      source={{ kind: 'userbook', id: bookId || null, idRef: userBookIdRef }}
+      webViewRef={webViewRef}
+      injectJs={injectJs}
+      chapter={{ id: chapter.id, title: chapter.title, html: chapter.html, prev: chapter.prev, next: chapter.next }}
+      chapterSlug={chapterSlug}
+      bookTitle={bookTitleRef.current}
+      chapters={chapters}
+      chaptersLoading={chaptersLoading}
+      progressRef={progressRef}
+      scrollOffsetRef={scrollOffsetRef}
+      currentChapterSlugRef={currentChapterSlugRef}
+      bookProgressRef={bookProgressRef}
+      totalWordCountRef={totalWordCountRef}
+      bumpProgress={bumpProgress}
+      saveProgress={saveProgress}
+      restoreScrolledRef={restoreScrolledRef}
+      savedScrollOffsetRef={savedScrollOffsetRef}
+      onChapterLoaded={() => {
+        if (chapter.next) {
+          nextChapterRef.current = chapter.next
+          injectJs('enableInfiniteScroll()')
+        }
+      }}
+      onRequestNextChapter={loadNextChapter}
+      onNavigateChapter={(slug) => router.replace(`/my-books/read/${bookId}/${slug}`)}
+      bookmarks={bookmarks}
+      onToggleCurrentBookmark={toggleBookmark}
+      onDeleteBookmark={deleteBookmark}
+      bookmarkChapterSlug={bookmarkSlug}
+      bookTitleRef={bookTitleRef}
+      wordCount={wordCountRef.current}
+    />
   )
 }
 
 const styles = StyleSheet.create({
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  container: { flex: 1 },
-  topBar: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    zIndex: 10,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderBottomWidth: 1,
-  },
-  topBarBtn: { minWidth: 44, minHeight: 44, justifyContent: 'center' as const },
-  topBarRight: { flexDirection: 'row' as const, alignItems: 'center' as const, gap: 4 },
-  iconBtn: { padding: 8, minWidth: 44, minHeight: 44, justifyContent: 'center' as const, alignItems: 'center' as const },
-  chapterTitle: { flex: 1, textAlign: 'center' as const, fontSize: 14, fontWeight: '500' as const, fontFamily: fonts.sansMedium },
-  webview: { flex: 1 },
-  footerOverlay: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    zIndex: 10,
-  },
-  progressContainer: {
-    paddingHorizontal: 16,
-    paddingVertical: 6,
-    borderTopWidth: StyleSheet.hairlineWidth,
-  },
-  progressBar: {
-    height: 3,
-    borderRadius: 2,
-  },
-  progressFill: {
-    height: 3,
-    borderRadius: 2,
-  },
-  progressText: {
-    fontSize: 11,
-    textAlign: 'center' as const,
-    marginTop: 4,
-    fontFamily: fonts.sans,
-  },
-  footerRow: { flexDirection: 'row', alignItems: 'center', paddingTop: 4, minHeight: 48 },
-  chevronBtn: { width: 44, height: 44, justifyContent: 'center' as const, alignItems: 'center' as const },
-  chevron: { fontSize: 28, fontFamily: fonts.sans, lineHeight: 28 },
-  footerInfo: { flex: 1, alignItems: 'center' as const, paddingHorizontal: 4 },
-  footerChapter: { fontSize: 13, fontFamily: fonts.sansMedium, fontWeight: '500' as const, textAlign: 'center' as const },
-  footerMeta: { flexDirection: 'row', alignItems: 'center' as const, gap: 12, marginTop: 2 },
-  footerCounter: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
-  footerPercent: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
 })

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -1,106 +1,53 @@
-import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, Linking } from 'react-native'
+import { useEffect, useRef, useCallback } from 'react'
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
-import { t, readingProgressApi, parseScrollLocator } from '@textstack/shared'
-import { buildReaderHtml } from '../../../src/lib/readerHtml'
+import { readingProgressApi, parseScrollLocator } from '@textstack/shared'
 import { getLocalProgress } from '../../../src/lib/progressStorage'
 import { useAuth } from '../../../src/context/AuthContext'
-import { useReaderSettings } from '../../../src/hooks/useReaderSettings'
-import { useReaderBars } from '../../../src/hooks/useReaderBars'
 import { useReaderBookmarks, getSlugFromLocator } from '../../../src/hooks/useReaderBookmarks'
-import { useReaderExitSummary } from '../../../src/hooks/useReaderExitSummary'
-import { useReaderHighlights } from '../../../src/hooks/useReaderHighlights'
-import { useReaderVocabMap } from '../../../src/hooks/useReaderVocabMap'
 import { useReaderProgress } from '../../../src/hooks/useReaderProgress'
-import { useReaderVocabActions } from '../../../src/hooks/useReaderVocabActions'
-import { useReaderSelection } from '../../../src/hooks/useReaderSelection'
 import { useReaderChapter } from '../../../src/hooks/useReaderChapter'
 import { useReaderBook } from '../../../src/hooks/useReaderBook'
 import { useReaderInfiniteScroll } from '../../../src/hooks/useReaderInfiniteScroll'
-import { ReaderSettingsDrawer } from '../../../src/components/ReaderSettingsDrawer'
-import { BookmarksSheet } from '../../../src/components/BookmarksSheet'
-import { SelectionActionBar } from '../../../src/components/SelectionActionBar'
-import { TranslationSheet } from '../../../src/components/TranslationSheet'
-import { ExplanationSheet } from '../../../src/components/ExplanationSheet'
-import { HighlightNoteModal } from '../../../src/components/HighlightNoteModal'
-import { TocSheet } from '../../../src/components/TocSheet'
-import { ReaderStatsWidget } from '../../../src/components/ReaderStatsWidget'
-import { ReaderTapCoachmark } from '../../../src/components/reader/ReaderTapCoachmark'
-import { ReaderTopBar } from '../../../src/components/reader/ReaderTopBar'
-import { useReadingSession } from '../../../src/hooks/useReadingSession'
-import { computeBookProgress } from '@textstack/shared'
-import { useReaderOverlayV2Active } from '../../../src/hooks/useReaderOverlayV2Active'
-import { useTts } from '../../../src/hooks/useTts'
-import { useQuickStats } from '../../../src/hooks/useQuickStats'
-import { useHaptics } from '../../../src/hooks/useHaptics'
+import { ReaderShell } from '../../../src/components/reader/ReaderShell'
 import { useToast } from '../../../src/context/ToastContext'
-import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '../../../src/context/ThemeContext'
 import { useLanguage } from '../../../src/context/LanguageContext'
-import { useNativeLanguage } from '../../../src/context/NativeLanguageContext'
 import { fonts } from '../../../src/theme/typography'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { StatusBar } from 'expo-status-bar'
+import { Ionicons } from '@expo/vector-icons'
 
-/** Lightweight {key} interpolation — shared `t()` returns raw keys, we fill them in here. */
-function interpolate(template: string, vars: Record<string, string | number>): string {
-  return template.replace(/\{(\w+)\}/g, (_, k) => String(vars[k] ?? `{${k}}`))
-}
-
+/**
+ * Public-library reader route. Thin wrapper around <ReaderShell>: owns the
+ * catalog data hooks (chapter, book, bookmarks, progress, infinite scroll),
+ * handles loading/error, and hands the loaded chapter + a `kind: 'edition'`
+ * source down to the shared shell.
+ */
 export default function ReaderScreen() {
   const { bookSlug, chapterSlug } = useLocalSearchParams<{ bookSlug: string; chapterSlug: string }>()
   const router = useRouter()
-  const { isAuthenticated, user } = useAuth()
-  const { settings, update: updateSettings, resolvedFontFamily, resolvedTheme } = useReaderSettings()
-  const overlayV2 = useReaderOverlayV2Active()
-  const [settingsOpen, setSettingsOpen] = useState(false)
-  const [bookmarksOpen, setBookmarksOpen] = useState(false)
-  const [translateOpen, setTranslateOpen] = useState(false)
-  const [explainOpen, setExplainOpen] = useState(false)
-  const [tocOpen, setTocOpen] = useState(false)
-  const [progress, setProgress] = useState(0)
-  // Book-wide percent (0..1) — derived from chapter scroll + chapter list +
-  // total word count. The footer shows this, not the chapter-only `progress`,
-  // so users see how far they are through the BOOK (was: how far through
-  // the current chapter, which reset to ~0% on every chapter boundary).
-  // null before chapters/wordCount lands — footer hides the % to avoid the
-  // misleading "0%" flash on initial load.
-  const [bookProgress, setBookProgress] = useState<number | null>(null)
-  const bookProgressRef = useRef<number | null>(null)
-  const { toggle: toggleTts, isSpeaking } = useTts()
+  const { isAuthenticated } = useAuth()
+  const { colors } = useTheme()
+  const { language } = useLanguage()
+  const { show: showToast } = useToast()
+
   const webViewRef = useRef<WebView>(null)
-  // Wrap in try/catch so runtime errors in injected JS are forwarded to RN
-  // via the console bridge, instead of being silently swallowed by the
-  // `;true;` sentinel (diagnostics Phase 1).
   const injectJs = useCallback((js: string) => {
     webViewRef.current?.injectJavaScript(`try{${js}}catch(e){console.error('[diag] injectJs failed:', e && e.message, ${JSON.stringify(js.slice(0, 80))});};true;`)
   }, [])
+
   const progressRef = useRef(0)
-  // Pixel-accurate scrollY, refreshed on every 'progress' message. Drives
-  // the 'scroll:slug:offset' locator so resume lands on the exact line,
-  // not just the nearest 1%-of-chapter band (apps/web/src/hooks/useReaderScrollSync.ts).
   const scrollOffsetRef = useRef(0)
+  const currentChapterSlugRef = useRef<string | null>(null)
+  const bookProgressRef = useRef<number | null>(null)
+  const totalWordCountRef = useRef(0)
   const editionIdRef = useRef<string | null>(null)
   const bookTitleRef = useRef<string | null>(null)
-  const totalWordCountRef = useRef(0)
-  // Saved in-chapter position for restore on WebView load. Loaded async
-  // from local AsyncStorage (server fallback for authed users) once the
-  // editionId resolves. Locator (pixel offset) wins; percent is fallback
-  // for legacy entries written before P0.2.
   const savedPercentRef = useRef<number | null>(null)
   const savedScrollOffsetRef = useRef<number | null>(null)
   const restoreScrolledRef = useRef(false)
 
-  const { colors } = useTheme()
-  const { language } = useLanguage()
-  const { nativeLanguage } = useNativeLanguage()
-  const quickStats = useQuickStats(isAuthenticated)
-  const haptics = useHaptics()
-  const { show: showToast } = useToast()
-  const sessionWordCountRef = useRef(0)
-
-  const { chapter, setChapter, loading, chapterError, wordCountRef } = useReaderChapter({
+  const { chapter, loading, chapterError, wordCountRef } = useReaderChapter({
     bookSlug,
     chapterSlug,
     language,
@@ -110,14 +57,10 @@ export default function ReaderScreen() {
   const {
     bookmarks,
     setBookmarks,
-    isBookmarked,
     toggle: toggleBookmark,
     remove: removeBookmark,
   } = useReaderBookmarks({ editionIdRef, isAuthenticated, showToast })
 
-  // Hoisted above useReaderHighlights so its `editionId` state is available
-  // — without it the highlights effect can race chapterId against editionId
-  // and miss the load when chapter wins.
   const { bookTitle, chapters, editionId, chaptersLoading } = useReaderBook({
     bookSlug,
     language,
@@ -126,91 +69,6 @@ export default function ReaderScreen() {
     bookTitleRef,
     totalWordCountRef,
     setBookmarks,
-  })
-
-  const {
-    highlightsRef,
-    editingHighlight,
-    setEditingHighlight,
-    create: createHighlight,
-    saveNote: saveHighlightNote,
-    updateColor: updateHighlightColor,
-    remove: removeHighlight,
-  } = useReaderHighlights({
-    editionId,
-    editionIdRef,
-    user,
-    isAuthenticated,
-    chapterId: chapter?.id,
-    injectJs,
-    showToast,
-  })
-
-  const { vocabMapRef, flushToCache: flushVocabMap, bumpVocab } = useReaderVocabMap({
-    user,
-    isAuthenticated,
-    chapterId: chapter?.id,
-    injectJs,
-    bookLanguage: language,
-    nativeLanguage,
-  })
-
-  const {
-    selection,
-    setSelection,
-    wordSaved,
-    setWordSaved,
-    lookupState,
-    setLookupState,
-    autoSavedRef,
-    openSelection,
-  } = useReaderSelection({ flushVocabMap })
-
-  // Single source of truth for "word added" feedback — keeps toast copy + haptic
-  // cue + session counter consistent across the two save paths (auto-save on
-  // single-word tap, and the manual "Save" button in SelectionActionBar).
-  const notifyWordSaved = useCallback(() => {
-    sessionWordCountRef.current += 1
-    const count = sessionWordCountRef.current
-    haptics.play('complete')
-    showToast({
-      variant: 'success',
-      message:
-        count > 1
-          ? interpolate(t(language, 'reader.toastWordAddedCount'), { count })
-          : t(language, 'reader.toastWordAdded'),
-      actionLabel: t(language, 'reader.toastTapToReview'),
-      onPress: () => router.push('/vocabulary'),
-      duration: 2400,
-    })
-  }, [haptics, showToast, language, router])
-
-  const { enableForChapter: enableInfiniteScrollFor, loadNext: loadNextChapter } = useReaderInfiniteScroll({
-    bookSlug,
-    language,
-    injectJs,
-    wordCountRef,
-  })
-  const insets = useSafeAreaInsets()
-  const topBarHeight = 56 + insets.top
-  const footerHeight = 60 + insets.bottom
-
-  // Immersive mode — auto-hide bars. Auto-hide on first chapter load gives
-  // the reader chrome to orient with; after that visibility is driven by
-  // scroll direction (see handleMessage 'scrollDir').
-  const { barsVisible, barsAnim, topBarTranslateY, footerTranslateY, showBars, hideBars, toggleBars } = useReaderBars({
-    topBarHeight,
-    footerHeight,
-    autoHideTrigger: !loading && !!chapter,
-  })
-  const currentChapterSlugRef = useRef<string | null>(null)
-  const [visibleChapterSlug, setVisibleChapterSlug] = useState<string | null>(null)
-
-  // Reading session tracking
-  const { updateProgress: updateSessionProgress, sessionStartedAt } = useReadingSession({
-    editionId: editionIdRef.current,
-    wordCount: wordCountRef.current,
-    isAuthenticated,
   })
 
   const { saveProgress, bumpProgress } = useReaderProgress({
@@ -224,168 +82,17 @@ export default function ReaderScreen() {
     isAuthenticated,
   })
 
-  const {
-    sessionWordCount,
-    setSessionWordCount,
-    exitSummary,
-    exit: handleExit,
-    exitToReview: handleExitReview,
-    exitLater: handleExitLater,
-  } = useReaderExitSummary({ router, saveProgress })
-
-  const vocabActions = useReaderVocabActions({
-    vocabMapRef,
-    bookTitleRef,
-    editionIdRef,
-    chapter,
+  const { enableForChapter: enableInfiniteScrollFor, loadNext: loadNextChapter } = useReaderInfiniteScroll({
+    bookSlug,
     language,
-    nativeLanguage,
-    isAuthenticated,
     injectJs,
-    bumpVocab,
-    notifyWordSaved,
-    setSessionWordCount,
-    setWordSaved,
-    setSelection,
-    setLookupState,
-    showToast,
+    wordCountRef,
   })
 
-  const handleMessage = useCallback((event: any) => {
-    try {
-      const data = JSON.parse(event.nativeEvent.data)
-      if (data.type === 'log') {
-        if (__DEV__) {
-          const fn = data.level === 'error' ? console.error : data.level === 'warn' ? console.warn : console.log
-          fn('[WV]', data.msg)
-        }
-        return
-      }
-      if (data.type === 'tap') {
-        toggleBars()
-      } else if (data.type === 'scrollDir') {
-        // ElevenReader-style reveal: scrolling back up (re-reading)
-        // brings chrome back; scrolling forward hides it. Tap remains
-        // as a manual toggle for discoverability.
-        if (data.dir === 'up') showBars()
-        else if (data.dir === 'down') hideBars()
-      } else if (data.type === 'progress') {
-        progressRef.current = data.progress
-        if (typeof data.scrollY === 'number') scrollOffsetRef.current = data.scrollY
-        setProgress(data.progress)
-        updateSessionProgress(data.progress)
-        if (data.chapterSlug) {
-          currentChapterSlugRef.current = data.chapterSlug
-          setVisibleChapterSlug(data.chapterSlug)
-        }
-        // Book-wide percent for the footer + LocalProgress. Derived here
-        // (not memoized) because chapters/progress change frequently and
-        // the compute is O(currentIdx) which is cheap.
-        const activeSlugForCalc = data.chapterSlug || currentChapterSlugRef.current || chapterSlug || null
-        const bp = computeBookProgress(chapters, activeSlugForCalc, data.progress, totalWordCountRef.current)
-        bookProgressRef.current = bp
-        setBookProgress(bp)
-        // 2s-debounced save (apps/mobile/src/hooks/useReaderProgress.ts).
-        // Prevents losing scroll position inside long chapters on
-        // unexpected app death.
-        bumpProgress()
-      } else if (data.type === 'loaded') {
-        enableInfiniteScrollFor(chapter)
-      } else if (data.type === 'requestNextChapter') {
-        loadNextChapter()
-      } else if (data.type === 'highlightTap') {
-        const hl = highlightsRef.current.find(h => h.id === data.highlightId)
-        if (hl) setEditingHighlight(hl)
-      } else if (data.type === 'selection') {
-        // mode is set by readerHtml: 'tap' = selectWordAtPoint, 'drag' = selectionchange.
-        // Default to 'drag' for any legacy payload that doesn't include mode.
-        const mode: 'tap' | 'drag' = data.mode === 'tap' ? 'tap' : 'drag'
-        const nextId = openSelection(data.text ? { ...data, mode } : null)
-        // Single-word tap = "peek": auto-TTS + show translation only. Saving is
-        // now an explicit tap on the Save button (no auto-save) so a word looked
-        // up by accident isn't added to vocabulary.
-        if (nextId !== null && !data.text.includes(' ')) {
-          toggleTts(data.text, { rate: settings.ttsSpeed, lang: language })
-        }
-      }
-    } catch (err) {
-      if (__DEV__) console.warn('[reader] postMessage handler threw', err, event?.nativeEvent?.data)
-    }
-    // Refs (highlightsRef, autoSavedRef) are read inside but intentionally
-    // omitted from deps — refs don't trigger re-creation and listing them
-    // here only adds noise.
-  }, [chapter, chapters, chapterSlug, language, settings.ttsSpeed, toggleTts, toggleBars, showBars, hideBars, vocabActions, setEditingHighlight, updateSessionProgress, enableInfiniteScrollFor, loadNextChapter, openSelection, bumpProgress])
-
-  const navigateChapter = (slug: string) => {
-    saveProgress()
-    // Eagerly seed book-progress for the new chapter (progress=0 at the
-    // top). Without this the footer keeps the OLD chapter's % until the
-    // first scroll event arrives, which reads as "I jumped ahead but the
-    // % didn't change". Reset progress + scroll refs too so the next
-    // save() in the new chapter starts from a clean slate.
-    progressRef.current = 0
-    scrollOffsetRef.current = 0
-    setProgress(0)
-    if (chapters.length > 0) {
-      const bp = computeBookProgress(chapters, slug, 0, totalWordCountRef.current)
-      bookProgressRef.current = bp
-      setBookProgress(bp)
-    }
-    router.replace(`/reader/${bookSlug}/${slug}`)
-  }
-
-  const activeSlug = visibleChapterSlug ?? chapterSlug
-  // Footer/topbar reflect the chapter that's actually visible — during
-  // infinite scroll the URL chapterSlug stays put while visibleChapterSlug
-  // advances, so reading `chapter.title` (URL-keyed via useReaderChapter)
-  // would show the wrong title and counter.
-  const activeChapter = chapters.find(c => c.slug === activeSlug)
-  const isCurrentBookmarked = isBookmarked(activeSlug)
-  const toggleCurrentBookmark = () => {
-    if (!chapter || !activeSlug) return
-    return toggleBookmark({ chapter, slug: activeSlug })
-  }
-
-  const handleSaveWord = () => selection ? vocabActions.saveWord(selection) : undefined
-  const handlePromoteLookup = () => lookupState ? vocabActions.promoteLookup(lookupState) : undefined
-  const handleMarkKnown = () => selection ? vocabActions.markKnown(selection) : undefined
-  const handleRemoveWord = () => selection ? vocabActions.removeWord(selection) : undefined
-
-  const handleHighlight = useCallback(async (color: string) => {
-    if (!selection || !chapter) return
-    await createHighlight({ color, selection, chapter })
-    // Remember this color so the next quick-tap on the highlight button
-    // uses it without opening the editor.
-    if (color === 'yellow' || color === 'green' || color === 'pink' || color === 'blue') {
-      updateSettings({ lastHighlightColor: color })
-    }
-    if (__DEV__) console.log('[diag] setSelection NULL (highlight created)')
-    setSelection(null)
-  }, [selection, chapter, createHighlight, updateSettings])
-
-
-  // Sync inline translations setting to WebView
-  useEffect(() => {
-    injectJs(`setShowInlineTranslations(${settings.showInlineTranslations})`)
-  }, [settings.showInlineTranslations])
-
-  // Recompute book-wide progress when chapters/wordCount finally lands —
-  // the first 'progress' messages from the WebView fire before useReaderBook
-  // resolves, so without this the footer shows 0% until the user scrolls
-  // again. Reads current progress refs to fold the existing scroll into
-  // the freshly-known book total.
-  useEffect(() => {
-    if (chapters.length === 0) return
-    const slug = currentChapterSlugRef.current || chapterSlug || null
-    const bp = computeBookProgress(chapters, slug, progressRef.current, totalWordCountRef.current)
-    bookProgressRef.current = bp
-    setBookProgress(bp)
-  }, [chapters, chapterSlug])
-
   // Load saved in-chapter position. Local-first (instant, offline-safe);
-  // fall back to server for the cross-device case (read on web → open on
-  // phone). One-shot per (editionId, chapterSlug) — guard with ref so we
-  // don't re-scroll after settings tweaks rebuild the HTML.
+  // fall back to server for the cross-device case. One-shot per
+  // (editionId, chapterSlug) — guard with ref so we don't re-scroll after
+  // settings tweaks rebuild the HTML.
   useEffect(() => {
     restoreScrolledRef.current = false
     savedPercentRef.current = null
@@ -399,10 +106,6 @@ export default function ReaderScreen() {
         const local = await getLocalProgress(editionId)
         if (local && local.chapterSlug === chapterSlug) {
           if (typeof local.percent === 'number') percent = local.percent
-          // Locator beats percent for in-chapter precision. Parser lives
-          // in @textstack/shared so it handles slug-contains-colon and
-          // malformed inputs the same way as user-book reader (P1 fix in
-          // ADR-011 bug sweep).
           const parsed = parseScrollLocator(local.locator)
           if (parsed && parsed.slug === chapterSlug && parsed.offset > 0) {
             scrollOffset = parsed.offset
@@ -418,8 +121,6 @@ export default function ReaderScreen() {
         } catch {}
       }
       if (cancelled) return
-      // Ignore near-zero (top) and near-one (chapter end) — these add jitter
-      // without any UX win.
       if (percent != null && percent > 0.005 && percent < 0.999) {
         savedPercentRef.current = percent
       }
@@ -430,59 +131,6 @@ export default function ReaderScreen() {
     return () => { cancelled = true }
   }, [editionId, chapterSlug, isAuthenticated])
 
-  // A tap always opens the single-word layout of SelectionActionBar
-  // (translation row + per-word actions); drag/long-press routes by
-  // content (single word → same layout, multi → multi-word layout).
-  // PWA's WordPopup is collapsed into the same bar — one overlay
-  // component instead of two on mobile.
-  const isMultiWord = !!(selection && selection.mode === 'drag' && selection.text.includes(' '))
-
-  // Chapter counter for footer — track the visible chapter, not the URL's.
-  const currentChapterIndex = chapters.findIndex(c => c.slug === activeSlug)
-  const totalChapters = chapters.length
-
-  // Large HTML string. Rebuilding every render burns CPU and — if the
-  // source prop object is recreated — triggers WebView work. Memoize on
-  // only the primitives the template actually reads (R-3).
-  //
-  // CRITICAL (B-77): these useMemo calls MUST run on every render — not
-  // behind the `loading` / `!chapter` early returns below. Placing hooks
-  // after early returns made React count fewer hooks on the loading frame
-  // than on the loaded frame, tripping "Rendered more hooks than during
-  // the previous render" and ErrorBoundary-unmounting the whole reader.
-  // That cascade explained the symptoms the user reported: system Android
-  // selection menu (no WebView overlay left to catch the tap), no
-  // WordCard popup, and no translation.
-  const html = useMemo(
-    () => chapter
-      ? buildReaderHtml(chapter.html, {
-          fontSize: settings.fontSize,
-          lineHeight: settings.lineHeight,
-          fontFamily: resolvedFontFamily,
-          textAlign: settings.textAlign,
-          backgroundColor: resolvedTheme.backgroundColor,
-          textColor: resolvedTheme.textColor,
-        }, chapterSlug, { top: insets.top, bottom: insets.bottom }, { overlayV2 })
-      : '',
-    [
-      chapter?.html,
-      settings.fontSize,
-      settings.lineHeight,
-      resolvedFontFamily,
-      settings.textAlign,
-      resolvedTheme.backgroundColor,
-      resolvedTheme.textColor,
-      chapterSlug,
-      insets.top,
-      insets.bottom,
-      overlayV2,
-    ],
-  )
-  // WebView source prop is compared shallowly; keeping the object
-  // stable across renders avoids any accidental reloads on platforms
-  // that key off reference.
-  const webViewSource = useMemo(() => ({ html }), [html])
-
   if (loading) {
     return (
       <View style={[styles.center, { backgroundColor: colors.background }]}>
@@ -492,8 +140,6 @@ export default function ReaderScreen() {
   }
 
   if (!chapter) {
-    // `chapterError` is 'offline' when we couldn't reach the server and
-    // had no cached copy, 'notfound' on a confirmed 404 (R-4).
     const isNotFound = chapterError === 'notfound'
     return (
       <>
@@ -526,382 +172,44 @@ export default function ReaderScreen() {
     )
   }
 
-  const barBg = resolvedTheme.backgroundColor
-  const barText = resolvedTheme.textColor
-
   return (
-    <>
-      <Stack.Screen options={{ headerShown: false }} />
-      <StatusBar hidden={!barsVisible} style={settings.theme === 'dark' ? 'light' : 'dark'} />
-      <View style={[styles.container, { backgroundColor: barBg }]}>
-        {/* Reader WebView — rendered first so overlay bars sit on top */}
-        <WebView
-          ref={webViewRef}
-          source={webViewSource}
-          style={[styles.webview, { backgroundColor: resolvedTheme.backgroundColor }]}
-          onMessage={handleMessage}
-          onLoadEnd={() => {
-            // `html` memo rebuilds on settings change → WebView reloads → JS state wiped.
-            // Re-apply highlights + vocab from refs so they survive font/theme tweaks.
-            for (const h of highlightsRef.current) {
-              injectJs(`renderHighlight(${JSON.stringify(h.id)}, ${JSON.stringify(h.anchorJson)}, ${JSON.stringify(h.color)}, ${JSON.stringify(h.selectedText)})`)
-            }
-            if (Object.keys(vocabMapRef.current).length > 0) {
-              injectJs(`markVocabWords(${JSON.stringify(vocabMapRef.current)})`)
-            }
-            injectJs(`setShowInlineTranslations(${settings.showInlineTranslations})`)
-            // Restore in-chapter position. One-shot — settings tweaks rebuild
-            // the HTML and re-fire onLoadEnd, but the user's already mid-read
-            // by then, so we must not yank them back. Prefer pixel-accurate
-            // locator (savedScrollOffsetRef); fall back to percent for legacy
-            // storage entries written before P0.2.
-            if (!restoreScrolledRef.current) {
-              const offset = savedScrollOffsetRef.current
-              const pct = savedPercentRef.current
-              if (offset != null) {
-                restoreScrolledRef.current = true
-                injectJs(`window.__textstackRestoreScroll && window.__textstackRestoreScroll(${offset})`)
-              } else if (pct != null) {
-                restoreScrolledRef.current = true
-                injectJs(`requestAnimationFrame(function(){ window.scrollTo(0, Math.round(document.documentElement.scrollHeight * ${pct})); });`)
-              }
-            }
-          }}
-          originWhitelist={['*']}
-          scrollEnabled
-          showsVerticalScrollIndicator={false}
-          // Android WebView defaults to a software-rendered view layer —
-          // visible jank on the reader's long scrolling content. Force a
-          // hardware layer so Chromium composites the page on the GPU.
-          androidLayerType="hardware"
-          overScrollMode="never"
-          bounces={false}
-          // Suppress the native Copy/Share/Web-Search callout that
-          // pops up on long-press. We already render our own
-          // SelectionToolbar above the selection (Translate / Explain /
-          // TTS / Highlight / Save word); the native menu is just
-          // visual duplication on both iOS and Android.
-          menuItems={[]}
-          // We build a fresh inline HTML string each chapter mount
-          // and bake the overlay script into it — there is no shared
-          // cached document to reuse across mounts. Skip the WebView
-          // cache to sidestep Android's stale-injection risk.
-          cacheEnabled={false}
-          // Block navigation. The WebView loads an inline HTML string;
-          // tapping a link inside the book (footnote anchor, external
-          // URL, img src) would navigate the WebView, wiping our
-          // injected overlay script + rendered chapter. Allow only the
-          // initial document load + in-page anchors (#id).
-          onShouldStartLoadWithRequest={(req) => {
-            const { url, navigationType } = req
-            if (url === 'about:blank' || url.startsWith('data:') || url.startsWith('file:')) return true
-            if (navigationType === 'click' && (url.startsWith('http://') || url.startsWith('https://'))) {
-              Linking.openURL(url).catch(() => {})
-              return false
-            }
-            return false
-          }}
-        />
-
-        {/* Top bar — rendered after WebView so it's on top of native layer */}
-        <ReaderTopBar
-          barBg={barBg}
-          barText={barText}
-          barsAnim={barsAnim}
-          topBarTranslateY={topBarTranslateY}
-          barsVisible={barsVisible}
-          topInset={insets.top}
-          bookTitle={bookTitle}
-          chapterTitle={activeChapter?.title ?? chapter.title}
-          sessionWordCount={sessionWordCount}
-          isAuthenticated={isAuthenticated}
-          hasChapters={chapters.length > 0}
-          isCurrentBookmarked={isCurrentBookmarked}
-          onExit={handleExit}
-          onBookmarksPress={() => setBookmarksOpen(true)}
-          onTocPress={() => setTocOpen(true)}
-          onSettingsPress={() => setSettingsOpen(true)}
-        />
-
-        {/* Unified selection toolbar: WordCard removed in favor of a single
-            SelectionActionBar that toggles its layout via isMultiWord
-            (single-word adds a translation row + per-word save/known). */}
-        {selection && (
-          <SelectionActionBar
-            selectedText={selection.text}
-            isMultiWord={isMultiWord}
-            language={language}
-            onTranslate={() => setTranslateOpen(true)}
-            onExplain={() => setExplainOpen(true)}
-            onSpeak={() => toggleTts(selection.text, { rate: settings.ttsSpeed, lang: language })}
-            onSaveWord={handleSaveWord}
-            onHighlight={handleHighlight}
-            highlightColor={settings.lastHighlightColor}
-            onMarkKnown={handleMarkKnown}
-            onRemove={handleRemoveWord}
-            isSpeaking={isSpeaking}
-            wordSaved={wordSaved}
-            vocabStage={vocabMapRef.current[selection.text.toLowerCase()]?.stage ?? null}
-            isAuthenticated={isAuthenticated}
-            bottomOffset={footerHeight}
-            onClose={() => {
-              // Also clear the WebView's native text-selection rectangle —
-              // otherwise the system-highlighted text stays painted under
-              // the reader after our overlay dismisses.
-              injectJs('try{window.getSelection&&window.getSelection().removeAllRanges()}catch(e){}')
-              setSelection(null)
-            }}
-          />
-        )}
-
-        {/* Footer — progress bar + chevrons + chapter title + counter (PWA parity) */}
-        <Animated.View style={[styles.footer, { backgroundColor: barBg, borderTopColor: barText + '15', paddingBottom: insets.bottom, opacity: barsAnim, transform: [{ translateY: footerTranslateY }] }]} pointerEvents={barsVisible ? 'auto' : 'none'}>
-          <View style={[styles.progressBar, { backgroundColor: colors.border }]}>
-            {/* Footer % bar reflects book-wide progress — was chapter-only,
-                which reset to ~0% on every chapter boundary and made the
-                book feel like it never advanced (B-?? mobile bug sweep).
-                Width=0 while bookProgress is null (chapters still loading)
-                so we don't flash a fake 0% bar before we know the answer. */}
-            <View style={[styles.progressFill, { width: `${bookProgress != null ? Math.round(bookProgress * 100) : 0}%`, backgroundColor: barText + '40' }]} />
-          </View>
-          <View style={styles.footerRow}>
-            <TouchableOpacity
-              onPress={() => chapter?.prev && navigateChapter(chapter.prev.slug)}
-              disabled={!chapter?.prev}
-              style={styles.chevronBtn}
-              accessibilityLabel="Previous chapter"
-              accessibilityRole="button"
-            >
-              <Text style={[styles.chevron, { color: barText + (chapter?.prev ? 'CC' : '40') }]}>‹</Text>
-            </TouchableOpacity>
-
-            <View style={styles.footerInfo}>
-              <Text style={[styles.footerChapter, { color: barText }]} numberOfLines={1}>
-                {activeChapter?.title ?? chapter?.title ?? ''}
-              </Text>
-              <View style={styles.footerMeta}>
-                {totalChapters > 1 && currentChapterIndex >= 0 && (
-                  <Text style={[styles.footerCounter, { color: barText + '99' }]}>
-                    {currentChapterIndex + 1} / {totalChapters}
-                  </Text>
-                )}
-                <Text style={[styles.footerPercent, { color: barText + '99' }]}>
-                  {bookProgress != null ? `${Math.round(bookProgress * 100)}%` : '—'}
-                </Text>
-              </View>
-            </View>
-
-            <TouchableOpacity
-              onPress={() => chapter?.next && navigateChapter(chapter.next.slug)}
-              disabled={!chapter?.next}
-              style={styles.chevronBtn}
-              accessibilityLabel="Next chapter"
-              accessibilityRole="button"
-            >
-              <Text style={[styles.chevron, { color: barText + (chapter?.next ? 'CC' : '40') }]}>›</Text>
-            </TouchableOpacity>
-          </View>
-        </Animated.View>
-
-        {/* First-run tap-to-save hint — self-gated by AsyncStorage flag */}
-        <ReaderTapCoachmark />
-
-        {/* Reading stats widget */}
-        {settings.showReaderStats && isAuthenticated && quickStats && barsVisible && (
-          <ReaderStatsWidget
-            sessionStartedAt={sessionStartedAt}
-            todaySeconds={quickStats.todaySeconds}
-            dailyGoalMinutes={quickStats.dailyGoalMinutes}
-          />
-        )}
-
-        {/* Settings drawer */}
-        <ReaderSettingsDrawer
-          visible={settingsOpen}
-          onClose={() => setSettingsOpen(false)}
-          settings={settings}
-          onUpdate={updateSettings}
-        />
-
-        {/* Bookmarks sheet */}
-        <BookmarksSheet
-          visible={bookmarksOpen}
-          onClose={() => setBookmarksOpen(false)}
-          bookmarks={bookmarks}
-          currentChapterSlug={activeSlug || ''}
-          onNavigate={navigateChapter}
-          onDelete={removeBookmark}
-          onToggleCurrent={toggleCurrentBookmark}
-          isCurrentBookmarked={isCurrentBookmarked}
-        />
-
-        {/* Translation sheet */}
-        <TranslationSheet
-          visible={translateOpen}
-          text={selection?.text || ''}
-          onClose={() => setTranslateOpen(false)}
-          onSpeak={(t) => toggleTts(t, { rate: settings.ttsSpeed, lang: language })}
-          fromLang={language}
-        />
-
-        {/* Explanation sheet */}
-        <ExplanationSheet
-          visible={explainOpen}
-          word={selection?.text || ''}
-          sentence={selection?.sentence || selection?.text || ''}
-          bookId={editionIdRef.current || undefined}
-          fromLang={language}
-          onClose={() => setExplainOpen(false)}
-        />
-
-        {/* TOC sheet */}
-        <TocSheet
-          visible={tocOpen}
-          chapters={chapters.map(c => ({ slug: c.slug, title: c.title, chapterNumber: c.chapterNumber }))}
-          currentChapterSlug={activeSlug || ''}
-          bookmarks={bookmarks.map(b => ({ chapterSlug: getSlugFromLocator(b.locator) }))}
-          onNavigate={navigateChapter}
-          onClose={() => setTocOpen(false)}
-          loading={chaptersLoading}
-        />
-
-        {/* Highlight note editor — Android-safe replacement for Alert.prompt */}
-        <HighlightNoteModal
-          visible={!!editingHighlight}
-          snippet={editingHighlight
-            ? editingHighlight.selectedText.substring(0, 120) + (editingHighlight.selectedText.length > 120 ? '…' : '')
-            : ''}
-          initialNote={editingHighlight?.noteText || ''}
-          initialColor={(editingHighlight?.color ?? settings.lastHighlightColor) as 'yellow' | 'green' | 'pink' | 'blue'}
-          onCancel={() => setEditingHighlight(null)}
-          onSave={async (note) => {
-            const hl = editingHighlight
-            setEditingHighlight(null)
-            if (hl) await saveHighlightNote(hl.id, note)
-          }}
-          onColorChange={async (color) => {
-            const hl = editingHighlight
-            if (!hl) return
-            // Persist as the user's default for the next quick-highlight.
-            updateSettings({ lastHighlightColor: color })
-            await updateHighlightColor(hl.id, color)
-          }}
-          onDelete={async () => {
-            const hl = editingHighlight
-            setEditingHighlight(null)
-            if (hl) await removeHighlight(hl.id)
-          }}
-        />
-
-        {/* Exit summary — words saved + review prompt */}
-        {exitSummary && (
-          <View style={styles.exitSummaryOverlay}>
-            <View style={styles.exitSummaryCard}>
-              <Ionicons name="checkmark-circle" size={40} color="#10B981" />
-              <Text style={styles.exitSummaryText}>
-                {sessionWordCount} word{sessionWordCount === 1 ? '' : 's'} saved
-              </Text>
-              <View style={styles.exitSummaryButtons}>
-                <TouchableOpacity
-                  style={[styles.exitSummaryBtn, { backgroundColor: '#C4704B' }]}
-                  onPress={handleExitReview}
-                >
-                  <Text style={styles.exitSummaryBtnText}>Review Now</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.exitSummaryBtn, { backgroundColor: 'rgba(255,255,255,0.15)' }]}
-                  onPress={handleExitLater}
-                >
-                  <Text style={styles.exitSummaryBtnText}>Later</Text>
-                </TouchableOpacity>
-              </View>
-            </View>
-          </View>
-        )}
-      </View>
-    </>
+    <ReaderShell
+      source={{ kind: 'edition', id: editionId, idRef: editionIdRef }}
+      webViewRef={webViewRef}
+      injectJs={injectJs}
+      chapter={{ id: chapter.id, title: chapter.title, html: chapter.html, prev: chapter.prev, next: chapter.next }}
+      chapterSlug={chapterSlug}
+      htmlChapterSlug={chapterSlug}
+      bookTitle={bookTitle}
+      chapters={chapters}
+      chaptersLoading={chaptersLoading}
+      progressRef={progressRef}
+      scrollOffsetRef={scrollOffsetRef}
+      currentChapterSlugRef={currentChapterSlugRef}
+      bookProgressRef={bookProgressRef}
+      totalWordCountRef={totalWordCountRef}
+      bumpProgress={bumpProgress}
+      saveProgress={saveProgress}
+      restoreScrolledRef={restoreScrolledRef}
+      savedScrollOffsetRef={savedScrollOffsetRef}
+      savedPercentRef={savedPercentRef}
+      onChapterLoaded={() => enableInfiniteScrollFor(chapter)}
+      onRequestNextChapter={loadNextChapter}
+      onNavigateChapter={(slug) => router.replace(`/reader/${bookSlug}/${slug}`)}
+      bookmarks={bookmarks}
+      onToggleCurrentBookmark={(slug) => { if (chapter) toggleBookmark({ chapter, slug }) }}
+      onDeleteBookmark={removeBookmark}
+      bookmarkChapterSlug={(b) => getSlugFromLocator(b.locator)}
+      bookTitleRef={bookTitleRef}
+      wordCount={wordCountRef.current}
+      explainBookId={editionIdRef.current || undefined}
+    />
   )
 }
 
 const styles = StyleSheet.create({
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  errorWrap: {
-    paddingHorizontal: 32,
-    gap: 6,
-  },
-  errorTitle: {
-    fontFamily: fonts.serifBold,
-    fontSize: 20,
-    marginTop: 16,
-    textAlign: 'center',
-  },
-  errorBody: {
-    fontFamily: fonts.sans,
-    fontSize: 14,
-    textAlign: 'center',
-    marginTop: 4,
-    maxWidth: 320,
-  },
-  container: { flex: 1 },
-  webview: { flex: 1 },
-  // Footer — absolute overlay, slides up on tap
-  footer: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    zIndex: 10,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: -1 },
-    shadowOpacity: 0.06,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  footerRow: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 4, paddingVertical: 4, minHeight: 48 },
-  chevronBtn: { width: 44, height: 44, justifyContent: 'center', alignItems: 'center' },
-  chevron: { fontSize: 28, fontFamily: fonts.sans, lineHeight: 28 },
-  footerInfo: { flex: 1, alignItems: 'center', paddingHorizontal: 4 },
-  footerChapter: { fontSize: 13, fontFamily: fonts.sansMedium, fontWeight: '500' as const, textAlign: 'center' },
-  footerMeta: { flexDirection: 'row', alignItems: 'center', gap: 12, marginTop: 2 },
-  footerCounter: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
-  footerPercent: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
-  progressBar: { height: 4, borderRadius: 0 },
-  progressFill: { height: 4, borderRadius: 0 },
-  // Exit summary
-  exitSummaryOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    zIndex: 200,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'rgba(0,0,0,0.5)',
-  },
-  exitSummaryCard: {
-    backgroundColor: '#fff',
-    borderRadius: 16,
-    paddingHorizontal: 32,
-    paddingVertical: 24,
-    alignItems: 'center',
-    gap: 8,
-  },
-  exitSummaryText: {
-    fontFamily: fonts.sansMedium,
-    fontSize: 18,
-    color: '#111827',
-  },
-  exitSummaryButtons: {
-    flexDirection: 'row',
-    gap: 12,
-    marginTop: 8,
-  },
-  exitSummaryBtn: {
-    paddingHorizontal: 24,
-    paddingVertical: 10,
-    borderRadius: 20,
-  },
-  exitSummaryBtnText: {
-    fontFamily: fonts.sansMedium,
-    fontSize: 14,
-    color: '#fff',
-  },
+  errorWrap: { paddingHorizontal: 32, gap: 6 },
+  errorTitle: { fontFamily: fonts.serifBold, fontSize: 20, marginTop: 16, textAlign: 'center' },
+  errorBody: { fontFamily: fonts.sans, fontSize: 14, textAlign: 'center', marginTop: 4, maxWidth: 320 },
 })

--- a/apps/mobile/src/components/reader/ReaderShell.tsx
+++ b/apps/mobile/src/components/reader/ReaderShell.tsx
@@ -168,8 +168,8 @@ export function ReaderShell(props: ReaderShellProps) {
 
   // Reading session — keyed by whichever catalog id the source carries.
   const { updateProgress: updateSessionProgress, sessionStartedAt } = useReadingSession({
-    editionId: source.kind === 'edition' ? source.idRef.current : null,
-    userBookId: source.kind === 'userbook' ? source.idRef.current : null,
+    editionId: source.kind === 'edition' ? source.id : null,
+    userBookId: source.kind === 'userbook' ? source.id : null,
     wordCount,
     isAuthenticated,
   })

--- a/apps/mobile/src/components/reader/ReaderShell.tsx
+++ b/apps/mobile/src/components/reader/ReaderShell.tsx
@@ -1,0 +1,686 @@
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
+import type { MutableRefObject, RefObject } from 'react'
+import { View, Text, StyleSheet, TouchableOpacity, Animated, Linking } from 'react-native'
+import { WebView } from 'react-native-webview'
+import { useRouter, Stack } from 'expo-router'
+import { t, computeBookProgress } from '@textstack/shared'
+import type { Chapter, BookmarkDto } from '@textstack/shared'
+import { buildReaderHtml } from '../../lib/readerHtml'
+import { useAuth } from '../../context/AuthContext'
+import { useReaderSettings } from '../../hooks/useReaderSettings'
+import { useReaderBars } from '../../hooks/useReaderBars'
+import { useReaderExitSummary } from '../../hooks/useReaderExitSummary'
+import { useReaderHighlights } from '../../hooks/useReaderHighlights'
+import { useReaderVocabMap } from '../../hooks/useReaderVocabMap'
+import { useReaderVocabActions } from '../../hooks/useReaderVocabActions'
+import { useReaderSelection } from '../../hooks/useReaderSelection'
+import { useReaderOverlayV2Active } from '../../hooks/useReaderOverlayV2Active'
+import { useReadingSession } from '../../hooks/useReadingSession'
+import { useTts } from '../../hooks/useTts'
+import { useQuickStats } from '../../hooks/useQuickStats'
+import { useHaptics } from '../../hooks/useHaptics'
+import { useToast } from '../../context/ToastContext'
+import { useTheme } from '../../context/ThemeContext'
+import { useLanguage } from '../../context/LanguageContext'
+import { useNativeLanguage } from '../../context/NativeLanguageContext'
+import { ReaderSettingsDrawer } from '../ReaderSettingsDrawer'
+import { BookmarksSheet } from '../BookmarksSheet'
+import { SelectionActionBar } from '../SelectionActionBar'
+import { TranslationSheet } from '../TranslationSheet'
+import { ExplanationSheet } from '../ExplanationSheet'
+import { HighlightNoteModal } from '../HighlightNoteModal'
+import { TocSheet } from '../TocSheet'
+import { ReaderStatsWidget } from '../ReaderStatsWidget'
+import { ReaderTapCoachmark } from './ReaderTapCoachmark'
+import { ReaderTopBar } from './ReaderTopBar'
+import { Ionicons } from '@expo/vector-icons'
+import { fonts } from '../../theme/typography'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { StatusBar } from 'expo-status-bar'
+
+/** Lightweight {key} interpolation — shared `t()` returns raw keys, we fill them in here. */
+function interpolate(template: string, vars: Record<string, string | number>): string {
+  return template.replace(/\{(\w+)\}/g, (_, k) => String(vars[k] ?? `{${k}}`))
+}
+
+/** Which catalog the book belongs to. Drives the FK column used by highlights,
+ *  vocab and reading-session — the ONLY thing that genuinely differs between the
+ *  public-library reader and the user-uploaded-book reader. */
+export type ReaderSource =
+  | { kind: 'edition'; id: string | null; idRef: MutableRefObject<string | null> }
+  | { kind: 'userbook'; id: string | null; idRef: MutableRefObject<string | null> }
+
+/** A loaded chapter, normalised across both data sources. */
+export interface ReaderShellChapter {
+  id: string
+  title: string
+  html: string
+  prev?: { slug: string } | null
+  next?: { slug: string } | null
+}
+
+export interface ReaderShellProps {
+  source: ReaderSource
+  /** Owned by the route (so its data hooks can inject too); attached to the WebView here. */
+  webViewRef: RefObject<WebView | null>
+  injectJs: (js: string) => void
+
+  /** A loaded chapter — the route handles loading/error and only renders the shell once ready. */
+  chapter: ReaderShellChapter
+  /** URL slug of the current chapter. */
+  chapterSlug: string
+  /** 3rd arg to buildReaderHtml (chapter slug baked into 'progress' messages).
+   *  Public passes its chapterSlug; user-book historically passed undefined. */
+  htmlChapterSlug?: string
+  bookTitle: string | null
+  chapters: { slug: string; title: string; chapterNumber?: number }[]
+  chaptersLoading: boolean
+
+  // Progress/session machinery — refs created by the route (its progress + session
+  // hooks read them); mutated here from the WebView 'progress' message.
+  progressRef: MutableRefObject<number>
+  scrollOffsetRef: MutableRefObject<number>
+  currentChapterSlugRef: MutableRefObject<string | null>
+  bookProgressRef: MutableRefObject<number | null>
+  totalWordCountRef: MutableRefObject<number>
+  bumpProgress: () => void
+  saveProgress: () => void
+
+  // Saved in-chapter scroll restore (route loads the values; shell applies on load).
+  restoreScrolledRef: MutableRefObject<boolean>
+  savedScrollOffsetRef: MutableRefObject<number | null>
+  savedPercentRef?: MutableRefObject<number | null>
+
+  // Infinite scroll — the per-source fetch lives in the route; these fire on the
+  // WebView 'loaded' / 'requestNextChapter' messages.
+  onChapterLoaded: () => void
+  onRequestNextChapter: () => void
+
+  /** Perform the actual router.replace to a chapter slug (path differs per source). */
+  onNavigateChapter: (slug: string) => void
+
+  // Bookmarks (state + mutations owned by the route; locator→slug mapping differs).
+  // "is the ACTIVE chapter bookmarked" is computed here since activeSlug lives here.
+  bookmarks: BookmarkDto[]
+  onToggleCurrentBookmark: (slug: string) => void
+  onDeleteBookmark: (id: string) => void
+  bookmarkChapterSlug: (b: BookmarkDto) => string
+
+  /** Book title ref (vocab-save payload). */
+  bookTitleRef: MutableRefObject<string | null>
+  /** Word count of the loaded chapter (reading-session input). */
+  wordCount: number
+  /** Explain sheet "bookId" — editionId for public, undefined for user-book. */
+  explainBookId?: string
+
+  /** Optional error fallback name for the top bar when chapters haven't loaded. */
+  chapterTitleFallback?: string
+}
+
+/**
+ * The shared reader body for BOTH the public-library reader and the user-uploaded
+ * book reader. Owns the WebView and every WebView-coupled concern — vocab underline +
+ * inline-translation gloss, highlights, text selection, immersive bars, top bar,
+ * footer, sheets, scroll restore and the 'progress'/'selection'/'highlightTap' message
+ * routing. The two routes stay thin: they load their source-specific data (chapter,
+ * chapter list, bookmarks, progress, reading session, infinite scroll) and hand the
+ * results + a `source` discriminator down here. This is the single place the reader
+ * UX lives, so a fix lands in both catalogs at once (was: copy-pasted + drifted).
+ */
+export function ReaderShell(props: ReaderShellProps) {
+  const {
+    source, webViewRef, injectJs, chapter, chapterSlug, htmlChapterSlug,
+    bookTitle, chapters, chaptersLoading,
+    progressRef, scrollOffsetRef, currentChapterSlugRef, bookProgressRef, totalWordCountRef,
+    bumpProgress, saveProgress,
+    restoreScrolledRef, savedScrollOffsetRef, savedPercentRef,
+    onChapterLoaded, onRequestNextChapter, onNavigateChapter,
+    bookmarks, onToggleCurrentBookmark, onDeleteBookmark, bookmarkChapterSlug,
+    bookTitleRef, wordCount, explainBookId,
+  } = props
+
+  const router = useRouter()
+  const { isAuthenticated, user } = useAuth()
+  const { settings, update: updateSettings, resolvedFontFamily, resolvedTheme } = useReaderSettings()
+  const overlayV2 = useReaderOverlayV2Active()
+  const { colors } = useTheme()
+  const { language } = useLanguage()
+  const { nativeLanguage } = useNativeLanguage()
+  const { toggle: toggleTts, isSpeaking } = useTts()
+  const quickStats = useQuickStats(isAuthenticated)
+  const haptics = useHaptics()
+  const { show: showToast } = useToast()
+  const insets = useSafeAreaInsets()
+
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [bookmarksOpen, setBookmarksOpen] = useState(false)
+  const [translateOpen, setTranslateOpen] = useState(false)
+  const [explainOpen, setExplainOpen] = useState(false)
+  const [tocOpen, setTocOpen] = useState(false)
+  const [progress, setProgress] = useState(0)
+  const [bookProgress, setBookProgress] = useState<number | null>(null)
+  const [visibleChapterSlug, setVisibleChapterSlug] = useState<string | null>(null)
+
+  const sessionWordCountRef = useRef(0)
+
+  const topBarHeight = 56 + insets.top
+  const footerHeight = 60 + insets.bottom
+
+  // Reading session — keyed by whichever catalog id the source carries.
+  const { updateProgress: updateSessionProgress, sessionStartedAt } = useReadingSession({
+    editionId: source.kind === 'edition' ? source.idRef.current : null,
+    userBookId: source.kind === 'userbook' ? source.idRef.current : null,
+    wordCount,
+    isAuthenticated,
+  })
+
+  const { barsVisible, barsAnim, topBarTranslateY, footerTranslateY, showBars, hideBars, toggleBars } = useReaderBars({
+    topBarHeight,
+    footerHeight,
+    autoHideTrigger: true,
+  })
+
+  const {
+    sessionWordCount,
+    setSessionWordCount,
+    exitSummary,
+    exit: handleExit,
+    exitToReview: handleExitReview,
+    exitLater: handleExitLater,
+  } = useReaderExitSummary({ router, saveProgress })
+
+  const { vocabMapRef, flushToCache: flushVocabMap, bumpVocab } = useReaderVocabMap({
+    user,
+    isAuthenticated,
+    chapterId: chapter.id,
+    injectJs,
+    bookLanguage: language,
+    nativeLanguage,
+  })
+
+  const {
+    selection,
+    setSelection,
+    wordSaved,
+    lookupState,
+    setLookupState,
+    setWordSaved,
+    openSelection,
+  } = useReaderSelection({ flushVocabMap })
+
+  const {
+    highlightsRef,
+    editingHighlight,
+    setEditingHighlight,
+    create: createHighlight,
+    saveNote: saveHighlightNote,
+    updateColor: updateHighlightColor,
+    remove: removeHighlight,
+  } = useReaderHighlights({
+    ...(source.kind === 'edition'
+      ? { editionId: source.id, editionIdRef: source.idRef }
+      : { userBookId: source.id, userBookIdRef: source.idRef }),
+    user,
+    isAuthenticated,
+    chapterId: chapter.id,
+    injectJs,
+    showToast,
+  })
+
+  const notifyWordSaved = useCallback(() => {
+    sessionWordCountRef.current += 1
+    const count = sessionWordCountRef.current
+    haptics.play('complete')
+    showToast({
+      variant: 'success',
+      message:
+        count > 1
+          ? interpolate(t(language, 'reader.toastWordAddedCount'), { count })
+          : t(language, 'reader.toastWordAdded'),
+      actionLabel: t(language, 'reader.toastTapToReview'),
+      onPress: () => router.push('/vocabulary'),
+      duration: 2400,
+    })
+  }, [haptics, showToast, language, router])
+
+  const vocabActions = useReaderVocabActions({
+    vocabMapRef,
+    bookTitleRef,
+    ...(source.kind === 'edition' ? { editionIdRef: source.idRef } : { userBookIdRef: source.idRef }),
+    chapter: { id: chapter.id } as unknown as Chapter,
+    language,
+    nativeLanguage,
+    isAuthenticated,
+    injectJs,
+    bumpVocab,
+    notifyWordSaved,
+    setSessionWordCount,
+    setWordSaved,
+    setSelection,
+    setLookupState,
+    showToast,
+  })
+
+  const handleMessage = useCallback((event: any) => {
+    try {
+      const data = JSON.parse(event.nativeEvent.data)
+      if (data.type === 'log') {
+        if (__DEV__) {
+          const fn = data.level === 'error' ? console.error : data.level === 'warn' ? console.warn : console.log
+          fn('[WV]', data.msg)
+        }
+        return
+      }
+      if (data.type === 'tap') {
+        toggleBars()
+      } else if (data.type === 'scrollDir') {
+        if (data.dir === 'up') showBars()
+        else if (data.dir === 'down') hideBars()
+      } else if (data.type === 'progress') {
+        progressRef.current = data.progress
+        if (typeof data.scrollY === 'number') scrollOffsetRef.current = data.scrollY
+        setProgress(data.progress)
+        updateSessionProgress(data.progress)
+        if (data.chapterSlug) {
+          currentChapterSlugRef.current = data.chapterSlug
+          setVisibleChapterSlug(data.chapterSlug)
+        }
+        const activeSlugForCalc = data.chapterSlug || currentChapterSlugRef.current || chapterSlug || null
+        const bp = computeBookProgress(chapters, activeSlugForCalc, data.progress, totalWordCountRef.current)
+        bookProgressRef.current = bp
+        setBookProgress(bp)
+        bumpProgress()
+      } else if (data.type === 'loaded') {
+        onChapterLoaded()
+      } else if (data.type === 'requestNextChapter') {
+        onRequestNextChapter()
+      } else if (data.type === 'highlightTap') {
+        const hl = highlightsRef.current.find(h => h.id === data.highlightId)
+        if (hl) setEditingHighlight(hl)
+      } else if (data.type === 'selection') {
+        const mode: 'tap' | 'drag' = data.mode === 'tap' ? 'tap' : 'drag'
+        const nextId = openSelection(data.text ? { ...data, mode } : null)
+        if (nextId !== null && !data.text.includes(' ')) {
+          toggleTts(data.text, { rate: settings.ttsSpeed, lang: language })
+        }
+      }
+    } catch (err) {
+      if (__DEV__) console.warn('[reader] postMessage handler threw', err, event?.nativeEvent?.data)
+    }
+  }, [chapters, chapterSlug, language, settings.ttsSpeed, toggleTts, toggleBars, showBars, hideBars,
+      setEditingHighlight, updateSessionProgress, onChapterLoaded, onRequestNextChapter, openSelection, bumpProgress])
+
+  const navigateChapter = (slug: string) => {
+    saveProgress()
+    progressRef.current = 0
+    scrollOffsetRef.current = 0
+    setProgress(0)
+    if (chapters.length > 0) {
+      const bp = computeBookProgress(chapters, slug, 0, totalWordCountRef.current)
+      bookProgressRef.current = bp
+      setBookProgress(bp)
+    }
+    onNavigateChapter(slug)
+  }
+
+  const activeSlug = visibleChapterSlug ?? chapterSlug
+  const activeChapter = chapters.find(c => c.slug === activeSlug)
+  const isCurrentBookmarked = bookmarks.some(b => bookmarkChapterSlug(b) === activeSlug)
+  const isMultiWord = !!(selection && selection.mode === 'drag' && selection.text.includes(' '))
+  const currentChapterIndex = chapters.findIndex(c => c.slug === activeSlug)
+  const totalChapters = chapters.length
+
+  const handleSaveWord = () => selection ? vocabActions.saveWord(selection) : undefined
+  const handleMarkKnown = () => selection ? vocabActions.markKnown(selection) : undefined
+  const handleRemoveWord = () => selection ? vocabActions.removeWord(selection) : undefined
+
+  const handleHighlight = useCallback(async (color: string) => {
+    if (!selection) return
+    await createHighlight({ color, selection, chapter: { id: chapter.id } })
+    if (color === 'yellow' || color === 'green' || color === 'pink' || color === 'blue') {
+      updateSettings({ lastHighlightColor: color })
+    }
+    setSelection(null)
+  }, [selection, chapter.id, createHighlight, updateSettings])
+
+  // Sync inline translations setting to the WebView — was missing on the
+  // user-book reader, so the gloss never showed there (now shared).
+  useEffect(() => {
+    injectJs(`setShowInlineTranslations(${settings.showInlineTranslations})`)
+  }, [settings.showInlineTranslations, injectJs])
+
+  // Recompute book-wide progress once chapters/wordCount land — early
+  // 'progress' messages fire before the chapter list resolves.
+  useEffect(() => {
+    if (chapters.length === 0) return
+    const slug = currentChapterSlugRef.current || chapterSlug || null
+    const bp = computeBookProgress(chapters, slug, progressRef.current, totalWordCountRef.current)
+    bookProgressRef.current = bp
+    setBookProgress(bp)
+  }, [chapters, chapterSlug])
+
+  const html = useMemo(
+    () => buildReaderHtml(chapter.html, {
+      fontSize: settings.fontSize,
+      lineHeight: settings.lineHeight,
+      fontFamily: resolvedFontFamily,
+      textAlign: settings.textAlign,
+      backgroundColor: resolvedTheme.backgroundColor,
+      textColor: resolvedTheme.textColor,
+    }, htmlChapterSlug, { top: insets.top, bottom: insets.bottom }, { overlayV2 }),
+    [chapter.html, settings.fontSize, settings.lineHeight, resolvedFontFamily, settings.textAlign,
+     resolvedTheme.backgroundColor, resolvedTheme.textColor, htmlChapterSlug, insets.top, insets.bottom, overlayV2],
+  )
+  const webViewSource = useMemo(() => ({ html }), [html])
+
+  const barBg = resolvedTheme.backgroundColor
+  const barText = resolvedTheme.textColor
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <StatusBar hidden={!barsVisible} style={settings.theme === 'dark' ? 'light' : 'dark'} />
+      <View style={[styles.container, { backgroundColor: barBg }]}>
+        <WebView
+          ref={webViewRef}
+          source={webViewSource}
+          style={[styles.webview, { backgroundColor: resolvedTheme.backgroundColor }]}
+          onMessage={handleMessage}
+          onLoadEnd={() => {
+            for (const h of highlightsRef.current) {
+              injectJs(`renderHighlight(${JSON.stringify(h.id)}, ${JSON.stringify(h.anchorJson)}, ${JSON.stringify(h.color)}, ${JSON.stringify(h.selectedText)})`)
+            }
+            if (Object.keys(vocabMapRef.current).length > 0) {
+              injectJs(`markVocabWords(${JSON.stringify(vocabMapRef.current)})`)
+            }
+            injectJs(`setShowInlineTranslations(${settings.showInlineTranslations})`)
+            if (!restoreScrolledRef.current) {
+              const offset = savedScrollOffsetRef.current
+              const pct = savedPercentRef?.current ?? null
+              if (offset != null) {
+                restoreScrolledRef.current = true
+                injectJs(`window.__textstackRestoreScroll && window.__textstackRestoreScroll(${offset})`)
+              } else if (pct != null) {
+                restoreScrolledRef.current = true
+                injectJs(`requestAnimationFrame(function(){ window.scrollTo(0, Math.round(document.documentElement.scrollHeight * ${pct})); });`)
+              }
+            }
+          }}
+          originWhitelist={['*']}
+          scrollEnabled
+          showsVerticalScrollIndicator={false}
+          androidLayerType="hardware"
+          overScrollMode="never"
+          bounces={false}
+          menuItems={[]}
+          cacheEnabled={false}
+          onShouldStartLoadWithRequest={(req) => {
+            const { url, navigationType } = req
+            if (url === 'about:blank' || url.startsWith('data:') || url.startsWith('file:')) return true
+            if (navigationType === 'click' && (url.startsWith('http://') || url.startsWith('https://'))) {
+              Linking.openURL(url).catch(() => {})
+              return false
+            }
+            return false
+          }}
+        />
+
+        <ReaderTopBar
+          barBg={barBg}
+          barText={barText}
+          barsAnim={barsAnim}
+          topBarTranslateY={topBarTranslateY}
+          barsVisible={barsVisible}
+          topInset={insets.top}
+          bookTitle={bookTitle ?? ''}
+          chapterTitle={activeChapter?.title ?? chapter.title}
+          sessionWordCount={sessionWordCount}
+          isAuthenticated={isAuthenticated}
+          hasChapters={chapters.length > 0}
+          isCurrentBookmarked={isCurrentBookmarked}
+          onExit={handleExit}
+          onBookmarksPress={() => setBookmarksOpen(true)}
+          onTocPress={() => setTocOpen(true)}
+          onSettingsPress={() => setSettingsOpen(true)}
+        />
+
+        {selection && (
+          <SelectionActionBar
+            selectedText={selection.text}
+            isMultiWord={isMultiWord}
+            language={language}
+            onTranslate={() => setTranslateOpen(true)}
+            onExplain={() => setExplainOpen(true)}
+            onSpeak={() => toggleTts(selection.text, { rate: settings.ttsSpeed, lang: language })}
+            onSaveWord={handleSaveWord}
+            onHighlight={handleHighlight}
+            highlightColor={settings.lastHighlightColor}
+            onMarkKnown={handleMarkKnown}
+            onRemove={handleRemoveWord}
+            isSpeaking={isSpeaking}
+            wordSaved={wordSaved}
+            vocabStage={vocabMapRef.current[selection.text.toLowerCase()]?.stage ?? null}
+            isAuthenticated={isAuthenticated}
+            bottomOffset={footerHeight}
+            onClose={() => {
+              injectJs('try{window.getSelection&&window.getSelection().removeAllRanges()}catch(e){}')
+              setSelection(null)
+            }}
+          />
+        )}
+
+        <Animated.View style={[styles.footer, { backgroundColor: barBg, borderTopColor: barText + '15', paddingBottom: insets.bottom, opacity: barsAnim, transform: [{ translateY: footerTranslateY }] }]} pointerEvents={barsVisible ? 'auto' : 'none'}>
+          <View style={[styles.progressBar, { backgroundColor: colors.border }]}>
+            <View style={[styles.progressFill, { width: `${bookProgress != null ? Math.round(bookProgress * 100) : 0}%`, backgroundColor: barText + '40' }]} />
+          </View>
+          <View style={styles.footerRow}>
+            <TouchableOpacity
+              onPress={() => chapter.prev && navigateChapter(chapter.prev.slug)}
+              disabled={!chapter.prev}
+              style={styles.chevronBtn}
+              accessibilityLabel="Previous chapter"
+              accessibilityRole="button"
+            >
+              <Text style={[styles.chevron, { color: barText + (chapter.prev ? 'CC' : '40') }]}>‹</Text>
+            </TouchableOpacity>
+
+            <View style={styles.footerInfo}>
+              <Text style={[styles.footerChapter, { color: barText }]} numberOfLines={1}>
+                {activeChapter?.title ?? chapter.title ?? ''}
+              </Text>
+              <View style={styles.footerMeta}>
+                {totalChapters > 1 && currentChapterIndex >= 0 && (
+                  <Text style={[styles.footerCounter, { color: barText + '99' }]}>
+                    {currentChapterIndex + 1} / {totalChapters}
+                  </Text>
+                )}
+                <Text style={[styles.footerPercent, { color: barText + '99' }]}>
+                  {bookProgress != null ? `${Math.round(bookProgress * 100)}%` : '—'}
+                </Text>
+              </View>
+            </View>
+
+            <TouchableOpacity
+              onPress={() => chapter.next && navigateChapter(chapter.next.slug)}
+              disabled={!chapter.next}
+              style={styles.chevronBtn}
+              accessibilityLabel="Next chapter"
+              accessibilityRole="button"
+            >
+              <Text style={[styles.chevron, { color: barText + (chapter.next ? 'CC' : '40') }]}>›</Text>
+            </TouchableOpacity>
+          </View>
+        </Animated.View>
+
+        <ReaderTapCoachmark />
+
+        {settings.showReaderStats && isAuthenticated && quickStats && barsVisible && (
+          <ReaderStatsWidget
+            sessionStartedAt={sessionStartedAt}
+            todaySeconds={quickStats.todaySeconds}
+            dailyGoalMinutes={quickStats.dailyGoalMinutes}
+          />
+        )}
+
+        <ReaderSettingsDrawer
+          visible={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          settings={settings}
+          onUpdate={updateSettings}
+        />
+
+        <BookmarksSheet
+          visible={bookmarksOpen}
+          onClose={() => setBookmarksOpen(false)}
+          bookmarks={bookmarks}
+          currentChapterSlug={activeSlug || ''}
+          onNavigate={navigateChapter}
+          onDelete={onDeleteBookmark}
+          onToggleCurrent={() => onToggleCurrentBookmark(activeSlug)}
+          isCurrentBookmarked={isCurrentBookmarked}
+        />
+
+        <TranslationSheet
+          visible={translateOpen}
+          text={selection?.text || ''}
+          onClose={() => setTranslateOpen(false)}
+          onSpeak={(txt) => toggleTts(txt, { rate: settings.ttsSpeed, lang: language })}
+          fromLang={language}
+        />
+
+        <ExplanationSheet
+          visible={explainOpen}
+          word={selection?.text || ''}
+          sentence={selection?.sentence || selection?.text || ''}
+          bookId={explainBookId}
+          fromLang={language}
+          onClose={() => setExplainOpen(false)}
+        />
+
+        <TocSheet
+          visible={tocOpen}
+          chapters={chapters.map(c => ({ slug: c.slug, title: c.title, chapterNumber: c.chapterNumber }))}
+          currentChapterSlug={activeSlug || ''}
+          bookmarks={bookmarks.map(b => ({ chapterSlug: bookmarkChapterSlug(b), title: b.title || undefined }))}
+          onNavigate={navigateChapter}
+          onClose={() => setTocOpen(false)}
+          loading={chaptersLoading}
+        />
+
+        <HighlightNoteModal
+          visible={!!editingHighlight}
+          snippet={editingHighlight
+            ? editingHighlight.selectedText.substring(0, 120) + (editingHighlight.selectedText.length > 120 ? '…' : '')
+            : ''}
+          initialNote={editingHighlight?.noteText || ''}
+          initialColor={(editingHighlight?.color ?? settings.lastHighlightColor) as 'yellow' | 'green' | 'pink' | 'blue'}
+          onCancel={() => setEditingHighlight(null)}
+          onSave={async (note) => {
+            const hl = editingHighlight
+            setEditingHighlight(null)
+            if (hl) await saveHighlightNote(hl.id, note)
+          }}
+          onColorChange={async (color) => {
+            const hl = editingHighlight
+            if (!hl) return
+            updateSettings({ lastHighlightColor: color })
+            await updateHighlightColor(hl.id, color)
+          }}
+          onDelete={async () => {
+            const hl = editingHighlight
+            setEditingHighlight(null)
+            if (hl) await removeHighlight(hl.id)
+          }}
+        />
+
+        {exitSummary && (
+          <View style={styles.exitSummaryOverlay}>
+            <View style={styles.exitSummaryCard}>
+              <Ionicons name="checkmark-circle" size={40} color="#10B981" />
+              <Text style={styles.exitSummaryText}>
+                {sessionWordCount} word{sessionWordCount === 1 ? '' : 's'} saved
+              </Text>
+              <View style={styles.exitSummaryButtons}>
+                <TouchableOpacity
+                  style={[styles.exitSummaryBtn, { backgroundColor: '#C4704B' }]}
+                  onPress={handleExitReview}
+                >
+                  <Text style={styles.exitSummaryBtnText}>Review Now</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.exitSummaryBtn, { backgroundColor: 'rgba(255,255,255,0.15)' }]}
+                  onPress={handleExitLater}
+                >
+                  <Text style={styles.exitSummaryBtnText}>Later</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        )}
+      </View>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  webview: { flex: 1 },
+  footer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: -1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  footerRow: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 4, paddingVertical: 4, minHeight: 48 },
+  chevronBtn: { width: 44, height: 44, justifyContent: 'center', alignItems: 'center' },
+  chevron: { fontSize: 28, fontFamily: fonts.sans, lineHeight: 28 },
+  footerInfo: { flex: 1, alignItems: 'center', paddingHorizontal: 4 },
+  footerChapter: { fontSize: 13, fontFamily: fonts.sansMedium, fontWeight: '500' as const, textAlign: 'center' },
+  footerMeta: { flexDirection: 'row', alignItems: 'center', gap: 12, marginTop: 2 },
+  footerCounter: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
+  footerPercent: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
+  progressBar: { height: 4, borderRadius: 0 },
+  progressFill: { height: 4, borderRadius: 0 },
+  exitSummaryOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 200,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  exitSummaryCard: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    paddingHorizontal: 32,
+    paddingVertical: 24,
+    alignItems: 'center',
+    gap: 8,
+  },
+  exitSummaryText: {
+    fontFamily: fonts.sansMedium,
+    fontSize: 18,
+    color: '#111827',
+  },
+  exitSummaryButtons: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 8,
+  },
+  exitSummaryBtn: {
+    paddingHorizontal: 24,
+    paddingVertical: 10,
+    borderRadius: 20,
+  },
+  exitSummaryBtnText: {
+    fontFamily: fonts.sansMedium,
+    fontSize: 14,
+    color: '#fff',
+  },
+})


### PR DESCRIPTION
## Why
The mobile app had **two near-identical reader screens** — `app/reader/[bookSlug]/[chapterSlug].tsx` (public library) and `app/my-books/read/[bookId]/[chapterSlug].tsx` (user-uploaded books), ~900 lines each. They were copy-pasted and drifted: the user-book reader was missing the `setShowInlineTranslations` injection (the inline translation gloss never showed there), the `ReaderTopBar`, and the exit summary. Same class of bug will keep recurring as long as the body is duplicated.

## What
Extract the shared reader body into one `ReaderShell` component, parameterized by a `source: { kind: 'edition' | 'userbook' }` discriminator (the only thing that genuinely differs — the FK column used by highlights / vocab / reading-session). Both routes become thin wrappers that own only their catalog data hooks (chapter, chapter list, bookmarks, progress, infinite scroll) and hand the loaded chapter down.

- `src/components/reader/ReaderShell.tsx` (new, 686) — WebView + vocab/inline-translation + highlights + selection + bars + top bar + footer + sheets + scroll restore + message routing.
- `app/reader/...` 907 → 215 lines (thin wrapper).
- `app/my-books/read/...` 842 → 231 lines (thin wrapper).
- Net: **1749 duplicated lines → 446 wrappers + 686 shared shell.**

## Parity gained by user-book reader
- Inline-translation gloss sync (`setShowInlineTranslations`) — was missing.
- `ReaderTopBar` (was an inline copy).
- Exit summary ("N words saved").

## Verification
- `npx tsc --noEmit` (apps/mobile): clean.
- **Requires on-device dev-build verification before merge** (cannot run a device in this environment). Checklist — on BOTH a public and a user-uploaded book:
  1. Chapter renders, scroll smooth.
  2. **Translation gloss above saved words shows on load.**
  3. Tap word → card (translation/TTS); Save adds the word.
  4. Phrase select → Translate/Explain/Highlight bar.
  5. Highlights create + survive font/theme changes.
  6. Footer % advances; exit + reopen restores position.
  7. Bookmarks, TOC, settings, infinite-scroll next chapter.
  8. Exit summary on leave.

## Relation to #280
Independent. #280 fixes the gloss default at the WebView layer (ships via OTA); this PR removes the structural drift that hid it on the user-book reader. They compose.

## Rollback
Revert the 3 commits — restores the two standalone reader screens. No data/schema impact (pure RN/UI refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)