### PR TITLE
feat(rag): sentence-aware chunker (AI-019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — sentence-aware chunker (2026-06-09)
+
+Second PR of Phase 4 (playbook **AI-019**). Fills the `chapter_chunk` table created in AI-018: catalog ingestion now emits retrieval-sized chunks (embeddings come in AI-020/021).
+
+- **New `TextStack.Ai.Rag` library** with a hand-rolled, sentence-aware `Chunker`: splits chapter plain text into ~512-token windows with 64-token overlap, recording exact `char_start`/`char_end` offsets back into the source text (parent-context expansion + citation deep-links). Hand-rolled rather than SemanticKernel `TextChunker` because the latter returns strings without offsets.
+- **Exact token counts** via `Microsoft.ML.Tokenizers` (cl100k tiktoken, matching `text-embedding-3-small`) for both chunk boundaries and the stored `token_count`. The `Data.Cl100kBase` package ships the vocab so it works offline. Transitive `Microsoft.Bcl.Memory` pinned to 10.0.9 to clear advisory GHSA-73j8-2gch-69rq (NU1903).
+- **Wired into catalog ingestion** (Worker `IngestionService`, right after search indexing): loads the just-saved chapters, chunks each, bulk-inserts `chapter_chunk` rows with `embedding = null` and `chapter_ord` copied from the chapter. Best-effort — a chunking failure logs a warning and never fails the ingestion job; old chunks cascade-delete on reprocess.
+- **Scope:** catalog editions only (the AI-018 schema FKs to `chapters`/`editions`). User-uploaded books deferred to a future PR. Existing already-ingested editions get chunks on next reprocess until the AI-021 backfill lands.
+- Unit tests (`ChunkerTests`, 13 cases): sentence-split offset round-trip, token-budget bound, overlap, 0-based contiguous `Ord`, empty input, oversized-single-sentence.
+
 ### Phase 4 RAG — pgvector + chapter_chunk storage (2026-06-09)
 
 First PR of Phase 4 "Ask this book" (playbook PR **AI-018**). Lays the vector-storage foundation only — no chunker/embeddings/retrieval yet.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,14 @@
          Npgsql.EFCore.PostgreSQL >=9.0.1 — satisfied by our 10.0.1. -->
     <PackageVersion Include="Pgvector" Version="0.3.2" />
     <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
+    <!-- Tokenizer (Phase 4 RAG chunker). Exact cl100k tiktoken counts matching
+         text-embedding-3-small; the Data.Cl100kBase package ships the vocab so
+         TiktokenTokenizer.CreateForModel works offline (no download). -->
+    <PackageVersion Include="Microsoft.ML.Tokenizers" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="2.0.0" />
+    <!-- Override transitive (ML.Tokenizers pulls 9.0.4) to clear NU1903 high-sev
+         advisory GHSA-73j8-2gch-69rq; 10.0.9 aligns with our other 10.0.x packages. -->
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.9" />
     <!-- Search -->
     <PackageVersion Include="Dapper" Version="2.1.72" />
     <PackageVersion Include="Meilisearch" Version="0.16.0" />

--- a/backend/src/Ai/TextStack.Ai.Rag/Chunker.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/Chunker.cs
@@ -1,0 +1,148 @@
+using Microsoft.ML.Tokenizers;
+
+namespace TextStack.Ai.Rag;
+
+/// <summary>
+/// Sentence-aware chunker. Splits plain text into sentences (offset-preserving), then packs
+/// them into ~<see cref="MaxTokens"/>-token windows with a ~<see cref="OverlapTokens"/>-token
+/// trailing overlap between consecutive chunks. Token counts use the exact cl100k tiktoken
+/// vocab (same as <c>text-embedding-3-small</c>), built once and reused (thread-safe).
+/// </summary>
+public sealed class Chunker : IChunker
+{
+    /// <summary>Target upper bound on tokens per chunk.</summary>
+    public const int MaxTokens = 512;
+
+    /// <summary>Approximate token overlap re-included at the start of the next chunk.</summary>
+    public const int OverlapTokens = 64;
+
+    private readonly Tokenizer _tokenizer;
+    private readonly int _maxTokens;
+    private readonly int _overlapTokens;
+
+    public Chunker() : this(MaxTokens, OverlapTokens) { }
+
+    /// <summary>Test/override ctor for custom window sizes.</summary>
+    public Chunker(int maxTokens, int overlapTokens)
+    {
+        if (maxTokens <= 0) throw new ArgumentOutOfRangeException(nameof(maxTokens));
+        if (overlapTokens < 0 || overlapTokens >= maxTokens)
+            throw new ArgumentOutOfRangeException(nameof(overlapTokens));
+        _maxTokens = maxTokens;
+        _overlapTokens = overlapTokens;
+        // cl100k_base vocab ships in Microsoft.ML.Tokenizers.Data.Cl100kBase (offline).
+        _tokenizer = TiktokenTokenizer.CreateForModel("text-embedding-3-small");
+    }
+
+    public IReadOnlyList<TextChunk> Chunk(string plainText)
+    {
+        if (string.IsNullOrWhiteSpace(plainText))
+            return [];
+
+        var sentences = SplitSentences(plainText);
+        if (sentences.Count == 0)
+            return [];
+
+        // Per-sentence token counts drive boundary decisions; the stored TokenCount is the
+        // exact count of the final joined slice (whitespace between sentences may tokenize
+        // slightly differently than the sum of parts).
+        var counts = new int[sentences.Count];
+        for (var i = 0; i < sentences.Count; i++)
+            counts[i] = _tokenizer.CountTokens(sentences[i].Text);
+
+        var chunks = new List<TextChunk>();
+        var ord = 0;
+        var idx = 0;
+        while (idx < sentences.Count)
+        {
+            var windowStart = idx;
+            var tokenSum = 0;
+            var lastIdx = idx;
+            while (idx < sentences.Count)
+            {
+                // Always take at least one sentence, even if it alone exceeds the budget.
+                if (tokenSum > 0 && tokenSum + counts[idx] > _maxTokens)
+                    break;
+                tokenSum += counts[idx];
+                lastIdx = idx;
+                idx++;
+            }
+
+            var charStart = sentences[windowStart].Start;
+            var charEnd = sentences[lastIdx].End;
+            var text = plainText[charStart..charEnd];
+            chunks.Add(new TextChunk(ord++, text, _tokenizer.CountTokens(text), charStart, charEnd));
+
+            if (idx >= sentences.Count)
+                break;
+
+            // Overlap: walk back from the last sentence, re-including trailing sentences whose
+            // cumulative tokens stay within the overlap budget; the next window starts there.
+            var overlapSum = 0;
+            var nextStart = lastIdx + 1;
+            for (var b = lastIdx; b > windowStart; b--)
+            {
+                if (overlapSum + counts[b] > _overlapTokens)
+                    break;
+                overlapSum += counts[b];
+                nextStart = b;
+            }
+            // Guarantee forward progress (avoid restarting on the same window).
+            idx = Math.Max(nextStart, windowStart + 1);
+        }
+
+        return chunks;
+    }
+
+    private const string Terminators = ".!?…";          // . ! ? …
+    private const string Closers = "\"')]”’";      // " ' ) ] ” ’
+
+    /// <summary>
+    /// Offset-preserving sentence split: each span runs from its first non-whitespace char
+    /// through its terminating punctuation (plus any closing quotes/brackets). A trailing
+    /// run without terminal punctuation becomes a final sentence. Approximate (over-splits
+    /// abbreviations like "Mr.") but offsets are exact, since chunks slice the original text.
+    /// </summary>
+    public static List<Sentence> SplitSentences(string text)
+    {
+        var result = new List<Sentence>();
+        var n = text.Length;
+        var start = -1;
+        var i = 0;
+        while (i < n)
+        {
+            if (start < 0)
+            {
+                if (!char.IsWhiteSpace(text[i])) start = i;
+                i++;
+                continue;
+            }
+
+            if (Terminators.IndexOf(text[i]) >= 0)
+            {
+                var end = i + 1;
+                while (end < n && Terminators.IndexOf(text[end]) >= 0) end++;
+                while (end < n && Closers.IndexOf(text[end]) >= 0) end++;
+                result.Add(new Sentence(text[start..end], start, end));
+                start = -1;
+                i = end;
+                continue;
+            }
+
+            i++;
+        }
+
+        if (start >= 0)
+        {
+            var end = n;
+            while (end > start && char.IsWhiteSpace(text[end - 1])) end--;
+            if (end > start)
+                result.Add(new Sentence(text[start..end], start, end));
+        }
+
+        return result;
+    }
+
+    /// <summary>A sentence span with its offsets into the source text.</summary>
+    public readonly record struct Sentence(string Text, int Start, int End);
+}

--- a/backend/src/Ai/TextStack.Ai.Rag/IChunker.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/IChunker.cs
@@ -1,0 +1,14 @@
+namespace TextStack.Ai.Rag;
+
+/// <summary>
+/// Splits a chapter's plain text into sentence-aware, token-bounded chunks for embedding.
+/// Implementations are stateless and thread-safe (the tokenizer is built once and reused).
+/// </summary>
+public interface IChunker
+{
+    /// <summary>
+    /// Chunk <paramref name="plainText"/> into ordered, overlapping windows. Returns an empty
+    /// list for null/whitespace input. Chunk offsets reference <paramref name="plainText"/>.
+    /// </summary>
+    IReadOnlyList<TextChunk> Chunk(string plainText);
+}

--- a/backend/src/Ai/TextStack.Ai.Rag/ServiceCollectionExtensions.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/ServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TextStack.Ai.Rag;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the RAG chunker. <see cref="IChunker"/> is a singleton — the tiktoken
+    /// vocab is loaded once at construction and reused across ingestion jobs.
+    /// </summary>
+    public static IServiceCollection AddAiRag(this IServiceCollection services)
+    {
+        services.AddSingleton<IChunker, Chunker>();
+        return services;
+    }
+}

