### PR TITLE
feat(eval): dedicated OpenAI judge model (gpt-4.1)

### DIFF
--- a/apps/admin/src/pages/AiQualityPage.tsx
+++ b/apps/admin/src/pages/AiQualityPage.tsx
@@ -366,7 +366,7 @@ function EvalsTab() {
     <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 16, flexWrap: 'wrap' }}>
       <select value={judge} onChange={(e) => setJudge(e.target.value as 'ollama' | 'openai')} style={input} disabled={running}>
         <option value="ollama">Judge: Ollama (free)</option>
-        <option value="openai">Judge: OpenAI</option>
+        <option value="openai">Judge: OpenAI (gpt-4.1)</option>
       </select>
       <button onClick={run} disabled={running} style={rangeBtn(false)}>
         {running ? 'Running…' : 'Run evals'}

--- a/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
@@ -20,7 +20,7 @@ public sealed class OpenAiLlmClient : ILlmService
     private readonly int _reasoningBudget;
     private readonly ILogger<OpenAiLlmClient> _logger;
 
-    public OpenAiLlmClient(IConfiguration config, ILogger<OpenAiLlmClient> logger)
+    public OpenAiLlmClient(IConfiguration config, ILogger<OpenAiLlmClient> logger, string? modelOverride = null)
     {
         _logger = logger;
 
@@ -28,7 +28,11 @@ public sealed class OpenAiLlmClient : ILlmService
             ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY")
             ?? throw new InvalidOperationException("OPENAI_API_KEY not configured");
 
-        _model = config["OpenAI:Model"]
+        // modelOverride lets a second instance (e.g. the eval judge) run a different,
+        // stronger model than the default generation model — without it every OpenAI
+        // caller is pinned to OpenAI:Model.
+        _model = modelOverride
+            ?? config["OpenAI:Model"]
             ?? Environment.GetEnvironmentVariable("OPENAI_MODEL")
             ?? "gpt-4.1-nano";
 

--- a/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
@@ -51,9 +51,12 @@ public static class AdminAiQualityEndpoints
 
         // Judge defaults to local Ollama (free); generation always goes through the
         // gateway (routes by FeatureTag → OpenAI/Ollama exactly like prod).
-        var judgeKey = string.Equals(body?.Judge, "openai", StringComparison.OrdinalIgnoreCase) ? "openai" : "ollama";
-        var judgeModelId = judgeKey == "openai"
-            ? config["OpenAI:Model"] ?? "gpt-4.1-nano"
+        // The OpenAI judge runs the dedicated 'openai-judge' provider (Eval:JudgeModel,
+        // default gpt-4.1) — stronger + independent of the nano generation model.
+        var useOpenAiJudge = string.Equals(body?.Judge, "openai", StringComparison.OrdinalIgnoreCase);
+        var judgeKey = useOpenAiJudge ? "openai-judge" : "ollama";
+        var judgeModelId = useOpenAiJudge
+            ? config["Eval:JudgeModel"] ?? "gpt-4.1"
             : config["Ollama:Model"] ?? "gemma4:e4b";
         var gitSha = Environment.GetEnvironmentVariable("GIT_SHA");
         var features = body?.Features;

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -27,6 +27,9 @@
       "MaxTextLength": 500
     }
   },
+  "Eval": {
+    "JudgeModel": "gpt-4.1"
+  },
   "Translate": {
     "CachePath": "data/translate-cache",
     "CacheTtlDays": 30

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -67,8 +67,17 @@ public static class DependencyInjection
         services.AddKeyedSingleton<global::TextStack.Ai.Core.ILlmService, global::TextStack.Ai.Llm.OpenAiLlmClient>("openai-raw");
         services.AddKeyedSingleton<global::TextStack.Ai.Core.ILlmService, global::TextStack.Ai.Llm.OllamaLlmClient>("ollama-raw");
 
+        // A dedicated OpenAI judge provider on a STRONGER model (Eval:JudgeModel,
+        // default gpt-4.1) — separate from the nano generation model so the eval
+        // judge is both more reliable and not the same model it's grading.
+        services.AddKeyedSingleton<global::TextStack.Ai.Core.ILlmService>("openai-judge-raw", (sp, key) =>
+            new global::TextStack.Ai.Llm.OpenAiLlmClient(
+                sp.GetRequiredService<IConfiguration>(),
+                sp.GetRequiredService<ILogger<global::TextStack.Ai.Llm.OpenAiLlmClient>>(),
+                sp.GetRequiredService<IConfiguration>()["Eval:JudgeModel"] ?? "gpt-4.1"));
+
         // Decorated providers (keyed): TracingDecorator wraps each raw provider.
-        foreach (var providerKey in new[] { "openai", "ollama" })
+        foreach (var providerKey in new[] { "openai", "ollama", "openai-judge" })
         {
             services.AddKeyedSingleton<global::TextStack.Ai.Core.ILlmService>(providerKey, (sp, key) =>
                 new global::TextStack.Ai.Llm.TracingDecorator(


### PR DESCRIPTION
## Why
The eval judge reused `OpenAI:Model` (`gpt-4.1-nano`). Two problems:
1. **Self-judging bias** — explain/translate generate on nano, so a nano judge was nano grading nano.
2. **Weak judge** — nano is the cheapest model; judging needs more capability, so scores (esp. translate accuracy 3.17) were noisy/unreliable.

## What
A dedicated judge provider on a stronger, independent model (`Eval:JudgeModel`, default **`gpt-4.1`**):
- `OpenAiLlmClient` gains an optional `modelOverride` param (default null → unchanged).
- DI registers `openai-judge-raw` (gpt-4.1) + a traced `openai-judge`.
- Admin **Run evals** with **Judge: OpenAI** now resolves `openai-judge` (gpt-4.1) and persists it as `JudgeModelId`. **Generation models are unchanged** (explain/translate still nano, vocab/bookmeta still Ollama).
- Admin dropdown label → "Judge: OpenAI (gpt-4.1)".

Judge calls still flow through the TracingDecorator, so they keep showing in `/ai-quality` traces.

## Result
A stronger, independent judge → eval scores you can trust. Re-running with this judge will tell us whether translate's low accuracy axis is real or was judge noise from gemma2b/nano.

## Cost
Evals are infrequent (manual). ~180 judge calls/run × gpt-4.1 ≈ cents per run.

## Verification
Backend `Api` build: 0 warnings. Admin `tsc`: clean. Set `Eval:JudgeModel` to override the model (or pin a cheaper `gpt-4.1-mini`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)