### PR TITLE
feat(podcast): description-anchored intro prompt + evals

### DIFF
--- a/backend/src/Ai/TextStack.Ai.EvalSuite/Datasets/podcast.json
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/Datasets/podcast.json
@@ -2,26 +2,31 @@
   {
     "title": "Designing Data-Intensive Applications",
     "author": "Martin Kleppmann",
+    "description": "A deep, vendor-neutral tour of the ideas behind reliable, scalable, and maintainable data systems — replication, partitioning, transactions, consistency models, and the trade-offs between batch and stream processing.",
     "excerpt": "Replication keeps a copy of the same data on multiple machines connected over a network. It serves three goals: keeping data geographically close to users to reduce latency, letting the system keep working when some parts fail, and scaling out the number of machines that can serve read queries. The hard part is not storing copies but handling changes to replicated data. The most common approach is leader-based replication: one replica is the leader and all writes go to it; the others are followers that copy the leader's change stream. Reads can go to any replica, but only the leader accepts writes. A key trade-off is synchronous versus asynchronous replication: synchronous guarantees a follower is up to date but blocks writes if that follower is slow, while asynchronous is fast but risks losing recent writes if the leader fails."
   },
   {
     "title": "Clean Code",
     "author": "Robert C. Martin",
+    "description": "A practical guide to writing readable, maintainable software — meaningful names, small focused functions, honest comments, error handling, and the discipline of continuously refactoring toward clarity.",
     "excerpt": "Names are everywhere in software, so naming well pays off constantly. A name should reveal intent: why something exists, what it does, and how it is used. If a name needs a comment to explain it, the name does not reveal intent. Prefer names you can pronounce and search for; single-letter names and magic numbers are hard to locate across a codebase. Avoid disinformation — do not call a grouping a 'list' unless it really is one. Make meaningful distinctions instead of noise words: accountData and account are not different things. Class names should be nouns, method names should be verbs. The goal is code that reads like well-written prose, where a later reader spends their effort understanding the problem, not decoding the names."
   },
   {
     "title": "The Pragmatic Programmer",
     "author": "Andrew Hunt and David Thomas",
+    "description": "A career-spanning collection of pragmatic principles and habits for software craftsmanship — DRY, orthogonality, tracer bullets, and taking responsibility for your craft.",
     "excerpt": "The DRY principle — Don't Repeat Yourself — states that every piece of knowledge must have a single, unambiguous, authoritative representation within a system. Duplication is dangerous because when one copy changes, every other copy must change too, and the ones you forget become bugs. Duplication is not only copy-pasted code: it also appears when the same fact is encoded in a database schema and again in code, or in documentation that drifts from the implementation. The fix is to make the knowledge live in one place and derive everything else from it — through functions, code generation, or a single source of truth. The authors pair this with orthogonality: keep unrelated things independent so a change in one area does not ripple unpredictably into others."
   },
   {
     "title": "Refactoring",
     "author": "Martin Fowler",
+    "description": "A catalog of disciplined techniques for improving the design of existing code without changing its behavior, backed by tests and small, safe, behavior-preserving steps.",
     "excerpt": "Refactoring is the process of changing a software system in a way that does not alter its external behavior yet improves its internal structure. It is a disciplined way to clean up code that minimizes the chance of introducing bugs: you make many small, behavior-preserving transformations, running the tests after each one. Code smells are the hints that tell you when to refactor. Long methods are hard to follow; large classes try to do too much; duplicated code begs to be unified; long parameter lists are confusing. Feature envy is when a method seems more interested in another class's data than its own. None of these are bugs, but they make the code harder to change. The remedy is a catalog of named refactorings — Extract Function, Move Method, Rename — applied in small steps backed by tests."
   },
   {
     "title": "Site Reliability Engineering",
     "author": "Google",
+    "description": "Google's account of running large-scale production systems with software-engineering discipline — SLOs and error budgets, eliminating toil, monitoring, incident response, and blameless postmortems.",
     "excerpt": "An error budget reframes reliability as a resource to be spent rather than a goal of perfection. One hundred percent is the wrong reliability target for almost everything: users cannot tell the difference between a service that is perfectly available and one that is 99.99 percent available, and chasing the last fraction is enormously expensive. So teams pick a service level objective — say 99.9 percent — and the gap, the remaining 0.1 percent, is the error budget. As long as the service is within budget, the development team is free to ship new features and take risks. When the budget is exhausted by outages, the team freezes risky launches and focuses on reliability until the budget recovers. This aligns the often-opposing incentives of developers, who want to ship, and operators, who want stability."
   }
 ]

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/EvalDefinitions.cs
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/EvalDefinitions.cs
@@ -46,9 +46,9 @@ public static class EvalDefinitions
         "description-quality: is the DESCRIPTION accurate, 2-3 sentences, no spoilers?");
 
     private static readonly Rubric PodcastRubric = new(
-        "grounding: does the dialogue stay strictly to the source excerpt, with no invented facts?",
+        "faithfulness: is the intro consistent with the overview/excerpt, with NO invented plot points, quotes, or characters (and spoiler-light)?",
         "naturalness: does it sound like a real spoken 2-host conversation (not a written summary)?",
-        "structure: do Aria and Guy alternate in short 1-3 sentence turns with a hook and a wrap-up?");
+        "intro-shape: does it introduce the book and entice the listener — Aria/Guy alternating in short 1-3 sentence turns, a hook, and a brief 'give it a read' wrap-up?");
 
     /// <summary>Build all eval definitions (optionally filtered to <paramref name="keys"/>).</summary>
     public static IReadOnlyList<EvalDefinition> Build(IEnumerable<string>? keys = null)
