### PR TITLE
fix(worker): OpenAI API key for podcast generation

### DIFF
--- a/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
@@ -24,9 +24,15 @@ public sealed class OpenAiLlmClient : ILlmService
     {
         _logger = logger;
 
-        var apiKey = config["OpenAI:ApiKey"]
-            ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY")
-            ?? throw new InvalidOperationException("OPENAI_API_KEY not configured");
+        // Treat an empty/whitespace value as "not configured" — otherwise an empty
+        // string flows into the OpenAI SDK and surfaces as a cryptic
+        // "Value cannot be an empty string. (Parameter 'key')" deep in the call stack
+        // (this exact trap cost a debugging session when the worker lacked the key).
+        var apiKey = config["OpenAI:ApiKey"];
+        if (string.IsNullOrWhiteSpace(apiKey))
+            apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new InvalidOperationException("OPENAI_API_KEY not configured (OpenAI:ApiKey / OPENAI_API_KEY is empty)");
 
         // modelOverride lets a second instance (e.g. the eval judge) run a different,
         // stronger model than the default generation model — without it every OpenAI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,10 @@ services:
       ConnectionStrings__Default: "Host=db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
       Storage__RootPath: /storage
       Search__Provider: ${SEARCH_PROVIDER:-postgres}
+      # The worker routes podcast.script generation to OpenAI (Ai:Routes), so it
+      # needs the key too — without it OpenAiLlmClient throws on an empty key and
+      # podcast jobs fail. The 'api' service already has this; the worker was missed.
+      OpenAI__ApiKey: ${OPENAI_API_KEY:-}
       # Worker reaches Ollama via the Docker service name, not localhost
       # (without this override it falls back to appsettings.json's
       # "http://localhost:11434" and silently fails every vocab-enrichment


### PR DESCRIPTION
## Root cause (found via SSH + worker logs)
The first-ever podcast generation **Failed** with:
`System.ArgumentException: Value cannot be an empty string. (Parameter 'key')` at `PodcastScriptBuilder.BuildAsync:56`.

Not the LLM/TTS/ffmpeg — the **worker container had no OpenAI API key**. Podcast script generation runs in the **worker** and routes `podcast.script` → OpenAI (`Ai:Routes`), but `docker-compose.yml` only set `OpenAI__ApiKey` on the **api** service. The worker built `OpenAiLlmClient` with an empty key → the OpenAI SDK threw the cryptic empty-`key` error. It only surfaced now because podcast is the worker's only OpenAI-routed feature and had never been run before (0 jobs ever).

Confirmed on prod: `api` → `OpenAI__ApiKey=SET`, `worker` → empty.

## Fix
- **docker-compose**: add `OpenAI__ApiKey: ${OPENAI_API_KEY:-}` to the `worker` service (mirrors `api`).
- **OpenAiLlmClient**: treat an empty/whitespace key as not-configured → throw a clear `OPENAI_API_KEY not configured` instead of the SDK's opaque error (so this is diagnosable instantly next time).

## After deploy
Re-click **Generate podcast** on a published edition → it should run Queued → Running → Succeeded. (OpenAI balance is funded; worker ffmpeg + Edge TTS are already in place.)

## Rollback
Revert — additive env + a stricter (clearer) key check. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)