### PR TITLE
feat(rag): spoiler gate + private corpus (AI-024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Fifth PR of Phase 4 (playbook **AI-024**). Makes retrieval spoiler-safe and adds
 - **Admin debug endpoints** — `/admin/rag/{ed}/search` gains `&maxChapterOrd=` (test the gate with a synthetic ceiling); new `/admin/rag/{ed}/context?userId=&q=` runs the full spoiler-safe path for a user (admin impersonation) → `{ lastReadOrd, chunks[], notes[] }`, so AI-024 is verifiable before AI-025.
 - Tests: `HighlightToText` unit tests + an integration test asserting `maxChapterOrd=0` → `[]` (gate works).
 
+**Review follow-ups folded in:**
+- **High-water mark** — the gate now uses the *furthest* chapter the user has reached, not their current position, so flipping back to an earlier chapter no longer hides already-read later chapters. New nullable `reading_progress.max_chapter_number` (migration `AddMaxChapterToReadingProgress`), maintained monotonically on each progress save; legacy rows fall back to the current chapter (no backfill, self-heals).
+- **Private-corpus cap** — `RagContextService` caps included highlights/notes at 30 (most recent chapters first) so a heavy annotator can't blow the prompt budget.
+- **Note dedup** — notes attached to a highlight are skipped (the highlight's inline `NoteText` already carries them) to avoid double-counting.
+- **Skip wasted embedding** — `RagService` short-circuits to empty when the gate is ≤ 0 (no chapters read), avoiding an embedding API call.
+- Deferred (by design): min-score relevance threshold → AI-023; within-chapter spoiler precision → future.
+
 ### Phase 4 RAG — vector retrieval (RagService) (2026-06-10)
 
 Fourth PR of Phase 4 (playbook **AI-022**). First retrieval step: embed a query, find the nearest chunks in an edition by cosine similarity over pgvector.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — spoiler gate + private corpus (2026-06-10)
+
+Fifth PR of Phase 4 (playbook **AI-024**). Makes retrieval spoiler-safe and adds the user's own annotations as guaranteed context — the capability the public Ask endpoint (AI-025) consumes.
+
+- **Spoiler gate** — `RagService.RetrieveAsync` gains an optional `maxChapterOrd`; the SQL adds `AND (@maxChapterOrd IS NULL OR chapter_ord <= @maxChapterOrd)`. A **hard SQL filter**, never a prompt instruction — only chunks from chapters the user has read are returned.
+- **`RagContextService`** (`Application/Rag`) — resolves the user's last-read chapter ordinal from `ReadingProgress` (join `Chapter.ChapterNumber`; **0 = no progress → empty context, strict**), runs gated retrieval, and gathers the user's **highlights + notes** from read chapters as guaranteed private-corpus context. The gate is inclusive of the current chapter (within-chapter leakage is an accepted v1 limit — chunking is chapter-granular).
+- **Admin debug endpoints** — `/admin/rag/{ed}/search` gains `&maxChapterOrd=` (test the gate with a synthetic ceiling); new `/admin/rag/{ed}/context?userId=&q=` runs the full spoiler-safe path for a user (admin impersonation) → `{ lastReadOrd, chunks[], notes[] }`, so AI-024 is verifiable before AI-025.
+- Tests: `HighlightToText` unit tests + an integration test asserting `maxChapterOrd=0` → `[]` (gate works).
+
 ### Phase 4 RAG — vector retrieval (RagService) (2026-06-10)
 
 Fourth PR of Phase 4 (playbook **AI-022**). First retrieval step: embed a query, find the nearest chunks in an edition by cosine similarity over pgvector.

--- a/backend/src/Ai/TextStack.Ai.Rag/IRagService.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/IRagService.cs
@@ -15,6 +15,10 @@ public interface IRagService
     /// <paramref name="query"/>, ranked by descending cosine similarity. Skips chunks without an
     /// embedding. Returns empty for a blank query.
     /// </summary>
+    /// <param name="maxChapterOrd">
+    /// Spoiler gate (AI-024): if set, only chunks with <c>chapter_ord ≤ maxChapterOrd</c> are
+    /// returned (chapters the user has read). Null disables the gate.
+    /// </param>
     Task<IReadOnlyList<RetrievedChunk>> RetrieveAsync(
-        Guid editionId, string query, int k, CancellationToken ct);
+        Guid editionId, string query, int k, int? maxChapterOrd, CancellationToken ct);
 }