--- a/backend/src/Ai/TextStack.Ai.Rag/TextChunk.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/TextChunk.cs
@@ -1,0 +1,14 @@
+namespace TextStack.Ai.Rag;
+
+/// <summary>
+/// One retrieval-sized slice of a chapter's plain text, produced by <see cref="IChunker"/>.
+/// Maps onto a <c>chapter_chunk</c> row (Phase 4 RAG). Offsets are UTF-16 code-unit indices
+/// into the SAME <c>plain_text</c> string that was chunked — retrieval/citation code must
+/// slice that identical string to reconstruct the chunk or expand parent context.
+/// </summary>
+/// <param name="Ord">0-based position of this chunk within its chapter.</param>
+/// <param name="Text">The chunk's plain text (the unit that gets embedded).</param>
+/// <param name="TokenCount">Exact cl100k token count of <paramref name="Text"/>.</param>
+/// <param name="CharStart">Inclusive start offset of the chunk in the chapter plain text.</param>
+/// <param name="CharEnd">Exclusive end offset of the chunk in the chapter plain text.</param>
+public readonly record struct TextChunk(int Ord, string Text, int TokenCount, int CharStart, int CharEnd);

--- a/backend/src/Ai/TextStack.Ai.Rag/TextStack.Ai.Rag.csproj
+++ b/backend/src/Ai/TextStack.Ai.Rag/TextStack.Ai.Rag.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>TextStack.Ai.Rag</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TextStack.Ai.Core\TextStack.Ai.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.Tokenizers" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" />
+    <!-- Force the transitive Microsoft.Bcl.Memory up to a non-vulnerable version (NU1903). -->
+    <PackageReference Include="Microsoft.Bcl.Memory" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+</Project>

