### PR TITLE
feat(rag): pgvector + chapter_chunk migration (AI-018)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        # pgvector image (stock pg16 + vector ext) so `dotnet ef database update`
+        # can run the AddPgVectorAndChunks migration's CREATE EXTENSION vector.
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: app
           POSTGRES_PASSWORD: changeme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — pgvector + chapter_chunk storage (2026-06-09)
+
+First PR of Phase 4 "Ask this book" (playbook PR **AI-018**). Lays the vector-storage foundation only — no chunker/embeddings/retrieval yet.
+
+- **pgvector enabled.** DB image `postgres:16` → `pgvector/pgvector:pg16` (docker-compose + CI service); existing data volume is compatible (stock pg16 + extension binary, no re-init). Migration `AddPgVectorAndChunks` emits `CREATE EXTENSION IF NOT EXISTS vector` ahead of the table.
+- **`chapter_chunk` table** (singular name to match the playbook DDL and the future raw-Npgsql retrieval SQL). Columns: uuid PK, `edition_id`/`chapter_id` (cascade FKs), `ord`, `text`, `embedding vector(1536)`, `token_count`, `created_at`. Two columns beyond the playbook schema, per `bootcamp-rag-analysis.md`: `chapter_ord` (denormalized so the spoiler gate filters in SQL without a join) and `char_start`/`char_end` (parent-context expansion + citation deep-links).
+- **Embedding nullable** — the chunker (AI-019) inserts text first; the batch embedder (AI-020/021) fills vectors later. Retrieval SQL adds `embedding IS NOT NULL`.
+- **Indexes:** HNSW `(embedding vector_cosine_ops)` for cosine ANN; btree `(edition_id, chapter_id, ord)`.
+- **Domain stays framework-free** — `ChapterChunk.Embedding` is `float[]`, converted to `Pgvector.Vector` only in EF mapping (`AppDbContext.Rag.cs`). `Pgvector` + `Pgvector.EntityFrameworkCore` added centrally; `.UseVector()` wired in all 3 DbContext registrations (Api/Worker/Factory). Not exposed on `IAppDbContext` — retrieval uses raw Npgsql.
+- **Microsoft-libs boundary:** generation layer (chunker/embeddings, AI-019/020) will use `Microsoft.Extensions.AI` + SK `TextChunker`; the pgvector storage/access layer stays raw Npgsql so the spoiler gate lives in SQL.
+
 ### EPUB chapter parsing fix + correct book progress on book detail (2026-06-09)
 
 - **Fix: book detail page showed chapter % as book %** (e.g. "85%" on `my-books/[id]` while on chapter 2). The page rendered `savedProgress.percent` (chapter-scroll) directly; it now computes book-wide percent via `computeBookProgress`, matching the reader footer and library cards.
