### PR TITLE
chore(ai): route translate to Ollama (OpenAI quota exhausted)

### DIFF
--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -61,7 +61,7 @@
     "DefaultProvider": "openai",
     "Routes": {
       "explain": "openai",
-      "translate": "openai",
+      "translate": "ollama",
       "distractor": "ollama",
       "bookmeta": "ollama",
       "tagsuggestion": "ollama",


### PR DESCRIPTION
## Why
OpenAI hit `insufficient_quota` (429) → `POST /api/translate` returned 503 "Translation failed" on the mobile reader. Switch the `translate` FeatureTag route from OpenAI to the self-hosted Ollama provider (free, no quota) so translation keeps working while OpenAI billing is sorted.

## What
`appsettings.json` → `Ai:Routes:translate`: `openai` → `ollama`. One line. Prod Ollama model is `gemma4:e2b` (docker-compose). No env override of `Ai:Routes`, so this is the effective config.

## Quality note
On a local check, a ~4B Ollama model translated EN→RU words correctly and context-aware ("nod" → "кивать", "charisma" → "Харизма"). Prod's `gemma4:e2b` is smaller (2B) — good enough for word-level reader translation, a notch below `gpt-4.1-nano` on edge cases. To verify on prod after deploy.

## Rollback
Flip the line back to `"translate": "openai"` once OpenAI is topped up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)