@@ -123,11 +123,12 @@ public static class EvalDefinitions
         {
             var units = GoldenLoader.Load<PodcastGolden>("podcast.json").Select(g =>
             {
-                var (sys, user) = PodcastPrompt.Build(g.Title, g.Author, "en", g.Excerpt);
+                var (sys, user) = PodcastPrompt.Build(g.Title, g.Author, "en", g.Description, g.Excerpt);
                 return new EvalUnit(
                     new LlmRequest(sys, [new LlmMessage("user", user)], MaxOutputTokens: 4000, FeatureTag: "podcast.script"),
                     [new FacetEval("podcast", PodcastRubric, actual =>
-                        $"Source excerpt:\n{g.Excerpt}\n\nGenerated dialogue (JSON array of speaker/line):\n{actual}")]);
+                        $"Book: {g.Title}{(g.Author is null ? "" : $" by {g.Author}")}\nOverview: {g.Description}\n" +
+                        $"Opening excerpt:\n{g.Excerpt}\n\nGenerated intro dialogue (JSON array of speaker/line):\n{actual}")]);
             }).ToList();
             defs.Add(new EvalDefinition("podcast", units));
         }

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/PodcastGolden.cs
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/PodcastGolden.cs
@@ -1,5 +1,6 @@
 namespace TextStack.Ai.EvalSuite;
 
-/// <summary>One podcast golden: a book + a source excerpt the generated 2-host dialogue
-/// must stay grounded in. The judge scores the dialogue for grounding/naturalness/structure.</summary>
-public record PodcastGolden(string Title, string? Author, string Excerpt);
+/// <summary>One podcast golden: a book (title/author), its curated Description (the
+/// primary anchor for the intro) and a short opening Excerpt. The judge scores the
+/// generated 2-host intro for faithfulness/naturalness/structure.</summary>
+public record PodcastGolden(string Title, string? Author, string Description, string Excerpt);

--- a/backend/src/Application/Ai/PodcastPrompt.cs
+++ b/backend/src/Application/Ai/PodcastPrompt.cs
@@ -1,32 +1,38 @@
+using System.Text;
+
 namespace Application.Ai;
 
 /// <summary>
-/// Prompt for the 2-voice podcast script (Phase 3). Two hosts — Aria (curious, asks)
-/// and Guy (explains) — discuss a book grounded ONLY in its text. Output is a strict
-/// JSON dialogue array consumed by ScriptBuilder. Pure string building, no deps.
+/// Prompt for the 2-voice book INTRO (Phase 3). Two hosts — Aria (curious, asks) and
+/// Guy (explains) — introduce a book to a new listener and make them want to read it.
+/// Anchored on the book's human-curated Description (+ a short opening excerpt) rather
+/// than thousands of words of chapter text: cheaper, and it leans on what the model
+/// already knows about well-known titles without licensing it to invent specifics.
+/// Output is a strict JSON dialogue array consumed by ScriptBuilder.
 /// </summary>
 public static class PodcastPrompt
 {
-    public static (string System, string User) Build(string title, string? author, string language, string bookText)
+    public static (string System, string User) Build(string title, string? author, string language, string? description, string? excerpt)
     {
         var system =
-            "You write a two-host audio podcast script discussing a book, in the style of NotebookLM. " +
+            "You write a short two-host audio INTRO that introduces a book to a new listener, in the style of NotebookLM. " +
             "The hosts are Aria (curious, asks questions and reacts) and Guy (knowledgeable, explains). " +
-            "Ground EVERYTHING strictly in the provided book text — never invent facts, quotes, or details. " +
-            $"Write natural, engaging spoken dialogue in {language}; 1-3 sentences per turn; alternate speakers; " +
-            "open with a short hook and close with a brief wrap-up. " +
+            "Goal: make the listener want to read the book — cover what it's about, its core themes, and why it matters; keep it spoiler-light (do not give away the ending). " +
+            "Anchor on the provided overview and excerpt. You may draw on well-established facts about a widely-known book, but NEVER invent plot points, quotes, characters, or specifics — if the book is unfamiliar, stay strictly with what's provided. " +
+            $"Write natural, engaging spoken dialogue in {language}; 1-3 sentences per turn; alternate speakers; open with a hook and close with a brief, warm 'give it a read' wrap-up. " +
             "Return ONLY a strict JSON array, no markdown and no preface: " +
             "[{\"speaker\":\"Aria\"|\"Guy\",\"line\":\"...\"}].";
 
-        var header = $"Book: \"{title}\"";
+        var user = new StringBuilder();
+        user.Append($"Book: \"{title}\"");
         if (!string.IsNullOrWhiteSpace(author))
-            header += $"\nAuthor: {author}";
+            user.Append($"\nAuthor: {author}");
+        if (!string.IsNullOrWhiteSpace(description))
+            user.Append($"\n\nOverview:\n{description.Trim()}");
+        if (!string.IsNullOrWhiteSpace(excerpt))
+            user.Append($"\n\nOpening excerpt:\n{excerpt.Trim()}");
+        user.Append("\n\nWrite the intro dialogue.");
 
-        var user =
-            $"{header}\n\n" +
-            "Write the podcast dialogue covering the book's key ideas and themes.\n\n" +
-            $"Book text:\n{bookText}";
-
-        return (system, user);
+        return (system, user.ToString());
     }
 }

