### PR TITLE
feat(rag): web AskPanel — "Ask this book" UI (AI-026a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — web AskPanel (2026-06-10)
+
+Seventh PR of Phase 4 (playbook **AI-026**, slice 1 of 4 — web panel, chapter-level citations). Surfaces the AI-025 "Ask this book" endpoint in the web reader.
+
+- **`AskPanel`** — a right slide-in panel (mirrors `ReaderSettingsDrawer`) with a session Q&A history (chat-style, not persisted) and a composer. Reached via a new "Ask" button in `ReaderTopBar`, shown only for catalog editions (user uploads aren't chunked). Auth-gated: signed-out readers get a sign-in CTA.
+- **Citations** render as `[ch.N]` chips (hover → the backend text preview); clicking navigates the reader to that chapter (exact char-offset scroll is slice 026b).
+- **`useAsk` hook** + `api/ask.ts` (cookie `authFetch` POST `/books/{editionId}/ask`); shared `AskCitation`/`AskResponse` types in `@textstack/shared` (mobile reuses them in 026c).
+- Tests: `useAsk` (append / error / insufficient / no-edition) + `AskPanel` render (auth branching, citation-chip click). The render test caught a real bug — the auto-scroll used `Element.scrollTo` (absent in jsdom / fragile); switched to the robust `scrollTop` setter.
+
 ### Phase 4 RAG — "Ask this book" endpoint (2026-06-10)
 
 Sixth PR of Phase 4 (playbook **AI-025**). The feature itself: ask a question about a book you're reading, get a grounded 2–4 sentence answer with citations.

--- a/apps/web/src/api/ask.ts
+++ b/apps/web/src/api/ask.ts
@@ -1,0 +1,22 @@
+import { authFetch } from './client'
+import type { AskResponse } from '@textstack/shared'
+
+export type { AskResponse, AskCitation } from '@textstack/shared'
+
+/**
+ * "Ask this book" (AI-025). Authenticated POST — spoiler-safe answer + citations for a catalog
+ * edition. Uses cookie auth via {@link authFetch}; throws `ApiError` (status carried) on failure.
+ */
+export function ask(
+  editionId: string,
+  question: string,
+  k?: number,
+  signal?: AbortSignal,
+): Promise<AskResponse> {
+  return authFetch<AskResponse>(`/books/${editionId}/ask`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ question, k }),
+    signal,
+  })
+}

