### PR TITLE
Fix EPUB split-chapter mis-titling + book% on book detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### EPUB chapter parsing fix + correct book progress on book detail (2026-06-09)
+
+- **Fix: book detail page showed chapter % as book %** (e.g. "85%" on `my-books/[id]` while on chapter 2). The page rendered `savedProgress.percent` (chapter-scroll) directly; it now computes book-wide percent via `computeBookProgress`, matching the reader footer and library cards.
+- **Fix: EPUB chapters mis-titled / content not matching titles.** On EPUBs that split one logical chapter across two spine files — a heading-only file (`<h1>10</h1>`) plus a separate body file — the extractor produced doubled, mis-titled chapters (a 1-word "10" chapter, then a body titled with the book name, with titles drifting against content). Root causes:
+  - `HtmlCleaner.ExtractTitle` fell back to the `<head><title>` element, which in professionally-produced EPUBs is the **book** title on every page. That mislabeled untitled spine files and, via `HasProperTitle`, blocked the merge of a heading file with its body. New `HtmlCleaner.ExtractHeadingTitle` (visible `h1/h2/h3` only) is now used for per-chapter titling; book-level `ExtractTitle` is unchanged.
+  - Added heading-stub recombination in `EpubTextExtractor`: a bare chapter-number file (`IsHeadingNumberStub` — ≤3 words, digits only) is merged into the following body file, keeping the stub's nav-derived title.
+  - Not an AI-model issue — chapter splitting/titling is deterministic extraction; the LLM only fills genre/year/description metadata.
+  - Already-uploaded books re-parse via `POST /me/books/{id}/retry`.
+
 ### Mobile — unified reader + correct book progress (2026-06-09)
 
 Reading-progress fixes + a structural refactor that collapses the two readers (catalog + user-uploaded) into one code path, killing the "two readers drift" bug class.

--- a/apps/mobile/app/my-books/[id].tsx
+++ b/apps/mobile/app/my-books/[id].tsx
@@ -3,7 +3,7 @@ import { View, Text, ScrollView, StyleSheet, TouchableOpacity, ActivityIndicator
 import { Image } from 'expo-image'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
-import { userBooksApi, getStorageUrl, getApiConfig } from '@textstack/shared'
+import { userBooksApi, getStorageUrl, getApiConfig, computeBookProgress } from '@textstack/shared'
 import type { UserBookDetailResponse } from '@textstack/shared'
 import { useTheme } from '../../src/context/ThemeContext'
 import { useToast } from '../../src/context/ToastContext'
@@ -221,7 +221,18 @@ export default function UserBookDetailScreen() {
   }
 
   const estPages = book.totalWordCount ? Math.round(book.totalWordCount / 250) : null
-  const progressPct = savedProgress?.percent ? Math.round(savedProgress.percent * 100) : 0
+  // Book-wide percent (not chapter-scroll percent) — mirror the reader/library
+  // so the detail page doesn't show "85%" while the user is on chapter 2. Slug
+  // fallback matches the reader's `slug || chapter-{n}` synthesis.
+  const bookPct = savedProgress?.chapterSlug
+    ? computeBookProgress(
+        (book.chapters ?? []).map(c => ({ slug: c.slug || `chapter-${c.chapterNumber}`, wordCount: c.wordCount })),
+        savedProgress.chapterSlug,
+        savedProgress.percent ?? 0,
+        book.totalWordCount ?? undefined,
+      )
+    : null
+  const progressPct = bookPct != null ? Math.round(bookPct * 100) : 0
 
   return (
     <>

--- a/backend/src/Extraction/TextStack.Extraction/Extractors/EpubTextExtractor.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Extractors/EpubTextExtractor.cs
@@ -147,6 +147,31 @@ public sealed class EpubTextExtractor : ITextExtractor
                     continue;
                 }
 
+                // Heading-stub recombination: the previous unit is a bare
+                // chapter-number file (e.g. "<h1>10</h1>" → a 1-word chapter)
+                // and THIS file is its body, split into a separate spine file.
+                // Merge the body into the stub, keeping the stub's nav-derived
+                // title — otherwise the book shows a 1-word "10" chapter followed
+                // by a mis-titled body (Charisma Myth ch.10-13 in production).
+                if (previousUnit != null && IsHeadingNumberStub(previousUnit))
+                {
+                    var mergedHtml = previousUnit.Html + cleanHtml;
+                    var mergedPlainText = previousUnit.PlainText + " " + plainText;
+                    var mergedWordCount = previousUnit.WordCount + wordCount;
+
+                    var updatedUnit = previousUnit with
+                    {
+                        Html = mergedHtml,
+                        PlainText = mergedPlainText,
+                        WordCount = mergedWordCount
+                    };
+
+                    units[previousUnitIndex] = updatedUnit;
+                    tocChapters[previousUnitIndex] = (previousUnit.OrderIndex + 1, mergedHtml);
+                    previousUnit = updatedUnit;
+                    continue;
+                }
+
                 // Regular chapter - create new unit
                 var chapterNumber = order + 1;
                 var chapterTitle = GetChapterTitle(filePath, navTitleMap, html, chapterNumber);
@@ -364,8 +389,10 @@ public sealed class EpubTextExtractor : ITextExtractor
                 return navTitle;
         }
 
