### PR TITLE
feat(rag): OpenAI embeddings + batch embedding worker (AI-020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — OpenAI embeddings + batch worker (2026-06-10)
+
+Third PR of Phase 4 (playbook **AI-020**). Fills `chapter_chunk.embedding` so retrieval (AI-022+) has vectors to search.
+
+- **`OpenAiEmbeddingClient`** (`TextStack.Ai.Llm`, next to `OpenAiLlmClient`) — first implementation of `IEmbeddingService`, wrapping the OpenAI SDK `EmbeddingClient` for `text-embedding-3-small` (1536-d). Same config/empty-key guard as the LLM client; cost logged per batch via `ModelPricing` (added `text-embedding-3-small` = $0.02/1M input).
+- **`ChapterEmbeddingWorker`** — perpetual `BackgroundService` that polls `chapter_chunk WHERE embedding IS NULL`, embeds in batches of 100, and writes the vectors back. Covers freshly-ingested books **and** drains the existing backlog, so AI-021 backfill becomes a roll-out concern rather than new code. **Self-disables** with no OpenAI key (keyless dev host still starts); survives errors (outer retry); on a batch failure falls back to per-item so one bad chunk can't stall the backlog (parked in-memory to avoid re-fetch).
+- **Scope:** catalog chunks only. Embedding observability is cost-log only for now (full `llm_traces` for embeddings deferred).
+- Unit tests: `ModelPricing` embedding cost (input-only, ignores output tokens) + `AssignEmbeddings` order-preserving assignment / count-mismatch guard.
+
 ### Phase 4 RAG — sentence-aware chunker (2026-06-09)
 
 Second PR of Phase 4 (playbook **AI-019**). Fills the `chapter_chunk` table created in AI-018: catalog ingestion now emits retrieval-sized chunks (embeddings come in AI-020/021).

--- a/backend/src/Ai/TextStack.Ai.Llm/ModelPricing.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/ModelPricing.cs
@@ -17,6 +17,8 @@ public static class ModelPricing
         {
             ["gpt-4.1-nano"] = (0.10m, 0.40m),
             ["gpt-4o-mini"] = (0.15m, 0.60m),
+            // Embedding model (Phase 4 RAG): input-only, no output tokens.
+            ["text-embedding-3-small"] = (0.02m, 0m),
         };
 
     /// <summary>True if we have an explicit price for this model id.</summary>

--- a/backend/src/Ai/TextStack.Ai.Llm/OpenAiEmbeddingClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/OpenAiEmbeddingClient.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using OpenAI;
+using OpenAI.Embeddings;
+using TextStack.Ai.Core;
+
+namespace TextStack.Ai.Llm;
+
+/// <summary>
+/// OpenAI implementation of <see cref="IEmbeddingService"/> (Phase 4 RAG). Wraps the OpenAI
+/// SDK <see cref="EmbeddingClient"/> for <c>text-embedding-3-small</c> (1536-d), mirroring
+/// <see cref="OpenAiLlmClient"/>'s config/construction. Stateless and thread-safe; registered
+/// as a singleton. Cost is logged per batch via <see cref="ModelPricing"/>.
+/// </summary>
+public sealed class OpenAiEmbeddingClient : IEmbeddingService
+{
+    private const string DefaultModel = "text-embedding-3-small";
+
+    private readonly EmbeddingClient _client;
+    private readonly string _model;
+    private readonly ILogger<OpenAiEmbeddingClient> _logger;
+
+    public int Dimensions => 1536;
+
+    public OpenAiEmbeddingClient(IConfiguration config, ILogger<OpenAiEmbeddingClient> logger)
+    {
+        _logger = logger;
+
+        // Same empty-key trap guard as OpenAiLlmClient — an empty string flows into the SDK
+        // and surfaces as a cryptic "Value cannot be an empty string" deep in the stack.
+        var apiKey = config["OpenAI:ApiKey"];
+        if (string.IsNullOrWhiteSpace(apiKey))
+            apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new InvalidOperationException("OPENAI_API_KEY not configured (OpenAI:ApiKey / OPENAI_API_KEY is empty)");
+
+        _model = config["OpenAI:Embedding:Model"]
+            ?? Environment.GetEnvironmentVariable("OPENAI_EMBEDDING_MODEL")
+            ?? DefaultModel;
+
+        _client = new OpenAIClient(apiKey).GetEmbeddingClient(_model);
+    }
+
+    public async Task<float[]> EmbedAsync(string text, CancellationToken ct)
+        => (await EmbedBatchAsync([text], ct))[0];
+
+    public async Task<IReadOnlyList<float[]>> EmbedBatchAsync(IReadOnlyList<string> texts, CancellationToken ct)
+    {
+        if (texts.Count == 0)
+            return [];
+
+        var options = new EmbeddingGenerationOptions { Dimensions = Dimensions };
+        var result = await _client.GenerateEmbeddingsAsync(texts, options, ct);
+        var collection = result.Value;
+
+        // Order by Index defensively (the API returns request order, but don't rely on it).
+        var vectors = collection
+            .OrderBy(e => e.Index)
+            .Select(e => e.ToFloats().ToArray())
+            .ToArray();
+
+        var inputTokens = collection.Usage?.InputTokenCount ?? 0;
+        if (!ModelPricing.IsPriced(_model))
+            _logger.LogWarning("No pricing entry for embedding model {Model}; cost recorded as 0", _model);
+        var cost = ModelPricing.CostUsd(_model, inputTokens, 0);
+        _logger.LogInformation(
+            "Embedded {Count} texts ({Tokens} tokens) via {Model} — ${Cost:F6}",
+            vectors.Length, inputTokens, _model, cost);
+
+        return vectors;
+    }
+}

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -23,6 +23,9 @@
   "OpenAI": {
     "ApiKey": "",
     "Model": "gpt-4.1-nano",
+    "Embedding": {
+      "Model": "text-embedding-3-small"
+    },
     "Translate": {
       "MaxTextLength": 500
     }

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -90,6 +90,10 @@ public static class DependencyInjection
         // Default Core.ILlmService = the gateway (routes FeatureTag → decorated provider).
         services.AddSingleton<global::TextStack.Ai.Core.ILlmService, global::TextStack.Ai.Llm.ModelGateway>();
 
+        // Embeddings (Phase 4 RAG). Single OpenAI provider; resolved lazily so a keyless
+        // host still starts (the client throws on construction without a key).
+        services.AddSingleton<global::TextStack.Ai.Core.IEmbeddingService, global::TextStack.Ai.Llm.OpenAiEmbeddingClient>();
+
         // SSG Rebuild - interfaces for SOLID compliance
         services.AddScoped<ISsgRouteProvider, SsgRouteProvider>();
         services.AddScoped<ISsgJobService, SsgRebuildService>();

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -77,6 +77,8 @@ builder.Services.AddSingleton<IngestionWorkerService>();
 builder.Services.AddSingleton<UserIngestionService>();
 builder.Services.AddHostedService<IngestionWorker>();
 builder.Services.AddHostedService<PodcastWorker>();
+// Phase 4 RAG: fills chapter_chunk.embedding for chunks the chunker left null.
+builder.Services.AddHostedService<ChapterEmbeddingWorker>();
 
 // SSG Rebuild handled by dedicated ssg_worker container (apps/web/scripts/ssg-worker.mjs)
 

--- a/backend/src/Worker/Services/ChapterEmbeddingWorker.cs
+++ b/backend/src/Worker/Services/ChapterEmbeddingWorker.cs
@@ -1,0 +1,136 @@
+using Domain.Entities;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TextStack.Ai.Core;
+
+namespace Worker.Services;
+
+/// <summary>
+/// Phase 4 RAG: perpetually embeds <see cref="ChapterChunk"/> rows that the chunker (AI-019)
+/// left with a null embedding. Polls <c>WHERE embedding IS NULL</c> in batches and fills them
+/// via <see cref="IEmbeddingService"/>, covering both freshly-ingested books and the existing
+/// backlog (so AI-021 backfill is just letting this drain). Self-disables when no OpenAI key
+/// is configured so a keyless dev host still starts.
+/// </summary>
+public sealed class ChapterEmbeddingWorker : BackgroundService
+{
+    private const int BatchSize = 100;
+    private static readonly TimeSpan IdlePoll = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan InterBatchDelay = TimeSpan.FromSeconds(1);
+
+    private readonly IDbContextFactory<AppDbContext> _dbFactory;
+    private readonly IConfiguration _config;
+    private readonly IServiceProvider _services;
+    private readonly ILogger<ChapterEmbeddingWorker> _logger;
+
+    // Chunks that fail even per-item are parked in-memory so they don't re-appear at the head
+    // of every batch (oldest-first) and force the whole backlog through the slow per-item path.
+    private readonly HashSet<Guid> _poisoned = [];
+
+    public ChapterEmbeddingWorker(
+        IDbContextFactory<AppDbContext> dbFactory,
+        IConfiguration config,
+        IServiceProvider services,
+        ILogger<ChapterEmbeddingWorker> logger)
+    {
+        _dbFactory = dbFactory;
+        _config = config;
+        _services = services;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!HasOpenAiKey())
+        {
+            _logger.LogInformation("ChapterEmbeddingWorker disabled — no OpenAI key configured.");
+            return;
+        }
+
+        // Resolved lazily (not ctor-injected) so the worker — and thus the host — still starts
+        // when keyless; OpenAiEmbeddingClient throws on construction without a key.
+        var embedder = _services.GetRequiredService<IEmbeddingService>();
+        _logger.LogInformation("ChapterEmbeddingWorker started (batch={Batch}).", BatchSize);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var processed = await EmbedNextBatchAsync(embedder, stoppingToken);
+                await Task.Delay(processed == 0 ? IdlePoll : InterBatchDelay, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "ChapterEmbeddingWorker cycle failed; retrying after delay.");
+                await Task.Delay(IdlePoll, stoppingToken);
+            }
+        }
+    }
+
+    private async Task<int> EmbedNextBatchAsync(IEmbeddingService embedder, CancellationToken ct)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+
+        var poisoned = _poisoned.ToList();
+        var batch = await db.ChapterChunks
+            .Where(c => c.Embedding == null && !poisoned.Contains(c.Id))
+            .OrderBy(c => c.CreatedAt)
+            .Take(BatchSize)
+            .ToListAsync(ct);
+
+        if (batch.Count == 0)
+            return 0;
+
+        try
+        {
+            var vectors = await embedder.EmbedBatchAsync(batch.Select(c => c.Text).ToList(), ct);
+            AssignEmbeddings(batch, vectors);
+        }
+        catch (Exception ex)
+        {
+            // One bad text shouldn't stall the whole backlog — embed the rest one by one.
+            _logger.LogWarning(ex, "Batch embed failed for {Count} chunks; falling back to per-item.", batch.Count);
+            await EmbedPerItemAsync(embedder, batch, ct);
+        }
+
+        await db.SaveChangesAsync(ct);
+        return batch.Count;
+    }
+
+    private async Task EmbedPerItemAsync(IEmbeddingService embedder, List<ChapterChunk> batch, CancellationToken ct)
+    {
+        foreach (var chunk in batch)
+        {
+            try
+            {
+                chunk.Embedding = await embedder.EmbedAsync(chunk.Text, ct);
+            }
+            catch (Exception ex)
+            {
+                _poisoned.Add(chunk.Id);
+                _logger.LogWarning(ex, "Failed to embed chunk {ChunkId}; parked for this process lifetime.", chunk.Id);
+            }
+        }
+    }
+
+    /// <summary>Assigns a batch of vectors onto chunks by position (order-preserving).</summary>
+    public static void AssignEmbeddings(IReadOnlyList<ChapterChunk> chunks, IReadOnlyList<float[]> vectors)
+    {
+        if (vectors.Count != chunks.Count)
+            throw new InvalidOperationException($"Embedding count {vectors.Count} != chunk count {chunks.Count}");
+        for (var i = 0; i < chunks.Count; i++)
+            chunks[i].Embedding = vectors[i];
+    }
+
+    private bool HasOpenAiKey()
+        => !string.IsNullOrWhiteSpace(_config["OpenAI:ApiKey"])
+           || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
+}