--- a/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
@@ -31,6 +31,9 @@ public sealed class RagService : IRagService
     {
         if (string.IsNullOrWhiteSpace(query))
             return [];
+        // Gate ≤ 0 means "no chapters read" → guaranteed empty; skip the embedding API call.
+        if (maxChapterOrd is <= 0)
+            return [];
         if (k <= 0)
             k = IRagService.DefaultK;
 

--- a/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
@@ -27,7 +27,7 @@ public sealed class RagService : IRagService
     }
 
     public async Task<IReadOnlyList<RetrievedChunk>> RetrieveAsync(
-        Guid editionId, string query, int k, CancellationToken ct)
+        Guid editionId, string query, int k, int? maxChapterOrd, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(query))
             return [];
@@ -37,6 +37,8 @@ public sealed class RagService : IRagService
         var queryVector = await _embedder.EmbedAsync(query, ct);
         var vectorLiteral = FormatVector(queryVector);
 
+        // Spoiler gate (AI-024): when maxChapterOrd is set, only chunks from chapters the user
+        // has read are visible. Hard SQL filter (never a prompt instruction). Null = no gate.
         const string sql = """
             SELECT id            AS ChunkId,
                    chapter_id    AS ChapterId,
@@ -47,7 +49,9 @@ public sealed class RagService : IRagService
                    char_end      AS CharEnd,
                    1 - (embedding <=> CAST(@q AS vector)) AS Score
             FROM chapter_chunk
-            WHERE edition_id = @editionId AND embedding IS NOT NULL
+            WHERE edition_id = @editionId
+              AND embedding IS NOT NULL
+              AND (@maxChapterOrd::int IS NULL OR chapter_ord <= @maxChapterOrd::int)
             ORDER BY embedding <=> CAST(@q AS vector)
             LIMIT @k
             """;
@@ -56,7 +60,7 @@ public sealed class RagService : IRagService
         var rows = await connection.QueryAsync<Row>(
             new CommandDefinition(
                 sql,
-                new { q = vectorLiteral, editionId, k },
+                new { q = vectorLiteral, editionId, k, maxChapterOrd },
                 cancellationToken: ct,
                 commandTimeout: QueryTimeoutSeconds));
 

--- a/backend/src/Api/Endpoints/AdminRagEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminRagEndpoints.cs
@@ -1,3 +1,5 @@
+using Api.Sites;
+using Application.Rag;
 using Contracts.Admin;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,9 +8,10 @@ using TextStack.Ai.Rag;
 namespace Api.Endpoints;
 
 /// <summary>
