### PR TITLE
feat(rag): public "Ask this book" endpoint (AI-025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — "Ask this book" endpoint (2026-06-10)
+
+Sixth PR of Phase 4 (playbook **AI-025**). The feature itself: ask a question about a book you're reading, get a grounded 2–4 sentence answer with citations.
+
+- **`POST /books/{editionId}/ask`** (authenticated) — retrieves spoiler-safe context (AI-024 `RagContextService`), generates an answer via the LLM gateway (FeatureTag `rag.ask` → OpenAI, traced into `llm_traces`), returns `{ answer, citations[], lastReadOrd, insufficient }`. Rate-limited 30/min per IP.
+- **`RagAskService`** (`Application/Rag`) + **`RagAskPrompt`** (pure static, eval-reusable): numbered excerpts `[1] (ch.N) …` + the reader's private notes → an answer that cites every claim with `[n]`; `ParseCitations` maps markers back to the cited chunks (with chapter ord + char offsets for the reader deep-link).
+- **No-context short-circuit** — a reader with no progress gets a plain "read more first" answer with **no LLM call** (zero cost).
+- **JSON for now** — `ILlmService.StreamAsync` is still one-shot, so SSE/token streaming is deferred to AI-028 (Phase 5) where it's real; the answer arrives whole today (identical UX). The reader UI + clickable citations are AI-026.
+- Tests: `RagAskPrompt`/`ParseCitations` unit tests + an integration test (no-auth → 401; answer path skips without a key/corpus).
+
 ### Phase 4 RAG — spoiler gate + private corpus (2026-06-10)
 
 Fifth PR of Phase 4 (playbook **AI-024**). Makes retrieval spoiler-safe and adds the user's own annotations as guaranteed context — the capability the public Ask endpoint (AI-025) consumes.

--- a/backend/src/Api/Endpoints/AskEndpoints.cs
+++ b/backend/src/Api/Endpoints/AskEndpoints.cs
@@ -1,0 +1,84 @@
+using Api.Extensions;
+using Api.Sites;
+using Application.Auth;
+using Application.Common.Interfaces;
+using Application.Rag;
+using Contracts.Books;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Rag;
+
+namespace Api.Endpoints;
+
+/// <summary>
+/// Public "Ask this book" (Phase 4 RAG, AI-025). Authenticated question over a catalog edition →
+/// spoiler-safe retrieval (<see cref="RagContextService"/>) → grounded answer with citations. JSON
+/// for now; SSE/token streaming lands in AI-028. The reader UI + citation deep-links are AI-026.
+/// </summary>
+public static class AskEndpoints
+{
+    private const int PreviewChars = 200;
+
+    public static void MapAskEndpoints(this WebApplication app)
+    {
+        app.MapPost("/books/{editionId:guid}/ask", Ask)
+            .WithTags("RAG")
+            .RequireRateLimiting("rag.ask");
+    }
+
+    private static async Task<IResult> Ask(
+        Guid editionId,
+        AskRequest request,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        IServiceProvider services,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(request.Question))
+            return Results.BadRequest(new { error = "Question is required." });
+
+        var siteId = httpContext.GetSiteId();
+
+        var editionExists = await db.Editions.AnyAsync(e => e.Id == editionId && e.SiteId == siteId, ct);
+        if (!editionExists) return Results.NotFound("Edition not found");
+
+        // RagAskService construction pulls in the embedder, which throws without an OpenAI key —
+        // surface that as a clean 503 rather than a generic 500.
+        RagAskService ask;
+        try
+        {
+            ask = services.GetRequiredService<RagAskService>();
+        }
+        catch (InvalidOperationException)
+        {
+            return Results.Problem("Ask is not configured (no OpenAI key).", statusCode: 503);
+        }
+
+        try
+        {
+            var k = request.K is > 0 ? request.K.Value : IRagService.DefaultK;
+            var answer = await ask.AskAsync(userId.Value, siteId, editionId, request.Question, k, ct);
+
+            var citations = answer.Citations.Select(c => new AskCitation(
+                c.Marker, c.Chunk.ChunkId, c.Chunk.ChapterId, c.Chunk.ChapterOrd,
+                c.Chunk.CharStart, c.Chunk.CharEnd, Preview(c.Chunk.Text))).ToList();
+
+            return Results.Ok(new AskResponse(answer.Answer, citations, answer.LastReadOrd, answer.Insufficient));
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+        catch (Exception)
+        {
+            return Results.Problem("Ask is temporarily unavailable.", statusCode: 503);
+        }
+    }
+
+    private static string Preview(string text) =>
+        text.Length <= PreviewChars ? text : text[..PreviewChars] + "…";
+}

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -112,6 +112,8 @@ else
 builder.Services.AddRagRetrieval(_ => () => new NpgsqlConnection(connectionString));
 // Spoiler-safe context builder (AI-024): resolves lastRead + gates chunks + private corpus.
 builder.Services.AddScoped<Application.Rag.RagContextService>();
+// "Ask this book" orchestration (AI-025): context + LLM gateway → grounded answer with citations.
+builder.Services.AddScoped<Application.Rag.RagAskService>();
 
 // Reindex service (used by CLI)
 builder.Services.AddScoped<SearchReindexService>();
@@ -276,6 +278,18 @@ builder.Services.AddRateLimiter(options =>
         {
             Window = TimeSpan.FromMinutes(1),
             PermitLimit = 20,
+            QueueLimit = 0,
+        });
+    });
+    // "Ask this book" (RAG) — one LLM call per request, per-user reading. 30/min per IP is
+    // generous for genuine use and caps scripted abuse.
+    options.AddPolicy("rag.ask", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromMinutes(1),
+            PermitLimit = 30,
             QueueLimit = 0,
         });
     });