--- a/backend/src/Worker/appsettings.json
+++ b/backend/src/Worker/appsettings.json
@@ -7,7 +7,10 @@
   },
   "OpenAI": {
     "ApiKey": "",
-    "Model": "gpt-4.1-nano"
+    "Model": "gpt-4.1-nano",
+    "Embedding": {
+      "Model": "text-embedding-3-small"
+    }
   },
   "Ollama": {
     "BaseUrl": "http://localhost:11434",

--- a/tests/TextStack.UnitTests/EmbeddingTests.cs
+++ b/tests/TextStack.UnitTests/EmbeddingTests.cs
@@ -1,0 +1,58 @@
+using Domain.Entities;
+using TextStack.Ai.Llm;
+using Worker.Services;
+
+namespace TextStack.UnitTests;
+
+public class ModelPricingEmbeddingTests
+{
+    [Fact]
+    public void IsPriced_EmbeddingModel_True()
+        => Assert.True(ModelPricing.IsPriced("text-embedding-3-small"));
+
+    [Theory]
+    [InlineData(1_000_000, 0.02)] // $0.02 / 1M input tokens
+    [InlineData(500_000, 0.01)]
+    [InlineData(0, 0.0)]
+    public void CostUsd_EmbeddingInputOnly_ComputesInputPrice(int inputTokens, double expected)
+        => Assert.Equal((decimal)expected, ModelPricing.CostUsd("text-embedding-3-small", inputTokens, outputTokens: 0));
+
+    [Fact]
+    public void CostUsd_EmbeddingIgnoresOutputTokens()
+        // Embeddings have no output price, so output tokens must not add cost.
+        => Assert.Equal(0.02m, ModelPricing.CostUsd("text-embedding-3-small", 1_000_000, 9_999));
+
+    [Fact]
+    public void CostUsd_UnknownModel_Zero()
+        => Assert.Equal(0m, ModelPricing.CostUsd("text-embedding-unknown", 1_000_000, 0));
+}
+
+public class ChapterEmbeddingWorkerTests
+{
+    [Fact]
+    public void AssignEmbeddings_MatchingCounts_AssignsInOrder()
+    {
+        var chunks = new List<ChapterChunk> { new(), new(), new() };
+        var vectors = new[]
+        {
+            new[] { 1f, 0f },
+            new[] { 0f, 1f },
+            new[] { 1f, 1f },
+        };
+
+        ChapterEmbeddingWorker.AssignEmbeddings(chunks, vectors);
+
+        Assert.Same(vectors[0], chunks[0].Embedding);
+        Assert.Same(vectors[1], chunks[1].Embedding);
+        Assert.Same(vectors[2], chunks[2].Embedding);
+    }
+
+    [Fact]
+    public void AssignEmbeddings_CountMismatch_Throws()
+    {
+        var chunks = new List<ChapterChunk> { new(), new() };
+        var vectors = new[] { new[] { 1f } };
+
+        Assert.Throws<InvalidOperationException>(() => ChapterEmbeddingWorker.AssignEmbeddings(chunks, vectors));
+    }
+}


### PR DESCRIPTION
## Summary

Third PR of **Phase 4 — "Ask this book"** (playbook **AI-020**). Fills `chapter_chunk.embedding` so retrieval (AI-022+) has real vectors to search. Completes the producer chain: AI-019's chunker writes rows with `embedding = null`; this worker fills them.

## Changes

- **`OpenAiEmbeddingClient : IEmbeddingService`** (`TextStack.Ai.Llm`, next to `OpenAiLlmClient`) — first implementation of the Core `IEmbeddingService` seam, wrapping the OpenAI SDK `EmbeddingClient` for `text-embedding-3-small` (1536-d, pinned). Same config + empty-key guard as the LLM client. Cost logged per batch via `ModelPricing` (added `text-embedding-3-small` = $0.02/1M input, $0 output).
- **`ChapterEmbeddingWorker`** — perpetual `BackgroundService` polling `chapter_chunk WHERE embedding IS NULL`, embedding in batches of 100 via `EmbedBatchAsync`, writing vectors back. Covers freshly-ingested books **and** drains the existing backlog → AI-021 backfill becomes a roll-out concern, not new code.
  - **Self-disables** when no OpenAI key is configured (keyless dev host still starts; the client is resolved lazily so it isn't constructed).
  - **Resilient:** outer try/catch survives transient errors; on a batch failure falls back to per-item embedding so one bad chunk can't stall the backlog; a chunk that fails even per-item is parked in-memory (won't re-appear at the head of every batch).
- **DI:** `IEmbeddingService` singleton registered in `Application/DependencyInjection.cs`. Config `OpenAI:Embedding:Model` added to Api + Worker appsettings.

## Scope

Catalog chunks only. Embedding observability is **cost-log only** for now (full `llm_traces` rows for embeddings deferred). User-book chunks out of scope.

## Tests

- `tests/TextStack.UnitTests/EmbeddingTests.cs` — `ModelPricing` embedding cost (input-only, ignores output tokens, unknown→0) + `ChapterEmbeddingWorker.AssignEmbeddings` (order-preserving, count-mismatch guard).
- Full suite: 159 passed (151 + 8). `dotnet build textstack.sln` → 0 warnings / 0 errors. `dotnet format --verify-no-changes` clean.
- OpenAI/DB round-trip is covered by manual/e2e verification (needs a key) — see rollout note.

## Verification (manual, needs Docker + OPENAI_API_KEY)

`make up`, reprocess an edition to create null-embedding chunks, watch Worker logs (`Embedded N texts … $X`), then:
```sql
SELECT count(*) FILTER (WHERE embedding IS NULL) AS pending,
       count(*) FILTER (WHERE embedding IS NOT NULL) AS done FROM chapter_chunk;
SELECT vector_dims(embedding) FROM chapter_chunk WHERE embedding IS NOT NULL LIMIT 1; -- 1536
```
`pending` should drain to 0. Keyless dev: Worker logs "disabled — no OpenAI key" and the host still starts.

## Rollback plan

Revert the commit. Additive and best-effort — no schema change; stops new embeddings from being written, existing vectors untouched.

## Cost note

First backlog drain ≈ 1500 books × ~50 chunks × ~$0.02/1M ≈ **$1.50** one-time, throttled by batch + inter-batch delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)