### PR TITLE
chore(ai): route translate back to OpenAI

### DIFF
--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -61,7 +61,7 @@
     "DefaultProvider": "openai",
     "Routes": {
       "explain": "openai",
-      "translate": "ollama",
+      "translate": "openai",
       "distractor": "ollama",
       "bookmeta": "ollama",
       "tagsuggestion": "ollama",


### PR DESCRIPTION
Reverts the temporary Ollama switch (#285). Translation goes back to `gpt-4.1-nano` for quality — Ollama `gemma4:e2b` (2B) got common words wrong on prod (`nod` → `нет`).

Requires the OpenAI **credit balance to be topped up** (it hit \$0.00 → `insufficient_quota`); until then `/translate` will 503. No automatic Ollama fallback — by deliberate choice, so an OpenAI outage stays visible rather than silently degrading.

One-line config: `Ai:Routes:translate` ollama → openai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)