-/// Admin debug surface for Phase 4 RAG retrieval (AI-022). Lets an admin inspect which chunks a
-/// query retrieves for an edition, before the public Ask + SSE endpoint (AI-025) is built.
-/// Vector-only, no spoiler gate yet — admin-only, so returning chunks from any chapter is fine.
+/// Admin debug surface for Phase 4 RAG retrieval. <c>/search</c> (AI-022) inspects raw vector
+/// retrieval, optionally with a synthetic spoiler ceiling; <c>/context</c> (AI-024) runs the full
+/// spoiler-safe path for a given user (admin impersonation) — gated chunks + their private corpus.
+/// Admin-only. The public Ask + SSE endpoint (AI-025) builds on the same <see cref="RagContextService"/>.
 /// </summary>
 public static class AdminRagEndpoints
 {
@@ -19,43 +22,78 @@ public static class AdminRagEndpoints
     {
         var group = app.MapGroup("/admin/rag").WithTags("RAG");
         group.MapGet("/{editionId:guid}/search", Search);
+        group.MapGet("/{editionId:guid}/context", Context);
     }
 
     private static async Task<IResult> Search(
         Guid editionId,
         [FromQuery] string? q,
         [FromQuery] int? k,
+        [FromQuery] int? maxChapterOrd,
         IServiceProvider services,
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(q))
             return Results.BadRequest(new { error = "Query parameter 'q' is required." });
 
-        // Resolved lazily: RagService construction pulls in IEmbeddingService, which throws
-        // without an OpenAI key. Surface that as a clean 503 instead of a generic 500.
-        IRagService rag;
+        if (!TryResolve<IRagService>(services, out var rag, out var unavailable))
+            return unavailable;
+
+        var limit = Math.Clamp(k ?? IRagService.DefaultK, 1, MaxK);
+        var chunks = await rag.RetrieveAsync(editionId, q, limit, maxChapterOrd, ct);
+
+        return Results.Ok(chunks.Select(ToDto).ToList());
+    }
+
+    private static async Task<IResult> Context(
+        Guid editionId,
+        [FromQuery] Guid userId,
+        [FromQuery] string? q,
+        [FromQuery] int? k,
+        HttpContext httpContext,
+        IServiceProvider services,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(q))
+            return Results.BadRequest(new { error = "Query parameter 'q' is required." });
+        if (userId == Guid.Empty)
+            return Results.BadRequest(new { error = "Query parameter 'userId' is required." });
+
+        if (!TryResolve<RagContextService>(services, out var ctxService, out var unavailable))
+            return unavailable;
+
+        var siteId = httpContext.GetSiteId();
+        var limit = Math.Clamp(k ?? IRagService.DefaultK, 1, MaxK);
+        var ctx = await ctxService.BuildAsync(userId, siteId, editionId, q, limit, ct);
+
+        return Results.Ok(new RagContextDto(
+            ctx.LastReadOrd,
+            ctx.Chunks.Select(ToDto).ToList(),
+            ctx.Notes.Select(n => new PrivateNoteDto(n.ChapterId, n.ChapterOrd, n.Kind, Preview(n.Text))).ToList()));
+    }
+
+    // RagService construction pulls in IEmbeddingService, which throws without an OpenAI key —
+    // surface that as a clean 503 instead of a generic 500.
+    private static bool TryResolve<T>(IServiceProvider services, out T service, out IResult unavailable)
+        where T : notnull
+    {
         try
         {
-            rag = services.GetRequiredService<IRagService>();
+            service = services.GetRequiredService<T>();
+            unavailable = Results.Empty;
+            return true;
         }
         catch (InvalidOperationException)
         {
-            return Results.Problem("Embeddings are not configured (no OpenAI key).", statusCode: 503);
+            service = default!;
+            unavailable = Results.Problem("Embeddings are not configured (no OpenAI key).", statusCode: 503);
+            return false;
         }
-
-        var limit = Math.Clamp(k ?? IRagService.DefaultK, 1, MaxK);
-        var chunks = await rag.RetrieveAsync(editionId, q, limit, ct);
-
-        var dtos = chunks.Select(c => new RagChunkDto(
-            c.ChunkId,
-            c.ChapterId,
-            c.ChapterOrd,
-            c.Ord,
-            Math.Round(c.Score, 4),
-            c.CharStart,
-            c.CharEnd,
-            c.Text.Length <= PreviewChars ? c.Text : c.Text[..PreviewChars] + "…")).ToList();
-
-        return Results.Ok(dtos);
     }
+
+    private static RagChunkDto ToDto(RetrievedChunk c) => new(
+        c.ChunkId, c.ChapterId, c.ChapterOrd, c.Ord, Math.Round(c.Score, 4), c.CharStart, c.CharEnd, Preview(c.Text));
+
+    private static string Preview(string text) =>
+        text.Length <= PreviewChars ? text : text[..PreviewChars] + "…";
 }

--- a/backend/src/Api/Endpoints/UserDataEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserDataEndpoints.cs
@@ -148,6 +148,8 @@ public static class UserDataEndpoints
             existing.ChapterId = request.ChapterId;
             existing.Locator = request.Locator;
             existing.Percent = request.Percent;
+            // High-water mark for the RAG spoiler gate — monotonic, never decreases.
+            existing.MaxChapterNumber = Math.Max(existing.MaxChapterNumber ?? 0, chapter.ChapterNumber);
             existing.UpdatedAt = DateTimeOffset.UtcNow;
         }
         else
@@ -161,6 +163,7 @@ public static class UserDataEndpoints
                 ChapterId = request.ChapterId,
                 Locator = request.Locator,
                 Percent = request.Percent,
