### PR TITLE
feat(web): polished podcast player on book detail page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -50,6 +50,7 @@ import './styles/highlights.css'
 import './styles/auth.css'
 import './styles/profile.css'
 import './styles/dropzone.css'
+import './styles/podcast-player.css'
 
 function AuthSuccessToast() {
   const { authSuccessToast, dismissAuthSuccessToast } = useAuth()

--- a/apps/web/src/components/BookPodcastPlayer.tsx
+++ b/apps/web/src/components/BookPodcastPlayer.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+interface BookPodcastPlayerProps {
+  src: string
+  title: string
+  coverUrl?: string | null
+  /** Server-reported length; used as a fallback until the media metadata loads. */
+  durationSeconds?: number | null
+}
+
+const SPEEDS = [1, 1.25, 1.5, 1.75, 2] as const
+
+function fmt(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return '0:00'
+  const m = Math.floor(sec / 60)
+  const s = Math.floor(sec % 60)
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+/**
+ * Custom, on-brand audio player for a book's AI-narrated intro — replaces the raw
+ * browser <audio controls>. Native <input type="range"> drives the seek bar so it
+ * stays keyboard- and screen-reader-accessible; everything else is styled to match
+ * the reading app (terracotta accent, serif eyebrow, dark-mode via theme vars).
+ */
+export function BookPodcastPlayer({ src, title, coverUrl, durationSeconds }: BookPodcastPlayerProps) {
+  const audioRef = useRef<HTMLAudioElement>(null)
+  const [playing, setPlaying] = useState(false)
+  const [current, setCurrent] = useState(0)
+  const [duration, setDuration] = useState(durationSeconds && durationSeconds > 0 ? durationSeconds : 0)
+  const [buffered, setBuffered] = useState(0)
+  const [speedIdx, setSpeedIdx] = useState(0)
+  const [ready, setReady] = useState(false)
+
+  // Reset when the source changes (e.g. navigating between books).
+  useEffect(() => {
+    setPlaying(false); setCurrent(0); setBuffered(0); setSpeedIdx(0); setReady(false)
+    setDuration(durationSeconds && durationSeconds > 0 ? durationSeconds : 0)
+  }, [src, durationSeconds])
+
+  const speed = SPEEDS[speedIdx]
+  useEffect(() => { if (audioRef.current) audioRef.current.playbackRate = speed }, [speed])
+
+  const toggle = () => {
+    const a = audioRef.current
+    if (!a) return
+    if (a.paused) { void a.play() } else { a.pause() }
+  }
+
+  const skip = (delta: number) => {
+    const a = audioRef.current
+    if (!a) return
+    a.currentTime = Math.min(Math.max(0, a.currentTime + delta), duration || a.duration || 0)
+  }
+
+  const onSeek = (value: number) => {
+    const a = audioRef.current
+    if (!a) return
+    a.currentTime = value
+    setCurrent(value)
+  }
+
+  const progress = duration > 0 ? (current / duration) * 100 : 0
+  const bufferedPct = duration > 0 ? Math.min(100, (buffered / duration) * 100) : 0
+
+  const cover = useMemo(() => coverUrl || null, [coverUrl])
+
+  return (
+    <section className="podcast-player" aria-label={`Audio intro for ${title}`}>
+      <div className="podcast-player__media" aria-hidden="true">
+        {cover
+          ? <img className="podcast-player__cover" src={cover} alt="" loading="lazy" />
+          : <div className="podcast-player__cover podcast-player__cover--blank" />}
+        <span className="podcast-player__badge">
+          <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 14v-2a9 9 0 0 1 18 0v2" /><rect x="2.5" y="13.5" width="4" height="7" rx="2" /><rect x="17.5" y="13.5" width="4" height="7" rx="2" />
+          </svg>
+        </span>
+      </div>
+
+      <div className="podcast-player__body">
+        <div className="podcast-player__head">
+          <p className="podcast-player__eyebrow">Audio intro · 2 voices</p>
+          <h3 className="podcast-player__title" title={title}>{title}</h3>
+          <p className="podcast-player__note">AI-narrated · ~{fmt(duration)}</p>
+        </div>
+
+        <div className="podcast-player__transport">
+          <button type="button" className="podcast-player__skip" onClick={() => skip(-15)} aria-label="Back 15 seconds">
+            <svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M11 17a5 5 0 1 0-5-5" /><polyline points="6 9 6 12 9 12" />
+            </svg>
+            <span className="podcast-player__skip-n">15</span>
+          </button>
+
+          <button
+            type="button"
+            className={`podcast-player__play${playing ? ' is-playing' : ''}`}
+            onClick={toggle}
+            aria-label={playing ? 'Pause' : 'Play'}
+            aria-pressed={playing}
+          >
+            {playing
+              ? <svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor"><rect x="6" y="5" width="4" height="14" rx="1" /><rect x="14" y="5" width="4" height="14" rx="1" /></svg>
+              : <svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor"><path d="M8 5.5v13a1 1 0 0 0 1.5.87l11-6.5a1 1 0 0 0 0-1.74l-11-6.5A1 1 0 0 0 8 5.5Z" /></svg>}
+          </button>
+
+          <button type="button" className="podcast-player__skip" onClick={() => skip(15)} aria-label="Forward 15 seconds">
+            <svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M13 17a5 5 0 1 1 5-5" /><polyline points="18 9 18 12 15 12" />
+            </svg>
+            <span className="podcast-player__skip-n">15</span>
+          </button>
+
+          <div className="podcast-player__scrub">
+            <div className="podcast-player__rail" style={{ ['--buffered' as string]: `${bufferedPct}%`, ['--progress' as string]: `${progress}%` }}>
+              <input
+                className="podcast-player__range"
+                type="range"
+                min={0}
+                max={duration || 0}
+                step={0.1}
+                value={current}
+                onChange={(e) => onSeek(Number(e.target.value))}
+                aria-label="Seek"
+                aria-valuetext={`${fmt(current)} of ${fmt(duration)}`}
+                disabled={!ready && duration === 0}
+              />
+            </div>
+            <time className="podcast-player__time">{fmt(current)} <span>/</span> {fmt(duration)}</time>
+          </div>
+
+          <button
+            type="button"
+            className="podcast-player__speed"
+            onClick={() => setSpeedIdx((i) => (i + 1) % SPEEDS.length)}
+            aria-label={`Playback speed ${speed}×`}
+          >
+            {speed}×
+          </button>
+
+          <a className="podcast-player__download" href={src} download aria-label="Download audio">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+          </a>
+        </div>
+      </div>
+
+      <audio
+        ref={audioRef}
+        src={src}
+        preload="metadata"
+        onLoadedMetadata={(e) => { const d = e.currentTarget.duration; if (Number.isFinite(d) && d > 0) setDuration(d); setReady(true) }}
+        onCanPlay={() => setReady(true)}
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
+        onTimeUpdate={(e) => setCurrent(e.currentTarget.currentTime)}
+        onProgress={(e) => {
+          const a = e.currentTarget
+          if (a.buffered.length) setBuffered(a.buffered.end(a.buffered.length - 1))
+        }}
+      />
+    </section>
+  )
+}

--- a/apps/web/src/pages/BookDetailPage.tsx
+++ b/apps/web/src/pages/BookDetailPage.tsx
@@ -8,6 +8,7 @@ import { useDownload } from '../context/DownloadContext'
 import { useLibrary } from '../hooks/useLibrary'
 import { useSite } from '../context/SiteContext'
 import { LocalizedLink } from '../components/LocalizedLink'
+import { BookPodcastPlayer } from '../components/BookPodcastPlayer'
 import { SeoHead } from '../components/SeoHead'
 import { JsonLd } from '../components/JsonLd'
 import { Breadcrumbs } from '../components/Breadcrumbs'
@@ -294,10 +295,12 @@ export function BookDetailPage() {
             )}
 
             {podcast?.status === 'Succeeded' && podcast.audioUrl && (
-              <div className="book-hero__podcast">
-                <span className="book-hero__podcast-label">🎧 Listen as a podcast</span>
-                <audio controls preload="none" src={podcast.audioUrl} className="book-hero__podcast-audio" />
-              </div>
+              <BookPodcastPlayer
+                src={podcast.audioUrl}
+                title={book.title}
+                coverUrl={book.coverPath ? getStorageUrl(book.coverPath) : null}
+                durationSeconds={podcast.durationSeconds}
+              />
             )}
 
             {book.id && isDownloading(book.id) && (

--- a/apps/web/src/styles/podcast-player.css
+++ b/apps/web/src/styles/podcast-player.css
@@ -1,0 +1,233 @@
+/* Book "Audio intro" player — refined, literary, on-brand.
+   Uses the app theme vars (--color-bg/text/border/brand) so it follows dark mode. */
+.podcast-player {
+  --pp-accent: var(--color-brand, #C4704B);
+  --pp-ink: var(--color-text, #1c1b1a);
+  --pp-muted: color-mix(in srgb, var(--pp-ink) 55%, transparent);
+  --pp-track: color-mix(in srgb, var(--pp-ink) 14%, transparent);
+  --pp-buffered: color-mix(in srgb, var(--pp-ink) 26%, transparent);
+  --pp-surface: color-mix(in srgb, var(--pp-accent) 5%, var(--color-bg, #fff));
+  --pp-border: color-mix(in srgb, var(--pp-accent) 16%, var(--color-border, #e7e3df));
+
+  display: flex;
+  align-items: stretch;
+  gap: 18px;
+  max-width: 460px;
+  padding: 16px;
+  border: 1px solid var(--pp-border);
+  border-radius: 18px;
+  background: var(--pp-surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 10px 30px -18px color-mix(in srgb, var(--pp-accent) 50%, transparent);
+}
+
+/* Cover + headphone badge */
+.podcast-player__media { position: relative; flex: 0 0 auto; }
+.podcast-player__cover {
+  width: 62px;
+  height: 88px;
+  object-fit: cover;
+  border-radius: 9px;
+  box-shadow: 0 6px 16px -8px rgba(0, 0, 0, 0.5);
+  background: color-mix(in srgb, var(--pp-ink) 8%, transparent);
+}
+.podcast-player__cover--blank {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--pp-accent) 22%, var(--color-bg)) 0%, color-mix(in srgb, var(--pp-accent) 6%, var(--color-bg)) 100%);
+}
+.podcast-player__badge {
+  position: absolute;
+  right: -8px;
+  bottom: -8px;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #fff;
+  background: var(--pp-accent);
+  box-shadow: 0 2px 8px -2px color-mix(in srgb, var(--pp-accent) 70%, transparent);
+  border: 2px solid var(--pp-surface);
+}
+
+.podcast-player__body { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 12px; }
+
+/* Header copy */
+.podcast-player__head { display: flex; flex-direction: column; gap: 2px; }
+.podcast-player__eyebrow {
+  margin: 0;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pp-accent);
+}
+.podcast-player__title {
+  margin: 0;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--pp-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.podcast-player__note { margin: 0; font-size: 11.5px; color: var(--pp-muted); }
+
+/* Transport row */
+.podcast-player__transport { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+
+.podcast-player__play {
+  flex: 0 0 auto;
+  width: 50px;
+  height: 50px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 50%;
+  color: #fff;
+  background: var(--pp-accent);
+  cursor: pointer;
+  box-shadow: 0 8px 18px -8px color-mix(in srgb, var(--pp-accent) 85%, transparent);
+  transition: transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.18s, filter 0.18s;
+}
+.podcast-player__play:hover { transform: scale(1.06); filter: brightness(1.04); }
+.podcast-player__play:active { transform: scale(0.96); }
+.podcast-player__play svg { transform: translateX(0.5px); }
+.podcast-player__play.is-playing svg { transform: none; }
+
+.podcast-player__skip {
+  position: relative;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--pp-ink);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.podcast-player__skip:hover { background: color-mix(in srgb, var(--pp-ink) 8%, transparent); color: var(--pp-accent); }
+.podcast-player__skip-n {
+  position: absolute;
+  bottom: 4px;
+  font-size: 7.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Scrubber */
+.podcast-player__scrub { flex: 1 1 150px; min-width: 130px; display: flex; flex-direction: column; gap: 5px; }
+.podcast-player__rail { position: relative; height: 18px; display: flex; align-items: center; }
+.podcast-player__rail::before {
+  content: '';
+  position: absolute;
+  left: 0; right: 0;
+  height: 4px;
+  border-radius: 99px;
+  background: linear-gradient(to right,
+    var(--pp-buffered) 0, var(--pp-buffered) var(--buffered, 0%),
+    var(--pp-track) var(--buffered, 0%), var(--pp-track) 100%);
+}
+.podcast-player__rail::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: var(--progress, 0%);
+  height: 4px;
+  border-radius: 99px;
+  background: var(--pp-accent);
+}
+.podcast-player__range {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+}
+.podcast-player__range:disabled { cursor: default; }
+.podcast-player__range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 13px; height: 13px;
+  border-radius: 50%;
+  background: var(--pp-accent);
+  border: 2px solid var(--pp-surface);
+  box-shadow: 0 1px 4px -1px color-mix(in srgb, var(--pp-accent) 80%, transparent);
+  opacity: 0;
+  transition: opacity 0.15s, transform 0.15s;
+}
+.podcast-player__range::-moz-range-thumb {
+  width: 13px; height: 13px;
+  border-radius: 50%;
+  background: var(--pp-accent);
+  border: 2px solid var(--pp-surface);
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.podcast-player__rail:hover .podcast-player__range::-webkit-slider-thumb,
+.podcast-player__range:focus-visible::-webkit-slider-thumb { opacity: 1; }
+.podcast-player__rail:hover .podcast-player__range::-moz-range-thumb,
+.podcast-player__range:focus-visible::-moz-range-thumb { opacity: 1; }
+
+.podcast-player__time {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  color: var(--pp-muted);
+  font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, monospace;
+}
+.podcast-player__time span { opacity: 0.5; margin: 0 1px; }
+
+.podcast-player__speed {
+  flex: 0 0 auto;
+  min-width: 42px;
+  height: 28px;
+  padding: 0 9px;
+  border: 1px solid var(--pp-border);
+  border-radius: 99px;
+  background: transparent;
+  color: var(--pp-ink);
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.podcast-player__speed:hover { border-color: var(--pp-accent); color: var(--pp-accent); }
+
+.podcast-player__download {
+  flex: 0 0 auto;
+  width: 32px; height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  color: var(--pp-muted);
+  transition: background 0.15s, color 0.15s;
+}
+.podcast-player__download:hover { background: color-mix(in srgb, var(--pp-ink) 8%, transparent); color: var(--pp-accent); }
+
+/* Shared focus ring */
+.podcast-player__play:focus-visible,
+.podcast-player__skip:focus-visible,
+.podcast-player__speed:focus-visible,
+.podcast-player__download:focus-visible,
+.podcast-player__range:focus-visible {
+  outline: 2px solid var(--pp-accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 420px) {
+  .podcast-player { gap: 14px; padding: 14px; }
+  .podcast-player__cover { width: 54px; height: 78px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .podcast-player__play, .podcast-player__range::-webkit-slider-thumb { transition: none; }
+}


### PR DESCRIPTION
## Why
The "Listen as a podcast" block was a raw browser `<audio controls>` — generic and off-brand.

## What
A custom, accessible **`BookPodcastPlayer`** matching the reading-app aesthetic (terracotta accent, serif title, calm paper card, dark-mode via theme vars):
- Cover thumbnail with a headphone badge.
- Play / pause + **±15s** skip.
- **Accessible seek**: a native `<input type="range">` (keyboard + screen-reader) styled with a track + **buffered** + **progress** fill and a thumb that appears on hover/focus.
- Monospace `current / duration`, **speed** pill (1→1.25→1.5→1.75→2×), **download**.
- Reduced-motion + focus-visible rings; responsive (wraps on narrow screens).

Reframed copy to **"Audio intro · 2 voices · AI-narrated · ~3 min"** — the clips are short by design (a book intro, not a full episode), so the label sets the right expectation.

## Notes
- No new deps. CSS uses `color-mix` for tasteful warmth and follows the existing `--color-*` theme vars (so dark mode just works).
- Verify visually after deploy on a book that has a podcast (e.g. `/en/books/the-plague`).

## Cost context (for the record)
One podcast script generation ≈ **$0.0002–0.003** on gpt-4.1-nano (fractions of a cent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)