### PR TITLE
ci(mobile): EAS update channels + release pipeline

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,20 +1,22 @@
 name: Mobile Release (EAS)
 
-# Manual mobile shipping via EAS. Two paths:
-#   • ota-update   — `eas update` to the production channel (JS-only changes, instant).
-#   • build-submit — `eas build --auto-submit` (native changes / store release; Play
-#                    Internal Testing). iOS submit needs a submit profile in eas.json.
+# Manual mobile shipping via EAS. Three SEPARATE, explicit actions — nothing reaches
+# the store automatically; each run is a deliberate human click:
+#   • ota-update — `eas update` to the production channel (JS-only changes, instant).
+#   • build      — `eas build` only. Produces an artifact; does NOT touch the store.
+#   • submit     — `eas submit --latest` — pushes the latest build to the store.
+#                  Run this yourself, on purpose, when you've decided to release.
 #
 # Requires repo secret EXPO_TOKEN (expo.dev → Account → Access tokens).
-# Manual-only on purpose — EAS build minutes + store submissions shouldn't fire on
-# every push. (A tag trigger like `mobile-v*` can be added later if wanted.)
+# workflow_dispatch ONLY — no push/tag/schedule triggers, so the store is never
+# deployed to automatically.
 on:
   workflow_dispatch:
     inputs:
       action:
-        description: What to ship
+        description: What to do (store submit is its own explicit action)
         type: choice
-        options: [ota-update, build-submit]
+        options: [ota-update, build, submit]
         default: ota-update
       platform:
         description: Target platform
@@ -22,7 +24,7 @@ on:
         options: [all, android, ios]
         default: all
       profile:
-        description: Build profile (build-submit only)
+        description: Build/submit profile
         type: choice
         options: [production, preview]
         default: production
@@ -70,12 +72,23 @@ jobs:
             --message "${{ inputs.message }}" \
             --non-interactive
 
-      - name: Build + submit
-        if: ${{ inputs.action == 'build-submit' }}
+      # Build only — never auto-submits. The artifact sits in EAS until you
+      # explicitly run the 'submit' action below.
+      - name: Build
+        if: ${{ inputs.action == 'build' }}
         run: |
           eas build \
             --platform "${{ inputs.platform }}" \
             --profile "${{ inputs.profile }}" \
-            --auto-submit \
             --non-interactive \
             --no-wait
+
+      # Explicit, separate store push — submits the latest build to the store.
+      - name: Submit to store
+        if: ${{ inputs.action == 'submit' }}
+        run: |
+          eas submit \
+            --platform "${{ inputs.platform }}" \
+            --profile "${{ inputs.profile }}" \
+            --latest \
+            --non-interactive

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,0 +1,81 @@
+name: Mobile Release (EAS)
+
+# Manual mobile shipping via EAS. Two paths:
+#   • ota-update   — `eas update` to the production channel (JS-only changes, instant).
+#   • build-submit — `eas build --auto-submit` (native changes / store release; Play
+#                    Internal Testing). iOS submit needs a submit profile in eas.json.
+#
+# Requires repo secret EXPO_TOKEN (expo.dev → Account → Access tokens).
+# Manual-only on purpose — EAS build minutes + store submissions shouldn't fire on
+# every push. (A tag trigger like `mobile-v*` can be added later if wanted.)
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: What to ship
+        type: choice
+        options: [ota-update, build-submit]
+        default: ota-update
+      platform:
+        description: Target platform
+        type: choice
+        options: [all, android, ios]
+        default: all
+      profile:
+        description: Build profile (build-submit only)
+        type: choice
+        options: [production, preview]
+        default: production
+      message:
+        description: OTA message (ota-update only)
+        type: string
+        default: CI OTA update
+
+concurrency:
+  group: mobile-release
+  cancel-in-progress: false
+
+jobs:
+  ship:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/mobile/package-lock.json
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # @textstack/shared is consumed from source (Metro watchFolders), so the repo
+      # checkout already carries it; only the app's own deps need installing.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: OTA update
+        if: ${{ inputs.action == 'ota-update' }}
+        run: |
+          eas update \
+            --branch production \
+            --platform "${{ inputs.platform }}" \
+            --environment production \
+            --message "${{ inputs.message }}" \
+            --non-interactive
+
+      - name: Build + submit
+        if: ${{ inputs.action == 'build-submit' }}
+        run: |
+          eas build \
+            --platform "${{ inputs.platform }}" \
+            --profile "${{ inputs.profile }}" \
+            --auto-submit \
+            --non-interactive \
+            --no-wait

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -13,6 +13,7 @@
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "ios": {
         "simulator": false
       },
@@ -22,6 +23,7 @@
     },
     "production": {
       "autoIncrement": true,
+      "channel": "production",
       "ios": {
         "image": "latest"
       },


### PR DESCRIPTION
## Why
Two related mobile-shipping gaps:

1. **OTA never reached installed builds.** The `production`/`preview` build profiles in `eas.json` had **no `channel`**, so builds had `channel: None` and subscribed to no update channel — `eas update --branch production` published into the void. (This is why a fix OTA'd to the production branch didn't show up on an installed Android build.)
2. **No mobile CI.** CI only covers backend/web; mobile build + submit + OTA were entirely manual.

## What
- **`eas.json`**: add `channel: production` / `channel: preview` to the build profiles so new builds receive OTA going forward (EAS maps channel → same-named branch).
- **`.github/workflows/mobile-release.yml`**: a manual `workflow_dispatch` pipeline with two paths:
  - `ota-update` → `eas update --branch production` (JS-only, instant) for Android/iOS/all.
  - `build-submit` → `eas build --profile <production|preview> --auto-submit` (native / store release → Play Internal Testing).
  - Inputs: action, platform, profile, message.

## Setup required
- Add repo secret **`EXPO_TOKEN`** (expo.dev → Account → Access tokens) for the workflow to authenticate.
- Note: a **new build is required** for the channel fix to take effect — existing installs (channel: None) can't be reached by OTA. iOS `build-submit --auto-submit` needs an iOS submit profile in `eas.json` (only Android is configured today).

## Design notes
- Manual-only on purpose — EAS build minutes + store submissions shouldn't fire on every push. A `mobile-v*` tag trigger can be added later.
- Mobile uses npm (its own `package-lock.json`); `@textstack/shared` is consumed from source via Metro `watchFolders`, so the checkout carries it and only the app's deps are installed.

## Rollback
Revert the branch. eas.json channel addition is backward-compatible; the workflow is dormant until dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)