--- a/backend/src/Application/Library/LibraryShelvesService.cs
+++ b/backend/src/Application/Library/LibraryShelvesService.cs
@@ -117,7 +117,7 @@ public class LibraryShelvesService(IAppDbContext db)
         var bookPctUploads = await ComputeUserBookPercentsAsync(
             uploads.Select(u => (u.Id, u.ProgressChapterSlug, u.Progress)).ToList(), ct);
         var bookPctSaved = await ComputeEditionBookPercentsAsync(
-            saved.Select(s => (s.Id, s.CurrentChapterId, s.CurrentLocator, s.Progress)).ToList(), ct);
+            saved.Select(s => (s.Id, s.CurrentChapterId, (string?)s.CurrentLocator, s.Progress)).ToList(), ct);
 
         var merged = uploads
             .Select(u =>
@@ -203,7 +203,7 @@ public class LibraryShelvesService(IAppDbContext db)
         var bookPctUploads = await ComputeUserBookPercentsAsync(
             uploads.Select(u => (u.Id, u.ProgressChapterSlug, u.Progress)).ToList(), ct);
         var bookPctSaved = await ComputeEditionBookPercentsAsync(
-            saved.Select(s => (s.Id, s.CurrentChapterId, s.CurrentLocator, s.LatestProgress ?? 0)).ToList(), ct);
+            saved.Select(s => (s.Id, s.CurrentChapterId, (string?)s.CurrentLocator, s.LatestProgress ?? 0)).ToList(), ct);
 
         return uploads
             .Select(u =>
@@ -294,7 +294,7 @@ public class LibraryShelvesService(IAppDbContext db)
         var bookPctUploads = await ComputeUserBookPercentsAsync(
             uploads.Select(u => (u.Id, u.ProgressChapterSlug, u.Progress)).ToList(), ct);
         var bookPctSaved = await ComputeEditionBookPercentsAsync(
-            saved.Select(s => (s.Id, s.CurrentChapterId, s.CurrentLocator, s.Progress)).ToList(), ct);
+            saved.Select(s => (s.Id, s.CurrentChapterId, (string?)s.CurrentLocator, s.Progress)).ToList(), ct);
 
         bool IsQuick(int? words, double progress)
         {

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Npgsql;
 using TextStack.Extraction.Extractors;
 using TextStack.Extraction.Registry;
+using TextStack.Ai.Rag;
 using TextStack.Search;
 using TextStack.Search.Meilisearch;
 using TextStack.Tts;
@@ -70,6 +71,8 @@ builder.Services.AddScoped<IPodcastScriptBuilder, PodcastScriptBuilder>();
 builder.Services.Configure<TtsConfiguration>(builder.Configuration.GetSection("Tts"));
 builder.Services.AddSingleton<ITtsService, EdgeTtsService>();
 builder.Services.AddSingleton<IAudioAssembler, AudioAssembler>();
+// Phase 4 RAG: sentence-aware chunker emits chapter_chunk rows during ingestion.
+builder.Services.AddAiRag();
 builder.Services.AddSingleton<IngestionWorkerService>();
 builder.Services.AddSingleton<UserIngestionService>();
 builder.Services.AddHostedService<IngestionWorker>();

--- a/backend/src/Worker/Services/IngestionService.cs
+++ b/backend/src/Worker/Services/IngestionService.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using TextStack.Extraction.Contracts;
 using TextStack.Extraction.Enums;
 using TextStack.Extraction.Lint;
+using TextStack.Ai.Rag;
 using TextStack.Extraction.Registry;
 using TextStack.Search.Abstractions;
 using TextStack.Search.Contracts;
@@ -25,6 +26,7 @@ public class IngestionWorkerService
     private readonly IExtractorRegistry _extractorRegistry;
     private readonly ISearchIndexer _searchIndexer;
     private readonly IImageOptimizer _imageOptimizer;
+    private readonly IChunker _chunker;
     private readonly ILogger<IngestionWorkerService> _logger;
     private readonly ILogger<AppIngestion.IngestionService> _ingestionLogger;
 
@@ -34,6 +36,7 @@ public class IngestionWorkerService
         IExtractorRegistry extractorRegistry,
         ISearchIndexer searchIndexer,
         IImageOptimizer imageOptimizer,
+        IChunker chunker,
         ILogger<IngestionWorkerService> logger,
         ILogger<AppIngestion.IngestionService> ingestionLogger)
     {
@@ -42,6 +45,7 @@ public class IngestionWorkerService
         _extractorRegistry = extractorRegistry;
         _searchIndexer = searchIndexer;
         _imageOptimizer = imageOptimizer;
+        _chunker = chunker;
         _logger = logger;
         _ingestionLogger = ingestionLogger;
     }