--- a/apps/web/src/components/reader/AskPanel.tsx
+++ b/apps/web/src/components/reader/AskPanel.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from 'react'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import { useTranslation } from '../../hooks/useTranslation'
+import { useAsk } from '../../hooks/useAsk'
+import type { AskCitation } from '../../api/ask'
+
+interface Props {
+  open: boolean
+  editionId: string
+  isAuthenticated: boolean
+  onSignIn: () => void
+  onNavigateToCitation: (citation: AskCitation) => void
+  onClose: () => void
+}
+
+export function AskPanel({ open, editionId, isAuthenticated, onSignIn, onNavigateToCitation, onClose }: Props) {
+  const { t } = useTranslation()
+  const containerRef = useFocusTrap(open)
+  const { history, isLoading, error, ask } = useAsk(editionId)
+  const [input, setInput] = useState('')
+  const historyRef = useRef<HTMLDivElement>(null)
+
+  // Auto-scroll to the newest turn (scrollTop setter works in every environment).
+  useEffect(() => {
+    const el = historyRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [history, isLoading])
+
+  if (!open) return null
+
+  const submit = () => {
+    const q = input.trim()
+    if (!q || isLoading) return
+    ask(q)
+    setInput('')
+  }
+
+  return (
+    <>
+      <div className="reader-drawer-backdrop" onClick={onClose} />
+      <div className="ask-panel" ref={containerRef} role="dialog" aria-modal="true" aria-label={t('reader.ask.title')}>
+        <div className="ask-panel__header">
+          <h3>{t('reader.ask.title')}</h3>
+          <button onClick={onClose} className="ask-panel__close" aria-label={t('common.close')}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="ask-panel__history" ref={historyRef}>
+          {history.length === 0 && !isLoading && (
+            <p className="ask-panel__empty">{t('reader.ask.empty')}</p>
+          )}
+          {history.map((turn, i) => (
+            <div key={i} className="ask-panel__turn">
+              <p className="ask-panel__question">{turn.question}</p>
+              <p className="ask-panel__answer">{turn.answer}</p>
+              {turn.citations.length > 0 && (
+                <div className="ask-panel__citations">
+                  {turn.citations.map(c => (
+                    <button
+                      key={c.chunkId}
+                      className="ask-panel__chip"
+                      title={c.preview}
+                      onClick={() => onNavigateToCitation(c)}
+                    >
+                      {t('reader.ask.citation', { ch: c.chapterOrd })}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+          {isLoading && (
+            <div className="ask-panel__loading">
+              <span className="ask-panel__spinner" />
+              {t('reader.ask.thinking')}
+            </div>
+          )}
+          {error && error !== 'auth' && <p className="ask-panel__error">{error}</p>}
+        </div>
+
+        {isAuthenticated ? (
+          <div className="ask-panel__composer">
+            {error === 'auth' && <p className="ask-panel__error">{t('reader.ask.signIn')}</p>}
+            <textarea
+              className="ask-panel__input"
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault()
+                  submit()
+                }
+              }}
+              placeholder={t('reader.ask.placeholder')}
+              rows={2}
+            />
+            <button className="ask-panel__send" onClick={submit} disabled={isLoading || !input.trim()}>
+              {t('reader.ask.send')}
+            </button>
+          </div>
+        ) : (
+          <div className="ask-panel__composer ask-panel__composer--signin">
+            <p>{t('reader.ask.signIn')}</p>
+            <button className="ask-panel__send" onClick={onSignIn}>
+              {t('reader.ask.signInCta')}
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/components/reader/ReaderTopBar.tsx
+++ b/apps/web/src/components/reader/ReaderTopBar.tsx
@@ -9,6 +9,8 @@ interface Props {
   isBookmarked: boolean
   backUrl: string
   useLocalizedLink?: boolean // true for public books (uses LocalizedLink), false for user books (uses Link)
+  showAsk?: boolean // catalog editions only — user uploads aren't chunked for RAG
+  onAskClick?: () => void
   onSearchClick: () => void
   onTocClick: () => void
   onSettingsClick: () => void
@@ -23,6 +25,8 @@ export function ReaderTopBar({
   isBookmarked,
   backUrl,
   useLocalizedLink = true,
+  showAsk = false,
+  onAskClick,
   onSearchClick,
   onTocClick,
   onSettingsClick,
@@ -52,6 +56,15 @@ export function ReaderTopBar({
 
       <div className="reader-top-bar__right">
         <span className="reader-top-bar__progress">{Math.round(progress * 100)}%</span>
+        {showAsk && (
+          <button onClick={onAskClick} className="reader-top-bar__btn" title="Ask this book">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+              <path d="M9.5 9.5a2.5 2.5 0 1 1 3 2.45V13" strokeWidth="1.6" />
+              <circle cx="12" cy="15.5" r="0.6" fill="currentColor" stroke="none" />
+            </svg>
+          </button>
+        )}
         <button onClick={onSearchClick} className="reader-top-bar__btn" title="Search in chapter">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <circle cx="11" cy="11" r="8" />

--- a/apps/web/src/components/reader/ReaderTopBar.tsx
+++ b/apps/web/src/components/reader/ReaderTopBar.tsx
@@ -56,15 +56,6 @@ export function ReaderTopBar({
 
       <div className="reader-top-bar__right">
         <span className="reader-top-bar__progress">{Math.round(progress * 100)}%</span>
-        {showAsk && (
-          <button onClick={onAskClick} className="reader-top-bar__btn" title="Ask this book">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-              <path d="M9.5 9.5a2.5 2.5 0 1 1 3 2.45V13" strokeWidth="1.6" />
-              <circle cx="12" cy="15.5" r="0.6" fill="currentColor" stroke="none" />
-            </svg>
-          </button>
-        )}
         <button onClick={onSearchClick} className="reader-top-bar__btn" title="Search in chapter">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <circle cx="11" cy="11" r="8" />
@@ -89,6 +80,17 @@ export function ReaderTopBar({
             <circle cx="10" cy="18" r="2" fill="currentColor" />
           </svg>
         </button>
+        {/* Ask is appended LAST so it doesn't shift the positional indices that
+            the reader e2e tests use (search=0, bookmark=1, toc=2, settings=3). */}
+        {showAsk && (
+          <button onClick={onAskClick} className="reader-top-bar__btn" title="Ask this book">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+              <path d="M9.5 9.5a2.5 2.5 0 1 1 3 2.45V13" strokeWidth="1.6" />
+              <circle cx="12" cy="15.5" r="0.6" fill="currentColor" stroke="none" />
+            </svg>
+          </button>
+        )}
       </div>
     </header>
   )

--- a/apps/web/src/components/reader/__tests__/AskPanel.test.tsx
+++ b/apps/web/src/components/reader/__tests__/AskPanel.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k, language: 'en' }),
+}))
+vi.mock('../../../hooks/useFocusTrap', () => ({ useFocusTrap: () => ({ current: null }) }))
+
+const { askState } = vi.hoisted(() => ({
+  askState: { history: [] as unknown[], isLoading: false, error: null as string | null, ask: vi.fn() },
+}))
+vi.mock('../../../hooks/useAsk', () => ({ useAsk: () => askState }))
+
+import { AskPanel } from '../AskPanel'
+
+const baseProps = {
+  open: true,
+  editionId: 'ed-1',
+  onSignIn: vi.fn(),
+  onNavigateToCitation: vi.fn(),
+  onClose: vi.fn(),
+}
+
+afterEach(() => {
+  cleanup()
+  askState.history = []
+})
+
+describe('AskPanel', () => {
+  it('shows the sign-in CTA when unauthenticated', () => {
+    render(<AskPanel {...baseProps} isAuthenticated={false} />)
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByText('reader.ask.signInCta')).toBeTruthy()
+    expect(screen.queryByPlaceholderText('reader.ask.placeholder')).toBeNull()
+  })
+
+  it('shows the composer when authenticated', () => {
+    render(<AskPanel {...baseProps} isAuthenticated={true} />)
+    expect(screen.getByPlaceholderText('reader.ask.placeholder')).toBeTruthy()
+  })
+
+  it('renders a citation chip and navigates on click', () => {
+    const citation = { marker: 1, chunkId: 'c1', chapterId: 'ch1', chapterOrd: 4, charStart: 0, charEnd: 1, preview: 'snippet' }
+    askState.history = [{ question: 'q', answer: 'a [1]', citations: [citation], insufficient: false }]
+    const onNavigateToCitation = vi.fn()
+
+    render(<AskPanel {...baseProps} isAuthenticated={true} onNavigateToCitation={onNavigateToCitation} />)
+    const chip = screen.getByTitle('snippet')
+    fireEvent.click(chip)
+
+    expect(onNavigateToCitation).toHaveBeenCalledWith(citation)
+  })
+})

--- a/apps/web/src/hooks/useAsk.test.ts
+++ b/apps/web/src/hooks/useAsk.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+vi.mock('../api/ask', () => ({ ask: vi.fn() }))
+import { ask as askApi } from '../api/ask'
+import { useAsk } from './useAsk'
+
+const mockAsk = askApi as unknown as ReturnType<typeof vi.fn>
+
+const citation = {
+  marker: 1, chunkId: 'c1', chapterId: 'ch1', chapterOrd: 2, charStart: 0, charEnd: 5, preview: 'preview',
+}
+
+describe('useAsk', () => {
+  beforeEach(() => mockAsk.mockReset())
+
+  it('appends a turn on success', async () => {
+    mockAsk.mockResolvedValueOnce({ answer: 'Because [1].', citations: [citation], lastReadOrd: 3, insufficient: false })
+    const { result } = renderHook(() => useAsk('ed-1'))
+
+    await act(() => result.current.ask('why?'))
+
+    await waitFor(() => expect(result.current.history).toHaveLength(1))
+    expect(result.current.history[0]).toMatchObject({ question: 'why?', answer: 'Because [1].' })
+    expect(result.current.history[0].citations).toHaveLength(1)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('sets error and keeps history empty on failure', async () => {
+    mockAsk.mockRejectedValueOnce(new Error('boom'))
+    const { result } = renderHook(() => useAsk('ed-1'))
+
+    await act(() => result.current.ask('why?'))
+
+    await waitFor(() => expect(result.current.error).toBe('boom'))
+    expect(result.current.history).toHaveLength(0)
+  })
+
+  it('flags insufficient turns', async () => {
+    mockAsk.mockResolvedValueOnce({ answer: 'Read more first.', citations: [], lastReadOrd: 0, insufficient: true })
+    const { result } = renderHook(() => useAsk('ed-1'))
+
+    await act(() => result.current.ask('why?'))
+
+    await waitFor(() => expect(result.current.history).toHaveLength(1))
+    expect(result.current.history[0].insufficient).toBe(true)
+  })
+
+  it('no-ops without an editionId', async () => {
+    const { result } = renderHook(() => useAsk(undefined))
+    await act(() => result.current.ask('why?'))
+    expect(mockAsk).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/hooks/useAsk.ts
+++ b/apps/web/src/hooks/useAsk.ts
@@ -1,0 +1,53 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { ask as askApi, type AskCitation } from '../api/ask'
+import { ApiError } from '../api/client'
+
+export interface AskTurn {
+  question: string
+  answer: string
+  citations: AskCitation[]
+  insufficient: boolean
+}
+
+/**
+ * Session "Ask this book" state (AI-026a): an in-memory Q&A history (not persisted), plus loading
+ * and error. `ask` appends a turn; in-flight requests are aborted on a new question / unmount.
+ */
+export function useAsk(editionId: string | undefined) {
+  const [history, setHistory] = useState<AskTurn[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => () => abortRef.current?.abort(), [])
+
+  const ask = useCallback(
+    async (question: string) => {
+      const q = question.trim()
+      if (!q || !editionId || isLoading) return
+
+      abortRef.current?.abort()
+      const ctrl = new AbortController()
+      abortRef.current = ctrl
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const res = await askApi(editionId, q, undefined, ctrl.signal)
+        setHistory(prev => [
+          ...prev,
+          { question: q, answer: res.answer, citations: res.citations, insufficient: res.insufficient },
+        ])
+      } catch (err) {
+        if ((err as { name?: string })?.name === 'AbortError') return
+        if (err instanceof ApiError && err.status === 401) setError('auth')
+        else setError(err instanceof Error ? err.message : 'Ask failed')
+      } finally {
+        if (abortRef.current === ctrl) setIsLoading(false)
+      }
+    },
+    [editionId, isLoading],
+  )
+
+  return { history, isLoading, error, ask }
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -187,6 +187,16 @@
     "reject": "Reject analytics"
   },
   "reader": {
+    "ask": {
+      "title": "Ask this book",
+      "placeholder": "Ask a question about what you've read…",
+      "send": "Ask",
+      "thinking": "Thinking…",
+      "empty": "Ask a question about the book — answers come only from chapters you've read.",
+      "signIn": "Sign in to ask questions about this book.",
+      "signInCta": "Sign in",
+      "citation": "ch.{{ch}}"
+    },
     "wordPopup": {
       "known": "Known",
       "ignore": "Ignore",

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -19,6 +19,8 @@ import { ReaderSection } from '../components/reader/ReaderSection'
 import { ReaderNav } from '../components/reader/ReaderNav'
 import { ReaderFooterNav } from '../components/reader/ReaderFooterNav'
 import { ReaderSettingsDrawer } from '../components/reader/ReaderSettingsDrawer'
+import { AskPanel } from '../components/reader/AskPanel'
+import type { AskCitation } from '../api/ask'
 import { ReaderTocDrawer } from '../components/reader/ReaderTocDrawer'
 import { ReaderSearchDrawer } from '../components/reader/ReaderSearchDrawer'
 import { ReaderHighlights } from '../components/reader/ReaderHighlights'
@@ -65,6 +67,7 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
 
   const [tocOpen, setTocOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [askOpen, setAskOpen] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
 
   // Highlight ID from URL — scroll to this highlight after chapter loads
@@ -366,6 +369,15 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
     return `/${language}/library/my/${id}/read/${identifier}`
   }, [mode, bookSlug, id, language, getLocalizedPath])
 
+  // RAG "Ask this book" — catalog editions only (user uploads aren't chunked).
+  const askEditionId = mode === 'public' ? publicBook?.id : undefined
+  const handleNavigateToCitation = useCallback((c: AskCitation) => {
+    // Chapter-level navigation (slice 026a); exact char-offset scroll lands in 026b.
+    const target = chapterList?.find(ch => ch.chapterNumber === c.chapterOrd)
+    if (target) navigate(getChapterUrl(target.identifier))
+    setAskOpen(false)
+  }, [chapterList, getChapterUrl, navigate])
+
   // Back URL
   const backUrl = mode === 'public'
     ? `/books/${bookSlug}`
@@ -445,6 +457,8 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
         isBookmarked={isBookmarked(activeChapterIdentifier)}
         backUrl={backUrl}
         useLocalizedLink={mode === 'public'}
+        showAsk={!!askEditionId}
+        onAskClick={() => setAskOpen(true)}
         onSearchClick={() => setSearchOpen(true)}
         onTocClick={() => setTocOpen(true)}
         onSettingsClick={() => setSettingsOpen(true)}
@@ -534,6 +548,17 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
         onUpdate={update}
         onClose={() => setSettingsOpen(false)}
       />
+
+      {askEditionId && (
+        <AskPanel
+          open={askOpen}
+          editionId={askEditionId}
+          isAuthenticated={isAuthenticated}
+          onSignIn={openAuthModal}
+          onNavigateToCitation={handleNavigateToCitation}
+          onClose={() => setAskOpen(false)}
+        />
+      )}
 
       <ReaderSearchDrawer
         open={searchOpen}

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -2091,3 +2091,143 @@ html[data-theme="dark"] .vocab-translation-overlay__item {
   }
 }
 
+
+/* ── "Ask this book" panel (AI-026a) ─────────────────────────────── */
+.ask-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 380px;
+  max-width: 90vw;
+  background: var(--reader-bg);
+  color: var(--reader-text);
+  z-index: 201;
+  display: flex;
+  flex-direction: column;
+  box-shadow: -2px 0 20px rgba(0, 0, 0, 0.2);
+}
+.ask-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid var(--reader-border);
+  flex: 0 0 auto;
+}
+.ask-panel__header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+.ask-panel__close {
+  background: none;
+  border: none;
+  color: var(--reader-text);
+  padding: 4px;
+  cursor: pointer;
+}
+.ask-panel__history {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.ask-panel__empty {
+  color: var(--reader-secondary);
+  font-size: 14px;
+  margin: 0;
+}
+.ask-panel__turn {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ask-panel__question {
+  margin: 0;
+  font-weight: 600;
+  font-size: 14px;
+}
+.ask-panel__answer {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+.ask-panel__citations {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+.ask-panel__chip {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--reader-border);
+  background: var(--reader-bar-bg);
+  color: var(--reader-text);
+  cursor: pointer;
+}
+.ask-panel__chip:hover {
+  border-color: var(--reader-text);
+}
+.ask-panel__loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--reader-secondary);
+  font-size: 14px;
+}
+.ask-panel__spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--reader-border);
+  border-top-color: var(--reader-text);
+  border-radius: 50%;
+  animation: ask-spin 0.7s linear infinite;
+}
+@keyframes ask-spin {
+  to { transform: rotate(360deg); }
+}
+.ask-panel__error {
+  color: #d14343;
+  font-size: 14px;
+  margin: 0;
+}
+.ask-panel__composer {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--reader-border);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ask-panel__composer--signin {
+  align-items: flex-start;
+}
+.ask-panel__input {
+  width: 100%;
+  resize: none;
+  font: inherit;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--reader-border);
+  background: var(--reader-bg);
+  color: var(--reader-text);
+}
+.ask-panel__send {
+  align-self: flex-end;
+  padding: 8px 18px;
+  border: none;
+  border-radius: 8px;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ask-panel__send:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -423,3 +423,21 @@ export interface UserBookChapterDto {
   prev: ChapterNav | null
   next: ChapterNav | null
 }
+
+// "Ask this book" (Phase 4 RAG, AI-025/026). Mirrors backend Contracts.Books.Ask*.
+export interface AskCitation {
+  marker: number
+  chunkId: string
+  chapterId: string
+  chapterOrd: number
+  charStart: number
+  charEnd: number
+  preview: string
+}
+
+export interface AskResponse {
+  answer: string
+  citations: AskCitation[]
+  lastReadOrd: number
+  insufficient: boolean
+}


### PR DESCRIPTION
## Summary

Phase 4 **AI-026, slice 1 of 4** (web panel, chapter-level citations). Surfaces the AI-025 `POST /books/{editionId}/ask` endpoint in the web reader — ask a question, get a grounded answer with citation chips.

## Changes

- **`AskPanel`** (`components/reader/AskPanel.tsx`) — right slide-in panel (mirrors `ReaderSettingsDrawer`: backdrop + header + `useFocusTrap` + `role="dialog"`) with a **session Q&A history** (chat-style, auto-scroll, **not persisted**) and a composer (Enter to send). Reached via a new **"Ask" button in `ReaderTopBar`**, shown only for catalog editions (`editionId` present — user uploads aren't chunked). **Auth-gated**: signed-out readers see a sign-in CTA instead of the input.
- **Citations** render as `[ch.N]` chips (hover → backend text preview); clicking calls `onNavigateToCitation` → `ReaderPage` resolves `chapterOrd → slug` from the book's chapter list and navigates to that chapter. (Exact char-offset scroll is **slice 026b**.)
- **`useAsk`** hook (in-memory history, loading/error, abort on unmount) + **`api/ask.ts`** (cookie `authFetch` POST). Shared **`AskCitation`/`AskResponse`** types added to `@textstack/shared` so mobile (026c) reuses them.
- i18n keys under `reader.ask.*`; CSS `.ask-panel*` in `reader.css` (theme-variable driven).

## Slicing

This is slice 1 of 4 for AI-026: **(a) web panel + chapter-level citations** → (b) web exact-offset scroll → (c) mobile AskSheet → (d) mobile exact-offset scroll.

## Tests

- `useAsk.test.ts` — append-on-success / error / insufficient / no-edition no-op.
- `AskPanel.test.tsx` — renders, auth branching (sign-in CTA vs composer), citation-chip click → callback. **This render test caught a real bug**: the auto-scroll used `Element.scrollTo` (absent in jsdom, fragile) — switched to the robust `scrollTop` setter.
- Full web suite: **491 passed**. `pnpm -C apps/web build` (= `tsc && vite build`) clean.

## Verification

`tsc` + `vite build` + 491 unit tests green. A **live reader browser-check** (open a public book → click Ask → panel slides in → sign-in prompt when signed out; citation chip → chapter nav) is best done against a running stack — not run here (no local backend up; prod-API CORS blocks a localhost dev check). The jsdom render test exercises the mount + auth + citation paths.

## Rollback plan

Revert the commit. Additive UI behind a new button; no API/schema change (the endpoint already shipped in AI-025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)