--- a/backend/src/Worker/Services/PodcastScriptBuilder.cs
+++ b/backend/src/Worker/Services/PodcastScriptBuilder.cs
@@ -26,7 +26,9 @@ public record PodcastScript(IReadOnlyList<DialogueLine> Lines);
 /// </summary>
 public class PodcastScriptBuilder(IAppDbContext db, ILlmServiceFactory llmFactory) : IPodcastScriptBuilder
 {
-    private const int MaxSourceWords = 6000; // ~8k input tokens budget
+    // Intro is anchored on the Description; the excerpt is just a short secondary
+    // anchor (and a safety net for titles the model doesn't know), not the whole book.
+    private const int MaxExcerptWords = 800;
 
     private static readonly HashSet<string> Hosts = new(StringComparer.OrdinalIgnoreCase) { "Aria", "Guy" };
 
@@ -38,6 +40,7 @@ public class PodcastScriptBuilder(IAppDbContext db, ILlmServiceFactory llmFactor
             {
                 e.Title,
                 e.Language,
+                e.Description,
                 Author = e.EditionAuthors.OrderBy(a => a.Order).Select(a => a.Author.Name).FirstOrDefault(),
                 Chapters = e.Chapters.OrderBy(c => c.ChapterNumber).Select(c => c.PlainText).ToList(),
             })
@@ -45,12 +48,13 @@ public class PodcastScriptBuilder(IAppDbContext db, ILlmServiceFactory llmFactor
         if (edition is null)
             return null;
 
-        var bookText = TruncateToWords(string.Join("\n\n", edition.Chapters), MaxSourceWords);
-        if (string.IsNullOrWhiteSpace(bookText))
+        var excerpt = TruncateToWords(string.Join("\n\n", edition.Chapters), MaxExcerptWords);
+        // Need at least one anchor — the curated overview or some opening text.
+        if (string.IsNullOrWhiteSpace(edition.Description) && string.IsNullOrWhiteSpace(excerpt))
             return null;
 
         var language = string.IsNullOrWhiteSpace(lang) ? edition.Language : lang;
-        var (system, user) = PodcastPrompt.Build(edition.Title, edition.Author, language, bookText);
+        var (system, user) = PodcastPrompt.Build(edition.Title, edition.Author, language, edition.Description, excerpt);
 
         var llm = llmFactory.Get("PodcastScript");
         var raw = await llm.CompleteAsync(system, user, maxOutputTokens: 4000, ct);


### PR DESCRIPTION
## Why
We now present the podcast as an **"Audio intro"**, and the old prompt dumped ~6000 words of chapter text (often copyright/contents/front-matter) into the model — wasteful, and grounding the intro only on the opening. For well-known books the model already knows more than the first 6000 words convey; for unknown ones, raw front-matter is a poor anchor.

## What
- **`PodcastPrompt`**: reframed as a two-host **intro** that introduces the book and entices the listener — anchored on the book's curated **Description** + a short opening excerpt. It may use well-established facts about famous titles but **must not invent** plot/quotes/characters (spoiler-light), and closes with a brief "give it a read" wrap-up.
- **`PodcastScriptBuilder`**: feeds `Description` + an **800-word** excerpt (down from 6000) — cheaper input, no front-matter drowning. Requires at least one anchor (description or excerpt).
- **Evals in lockstep** (senior nuance — kept them honest):
  - `PodcastGolden` gains `Description`; the 5 goldens get curated blurbs.
  - `EvalDefinitions` passes the description and includes it in the judge evidence.
  - Rubric reframed: **faithfulness** (consistent with overview, no invented facts, spoiler-light) · naturalness · **intro-shape** (hook + entice + read-it wrap-up).

## Nuances / notes
- **Cheaper**: input drops from ~8k tokens to well under 2k → lower cost per intro.
- **Safe for the long tail**: the Description anchors unknown/obscure titles so the model doesn't hallucinate; it can still enrich famous ones from its own knowledge.
- **Existing podcasts are unchanged** (generation is idempotent) — regenerate to pick up the new intro style.
- New-run eval scores aren't directly comparable to the prior excerpt-grounding rubric.

## Verification
- `dotnet build textstack.sln`: 0 warnings. Eval suite: 10 passed / 5 skipped (live evals self-skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)