@@ -290,6 +294,14 @@ public class IngestionWorkerService
                 indexActivity?.SetTag("chapters_indexed", parsed.Chapters.Count);
             }
 
+            // Emit RAG chunks (Phase 4). Best-effort: chunks are regenerable and not
+            // required for reading, so a failure here must not fail the ingestion job.
+            using (var chunkActivity = IngestionActivitySource.Source.StartActivity("rag.chunk"))
+            {
+                var chunkCount = await ChunkChaptersAsync(db, job.EditionId, ct);
+                chunkActivity?.SetTag("chunks_created", chunkCount);
+            }
+
             // Run linter and save results
             using (var lintActivity = IngestionActivitySource.Source.StartActivity("lint.run"))
             {
@@ -435,6 +447,61 @@ public class IngestionWorkerService
         {
             await _searchIndexer.IndexBatchAsync(documents, ct);
             _logger.LogInformation("Indexed {Count} chapters for edition {EditionId}", documents.Count, editionId);
+        }
+    }
+
+    /// <summary>
+    /// Splits each just-saved chapter's plain text into RAG chunks (Phase 4) and persists
+    /// <see cref="ChapterChunk"/> rows with a null embedding (filled later by AI-020/021).
+    /// Old chunks were cascade-deleted when chapters were replaced. Best-effort: logs and
+    /// returns 0 on failure rather than failing the ingestion job.
+    /// </summary>
+    private async Task<int> ChunkChaptersAsync(AppDbContext db, Guid editionId, CancellationToken ct)
+    {
+        try
+        {
+            var chapters = await db.Chapters
+                .Where(c => c.EditionId == editionId)
+                .OrderBy(c => c.ChapterNumber)
+                .Select(c => new { c.Id, c.ChapterNumber, c.PlainText })
+                .ToListAsync(ct);
+
+            var rows = new List<ChapterChunk>();
+            foreach (var chapter in chapters)
+            {
+                foreach (var chunk in _chunker.Chunk(chapter.PlainText ?? string.Empty))
+                {
+                    rows.Add(new ChapterChunk
+                    {
+                        Id = Guid.NewGuid(),
+                        EditionId = editionId,
+                        ChapterId = chapter.Id,
+                        ChapterOrd = chapter.ChapterNumber,
+                        Ord = chunk.Ord,
+                        Text = chunk.Text,
+                        TokenCount = chunk.TokenCount,
+                        CharStart = chunk.CharStart,
+                        CharEnd = chunk.CharEnd,
+                        Embedding = null
+                    });
+                }
+            }
+
+            if (rows.Count > 0)
+            {
+                db.ChapterChunks.AddRange(rows);
+                await db.SaveChangesAsync(ct);
+                _logger.LogInformation(
+                    "Created {Count} RAG chunks for edition {EditionId}", rows.Count, editionId);
+            }
+
+            return rows.Count;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "RAG chunking failed for edition {EditionId}; chunks can be regenerated on reprocess", editionId);
+            return 0;
         }
     }
 