@@ -24,7 +35,7 @@ Reading-progress fixes + a structural refactor that collapses the two readers (c
 
 Migrated the hand-rolled eval runner/judge to the **stable** `Microsoft.Extensions.AI.Evaluation` framework (10.6.0), keeping our golden datasets the source of truth and scores comparable. Shipped as 7 small steps on one branch.
 
-- **AI-018 — eval suite on MEAI.Evaluation** (this PR) — replaces the bespoke `JudgeRunner.JudgeAsync` LLM-as-judge with MEAI's `IEvaluator` model, end to end:
+- **AI-010a — eval suite on MEAI.Evaluation** (this PR) — a follow-on refinement of the Phase 2 eval epic (AI-006/009/010), not a roadmap PR — AI-018 is reserved for Phase 4 (pgvector). Replaces the bespoke `JudgeRunner.JudgeAsync` LLM-as-judge with MEAI's `IEvaluator` model, end to end:
   - **`LlmServiceChatClient`** adapts our `ILlmService` seam to MEAI's `IChatClient`, so evaluators call the same Ollama/OpenAI gateway (no new service).
   - **`RubricEvaluator : IEvaluator`** ports the judge 1:1 — the **same** system prompt + **same** strict-JSON parse (now shared statics on `JudgeRunner`) → identical scores given the same judge reply; emits the 3 rubric axes + overall as `NumericMetric`s, gated Pass/Fail on the same floors.
   - **Goldens unchanged** (`GoldenLoader` + embedded `Datasets/*.json`) feed `ReportingConfiguration` scenarios; runs persist to a disk store with a **30-day response cache** (re-runs don't re-hit the judge) and an **HTML report** (`data/eval-meai/`).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,6 +34,11 @@
     <PackageVersion Include="Microsoft.Extensions.AI.Evaluation" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.Evaluation.Quality" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.Evaluation.Reporting" Version="10.6.0" />
+    <!-- pgvector (Phase 4 RAG). EF maps the `vector` column type + DDL; retrieval
+         stays raw Npgsql so the spoiler gate lives in SQL. Pgvector.EF 0.3.0 needs
+         Npgsql.EFCore.PostgreSQL >=9.0.1 — satisfied by our 10.0.1. -->
+    <PackageVersion Include="Pgvector" Version="0.3.2" />
+    <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
     <!-- Search -->
     <PackageVersion Include="Dapper" Version="2.1.72" />
     <PackageVersion Include="Meilisearch" Version="0.16.0" />

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -85,7 +85,7 @@ var connectionString = builder.Configuration.GetConnectionString("Default")
     ?? throw new InvalidOperationException("ConnectionStrings:Default is required");
 
 builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseNpgsql(connectionString)
+    options.UseNpgsql(connectionString, o => o.UseVector())
         .UseSnakeCaseNamingConvention()
         .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
 

--- a/backend/src/Domain/Entities/ChapterChunk.cs
+++ b/backend/src/Domain/Entities/ChapterChunk.cs
@@ -1,0 +1,47 @@
+namespace Domain.Entities;
+
+/// <summary>
+/// A retrieval unit for Phase 4 RAG ("Ask this book"): a sentence-aware slice of a
+/// chapter's plain text plus its embedding vector. Produced by the chunker (AI-019),
+/// embedded by the embedding client (AI-020/021), and queried by spoiler-safe
+/// retrieval via raw Npgsql (AI-022+). EF mapping in AppDbContext.Rag.cs (table
+/// <c>chapter_chunk</c>, snake_case columns).
+/// </summary>
+public class ChapterChunk
+{
+    public Guid Id { get; set; }
+    public Guid EditionId { get; set; }
+    public Guid ChapterId { get; set; }
+
+    /// <summary>Chunk order within its chapter (0-based).</summary>
+    public int Ord { get; set; }
+
+    /// <summary>
+    /// Denormalized chapter order, copied from the chapter. Lets the spoiler gate
+    /// filter <c>WHERE chapter_ord &lt;= @lastRead</c> in SQL without joining chapters.
+    /// </summary>
+    public int ChapterOrd { get; set; }
+
+    /// <summary>The chunk's plain text (the unit that gets embedded).</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 1536-d embedding (OpenAI text-embedding-3-small). Modeled as <c>float[]</c> to
+    /// keep Domain framework-free; mapped to pgvector <c>vector(1536)</c> in EF.
+    /// Nullable: the chunker inserts text first, the batch embedder fills this later.
+    /// </summary>
+    public float[]? Embedding { get; set; }
+
+    public int TokenCount { get; set; }
+
+    /// <summary>Start offset of this chunk in the chapter's plain_text (inclusive).</summary>
+    public int CharStart { get; set; }
+
+    /// <summary>End offset of this chunk in the chapter's plain_text (exclusive).</summary>
+    public int CharEnd { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public Edition? Edition { get; set; }
+    public Chapter? Chapter { get; set; }
+}

--- a/backend/src/Infrastructure/Infrastructure.csproj
+++ b/backend/src/Infrastructure/Infrastructure.csproj
@@ -2,6 +2,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Pgvector" />
+    <PackageReference Include="Pgvector.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="EFCore.NamingConventions" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/backend/src/Infrastructure/Migrations/20260609223301_AddPgVectorAndChunks.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260609223301_AddPgVectorAndChunks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609223301_AddPgVectorAndChunks")]
+    partial class AddPgVectorAndChunks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260609223301_AddPgVectorAndChunks.cs
+++ b/backend/src/Infrastructure/Migrations/20260609223301_AddPgVectorAndChunks.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pgvector;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPgVectorAndChunks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:vector", ",,");
+
+            migrationBuilder.CreateTable(
+                name: "chapter_chunk",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    edition_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    chapter_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ord = table.Column<int>(type: "integer", nullable: false),
+                    chapter_ord = table.Column<int>(type: "integer", nullable: false),
+                    text = table.Column<string>(type: "text", nullable: false),
+                    embedding = table.Column<Vector>(type: "vector(1536)", nullable: true),
+                    token_count = table.Column<int>(type: "integer", nullable: false),
+                    char_start = table.Column<int>(type: "integer", nullable: false),
+                    char_end = table.Column<int>(type: "integer", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_chapter_chunk", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_chapter_chunk_chapters_chapter_id",
+                        column: x => x.chapter_id,
+                        principalTable: "chapters",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_chapter_chunk_editions_edition_id",
+                        column: x => x.edition_id,
+                        principalTable: "editions",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_chapter_chunk_chapter_id",
+                table: "chapter_chunk",
+                column: "chapter_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_chapter_chunk_edition_id_chapter_id_ord",
+                table: "chapter_chunk",
+                columns: new[] { "edition_id", "chapter_id", "ord" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_chapter_chunk_embedding",
+                table: "chapter_chunk",
+                column: "embedding")
+                .Annotation("Npgsql:IndexMethod", "hnsw")
+                .Annotation("Npgsql:IndexOperators", new[] { "vector_cosine_ops" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "chapter_chunk");
+
+            migrationBuilder.AlterDatabase()
+                .OldAnnotation("Npgsql:PostgresExtension:vector", ",,");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Rag.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Rag.cs
@@ -1,0 +1,56 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Pgvector;
+
+namespace Infrastructure.Persistence;
+
+/// <summary>
+/// Phase 4 RAG mapping. <see cref="ChapterChunk"/> (table <c>chapter_chunk</c>,
+/// singular to match the playbook DDL + future raw retrieval SQL). The
+/// <c>vector</c> column type comes from the pgvector extension, enabled here via
+/// <c>HasPostgresExtension</c> so the migration emits CREATE EXTENSION before the
+/// table. Embedding is stored as <c>float[]</c> on the entity and converted to
+/// <see cref="Vector"/> for the database.
+/// </summary>
+public partial class AppDbContext
+{
+    private static void ConfigureRag(ModelBuilder modelBuilder)
+    {
+        // Emits `CREATE EXTENSION IF NOT EXISTS vector` ahead of the table.
+        modelBuilder.HasPostgresExtension("vector");
+
+        modelBuilder.Entity<ChapterChunk>(e =>
+        {
+            // Singular table name (matches playbook schema + hand-written retrieval SQL).
+            e.ToTable("chapter_chunk");
+
+            // float[] (framework-free Domain) <-> pgvector vector(1536). Nullable:
+            // chunks are inserted before the batch embedder fills the vector.
+            e.Property(x => x.Embedding)
+                .HasColumnType("vector(1536)")
+                .HasConversion(
+                    v => v == null ? null : new Vector(v),
+                    v => v == null ? null : v.ToArray());
+
+            e.Property(x => x.CreatedAt).HasDefaultValueSql("now()");
+
+            // Approximate-NN index for cosine similarity search (AI-022+).
+            e.HasIndex(x => x.Embedding)
+                .HasMethod("hnsw")
+                .HasOperators("vector_cosine_ops");
+
+            // Ordered fetch of a chapter's chunks; covers the spoiler-gate edition scope.
+            e.HasIndex(x => new { x.EditionId, x.ChapterId, x.Ord });
+
+            e.HasOne(x => x.Edition)
+                .WithMany()
+                .HasForeignKey(x => x.EditionId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(x => x.Chapter)
+                .WithMany()
+                .HasForeignKey(x => x.ChapterId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -82,6 +82,9 @@ public partial class AppDbContext : DbContext, IAppDbContext
     public DbSet<EvalRun> EvalRuns => Set<EvalRun>();
     public DbSet<PodcastGenerationJob> PodcastGenerationJobs => Set<PodcastGenerationJob>();
 
+    // Phase 4 RAG. Intentionally not on IAppDbContext — retrieval uses raw Npgsql.
+    public DbSet<ChapterChunk> ChapterChunks => Set<ChapterChunk>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -99,6 +102,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
         ConfigureCollections(modelBuilder);
         ConfigureAi(modelBuilder);
         ConfigurePodcasts(modelBuilder);
+        ConfigureRag(modelBuilder);
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/backend/src/Infrastructure/Persistence/AppDbContextFactory.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContextFactory.cs
@@ -11,7 +11,7 @@ public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
             ?? "Host=localhost;Port=5432;Database=books;Username=app;Password=changeme";
 
         var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
-        optionsBuilder.UseNpgsql(connectionString);
+        optionsBuilder.UseNpgsql(connectionString, o => o.UseVector());
 
         return new AppDbContext(optionsBuilder.Options);
     }

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -24,7 +24,7 @@ var connectionString = builder.Configuration.GetConnectionString("Default")
     ?? "Host=localhost;Port=5432;Database=books;Username=app;Password=changeme";
 
 builder.Services.AddDbContextFactory<AppDbContext>(options =>
-    options.UseNpgsql(connectionString)
+    options.UseNpgsql(connectionString, o => o.UseVector())
         .UseSnakeCaseNamingConvention()
         .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@
 
 services:
   db:
-    image: postgres:16
+    # pgvector image = stock postgres:16 + the `vector` extension binary.
+    # Existing ./data/postgres-prod volume is compatible (no re-init); the
+    # extension is activated by the AddPgVectorAndChunks migration.
+    image: pgvector/pgvector:pg16
     container_name: textstack_db_prod
     environment:
       POSTGRES_USER: ${POSTGRES_USER}


### PR DESCRIPTION
## Summary

First PR of **Phase 4 — "Ask this book"** (spoiler-safe RAG). Lays the vector-storage foundation only: enables the pgvector extension and creates the `chapter_chunk` table + indexes. No chunker, embeddings, retrieval, or backfill (those are AI-019/020/021/022).

## Context

- **Retrieval will use raw Npgsql/SQL, not EF LINQ** (decision in `docs/04-dev/bootcamp-rag-analysis.md`) — the spoiler gate lives in the SQL `WHERE`. That's why the table carries denormalized `chapter_ord` (gate without a join) and `char_start`/`char_end` (parent-context expansion + citation deep-links), two columns beyond the playbook schema.
- **Microsoft-libs boundary:** the generation layer (chunker/embeddings, AI-019/020) will use `Microsoft.Extensions.AI` + SK `TextChunker`; the pgvector storage/access layer is deliberately raw Npgsql + `Pgvector` EF mapping so the spoiler gate stays in SQL. This PR is pure schema — zero LLM/embedding calls.

## Changes

- **pgvector enabled.** DB image `postgres:16` → `pgvector/pgvector:pg16` (docker-compose **and** the CI `backend` Postgres service, so `dotnet ef database update` can run `CREATE EXTENSION`). Existing `./data/postgres-prod` volume is compatible (stock pg16 + extension binary, no re-init).
- **`chapter_chunk` table** (singular — matches playbook DDL + future raw retrieval SQL). uuid PK; cascade FKs to `editions`/`chapters`; `ord`, `text`, `embedding vector(1536)`, `token_count`, `created_at default now()`; extra `chapter_ord`, `char_start`, `char_end`.
- **Embedding nullable** — chunker inserts text first; batch embedder fills vectors later. Retrieval SQL adds `embedding IS NOT NULL`.
- **Indexes:** HNSW `(embedding vector_cosine_ops)`; btree `(edition_id, chapter_id, ord)`.
- **Domain framework-free** — `ChapterChunk.Embedding` is `float[]`, converted to `Pgvector.Vector` only in EF (`AppDbContext.Rag.cs`). `Pgvector` 0.3.2 + `Pgvector.EntityFrameworkCore` 0.3.0 added centrally; `.UseVector()` wired in Api/Worker/Factory. `ChapterChunk` is **not** on `IAppDbContext`.

## Tests / verification

- `dotnet build` — clean (0 warnings/errors).
- `dotnet ef migrations script` — `CREATE EXTENSION IF NOT EXISTS vector` renders **before** `CREATE TABLE chapter_chunk`; `vector(1536)`, HNSW `vector_cosine_ops`, btree, cascade FKs all present.
- `dotnet test tests/TextStack.UnitTests` — 138 passed.
- `dotnet format --verify-no-changes` — clean (Infrastructure/Domain/Api/Worker).
- **CI applies this migration against a real pgvector Postgres** (backend job + docker compose job), so the live `CREATE EXTENSION` + table creation is validated on every PR.

## Rollback plan

Revert the commit. The migration is additive (new table + extension); `Down()` drops `chapter_chunk` and the vector extension annotation. No existing data touched.

## Notes

- Numbering: an earlier MEAI eval-framework refactor had squatted on "AI-018" in CHANGELOG; relabeled to `AI-010a` here so AI-018 is the canonical Phase 4 PR.
- Planning docs (`PLAYBOOK/ROADMAP/ARCH-ai-portfolio.md`, `bootcamp-rag-analysis.md`) intentionally kept out of this code-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)