@@ -469,6 +483,7 @@ app.MapReadingTrackingEndpoints();
 app.MapAdminBookQualityEndpoints();
 app.MapAdminAiQualityEndpoints();
 app.MapAdminRagEndpoints();
+app.MapAskEndpoints();
 app.MapVocabularyEndpoints();
 app.MapTtsEndpoints();
 app.MapExportEndpoints();

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -71,7 +71,8 @@
       "distractor": "ollama",
       "bookmeta": "ollama",
       "tagsuggestion": "ollama",
-      "podcast.script": "openai"
+      "podcast.script": "openai",
+      "rag.ask": "openai"
     },
     "Tracing": {
       "Sampling": {

--- a/backend/src/Application/Ai/RagAskPrompt.cs
+++ b/backend/src/Application/Ai/RagAskPrompt.cs
@@ -1,0 +1,61 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using TextStack.Ai.Rag;
+
+namespace Application.Ai;
+
+/// <summary>
+/// The "Ask this book" prompt (Phase 4 RAG, AI-025), extracted so the eval harness exercises the
+/// SAME prompt production serves. Pure string building, no dependencies. The spoiler gate is
+/// enforced in SQL (AI-024) — the prompt does not need to mention it.
+/// </summary>
+public static class RagAskPrompt
+{
+    public static string BuildSystemPrompt() =>
+        "You answer a reader's question about a book using ONLY the numbered excerpts provided. " +
+        "Write 2-4 sentences. Cite every claim with [n] referring to the excerpt numbers you used. " +
+        "If the excerpts do not contain the answer, say so plainly — do NOT use outside knowledge. " +
+        "No preface, no markdown.";
+
+    /// <summary>
+    /// Numbered excerpts (1-based, matching the citation markers) + the reader's own notes, then the
+    /// question. <paramref name="chunks"/> order defines the [n] numbering.
+    /// </summary>
+    public static string BuildUserPrompt(
+        string question, IReadOnlyList<RetrievedChunk> chunks, IReadOnlyList<string> notes)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Excerpts:\n");
+        for (var i = 0; i < chunks.Count; i++)
+            sb.Append('[').Append(i + 1).Append("] (ch.").Append(chunks[i].ChapterOrd).Append(") ")
+              .Append(chunks[i].Text).Append('\n');
+
+        if (notes.Count > 0)
+        {
+            sb.Append("\nYour notes:\n");
+            foreach (var note in notes)
+                sb.Append("- ").Append(note).Append('\n');
+        }
+
+        sb.Append("\nQuestion: ").Append(question);
+        return sb.ToString();
+    }
+
+    private static readonly Regex CitationMarker = new(@"\[(\d+)\]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Distinct, in-range, 1-based citation markers found in the answer (order of first appearance).
+    /// Out-of-range / non-numeric markers are ignored.
+    /// </summary>
+    public static IReadOnlyList<int> ParseCitations(string answer, int excerptCount)
+    {
+        var seen = new HashSet<int>();
+        var result = new List<int>();
+        foreach (Match m in CitationMarker.Matches(answer))
+        {
+            if (int.TryParse(m.Groups[1].Value, out var n) && n >= 1 && n <= excerptCount && seen.Add(n))
+                result.Add(n);
+        }
+        return result;
+    }
+}

--- a/backend/src/Application/Rag/RagAskService.cs
+++ b/backend/src/Application/Rag/RagAskService.cs
@@ -1,0 +1,56 @@
+using Application.Ai;
+using TextStack.Ai.Core;
+using TextStack.Ai.Rag;
+
+namespace Application.Rag;
+
+/// <summary>A cited excerpt: its <c>[n]</c> marker in the answer plus the chunk it points to.</summary>
+public record AskCitationSource(int Marker, RetrievedChunk Chunk);
+
+/// <summary>
+/// The answer produced by <see cref="RagAskService"/>. <see cref="Insufficient"/> is true when the
+/// user hasn't read enough to have any context (no LLM call was made).
+/// </summary>
+public record AskAnswer(
+    string Answer,
+    IReadOnlyList<AskCitationSource> Citations,
+    int LastReadOrd,
+    bool Insufficient);
+
+/// <summary>
+/// "Ask this book" (Phase 4 RAG, AI-025): retrieves spoiler-safe context via
+/// <see cref="RagContextService"/>, generates a grounded 2-4 sentence answer with citations via the
+/// LLM gateway (FeatureTag <c>rag.ask</c>), and resolves the cited excerpts. Reused by the AI-027 eval.
+/// </summary>
+public sealed class RagAskService(RagContextService context, ILlmService llm)
+{
+    public const string FeatureTag = "rag.ask";
+    private const int MaxOutputTokens = 320;
+
+    private const string InsufficientMessage =
+        "You haven't read enough of this book yet for me to answer from it. Keep reading and ask again.";
+
+    public async Task<AskAnswer> AskAsync(
+        Guid userId, Guid siteId, Guid editionId, string question, int k, CancellationToken ct)
+    {
+        var ctx = await context.BuildAsync(userId, siteId, editionId, question, k, ct);
+
+        // No readable context → answer plainly without spending an LLM call.
+        if (ctx.Chunks.Count == 0)
+            return new AskAnswer(InsufficientMessage, [], ctx.LastReadOrd, Insufficient: true);
+
+        var noteTexts = ctx.Notes.Select(n => n.Text).ToList();
+        var request = new LlmRequest(
+            SystemPrompt: RagAskPrompt.BuildSystemPrompt(),
+            Messages: [new LlmMessage("user", RagAskPrompt.BuildUserPrompt(question, ctx.Chunks, noteTexts))],
+            MaxOutputTokens: MaxOutputTokens,
+            FeatureTag: FeatureTag);
+
+        var response = await llm.CompleteAsync(request, ct);
+
+        var markers = RagAskPrompt.ParseCitations(response.Text, ctx.Chunks.Count);
+        var citations = markers.Select(n => new AskCitationSource(n, ctx.Chunks[n - 1])).ToList();
+
+        return new AskAnswer(response.Text, citations, ctx.LastReadOrd, Insufficient: false);
+    }
+}

--- a/backend/src/Contracts/Books/AskDtos.cs
+++ b/backend/src/Contracts/Books/AskDtos.cs
@@ -1,0 +1,27 @@
+namespace Contracts.Books;
+
+/// <summary>"Ask this book" request (AI-025). <see cref="K"/> overrides the default retrieval count.</summary>
+public record AskRequest(string Question, int? K = null);
+
+/// <summary>
+/// A cited source for an answer. <see cref="Marker"/> is the <c>[n]</c> number in the answer text;
+/// <see cref="ChapterOrd"/> + offsets deep-link the citation back into the reader.
+/// </summary>
+public record AskCitation(
+    int Marker,
+    Guid ChunkId,
+    Guid ChapterId,
+    int ChapterOrd,
+    int CharStart,
+    int CharEnd,
+    string Preview);
+
+/// <summary>
+/// "Ask this book" answer. <see cref="Insufficient"/> is true when the user hasn't read enough to
+/// answer (no model was called); <see cref="LastReadOrd"/> is their furthest-read chapter.
+/// </summary>
+public record AskResponse(
+    string Answer,
+    IReadOnlyList<AskCitation> Citations,
+    int LastReadOrd,
+    bool Insufficient);

--- a/tests/TextStack.IntegrationTests/AskEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/AskEndpointTests.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the public "Ask this book" endpoint (AI-025), against the live API.
+/// The no-auth path runs without a key; the answer path needs a user session + OpenAI key + corpus,
+/// so it skips when not reachable.
+/// </summary>
+public class AskEndpointTests : IClassFixture<AuthenticatedApiFixture>
+{
+    private static readonly Guid SomeEdition = Guid.Parse("11111111-2222-3333-4444-555555555555");
+    private readonly AuthenticatedApiFixture _fixture;
+
+    public AskEndpointTests(AuthenticatedApiFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Ask_NoAuth_Unauthorized()
+    {
+        // Unauthenticated request → 401 before any retrieval/LLM work (no key needed).
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/books/{SomeEdition}/ask")
+        {
+            Content = JsonContent.Create(new { question = "anything" }),
+        };
+        request.Headers.Host = LiveApiFixture.TestHost;
+
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(response.StatusCode is HttpStatusCode.NotFound, "endpoint not deployed");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Ask_WithAuth_Returns200OrSkips()
+    {
+        Assert.SkipUnless(_fixture.IsAuthenticated, "auth unavailable");
+
+        var request = _fixture.CreateRequest(HttpMethod.Post, $"/books/{SomeEdition}/ask");
+        request.Content = JsonContent.Create(new { question = "how does it work?" });
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // 404 = unknown edition, 500 = erroring, 503 = no key → skip rather than fail.
+        Assert.SkipWhen(
+            IntegrationSkip.Unavailable(response) || response.StatusCode == HttpStatusCode.ServiceUnavailable,
+            "endpoint not reachable (no edition / key / corpus)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/tests/TextStack.UnitTests/RagAskPromptTests.cs
+++ b/tests/TextStack.UnitTests/RagAskPromptTests.cs
@@ -1,0 +1,49 @@
+using Application.Ai;
+using TextStack.Ai.Rag;
+
+namespace TextStack.UnitTests;
+
+public class RagAskPromptTests
+{
+    private static RetrievedChunk Chunk(int chapterOrd, string text) =>
+        new(Guid.NewGuid(), Guid.NewGuid(), chapterOrd, 0, text, 0, text.Length, 0.9);
+
+    [Fact]
+    public void BuildUserPrompt_NumbersExcerptsAndAppendsQuestion()
+    {
+        var prompt = RagAskPrompt.BuildUserPrompt(
+            "How does it work?",
+            [Chunk(3, "first excerpt"), Chunk(5, "second excerpt")],
+            []);
+
+        Assert.Contains("[1] (ch.3) first excerpt", prompt);
+        Assert.Contains("[2] (ch.5) second excerpt", prompt);
+        Assert.Contains("Question: How does it work?", prompt);
+        Assert.DoesNotContain("Your notes:", prompt);
+    }
+
+    [Fact]
+    public void BuildUserPrompt_WithNotes_IncludesNotesBlock()
+    {
+        var prompt = RagAskPrompt.BuildUserPrompt(
+            "Q?", [Chunk(1, "x")], ["my highlight", "another note"]);
+
+        Assert.Contains("Your notes:", prompt);
+        Assert.Contains("- my highlight", prompt);
+        Assert.Contains("- another note", prompt);
+    }
+
+    [Fact]
+    public void ParseCitations_ExtractsDistinctInOrder()
+        => Assert.Equal(new[] { 2, 1 }, RagAskPrompt.ParseCitations("see [2] and [1] and [2] again", 3));
+
+    [Fact]
+    public void ParseCitations_IgnoresOutOfRange()
+        => Assert.Equal(new[] { 1 }, RagAskPrompt.ParseCitations("valid [1], bogus [9]", 3));
+
+    [Theory]
+    [InlineData("no markers here")]
+    [InlineData("")]
+    public void ParseCitations_NoMarkers_Empty(string answer)
+        => Assert.Empty(RagAskPrompt.ParseCitations(answer, 5));
+}


### PR DESCRIPTION
## Summary

Sixth PR of **Phase 4 — "Ask this book"** (playbook **AI-025**) — the feature itself. Ask a question about a book you're reading; get a grounded 2–4 sentence answer with citations back into the text.

## Changes

- **`POST /books/{editionId:guid}/ask`** (authenticated) — `AskEndpoints`. Validates auth (401) + edition (404), retrieves spoiler-safe context via AI-024's `RagContextService`, generates an answer through the LLM gateway, returns `AskResponse { answer, citations[], lastReadOrd, insufficient }`. Rate-limited **30/min per IP** (`rag.ask` policy).
- **`RagAskService`** (`Application/Rag`) + **`RagAskPrompt`** (pure static, eval-reusable):
  - prompt = numbered excerpts `[1] (ch.N) …` + the reader's private notes + the question; system prompt constrains to *only* the excerpts, 2–4 sentences, cite every claim with `[n]`, no outside knowledge.
  - `ParseCitations` extracts distinct in-range `[n]` markers and maps them back to the cited chunks (chapter ord + char offsets → reader deep-link in AI-026).
  - **FeatureTag `rag.ask`** → routes to OpenAI and is **traced into `llm_traces`** for free.
- **No-context short-circuit** — a reader with no progress (`lastReadOrd = 0`) gets a plain "read more first" answer with **no LLM call** (zero cost).

## Decisions

- **JSON now, SSE later.** `ILlmService.StreamAsync` is still one-shot (real token streaming = AI-028), so SSE today streams one chunk — identical UX to JSON. Streaming + SSE refactor land in Phase 5.
- **Route on editionId (guid)** — reader already has it; reuses the `/books/{editionId:guid}/…` convention.

## Scope

Reader UI + clickable citations = **AI-026**; hybrid/RRF = **AI-023**; faithfulness/citation eval = **AI-027**; token streaming = **AI-028**. Ask-result caching (bootcamp v1.5) deferred.

## Tests

- Unit (`RagAskPromptTests`): excerpt numbering + notes block; `ParseCitations` (distinct/ordered, out-of-range ignored, empty).
- Integration (`AskEndpointTests`): **no-auth → 401** (CI-green); answer path skips when not reachable (401/404/500/503).
- Full unit suite: 174 passed (168 + 6). `dotnet build textstack.sln` → 0/0. `dotnet format --verify-no-changes` clean.

## Verification (manual, needs Docker + key + corpus + a user with progress)

\`\`\`
curl -X POST -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \
  -d '{"question":"how does replication work?"}' http://localhost:8080/books/{editionId}/ask
\`\`\`
→ `{ answer: "…[1]…[2]…", citations: [{marker:1, chapterOrd, charStart, …}], lastReadOrd, insufficient:false }`. No progress → `insufficient:true`, no LLM call. Trace lands in `llm_traces` (feature `rag.ask`).

## Rollback plan

Revert the commit. Additive — new authenticated read-only endpoint + services; no schema change.

## Notes

- **Citation fidelity** verified by AI-027's eval; v1 returns whatever `[n]` the model emits.
- Keyless dev → 503 (service graph needs the embedder to construct); consistent with the other RAG endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)