--- a/backend/src/Worker/Worker.csproj
+++ b/backend/src/Worker/Worker.csproj
@@ -18,5 +18,6 @@
     <ProjectReference Include="..\Search\TextStack.Search\TextStack.Search.csproj" />
     <ProjectReference Include="..\Search\TextStack.Search.Meilisearch\TextStack.Search.Meilisearch.csproj" />
     <ProjectReference Include="..\Tts\TextStack.Tts\TextStack.Tts.csproj" />
+    <ProjectReference Include="..\Ai\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/TextStack.UnitTests/ChunkerTests.cs
+++ b/tests/TextStack.UnitTests/ChunkerTests.cs
@@ -1,0 +1,136 @@
+using TextStack.Ai.Rag;
+
+namespace TextStack.UnitTests;
+
+public class ChunkerTests
+{
+    // ---- SplitSentences (pure, no tokenizer) ----
+
+    [Fact]
+    public void SplitSentences_MultipleSentences_PreservesOffsets()
+    {
+        const string text = "Hello world. How are you? Fine!";
+        var sentences = Chunker.SplitSentences(text);
+
+        Assert.Equal(3, sentences.Count);
+        // Every span's offsets must slice back to its exact text.
+        foreach (var s in sentences)
+            Assert.Equal(s.Text, text.Substring(s.Start, s.End - s.Start));
+        // Offsets are strictly increasing.
+        Assert.True(sentences[0].End <= sentences[1].Start);
+        Assert.True(sentences[1].End <= sentences[2].Start);
+    }
+
+    [Fact]
+    public void SplitSentences_TrailingFragmentWithoutTerminator_IsCaptured()
+    {
+        const string text = "First sentence. Second has no period";
+        var sentences = Chunker.SplitSentences(text);
+
+        Assert.Equal(2, sentences.Count);
+        Assert.Equal("Second has no period", sentences[1].Text);
+        Assert.Equal(text.Length, sentences[1].End);
+    }
+
+    [Fact]
+    public void SplitSentences_ClosingQuoteAfterTerminator_IncludedInSpan()
+    {
+        const string text = "He said \"hello.\" Bye.";
+        var sentences = Chunker.SplitSentences(text);
+
+        Assert.Equal(2, sentences.Count);
+        Assert.EndsWith("\"", sentences[0].Text); // closing quote stays with first sentence
+        Assert.Equal(sentences[0].Text, text.Substring(sentences[0].Start, sentences[0].End - sentences[0].Start));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   \n\t ")]
+    public void SplitSentences_BlankInput_ReturnsEmpty(string text)
+        => Assert.Empty(Chunker.SplitSentences(text));
+
+    // ---- Chunk (uses the real tiktoken vocab) ----
+
+    private const string Paragraph =
+        "Alpha beta gamma delta. Epsilon zeta eta theta. Iota kappa lambda mu. " +
+        "Nu xi omicron pi. Rho sigma tau upsilon.";
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("    ")]
+    public void Chunk_BlankInput_ReturnsEmpty(string text)
+        => Assert.Empty(new Chunker().Chunk(text));
+
+    [Fact]
+    public void Chunk_ShortText_ReturnsSingleChunkSpanningText()
+    {
+        const string text = "Just one short sentence here.";
+        var chunks = new Chunker().Chunk(text);
+
+        var chunk = Assert.Single(chunks);
+        Assert.Equal(0, chunk.Ord);
+        Assert.Equal(text, chunk.Text);
+        Assert.Equal(text, text.Substring(chunk.CharStart, chunk.CharEnd - chunk.CharStart));
+        Assert.True(chunk.TokenCount > 0);
+    }
+
+    [Fact]
+    public void Chunk_LongText_OffsetsAlwaysSliceBackToChunkText()
+    {
+        var chunks = new Chunker(maxTokens: 12, overlapTokens: 4).Chunk(Paragraph);
+
+        Assert.True(chunks.Count >= 2);
+        foreach (var c in chunks)
+            Assert.Equal(c.Text, Paragraph.Substring(c.CharStart, c.CharEnd - c.CharStart));
+    }
+
+    [Fact]
+    public void Chunk_MultipleChunks_OrdIsZeroBasedContiguous()
+    {
+        var chunks = new Chunker(maxTokens: 12, overlapTokens: 4).Chunk(Paragraph);
+
+        for (var i = 0; i < chunks.Count; i++)
+            Assert.Equal(i, chunks[i].Ord);
+    }
+
+    [Fact]
+    public void Chunk_WithOverlap_ConsecutiveChunksShareText()
+    {
+        // Overlap budget must clear one sentence (~5 tokens) for any to be re-included;
+        // production's 64-token overlap clears whole sentences comfortably.
+        var chunks = new Chunker(maxTokens: 20, overlapTokens: 10).Chunk(Paragraph);
+
+        Assert.True(chunks.Count >= 2);
+        // Overlap means a later chunk starts before the previous one ends, at least once.
+        var sawOverlap = false;
+        for (var i = 1; i < chunks.Count; i++)
+        {
+            Assert.True(chunks[i].CharStart <= chunks[i - 1].CharEnd); // never a gap
+            if (chunks[i].CharStart < chunks[i - 1].CharEnd) sawOverlap = true;
+        }
+        Assert.True(sawOverlap);
+    }
+
+    [Fact]
+    public void Chunk_RespectsTokenBudget_WithinTolerance()
+    {
+        const int max = 12;
+        var chunks = new Chunker(maxTokens: max, overlapTokens: 4).Chunk(Paragraph);
+
+        // Per-sentence packing bounds the window; joining whitespace can add a token or two.
+        foreach (var c in chunks)
+            Assert.True(c.TokenCount <= max + 3, $"chunk {c.Ord} had {c.TokenCount} tokens");
+    }
+
+    [Fact]
+    public void Chunk_SingleSentenceOverBudget_EmittedAsOneChunk()
+    {
+        // One sentence (no terminator) far larger than the budget.
+        var huge = string.Join(' ', Enumerable.Range(0, 80).Select(i => $"word{i}"));
+        var chunks = new Chunker(maxTokens: 10, overlapTokens: 2).Chunk(huge);
+
+        var chunk = Assert.Single(chunks);
+        Assert.True(chunk.TokenCount > 10); // not split mid-sentence
+        Assert.Equal(huge, chunk.Text);
+    }
+}

