### PR TITLE
feat(rag): RagService vector retrieval + admin debug endpoint (AI-022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — vector retrieval (RagService) (2026-06-10)
+
+Fourth PR of Phase 4 (playbook **AI-022**). First retrieval step: embed a query, find the nearest chunks in an edition by cosine similarity over pgvector.
+
+- **`RagService`** (`TextStack.Ai.Rag`) — embeds the query via `IEmbeddingService`, then runs **raw Npgsql + Dapper** (not EF, so the spoiler gate can later live in the SQL `WHERE`): `ORDER BY embedding <=> CAST(@q AS vector) LIMIT @k` over `chapter_chunk`, using the HNSW `vector_cosine_ops` index. Per-edition, `embedding IS NOT NULL`, top-K (default 8 = recall@8 target), score = 1 − cosine distance.
+- **Query-vector binding:** the embedding is formatted as a `[…]` text literal (`FormatVector`, invariant-culture) and cast server-side — a raw connection doesn't have the pgvector type registered (`UseVector()` is EF-only), so this avoids `NpgsqlDataSource`/type-handlers.
+- **Admin debug endpoint** `GET /admin/rag/{editionId}/search?q=&k=` — returns top-K chunks (score + citation offsets + text preview) so retrieval is inspectable now. Admin-only; vector-only (no spoiler gate yet — that's AI-024, before the public Ask endpoint). The public Ask + SSE + citations stay AI-025.
+- Tests: `FormatVector` unit tests (bracket/comma shape, invariant culture under a comma-decimal locale, empty/single) + an admin-endpoint integration test (missing-query → 400; query path skips without a key/corpus).
+
 ### Phase 4 RAG — OpenAI embeddings + batch worker (2026-06-10)
 
 Third PR of Phase 4 (playbook **AI-020**). Fills `chapter_chunk.embedding` so retrieval (AI-022+) has vectors to search.

--- a/backend/src/Ai/TextStack.Ai.Rag/IRagService.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/IRagService.cs
@@ -1,0 +1,20 @@
+namespace TextStack.Ai.Rag;
+
+/// <summary>
+/// Vector retrieval over a single edition's chunks (Phase 4 RAG, "Ask this book"). Embeds the
+/// query and returns the nearest <c>chapter_chunk</c> rows by cosine similarity. Vector-only in
+/// v1 — hybrid/RRF (AI-023) and the spoiler gate (AI-024) layer on top.
+/// </summary>
+public interface IRagService
+{
+    /// <summary>Default number of chunks to retrieve (matches the recall@8 eval target).</summary>
+    const int DefaultK = 8;
+
+    /// <summary>
+    /// Returns the <paramref name="k"/> chunks in <paramref name="editionId"/> most similar to
+    /// <paramref name="query"/>, ranked by descending cosine similarity. Skips chunks without an
+    /// embedding. Returns empty for a blank query.
+    /// </summary>
+    Task<IReadOnlyList<RetrievedChunk>> RetrieveAsync(
+        Guid editionId, string query, int k, CancellationToken ct);
+}

--- a/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
@@ -1,0 +1,82 @@
+using System.Data;
+using System.Globalization;
+using System.Text;
+using Dapper;
+using TextStack.Ai.Core;
+
+namespace TextStack.Ai.Rag;
+
+/// <summary>
+/// Raw-Npgsql vector retrieval (Phase 4 RAG). Embeds the query via <see cref="IEmbeddingService"/>
+/// and runs a cosine-distance nearest-neighbour search over <c>chapter_chunk</c> using the HNSW
+/// <c>vector_cosine_ops</c> index. SQL (not EF) so the spoiler gate (AI-024) can live in the WHERE.
+/// The query vector is passed as a string and cast server-side (<c>CAST(@q AS vector)</c>) — a raw
+/// connection doesn't have the pgvector type registered (<c>UseVector()</c> is EF-only).
+/// </summary>
+public sealed class RagService : IRagService
+{
+    private const int QueryTimeoutSeconds = 5;
+
+    private readonly Func<IDbConnection> _connectionFactory;
+    private readonly IEmbeddingService _embedder;
+
+    public RagService(Func<IDbConnection> connectionFactory, IEmbeddingService embedder)
+    {
+        _connectionFactory = connectionFactory;
+        _embedder = embedder;
+    }
+
+    public async Task<IReadOnlyList<RetrievedChunk>> RetrieveAsync(
+        Guid editionId, string query, int k, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return [];
+        if (k <= 0)
+            k = IRagService.DefaultK;
+
+        var queryVector = await _embedder.EmbedAsync(query, ct);
+        var vectorLiteral = FormatVector(queryVector);
+
+        const string sql = """
+            SELECT id            AS ChunkId,
+                   chapter_id    AS ChapterId,
+                   chapter_ord   AS ChapterOrd,
+                   ord           AS Ord,
+                   text          AS Text,
+                   char_start    AS CharStart,
+                   char_end      AS CharEnd,
+                   1 - (embedding <=> CAST(@q AS vector)) AS Score
+            FROM chapter_chunk
+            WHERE edition_id = @editionId AND embedding IS NOT NULL
+            ORDER BY embedding <=> CAST(@q AS vector)
+            LIMIT @k
+            """;
+
+        using var connection = _connectionFactory();
+        var rows = await connection.QueryAsync<RetrievedChunk>(
+            new CommandDefinition(
+                sql,
+                new { q = vectorLiteral, editionId, k },
+                cancellationToken: ct,
+                commandTimeout: QueryTimeoutSeconds));
+
+        return rows.ToList();
+    }
+
+    /// <summary>
+    /// Formats an embedding as a pgvector text literal <c>[v0,v1,…]</c> using invariant culture
+    /// (so a comma-decimal locale can't corrupt the literal). Cast to <c>vector</c> in SQL.
+    /// </summary>
+    public static string FormatVector(IReadOnlyList<float> vector)
+    {
+        var sb = new StringBuilder(vector.Count * 8 + 2);
+        sb.Append('[');
+        for (var i = 0; i < vector.Count; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append(vector[i].ToString("R", CultureInfo.InvariantCulture));
+        }
+        sb.Append(']');
+        return sb.ToString();
+    }
+}

--- a/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
@@ -53,14 +53,31 @@ public sealed class RagService : IRagService
             """;
 
         using var connection = _connectionFactory();
-        var rows = await connection.QueryAsync<RetrievedChunk>(
+        var rows = await connection.QueryAsync<Row>(
             new CommandDefinition(
                 sql,
                 new { q = vectorLiteral, editionId, k },
                 cancellationToken: ct,
                 commandTimeout: QueryTimeoutSeconds));
 
-        return rows.ToList();
+        return rows
+            .Select(r => new RetrievedChunk(
+                r.ChunkId, r.ChapterId, r.ChapterOrd, r.Ord, r.Text, r.CharStart, r.CharEnd, r.Score))
+            .ToList();
+    }
+
+    /// <summary>Dapper row — a sealed class with init props (the repo's proven mapping shape;
+    /// avoids relying on constructor mapping into a record struct).</summary>
+    private sealed class Row
+    {
+        public Guid ChunkId { get; init; }
+        public Guid ChapterId { get; init; }
+        public int ChapterOrd { get; init; }
+        public int Ord { get; init; }
+        public string Text { get; init; } = string.Empty;
+        public int CharStart { get; init; }
+        public int CharEnd { get; init; }
+        public double Score { get; init; }
     }
 
     /// <summary>
@@ -74,7 +91,8 @@ public sealed class RagService : IRagService
         for (var i = 0; i < vector.Count; i++)
         {
             if (i > 0) sb.Append(',');
-            sb.Append(vector[i].ToString("R", CultureInfo.InvariantCulture));
+            // "G9" is the shortest round-trippable form for float (preferred over "R").
+            sb.Append(vector[i].ToString("G9", CultureInfo.InvariantCulture));
         }
         sb.Append(']');
         return sb.ToString();

--- a/backend/src/Ai/TextStack.Ai.Rag/RetrievedChunk.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/RetrievedChunk.cs
@@ -1,0 +1,16 @@
+namespace TextStack.Ai.Rag;
+
+/// <summary>
+/// One chunk returned by <see cref="IRagService"/> vector retrieval, with its citation offsets
+/// and similarity score. Offsets reference the chapter's <c>plain_text</c> (see <see cref="TextChunk"/>).
+/// </summary>
+/// <param name="Score">Cosine similarity in [−1, 1] (1 − cosine distance); higher is closer.</param>
+public readonly record struct RetrievedChunk(
+    Guid ChunkId,
+    Guid ChapterId,
+    int ChapterOrd,
+    int Ord,
+    string Text,
+    int CharStart,
+    int CharEnd,
+    double Score);

--- a/backend/src/Ai/TextStack.Ai.Rag/ServiceCollectionExtensions.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
+using System.Data;
 using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
 
 namespace TextStack.Ai.Rag;
 
@@ -11,6 +13,20 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAiRag(this IServiceCollection services)
     {
         services.AddSingleton<IChunker, Chunker>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers vector retrieval (<see cref="IRagService"/>). The caller supplies a connection
+    /// factory (mirrors the search provider) — retrieval runs raw SQL, not EF. Requires
+    /// <see cref="IEmbeddingService"/> to be registered (query embedding).
+    /// </summary>
+    public static IServiceCollection AddRagRetrieval(
+        this IServiceCollection services,
+        Func<IServiceProvider, Func<IDbConnection>> connectionFactory)
+    {
+        services.AddSingleton<IRagService>(sp =>
+            new RagService(connectionFactory(sp), sp.GetRequiredService<IEmbeddingService>()));
         return services;
     }
 }

--- a/backend/src/Ai/TextStack.Ai.Rag/TextStack.Ai.Rag.csproj
+++ b/backend/src/Ai/TextStack.Ai.Rag/TextStack.Ai.Rag.csproj
@@ -13,5 +13,8 @@
     <!-- Force the transitive Microsoft.Bcl.Memory up to a non-vulnerable version (NU1903). -->
     <PackageReference Include="Microsoft.Bcl.Memory" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <!-- Vector retrieval (AI-022): raw Npgsql + Dapper, query vector cast server-side. -->
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Dapper" />
   </ItemGroup>
 </Project>

--- a/backend/src/Api/Api.csproj
+++ b/backend/src/Api/Api.csproj
@@ -24,5 +24,6 @@
     <ProjectReference Include="..\Tts\TextStack.Tts\TextStack.Tts.csproj" />
     <ProjectReference Include="..\Vocabulary\TextStack.Vocabulary\TextStack.Vocabulary.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.EvalSuite\TextStack.Ai.EvalSuite.csproj" />
+    <ProjectReference Include="..\Ai\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj" />
   </ItemGroup>
 </Project>

--- a/backend/src/Api/Endpoints/AdminRagEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminRagEndpoints.cs
@@ -1,0 +1,48 @@
+using Contracts.Admin;
+using Microsoft.AspNetCore.Mvc;
+using TextStack.Ai.Rag;
+
+namespace Api.Endpoints;
+
+/// <summary>
+/// Admin debug surface for Phase 4 RAG retrieval (AI-022). Lets an admin inspect which chunks a
+/// query retrieves for an edition, before the public Ask + SSE endpoint (AI-025) is built.
+/// Vector-only, no spoiler gate yet — admin-only, so returning chunks from any chapter is fine.
+/// </summary>
+public static class AdminRagEndpoints
+{
+    private const int MaxK = 50;
+    private const int PreviewChars = 160;
+
+    public static void MapAdminRagEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/admin/rag").WithTags("RAG");
+        group.MapGet("/{editionId:guid}/search", Search);
+    }
+
+    private static async Task<IResult> Search(
+        Guid editionId,
+        [FromQuery] string? q,
+        [FromQuery] int? k,
+        IRagService rag,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(q))
+            return Results.BadRequest(new { error = "Query parameter 'q' is required." });
+
+        var limit = Math.Clamp(k ?? IRagService.DefaultK, 1, MaxK);
+        var chunks = await rag.RetrieveAsync(editionId, q, limit, ct);
+
+        var dtos = chunks.Select(c => new RagChunkDto(
+            c.ChunkId,
+            c.ChapterId,
+            c.ChapterOrd,
+            c.Ord,
+            Math.Round(c.Score, 4),
+            c.CharStart,
+            c.CharEnd,
+            c.Text.Length <= PreviewChars ? c.Text : c.Text[..PreviewChars] + "…")).ToList();
+
+        return Results.Ok(dtos);
+    }
+}

--- a/backend/src/Api/Endpoints/AdminRagEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminRagEndpoints.cs
@@ -1,5 +1,6 @@
 using Contracts.Admin;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using TextStack.Ai.Rag;
 
 namespace Api.Endpoints;
@@ -24,11 +25,23 @@ public static class AdminRagEndpoints
         Guid editionId,
         [FromQuery] string? q,
         [FromQuery] int? k,
-        IRagService rag,
+        IServiceProvider services,
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(q))
             return Results.BadRequest(new { error = "Query parameter 'q' is required." });
+
+        // Resolved lazily: RagService construction pulls in IEmbeddingService, which throws
+        // without an OpenAI key. Surface that as a clean 503 instead of a generic 500.
+        IRagService rag;
+        try
+        {
+            rag = services.GetRequiredService<IRagService>();
+        }
+        catch (InvalidOperationException)
+        {
+            return Results.Problem("Embeddings are not configured (no OpenAI key).", statusCode: 503);
+        }
 
         var limit = Math.Clamp(k ?? IRagService.DefaultK, 1, MaxK);
         var chunks = await rag.RetrieveAsync(editionId, q, limit, ct);

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -17,6 +17,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.FileProviders;
 using Npgsql;
+using TextStack.Ai.Rag;
 using TextStack.Search;
 using TextStack.Search.Abstractions;
 using TextStack.Search.Meilisearch;
@@ -105,6 +106,10 @@ else
     builder.Services.AddPostgresFtsProvider(
         _ => () => new NpgsqlConnection(connectionString),
         options => options.ConnectionString = connectionString);
+
+// RAG vector retrieval (Phase 4). Raw Npgsql like the search provider; query embedded via
+// IEmbeddingService (registered in AddApplication). Used by the admin debug endpoint (AI-022).
+builder.Services.AddRagRetrieval(_ => () => new NpgsqlConnection(connectionString));
 
 // Reindex service (used by CLI)
 builder.Services.AddScoped<SearchReindexService>();
@@ -461,6 +466,7 @@ app.MapCollectionsEndpoints();
 app.MapReadingTrackingEndpoints();
 app.MapAdminBookQualityEndpoints();
 app.MapAdminAiQualityEndpoints();
+app.MapAdminRagEndpoints();
 app.MapVocabularyEndpoints();
 app.MapTtsEndpoints();
 app.MapExportEndpoints();

--- a/backend/src/Contracts/Admin/RagDtos.cs
+++ b/backend/src/Contracts/Admin/RagDtos.cs
@@ -1,0 +1,15 @@
+namespace Contracts.Admin;
+
+/// <summary>
+/// One retrieved chunk for the admin RAG debug endpoint — score + citation locators + a text
+/// preview (full text is large). Mirrors the retrieval result, minus the raw embedding.
+/// </summary>
+public record RagChunkDto(
+    Guid ChunkId,
+    Guid ChapterId,
+    int ChapterOrd,
+    int Ord,
+    double Score,
+    int CharStart,
+    int CharEnd,
+    string TextPreview);

--- a/tests/TextStack.IntegrationTests/RagEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/RagEndpointTests.cs
@@ -1,0 +1,41 @@
+using System.Net;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the admin RAG debug endpoint (AI-022), against the live API.
+/// Retrieval itself needs an embedded corpus + OpenAI key, so the query path skips when
+/// the endpoint is unavailable; the validation path (missing query) runs without a key.
+/// </summary>
+public class RagEndpointTests : IClassFixture<AuthenticatedApiFixture>
+{
+    private static readonly Guid SomeEdition = Guid.Parse("11111111-2222-3333-4444-555555555555");
+    private readonly AuthenticatedApiFixture _fixture;
+
+    public RagEndpointTests(AuthenticatedApiFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task RagSearch_MissingQuery_Returns400()
+    {
+        Assert.SkipUnless(_fixture.IsAuthenticated, "admin auth unavailable");
+
+        var request = _fixture.CreateAdminRequest(HttpMethod.Get, $"/admin/rag/{SomeEdition}/search");
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(response.StatusCode is HttpStatusCode.NotFound, "endpoint not deployed");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RagSearch_WithQuery_Returns200_WhenAvailable()
+    {
+        Assert.SkipUnless(_fixture.IsAuthenticated, "admin auth unavailable");
+
+        var request = _fixture.CreateAdminRequest(HttpMethod.Get, $"/admin/rag/{SomeEdition}/search?q=test&k=5");
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // 500 = no OpenAI key / no embedded corpus in this environment → skip rather than fail.
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (no key/corpus)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/tests/TextStack.IntegrationTests/RagEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/RagEndpointTests.cs
@@ -34,8 +34,10 @@ public class RagEndpointTests : IClassFixture<AuthenticatedApiFixture>
         var request = _fixture.CreateAdminRequest(HttpMethod.Get, $"/admin/rag/{SomeEdition}/search?q=test&k=5");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        // 500 = no OpenAI key / no embedded corpus in this environment → skip rather than fail.
-        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (no key/corpus)");
+        // 503 = no OpenAI key, 500/404 = not deployed/erroring → skip rather than fail.
+        Assert.SkipWhen(
+            IntegrationSkip.Unavailable(response) || response.StatusCode == HttpStatusCode.ServiceUnavailable,
+            "endpoint unavailable (no key/corpus)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 }

--- a/tests/TextStack.UnitTests/RagServiceTests.cs
+++ b/tests/TextStack.UnitTests/RagServiceTests.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using TextStack.Ai.Rag;
+
+namespace TextStack.UnitTests;
+
+public class RagServiceTests
+{
+    [Fact]
+    public void FormatVector_Integers_BracketedCommaJoined()
+        => Assert.Equal("[1,2,3]", RagService.FormatVector(new[] { 1f, 2f, 3f }));
+
+    [Fact]
+    public void FormatVector_Decimals_PreservesValues()
+        => Assert.Equal("[0.5,-0.25,1.5]", RagService.FormatVector(new[] { 0.5f, -0.25f, 1.5f }));
+
+    [Fact]
+    public void FormatVector_Empty_EmptyBrackets()
+        => Assert.Equal("[]", RagService.FormatVector(Array.Empty<float>()));
+
+    [Fact]
+    public void FormatVector_Single_NoTrailingComma()
+        => Assert.Equal("[42]", RagService.FormatVector(new[] { 42f }));
+
+    [Fact]
+    public void FormatVector_CommaDecimalCulture_StillUsesDot()
+    {
+        // A locale that writes decimals with a comma must NOT corrupt the pgvector literal.
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            Assert.Equal("[0.5,1.25]", RagService.FormatVector(new[] { 0.5f, 1.25f }));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fourth PR of **Phase 4 — "Ask this book"** (playbook **AI-022**). First retrieval step: embed a query and find the nearest chunks in an edition by cosine similarity over pgvector. Vector-only — hybrid/RRF is AI-023, the spoiler gate is AI-024, the public Ask+SSE endpoint is AI-025.

## Changes

- **`RagService`** (`TextStack.Ai.Rag`) — embeds the query via `IEmbeddingService`, then runs **raw Npgsql + Dapper** (not EF — so the spoiler gate can later live in the SQL `WHERE`, per the bootcamp decision):
  ```sql
  ORDER BY embedding <=> CAST(@q AS vector) LIMIT @k
  ```
  over `chapter_chunk`, using the HNSW `vector_cosine_ops` index. Per-edition, `embedding IS NOT NULL`, top-K (default **8** = recall@8 eval target), score = 1 − cosine distance.
- **Query-vector binding:** the embedding is formatted as a `[…]` text literal (`FormatVector`, invariant-culture) and cast server-side. A raw connection doesn't have the pgvector type registered (`UseVector()` is EF-only), so this avoids `NpgsqlDataSource` + Dapper type-handlers and matches the repo's existing `Func<IDbConnection>` + Dapper pattern.
- **Admin debug endpoint** `GET /admin/rag/{editionId}/search?q=&k=` — returns top-K chunks (score + citation offsets + ~160-char text preview) so retrieval is inspectable **now**. Admin-only (under `/admin/*`); `k` clamped ≤50.

## Scope

Vector-only, no spoiler gate yet — admin-only, so returning chunks from any chapter is fine. The public Ask path gets the spoiler filter (AI-024) before it ships. RagService registered in DI (`AddRagRetrieval`), ready for AI-025 to inject.

## Tests

- Unit (`RagServiceTests`): `FormatVector` — bracket/comma shape, **invariant culture under a comma-decimal (de-DE) locale** (so a locale can't corrupt the literal), empty/single.
- Integration (`RagEndpointTests`): admin endpoint — missing-query → **400** (runs without a key); query path returns 200 or skips when no key/corpus.
- Full unit suite: 164 passed (159 + 5). `dotnet build textstack.sln` → 0 warnings / 0 errors. `dotnet format --verify-no-changes` clean.

## Verification (manual, needs Docker + OPENAI_API_KEY + embedded chunks)

`make up`, then:
```
curl -H "<admin auth>" "http://localhost:8080/admin/rag/{editionId}/search?q=replication&k=8"
```
→ top-8 chunks ranked by descending score, previews relevant to the query. Cross-check vs psql `ORDER BY embedding <=> CAST('[…]' AS vector)`.

## Rollback plan

Revert the commit. Read-only retrieval behind an admin-only debug endpoint — no schema change, no writes.

## Notes

- Retrieval needs an OpenAI key (query embedding); keyless dev → the endpoint errors (no key ⇒ no embeddings ⇒ nothing to search). Documented.
- The `1 - (…)` similarity is only in the SELECT, not the `ORDER BY`, so the HNSW index engages on the bare `<=>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)