+                MaxChapterNumber = chapter.ChapterNumber,
                 UpdatedAt = DateTimeOffset.UtcNow
             };
             db.ReadingProgresses.Add(progress);

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -110,6 +110,8 @@ else
 // RAG vector retrieval (Phase 4). Raw Npgsql like the search provider; query embedded via
 // IEmbeddingService (registered in AddApplication). Used by the admin debug endpoint (AI-022).
 builder.Services.AddRagRetrieval(_ => () => new NpgsqlConnection(connectionString));
+// Spoiler-safe context builder (AI-024): resolves lastRead + gates chunks + private corpus.
+builder.Services.AddScoped<Application.Rag.RagContextService>();
 
 // Reindex service (used by CLI)
 builder.Services.AddScoped<SearchReindexService>();

--- a/backend/src/Application/Application.csproj
+++ b/backend/src/Application/Application.csproj
@@ -22,5 +22,6 @@
     <ProjectReference Include="..\Vocabulary\TextStack.Vocabulary\TextStack.Vocabulary.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.Core\TextStack.Ai.Core.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.Llm\TextStack.Ai.Llm.csproj" />
+    <ProjectReference Include="..\Ai\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj" />
   </ItemGroup>
 </Project>

--- a/backend/src/Application/Rag/RagContextService.cs
+++ b/backend/src/Application/Rag/RagContextService.cs
@@ -26,6 +26,9 @@ public record RagContext(
 /// </summary>
 public sealed class RagContextService(IAppDbContext db, IRagService rag)
 {
+    /// <summary>Upper bound on private-corpus items, so a heavy annotator can't blow the prompt budget.</summary>
+    public const int PrivateNoteCap = 30;
+
     /// <summary>
     /// Builds the spoiler-safe context. When the user has no progress (lastRead = 0) both lists
     /// are empty — nothing is retrievable until they've read.
@@ -42,14 +45,21 @@ public sealed class RagContextService(IAppDbContext db, IRagService rag)
         return new RagContext(chunks, notes, lastRead);
     }
 
-    /// <summary>The 1-based ordinal of the user's current chapter; 0 if no progress.</summary>
+    /// <summary>
+    /// The furthest chapter ordinal the user has reached in this edition (high-water mark), so
+    /// flipping back doesn't hide already-read chapters; falls back to the current chapter when the
+    /// mark is null (legacy rows). 0 when there's no progress at all.
+    /// </summary>
     public async Task<int> ResolveLastReadOrdAsync(
         Guid userId, Guid siteId, Guid editionId, CancellationToken ct)
     {
-        return await db.ReadingProgresses
+        var row = await db.ReadingProgresses
             .Where(p => p.UserId == userId && p.SiteId == siteId && p.EditionId == editionId)
-            .Join(db.Chapters, p => p.ChapterId, c => c.Id, (p, c) => c.ChapterNumber)
-            .FirstOrDefaultAsync(ct); // 0 when no progress row exists
+            .Join(db.Chapters, p => p.ChapterId, c => c.Id,
+                (p, c) => new { p.MaxChapterNumber, c.ChapterNumber })
+            .FirstOrDefaultAsync(ct);
+
+        return row is null ? 0 : row.MaxChapterNumber ?? row.ChapterNumber;
     }
 
     /// <summary>Highlights + notes from chapters with ChapterNumber ≤ maxOrd (read chapters).</summary>
@@ -66,15 +76,20 @@ public sealed class RagContextService(IAppDbContext db, IRagService rag)
             .Select(h => new { h.ChapterId, Ord = h.Chapter!.ChapterNumber, h.SelectedText, h.NoteText })
             .ToListAsync(ct);
 
+        // Only free-standing notes — a note attached to a highlight (HighlightId set) is already
+        // represented via that highlight's inline NoteText, so including it again would double-count.
         var noteRows = await db.Notes
             .Where(n => n.UserId == userId && n.SiteId == siteId && n.EditionId == editionId
-                        && n.Chapter.ChapterNumber <= maxOrd)
+                        && n.HighlightId == null && n.Chapter.ChapterNumber <= maxOrd)
             .Select(n => new { ChapterId = (Guid?)n.ChapterId, Ord = n.Chapter.ChapterNumber, n.Text })
             .ToListAsync(ct);
 
         return highlightRows
             .Select(h => new PrivateNote(h.ChapterId, h.Ord, "highlight", HighlightToText(h.SelectedText, h.NoteText)))
             .Concat(noteRows.Select(n => new PrivateNote(n.ChapterId, n.Ord, "note", n.Text)))