--- a/tests/TextStack.UnitTests/TextStack.UnitTests.csproj
+++ b/tests/TextStack.UnitTests/TextStack.UnitTests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\backend\src\Tts\TextStack.Tts\TextStack.Tts.csproj" />
     <ProjectReference Include="..\..\backend\src\Vocabulary\TextStack.Vocabulary\TextStack.Vocabulary.csproj" />
     <ProjectReference Include="..\..\backend\src\Ai\TextStack.Ai.Llm\TextStack.Ai.Llm.csproj" />
+    <ProjectReference Include="..\..\backend\src\Ai\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/textstack.sln
+++ b/textstack.sln
@@ -159,6 +159,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextStack.AiEvals", "tests\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextStack.Ai.EvalSuite", "backend\src\Ai\TextStack.Ai.EvalSuite\TextStack.Ai.EvalSuite.csproj", "{FBBD7C9B-97DA-46EB-BDB8-54ED5C0A0B92}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextStack.Ai.Rag", "backend\src\Ai\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj", "{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -409,6 +411,18 @@ Global
 		{FBBD7C9B-97DA-46EB-BDB8-54ED5C0A0B92}.Release|x64.Build.0 = Release|Any CPU
 		{FBBD7C9B-97DA-46EB-BDB8-54ED5C0A0B92}.Release|x86.ActiveCfg = Release|Any CPU
 		{FBBD7C9B-97DA-46EB-BDB8-54ED5C0A0B92}.Release|x86.Build.0 = Release|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Debug|x64.Build.0 = Debug|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Debug|x86.Build.0 = Debug|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Release|x64.ActiveCfg = Release|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Release|x64.Build.0 = Release|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Release|x86.ActiveCfg = Release|Any CPU
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -448,5 +462,6 @@ Global
 		{D7D191AD-4746-4095-9EA4-7AF60ABFA9E8} = {1D9F3A7C-AABB-CCDD-EEFF-A10001000001}
 		{9EC6C120-F53A-40A1-9A13-ECA484291EF5} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{FBBD7C9B-97DA-46EB-BDB8-54ED5C0A0B92} = {1D9F3A7C-AABB-CCDD-EEFF-A10001000001}
+		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE} = {1D9F3A7C-AABB-CCDD-EEFF-A10001000001}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary

Second PR of **Phase 4 — "Ask this book"** (playbook **AI-019**). Producer side of RAG: catalog ingestion now fills the `chapter_chunk` table created in AI-018 (#294). Embeddings are still null — they arrive in AI-020/021.

## Changes

- **New `TextStack.Ai.Rag` library** — hand-rolled sentence-aware `Chunker`: splits chapter `plain_text` into ~512-token windows with 64-token overlap, recording exact `char_start`/`char_end` offsets back into the source. Hand-rolled rather than SemanticKernel `TextChunker` because the latter returns strings without offsets — and offsets are what power parent-context expansion + citation deep-links (a TextStack differentiator per `bootcamp-rag-analysis.md`).
- **Exact token counts** via `Microsoft.ML.Tokenizers` (cl100k tiktoken, matching `text-embedding-3-small`) for both chunk boundaries and the stored `token_count`. `Data.Cl100kBase` ships the vocab so it works offline. Transitive `Microsoft.Bcl.Memory` pinned to 10.0.9 to clear advisory GHSA-73j8-2gch-69rq (NU1903).
- **Wired into catalog ingestion** (`Worker/Services/IngestionService.cs`, right after search indexing, same concrete `AppDbContext`): loads the just-saved chapters, chunks each, bulk-inserts `chapter_chunk` rows with `embedding = null` and `chapter_ord` copied from the chapter. **Best-effort** — a chunking failure logs a warning and never fails the ingestion job; old chunks cascade-delete on reprocess.
- **Scope:** catalog editions only (the AI-018 schema FKs to `chapters`/`editions`). User-uploaded books deferred. Already-ingested editions get chunks on next reprocess until the AI-021 backfill lands.

## Drive-by cleanup

Fixes 3 pre-existing **CS8620** nullability warnings in `LibraryShelvesService` (unrelated mobile book-% code): the `ComputeEditionBookPercentsAsync` tuple param correctly declares `string? Locator`, but the 3 call-site projections inferred non-null `string`; tuple-element nullability is invariant. Widened at the boundary with `(string?)`. The solution now builds **0 warnings**.

## Tests

- Unit: `tests/TextStack.UnitTests/ChunkerTests.cs` — 13 cases: sentence-split offset round-trip, token-budget bound, overlap, 0-based contiguous `Ord`, empty input, oversized-single-sentence.
- Full suite: 151 passed (was 138 + 13 new).
- `dotnet build textstack.sln` → 0 warnings / 0 errors. `dotnet format --verify-no-changes` clean.

## Rollback plan

Revert the commit. Chunking is additive and best-effort — no schema change, no existing data touched; turning it off just stops new `chapter_chunk` rows from being written.

## Notes

- `char_start/char_end` are UTF-16 code-unit offsets into `plain_text` — retrieval/citation code (AI-022+) must slice the same string the same way (documented on `TextChunk`).
- Planning docs (`PLAYBOOK/ROADMAP/ARCH-ai-portfolio.md`, `bootcamp-rag-analysis.md`) intentionally kept out of this code-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)