-        // 2. Try extracting from HTML (h1, h2, title tag)
-        var htmlTitle = HtmlCleaner.ExtractTitle(html);
+        // 2. Try extracting from a VISIBLE heading (h1/h2/h3) — never the
+        // <head><title>, which is the book title on every page in many EPUBs
+        // and would mislabel every untitled spine file with the book name.
+        var htmlTitle = HtmlCleaner.ExtractHeadingTitle(html);
         if (!string.IsNullOrWhiteSpace(htmlTitle) && !LooksLikeFileName(htmlTitle))
         {
             return htmlTitle;
@@ -430,8 +457,8 @@ public sealed class EpubTextExtractor : ITextExtractor
             !LooksLikeFileName(navTitle))
             return true;
 
-        // Has heading in HTML?
-        var htmlTitle = HtmlCleaner.ExtractTitle(html);
+        // Has a visible heading in HTML? (NOT <head><title> — see GetChapterTitle.)
+        var htmlTitle = HtmlCleaner.ExtractHeadingTitle(html);
         if (!string.IsNullOrWhiteSpace(htmlTitle) && !LooksLikeFileName(htmlTitle))
             return true;
 
@@ -573,6 +600,25 @@ public sealed class EpubTextExtractor : ITextExtractor
         }
 
         return sections.Count >= 2 ? sections : [];
+    }
+
+    // A bare chapter number like "10" — matched against a unit's collapsed plain
+    // text to detect heading-only spine files. Runtime Regex (not [GeneratedRegex])
+    // per the ARM64 SIGILL caveat in RULES.md.
+    private static readonly System.Text.RegularExpressions.Regex NumberStubRegex = new(@"^\d{1,3}$");
+
+    /// <summary>
+    /// True when a unit is just a chapter-number heading (e.g. a "&lt;h1&gt;10&lt;/h1&gt;"
+    /// spine file): a handful of words whose text is only digits. Such files are
+    /// the heading half of a chapter split across two spine files.
+    /// </summary>
+    private static bool IsHeadingNumberStub(ContentUnit unit)
+    {
+        if (unit.WordCount > 3) return false;
+        var text = unit.PlainText?.Trim();
+        if (string.IsNullOrEmpty(text)) return false;
+        text = System.Text.RegularExpressions.Regex.Replace(text, @"\s+", " ").Trim();
+        return NumberStubRegex.IsMatch(text);
     }
 
     private static readonly System.Text.RegularExpressions.Regex ChapterPartRegex = new(

--- a/backend/src/Extraction/TextStack.Extraction/Utilities/HtmlCleaner.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Utilities/HtmlCleaner.cs
@@ -86,6 +86,36 @@ public partial class HtmlCleaner
         return decoded;
     }
 