+            // Cap to the most recent chapters (closest to where the user is reading), then present in order.
+            .OrderByDescending(n => n.ChapterOrd)
+            .Take(PrivateNoteCap)
             .OrderBy(n => n.ChapterOrd)
             .ToList();
     }

--- a/backend/src/Application/Rag/RagContextService.cs
+++ b/backend/src/Application/Rag/RagContextService.cs
@@ -1,0 +1,85 @@
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using TextStack.Ai.Rag;
+
+namespace Application.Rag;
+
+/// <summary>A user's own annotation included as guaranteed RAG context (Phase 4 private corpus).</summary>
+/// <param name="Kind">"highlight" or "note".</param>
+public record PrivateNote(Guid? ChapterId, int ChapterOrd, string Kind, string Text);
+
+/// <summary>
+/// Spoiler-safe retrieval context for one user + edition: the book chunks they're allowed to see
+/// plus their own highlights/notes from read chapters.
+/// </summary>
+public record RagContext(
+    IReadOnlyList<RetrievedChunk> Chunks,
+    IReadOnlyList<PrivateNote> Notes,
+    int LastReadOrd);
+
+/// <summary>
+/// Builds spoiler-safe RAG context (AI-024). Resolves the user's last-read chapter from
+/// <see cref="ReadingProgress"/>, gates chunk retrieval to <c>chapter_ord ≤ lastRead</c>, and
+/// adds the user's highlights + notes from read chapters as guaranteed context. The hard gate
+/// lives in SQL (<see cref="RagService"/>) — never in a prompt. The public Ask endpoint (AI-025)
+/// consumes this.
+/// </summary>
+public sealed class RagContextService(IAppDbContext db, IRagService rag)
+{
+    /// <summary>
+    /// Builds the spoiler-safe context. When the user has no progress (lastRead = 0) both lists
+    /// are empty — nothing is retrievable until they've read.
+    /// </summary>
+    public async Task<RagContext> BuildAsync(
+        Guid userId, Guid siteId, Guid editionId, string query, int k, CancellationToken ct)
+    {
+        var lastRead = await ResolveLastReadOrdAsync(userId, siteId, editionId, ct);
+        if (lastRead <= 0)
+            return new RagContext([], [], 0);
+
+        var chunks = await rag.RetrieveAsync(editionId, query, k, maxChapterOrd: lastRead, ct);
+        var notes = await GetPrivateNotesAsync(userId, siteId, editionId, lastRead, ct);
+        return new RagContext(chunks, notes, lastRead);
+    }
+
+    /// <summary>The 1-based ordinal of the user's current chapter; 0 if no progress.</summary>
+    public async Task<int> ResolveLastReadOrdAsync(
+        Guid userId, Guid siteId, Guid editionId, CancellationToken ct)
+    {
+        return await db.ReadingProgresses
+            .Where(p => p.UserId == userId && p.SiteId == siteId && p.EditionId == editionId)
+            .Join(db.Chapters, p => p.ChapterId, c => c.Id, (p, c) => c.ChapterNumber)
+            .FirstOrDefaultAsync(ct); // 0 when no progress row exists
+    }
+
+    /// <summary>Highlights + notes from chapters with ChapterNumber ≤ maxOrd (read chapters).</summary>
+    public async Task<IReadOnlyList<PrivateNote>> GetPrivateNotesAsync(
+        Guid userId, Guid siteId, Guid editionId, int maxOrd, CancellationToken ct)
+    {
+        if (maxOrd <= 0)
+            return [];
+
+        // Materialize raw fields first — HighlightToText is a C# method EF can't translate.
+        var highlightRows = await db.Highlights
+            .Where(h => h.UserId == userId && h.SiteId == siteId && h.EditionId == editionId
+                        && h.ChapterId != null && h.Chapter!.ChapterNumber <= maxOrd)
+            .Select(h => new { h.ChapterId, Ord = h.Chapter!.ChapterNumber, h.SelectedText, h.NoteText })
+            .ToListAsync(ct);
+
+        var noteRows = await db.Notes
+            .Where(n => n.UserId == userId && n.SiteId == siteId && n.EditionId == editionId
+                        && n.Chapter.ChapterNumber <= maxOrd)
+            .Select(n => new { ChapterId = (Guid?)n.ChapterId, Ord = n.Chapter.ChapterNumber, n.Text })
+            .ToListAsync(ct);
+
+        return highlightRows
+            .Select(h => new PrivateNote(h.ChapterId, h.Ord, "highlight", HighlightToText(h.SelectedText, h.NoteText)))
+            .Concat(noteRows.Select(n => new PrivateNote(n.ChapterId, n.Ord, "note", n.Text)))
+            .OrderBy(n => n.ChapterOrd)
+            .ToList();
+    }
+
+    /// <summary>Renders a highlight as context text: the selection, plus its inline note if any.</summary>
+    public static string HighlightToText(string selectedText, string? noteText)
+        => string.IsNullOrWhiteSpace(noteText) ? selectedText : $"{selectedText} — note: {noteText}";
+}

--- a/backend/src/Contracts/Admin/RagDtos.cs
+++ b/backend/src/Contracts/Admin/RagDtos.cs
@@ -13,3 +13,15 @@ public record RagChunkDto(
     int CharStart,
     int CharEnd,
     string TextPreview);
+
+/// <summary>A user's own highlight/note returned as guaranteed private-corpus context (AI-024).</summary>
+public record PrivateNoteDto(Guid? ChapterId, int ChapterOrd, string Kind, string TextPreview);
+
+/// <summary>
+/// Spoiler-safe RAG context for the admin <c>/context</c> debug endpoint: the user's last-read
+/// chapter ordinal, the gated chunks, and their private corpus.
+/// </summary>
+public record RagContextDto(
+    int LastReadOrd,
+    IReadOnlyList<RagChunkDto> Chunks,
+    IReadOnlyList<PrivateNoteDto> Notes);

--- a/backend/src/Domain/Entities/ReadingProgress.cs
+++ b/backend/src/Domain/Entities/ReadingProgress.cs
@@ -9,6 +9,15 @@ public class ReadingProgress
     public Guid ChapterId { get; set; }
     public required string Locator { get; set; }
     public double? Percent { get; set; }
+
+    /// <summary>
+    /// High-water mark: the furthest chapter ordinal (<see cref="Chapter.ChapterNumber"/>) the user
+    /// has ever reached in this edition. Used by the RAG spoiler gate so flipping back to an earlier
+    /// chapter doesn't hide already-read later chapters. Null on legacy rows → callers fall back to
+    /// the current chapter (self-heals on the next progress save).
+    /// </summary>
+    public int? MaxChapterNumber { get; set; }
+
     public DateTimeOffset UpdatedAt { get; set; }
 
     public User User { get; set; } = null!;

--- a/backend/src/Infrastructure/Migrations/20260610120514_AddMaxChapterToReadingProgress.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260610120514_AddMaxChapterToReadingProgress.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610120514_AddMaxChapterToReadingProgress")]
+    partial class AddMaxChapterToReadingProgress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260610120514_AddMaxChapterToReadingProgress.cs
+++ b/backend/src/Infrastructure/Migrations/20260610120514_AddMaxChapterToReadingProgress.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMaxChapterToReadingProgress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "max_chapter_number",
+                table: "reading_progresses",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "max_chapter_number",
+                table: "reading_progresses");
+        }
+    }
+}

--- a/tests/TextStack.IntegrationTests/RagEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/RagEndpointTests.cs
@@ -45,4 +45,20 @@ public class RagEndpointTests : IClassFixture<AuthenticatedApiFixture>
         Assert.SkipWhen(NotReachable(response), "admin endpoint not reachable (no admin session / key / corpus)");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
+
+    [Fact]
+    public async Task RagSearch_SpoilerGateZero_ReturnsEmpty()
+    {
+        Assert.SkipUnless(_fixture.IsAuthenticated, "auth unavailable");
+
+        // maxChapterOrd=0 means "no chapters read" → the gate must return nothing.
+        var request = _fixture.CreateAdminRequest(
+            HttpMethod.Get, $"/admin/rag/{SomeEdition}/search?q=test&maxChapterOrd=0");
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(NotReachable(response), "admin endpoint not reachable (no admin session / key)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("[]", body.Trim());
+    }
 }