+    /// <summary>
+    /// Like <see cref="ExtractTitle"/> but only considers VISIBLE headings
+    /// (h1/h2/h3) — never the <c>&lt;head&gt;&lt;title&gt;</c> element. In many
+    /// professionally-produced EPUBs every spine file's &lt;title&gt; is the
+    /// BOOK title, so falling back to it mislabels chapters (and, via
+    /// HasProperTitle, blocks the merge of a heading-only file with its body).
+    /// Use this for per-chapter titling; use ExtractTitle for book-level title.
+    /// </summary>
+    public static string? ExtractHeadingTitle(string html)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var headingNode = doc.DocumentNode.SelectSingleNode("//h1")
+            ?? doc.DocumentNode.SelectSingleNode("//h2")
+            ?? doc.DocumentNode.SelectSingleNode("//h3");
+
+        var title = headingNode?.InnerText?.Trim();
+        if (string.IsNullOrWhiteSpace(title))
+            return null;
+
+        var decoded = HtmlEntity.DeEntitize(title).Trim();
+
+        if (string.Equals(decoded, "Unknown", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(decoded, "Untitled", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return decoded;
+    }
+
     public static int CountWords(string text)
     {
         if (string.IsNullOrWhiteSpace(text))

--- a/tests/TextStack.Extraction.Tests/HtmlCleanerTitleTests.cs
+++ b/tests/TextStack.Extraction.Tests/HtmlCleanerTitleTests.cs
@@ -1,0 +1,50 @@
+using TextStack.Extraction.Utilities;
+
+namespace TextStack.Extraction.Tests;
+
+public class HtmlCleanerTitleTests
+{
+    private const string BookTitlePollutedPage =
+        "<html><head><title>The Charisma Myth</title></head><body><p>Difficult Situations FOR THE MOST part…</p></body></html>";
+
+    [Fact]
+    public void ExtractHeadingTitle_IgnoresHeadTitle_ReturnsNullWhenNoVisibleHeading()
+    {
+        // The bug: every spine file's <head><title> is the BOOK title, so using
+        // it mislabeled chapters and blocked stub/body merges. Heading-only
+        // extraction must NOT see it.
+        Assert.Null(HtmlCleaner.ExtractHeadingTitle(BookTitlePollutedPage));
+    }
+
+    [Fact]
+    public void ExtractTitle_StillFallsBackToHeadTitle_UnchangedForBookLevel()
+    {
+        // Contrast: book-level ExtractTitle keeps the <title> fallback (used by
+        // other callers) — we only changed the per-chapter path.
+        Assert.Equal("The Charisma Myth", HtmlCleaner.ExtractTitle(BookTitlePollutedPage));
+    }
+
+    [Theory]
+    [InlineData("<h1>Difficult Situations</h1><p>body</p>", "Difficult Situations")]
+    [InlineData("<h2>Presenting with Charisma</h2>", "Presenting with Charisma")]
+    [InlineData("<h3>Notes</h3>", "Notes")]
+    public void ExtractHeadingTitle_ReturnsVisibleHeading(string html, string expected)
+    {
+        Assert.Equal(expected, HtmlCleaner.ExtractHeadingTitle(html));
+    }
+
+    [Fact]
+    public void ExtractHeadingTitle_PrefersH1OverDeeperHeadings()
+    {
+        var html = "<h1>Chapter</h1><h2>Subsection</h2>";
+        Assert.Equal("Chapter", HtmlCleaner.ExtractHeadingTitle(html));
+    }
+
+    [Theory]
+    [InlineData("<h1>Unknown</h1>")]
+    [InlineData("<h1>Untitled</h1>")]
+    public void ExtractHeadingTitle_RejectsPlaceholders(string html)
+    {
+        Assert.Null(HtmlCleaner.ExtractHeadingTitle(html));
+    }
+}


### PR DESCRIPTION
## What
Two fixes from the Charisma Myth report.

### 1. Book detail page showed chapter % as book %
`my-books/[id]` rendered `savedProgress.percent` (chapter-scroll) → "85%" on chapter 2. Now computes book-wide percent via `computeBookProgress`, matching the reader footer + library cards.

### 2. EPUB chapters mis-titled / content ≠ title
On EPUBs that split one logical chapter across two spine files (a heading-only `<h1>10</h1>` file + a separate body file), the extractor produced **doubled, mis-titled** chapters: a 1-word "10" chapter, then a body titled with the **book name**, titles drifting against content (verified in prod: 28 chapters, ch13-22 misaligned).

**Root causes (deterministic extraction, NOT the AI model):**
- `HtmlCleaner.ExtractTitle` fell back to `<head><title>`, which is the **book** title on every page in professionally-produced EPUBs → mislabeled untitled files and, via `HasProperTitle`, blocked the heading↔body merge. New `ExtractHeadingTitle` (visible `h1/h2/h3` only) for per-chapter titling; book-level `ExtractTitle` unchanged.
- Added **heading-stub recombination**: a bare chapter-number file (`IsHeadingNumberStub`, ≤3 words / digits only) is merged into the following body file, keeping the stub's nav-derived title.

The LLM (`BookMetadataGenerator`) only fills genre/year/description — it never touches chapter titles/content.

## Tests
- `TextStack.Extraction.Tests`: 256 pass, incl. 8 new `HtmlCleanerTitleTests` (proves `<title>` is ignored for chapter titling, kept for book-level).
- mobile `tsc` ✅ · worker build ✅

## Migration
Already-uploaded books re-parse with the new logic via `POST /me/books/{id}/retry` (or admin reprocess). No schema change.

## Rollback
Revert the merge commit — extraction + client only, no migration.

## Verify
- Charisma Myth detail page shows book% (≈ reader footer), not 85%.
- After re-parsing Charisma: chapters no longer doubled; titles match content (no 1-word "10" chapters, no "The Charisma Myth" as a chapter title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)