--- a/tests/TextStack.UnitTests/RagContextServiceTests.cs
+++ b/tests/TextStack.UnitTests/RagContextServiceTests.cs
@@ -1,0 +1,22 @@
+using Application.Rag;
+
+namespace TextStack.UnitTests;
+
+public class RagContextServiceTests
+{
+    [Fact]
+    public void HighlightToText_NoNote_ReturnsSelectionOnly()
+        => Assert.Equal("the selected passage", RagContextService.HighlightToText("the selected passage", null));
+
+    [Fact]
+    public void HighlightToText_WithNote_AppendsNote()
+        => Assert.Equal(
+            "the selected passage — note: my thought",
+            RagContextService.HighlightToText("the selected passage", "my thought"));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void HighlightToText_BlankNote_ReturnsSelectionOnly(string note)
+        => Assert.Equal("passage", RagContextService.HighlightToText("passage", note));
+}


### PR DESCRIPTION
## Summary

Fifth PR of **Phase 4 — "Ask this book"** (playbook **AI-024**). Makes retrieval **spoiler-safe** and adds the user's own highlights/notes as guaranteed context. This is the capability the public Ask endpoint (AI-025) will consume.

## Changes

- **Spoiler gate** — `RagService.RetrieveAsync` gains an optional `maxChapterOrd`. The SQL adds `AND (@maxChapterOrd::int IS NULL OR chapter_ord <= @maxChapterOrd::int)` — a **hard SQL filter, never a prompt instruction**. Only chunks from chapters the user has read are returned. (`::int` casts pin the param type so the null path can't hit Npgsql's "undetermined parameter type".)
- **`RagContextService`** (`Application/Rag`) — the spoiler-safe context builder:
  - resolves the user's **last-read chapter ordinal** from `ReadingProgress` (join `Chapter.ChapterNumber`); **0 when no progress → empty context, strict** (nothing retrievable until you've read).
  - runs gated chunk retrieval, then gathers the user's **highlights + notes from read chapters** as guaranteed private-corpus context.
  - gate is **inclusive** of the current chapter — within-chapter leakage is an accepted v1 limit (chunking is chapter-granular).
- **Admin debug endpoints** (`AdminRagEndpoints`):
  - `/admin/rag/{ed}/search` gains `&maxChapterOrd=` — test the gate with a synthetic ceiling (no user needed).
  - new `/admin/rag/{ed}/context?userId=&q=&k=` — runs the full path for a user (admin impersonation) → `{ lastReadOrd, chunks[], notes[] }`, so AI-024 is verifiable now, before AI-025.
- Both admin paths resolve the embedding-dependent services lazily and return **503** (not 500) when there's no OpenAI key.

## Scope

`RagContextService` is the reusable capability; AI-025 wires the public Ask + SSE endpoint on top. Hybrid/RRF (AI-023), embedding-ranked private corpus, and within-chapter precision are out of scope.

## Tests

- Unit (`RagContextServiceTests`): `HighlightToText` (selection only / with note / blank note).
- Integration (`RagEndpointTests`): `maxChapterOrd=0` → `200` + `[]` (gate returns nothing when no chapters read); skips when not reachable (401/404/500/503).
- Full unit suite: 168 passed (164 + 4). `dotnet build textstack.sln` → 0 warnings / 0 errors. `dotnet format --verify-no-changes` clean.

## Verification (manual, needs Docker + key + corpus + a user with progress)

```
GET /admin/rag/{ed}/search?q=…&maxChapterOrd=0   → []        (nothing readable)
GET /admin/rag/{ed}/search?q=…&maxChapterOrd=3   → only chapter_ord ≤ 3
GET /admin/rag/{ed}/context?userId={u}&q=…       → lastReadOrd = that user's chapter;
                                                    chunks all ≤ lastReadOrd; notes = their
                                                    highlights/notes from read chapters
```

## Rollback plan

Revert the commit. Additive — `maxChapterOrd` is optional (null = old behaviour); the new service + endpoint are admin-only and read-only.

## Notes

- `lastRead = 0` ⇒ empty context for brand-new readers; AI-025's answer should say "read more first" rather than erroring.
- Admin `/context` siteId comes from `GetSiteId()` on the admin host; if it doesn't map to the data's site, results are empty (debug tool — the public path uses the real site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)