### PR TITLE
feat(rag): scroll to cited passage on citation click (AI-026b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — web citation scroll (2026-06-10)
+
+Phase 4 **AI-026, slice 2 of 4**. Citation chips now land the reader on the cited **passage**, not just the chapter.
+
+- **`citationScroll`** (`lib/citationScroll.ts`) — clicking a citation scrolls to the cited text. The chunk offsets are into `PlainText` (which differs from the rendered HTML's DOM text), so instead of an unreliable offset→DOM mapping it **searches the DOM for a short prefix of the chunk** (`findTextMatches`, like in-book search) and centers that range; if the snippet doesn't match (spans inline markup), it **falls back to a proportional scroll** by `charStart / textLength` — exact in the common case, robust always.
+- Wired in `ReaderPage`: same-chapter citations scroll immediately; cross-chapter ones navigate and a `loading`-gated effect scrolls once the new chapter renders (after scroll-restore, so the explicit jump wins).
+- Tests: `makeSnippet` (word-boundary cut / too-short), `proportionalTop` (clamp + center), `findCitationRange` (jsdom DOM search hit / miss).
+
 ### Phase 4 RAG — web AskPanel (2026-06-10)
 
 Seventh PR of Phase 4 (playbook **AI-026**, slice 1 of 4 — web panel, chapter-level citations). Surfaces the AI-025 "Ask this book" endpoint in the web reader.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Phase 4 **AI-026, slice 2 of 4**. Citation chips now land the reader on the cite
 
 - **`citationScroll`** (`lib/citationScroll.ts`) — clicking a citation scrolls to the cited text. The chunk offsets are into `PlainText` (which differs from the rendered HTML's DOM text), so instead of an unreliable offset→DOM mapping it **searches the DOM for a short prefix of the chunk** (`findTextMatches`, like in-book search) and centers that range; if the snippet doesn't match (spans inline markup), it **falls back to a proportional scroll** by `charStart / textLength` — exact in the common case, robust always.
 - Wired in `ReaderPage`: same-chapter citations scroll immediately; cross-chapter ones navigate and a `loading`-gated effect scrolls once the new chapter renders (after scroll-restore, so the explicit jump wins).
-- Tests: `makeSnippet` (word-boundary cut / too-short), `proportionalTop` (clamp + center), `findCitationRange` (jsdom DOM search hit / miss).
+- **Flash-highlight** the landed passage briefly (CSS Custom Highlight API, no DOM mutation; graceful no-op where unsupported) so the reader sees *what* was cited.
+- Snippet search **skips reader decorations** (vocab glosses / overlays) so it anchors on the book text, not a gloss. Cross-chapter scroll fires via double-`requestAnimationFrame` (runs after scroll-restore) instead of a magic timeout.
+- Tests: `makeSnippet` (word-boundary cut / too-short), `proportionalTop` (clamp + center), `findCitationRange` (jsdom DOM search hit / miss / decoration-skip).
 
 ### Phase 4 RAG — web AskPanel (2026-06-10)
 

--- a/apps/web/src/lib/citationScroll.test.ts
+++ b/apps/web/src/lib/citationScroll.test.ts
@@ -54,4 +54,23 @@ describe('findCitationRange', () => {
     expect(findCitationRange(container, 'replication strategy')).toBeNull()
     expect(findCitationRange(container, '')).toBeNull()
   })
+
+  it('skips matches inside reader decorations (vocab glosses)', () => {
+    container = document.createElement('div')
+    container.innerHTML =
+      '<p>Intro. <span class="vocab-inline-translation">replication strategy</span> ' +
+      'and then the real replication strategy in the prose.</p>'
+    document.body.appendChild(container)
+
+    const range = findCitationRange(container, 'replication strategy')
+    expect(range).not.toBeNull()
+    // The returned match must NOT be the one inside the gloss span.
+    let el: Element | null = range!.startContainer.parentElement
+    let insideGloss = false
+    while (el) {
+      if (el.classList?.contains('vocab-inline-translation')) insideGloss = true
+      el = el.parentElement
+    }
+    expect(insideGloss).toBe(false)
+  })
 })

--- a/apps/web/src/lib/citationScroll.test.ts
+++ b/apps/web/src/lib/citationScroll.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { makeSnippet, proportionalTop, findCitationRange } from './citationScroll'
+
+describe('makeSnippet', () => {
+  it('returns the whole string when short enough (and collapses whitespace)', () => {
+    expect(makeSnippet('  the   quick brown  ')).toBe('the quick brown')
+  })
+
+  it('cuts a long preview at a word boundary', () => {
+    const s = makeSnippet('Replication keeps a copy of the same data on multiple machines for fault tolerance')
+    expect(s.length).toBeLessThanOrEqual(40)
+    expect(s).not.toMatch(/\s$/)
+    expect('Replication keeps a copy of the same data on multiple machines for fault tolerance').toContain(s)
+  })
+
+  it('returns empty for too-short input', () => {
+    expect(makeSnippet('short')).toBe('')
+    expect(makeSnippet('   ')).toBe('')
+  })
+})
+
+describe('proportionalTop', () => {
+  it('clamps the fraction to [0,1] and centers in the viewport', () => {
+    // frac = 50/100 = 0.5 → 0 + 1000*0.5 - 600/2 = 200
+    expect(proportionalTop(50, 100, 0, 1000, 600)).toBe(200)
+  })
+
+  it('clamps an over-range offset and never goes negative', () => {
+    expect(proportionalTop(999, 100, 0, 1000, 600)).toBe(700) // frac clamped to 1
+    expect(proportionalTop(0, 100, 0, 200, 600)).toBe(0) // would be -300 → clamped to 0
+  })
+})
+
+describe('findCitationRange', () => {
+  let container: HTMLElement
+
+  afterEach(() => container?.remove())
+
+  it('returns a Range for a snippet present in the DOM', () => {
+    container = document.createElement('div')
+    container.innerHTML = '<p>The replication strategy keeps copies on many machines.</p>'
+    document.body.appendChild(container)
+
+    const range = findCitationRange(container, 'replication strategy')
+    expect(range).not.toBeNull()
+    expect(range!.toString().toLowerCase()).toContain('replication strategy')
+  })
+
+  it('returns null when the snippet is absent or empty', () => {
+    container = document.createElement('div')
+    container.innerHTML = '<p>Nothing relevant here.</p>'
+    document.body.appendChild(container)
+
+    expect(findCitationRange(container, 'replication strategy')).toBeNull()
+    expect(findCitationRange(container, '')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/citationScroll.ts
+++ b/apps/web/src/lib/citationScroll.ts
@@ -19,10 +19,25 @@ export function makeSnippet(preview: string): string {
   return lastSpace >= SNIPPET_MIN ? cut.slice(0, lastSpace) : cut
 }
 
-/** First DOM Range matching the snippet within the container, or null. */
+/** True if the node sits inside a reader decoration (vocab gloss / overlay), not the book text. */
+function isInsideDecoration(node: Node): boolean {
+  let el: Element | null = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement
+  while (el) {
+    if (el.classList?.contains('vocab-inline-translation') || el.hasAttribute('data-vocab-overlay')) return true
+    el = el.parentElement
+  }
+  return false
+}
+
+/**
+ * First DOM Range matching the snippet within the container, skipping matches that land inside
+ * reader decorations (vocab glosses / overlays) so we anchor on the actual book text. Null if none.
+ */
 export function findCitationRange(container: HTMLElement, snippet: string): Range | null {
   if (!snippet) return null
-  for (const range of findTextMatches(container, snippet)) return range
+  for (const range of findTextMatches(container, snippet)) {
+    if (!isInsideDecoration(range.startContainer)) return range
+  }
   return null
 }
 
@@ -52,6 +67,30 @@ function scrollRangeToCenter(range: Range): void {
   window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' })
 }
 
+const HIGHLIGHT_NAME = 'rag-citation'
+const HIGHLIGHT_MS = 2400
+let flashTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Briefly tint the cited passage so the reader can see what was cited, then fade. Uses the CSS
+ * Custom Highlight API (no DOM mutation); a graceful no-op where it isn't supported.
+ */
+function flashHighlight(range: Range): void {
+  const cssApi = (globalThis as { CSS?: { highlights?: Map<string, unknown> } }).CSS
+  const HighlightCtor = (globalThis as { Highlight?: new (r: Range) => unknown }).Highlight
+  if (!cssApi?.highlights || !HighlightCtor) return
+  try {
+    cssApi.highlights.set(HIGHLIGHT_NAME, new HighlightCtor(range))
+    if (flashTimer) clearTimeout(flashTimer)
+    flashTimer = setTimeout(() => {
+      cssApi.highlights?.delete(HIGHLIGHT_NAME)
+      flashTimer = null
+    }, HIGHLIGHT_MS)
+  } catch {
+    // Range detached or API quirk — highlighting is best-effort.
+  }
+}
+
 /**
  * Scroll the reader to a citation: snippet-search the rendered DOM (exact when matched), else a
  * proportional scroll by the PlainText offset (lands in the right region).
@@ -60,8 +99,11 @@ export function scrollToCitation(container: HTMLElement, citation: AskCitation):
   const range = findCitationRange(container, makeSnippet(citation.preview))
   if (range) {
     scrollRangeToCenter(range)
+    flashHighlight(range)
     return
   }
+  // Fallback: no exact match (snippet spans markup) — scroll to the offset's region. textLength
+  // includes any overlay text, a small inflation that's immaterial for an approximate landing.
   const articleTop = container.getBoundingClientRect().top + window.scrollY
   const top = proportionalTop(
     citation.charStart,

--- a/apps/web/src/lib/citationScroll.ts
+++ b/apps/web/src/lib/citationScroll.ts
@@ -1,0 +1,74 @@
+import { findTextMatches } from '@textstack/reader-overlay'
+import type { AskCitation } from '../api/ask'
+
+const SNIPPET_MAX = 40
+const SNIPPET_MIN = 12
+
+/**
+ * A short, distinctive prefix of a citation's preview, cut at a word boundary. Kept short so it's
+ * likely to sit within a single DOM text node — `findTextMatches` matches within one node, and the
+ * RAG offsets are into PlainText (not the rendered DOM), so we locate by text, not by offset.
+ * Returns '' when there isn't enough to be distinctive.
+ */
+export function makeSnippet(preview: string): string {
+  const text = preview.replace(/\s+/g, ' ').trim()
+  if (text.length < SNIPPET_MIN) return ''
+  if (text.length <= SNIPPET_MAX) return text
+  const cut = text.slice(0, SNIPPET_MAX)
+  const lastSpace = cut.lastIndexOf(' ')
+  return lastSpace >= SNIPPET_MIN ? cut.slice(0, lastSpace) : cut
+}
+
+/** First DOM Range matching the snippet within the container, or null. */
+export function findCitationRange(container: HTMLElement, snippet: string): Range | null {
+  if (!snippet) return null
+  for (const range of findTextMatches(container, snippet)) return range
+  return null
+}
+
+function clamp01(x: number): number {
+  return Math.min(1, Math.max(0, x))
+}
+
+/**
+ * Document-Y target for the proportional fallback: position within the article by char fraction,
+ * centered in the viewport. Pure — geometry is passed in.
+ */
+export function proportionalTop(
+  charStart: number,
+  textLength: number,
+  articleTop: number,
+  articleHeight: number,
+  viewportH: number,
+): number {
+  const frac = clamp01(charStart / Math.max(1, textLength))
+  return Math.max(0, articleTop + articleHeight * frac - viewportH / 2)
+}
+
+function scrollRangeToCenter(range: Range): void {
+  const rect = range.getBoundingClientRect()
+  if (rect.width === 0 && rect.height === 0) return
+  const top = window.scrollY + rect.top - window.innerHeight / 2 + rect.height / 2
+  window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' })
+}
+
+/**
+ * Scroll the reader to a citation: snippet-search the rendered DOM (exact when matched), else a
+ * proportional scroll by the PlainText offset (lands in the right region).
+ */
+export function scrollToCitation(container: HTMLElement, citation: AskCitation): void {
+  const range = findCitationRange(container, makeSnippet(citation.preview))
+  if (range) {
+    scrollRangeToCenter(range)
+    return
+  }
+  const articleTop = container.getBoundingClientRect().top + window.scrollY
+  const top = proportionalTop(
+    citation.charStart,
+    container.textContent?.length ?? 0,
+    articleTop,
+    container.offsetHeight,
+    window.innerHeight,
+  )
+  window.scrollTo({ top, behavior: 'smooth' })
+}

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -21,6 +21,7 @@ import { ReaderFooterNav } from '../components/reader/ReaderFooterNav'
 import { ReaderSettingsDrawer } from '../components/reader/ReaderSettingsDrawer'
 import { AskPanel } from '../components/reader/AskPanel'
 import type { AskCitation } from '../api/ask'
+import { scrollToCitation } from '../lib/citationScroll'
 import { ReaderTocDrawer } from '../components/reader/ReaderTocDrawer'
 import { ReaderSearchDrawer } from '../components/reader/ReaderSearchDrawer'
 import { ReaderHighlights } from '../components/reader/ReaderHighlights'
@@ -371,12 +372,33 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
 
   // RAG "Ask this book" — catalog editions only (user uploads aren't chunked).
   const askEditionId = mode === 'public' ? publicBook?.id : undefined
+  const pendingCitationRef = useRef<AskCitation | null>(null)
   const handleNavigateToCitation = useCallback((c: AskCitation) => {
-    // Chapter-level navigation (slice 026a); exact char-offset scroll lands in 026b.
     const target = chapterList?.find(ch => ch.chapterNumber === c.chapterOrd)
-    if (target) navigate(getChapterUrl(target.identifier))
     setAskOpen(false)
-  }, [chapterList, getChapterUrl, navigate])
+    if (!target) return
+    if (target.identifier === activeChapterIdentifier && scrollContainerRef.current) {
+      // Already on the cited chapter — scroll to the passage now (026b).
+      scrollToCitation(scrollContainerRef.current, c)
+    } else {
+      // Different chapter: navigate, then the effect below scrolls once it renders.
+      pendingCitationRef.current = c
+      navigate(getChapterUrl(target.identifier))
+    }
+  }, [chapterList, activeChapterIdentifier, getChapterUrl, navigate])
+
+  // Consume a pending citation once its chapter has navigated in and rendered. Runs after
+  // scroll-restore (slight delay) so an explicit citation jump wins over position restore.
+  useEffect(() => {
+    const pending = pendingCitationRef.current
+    if (!pending || loading) return
+    const target = chapterList?.find(ch => ch.chapterNumber === pending.chapterOrd)
+    const container = scrollContainerRef.current
+    if (!target || target.identifier !== activeChapterIdentifier || !container) return
+    pendingCitationRef.current = null
+    const timer = setTimeout(() => scrollToCitation(container, pending), 100)
+    return () => clearTimeout(timer)
+  }, [activeChapterIdentifier, loading, chapterList])
 
   // Back URL
   const backUrl = mode === 'public'

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -396,8 +396,16 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
     const container = scrollContainerRef.current
     if (!target || target.identifier !== activeChapterIdentifier || !container) return
     pendingCitationRef.current = null
-    const timer = setTimeout(() => scrollToCitation(container, pending), 100)
-    return () => clearTimeout(timer)
+    // Double rAF: runs a frame after scroll-restore's single rAF, so the explicit citation jump
+    // wins without racing on a magic timeout.
+    let inner = 0
+    const outer = requestAnimationFrame(() => {
+      inner = requestAnimationFrame(() => scrollToCitation(container, pending))
+    })
+    return () => {
+      cancelAnimationFrame(outer)
+      cancelAnimationFrame(inner)
+    }
   }, [activeChapterIdentifier, loading, chapterList])
 
   // Back URL

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -2231,3 +2231,9 @@ html[data-theme="dark"] .vocab-translation-overlay__item {
   opacity: 0.5;
   cursor: default;
 }
+
+/* Cited-passage flash (AI-026b) — CSS Custom Highlight API, fades via the timer in citationScroll. */
+::highlight(rag-citation) {
+  background-color: rgba(37, 99, 235, 0.25);
+  border-radius: 2px;
+}


### PR DESCRIPTION
## Summary

Phase 4 **AI-026, slice 2 of 4**. Citation chips now land the reader on the cited **passage** within the chapter (026a got you to the chapter top).

## The constraint (why not a raw offset → DOM position)

`chapter_chunk.char_start/end` are offsets into `Chapter.PlainText` (backend strips tags→spaces + collapses whitespace), but the reader renders `Chapter.Html`. The DOM's text is **not** char-aligned to PlainText — a raw offset→DOM lands hundreds of chars off. So:

## Approach — snippet-search first, proportional fallback

- **`citationScroll.ts`**: `scrollToCitation(container, citation)` searches the rendered DOM for a **short prefix of the chunk** (`makeSnippet` → `findTextMatches`, the same machinery as in-book search — immune to offset drift) and centers that `Range`. If the snippet doesn't match (it spans inline markup / whitespace differs), it **falls back to a proportional scroll** by `charStart / textLength`. Exact in the common case, robust always.
- **`ReaderPage`** wiring: same-chapter citations scroll immediately; cross-chapter ones navigate, then a `loading`-gated effect scrolls once the new chapter's HTML is in the DOM — fired after scroll-restore (100 ms) so the explicit citation jump wins over position restore.

## Tests

- `citationScroll.test.ts` — `makeSnippet` (word-boundary cut, too-short → ''), `proportionalTop` (clamp `charStart/len` to [0,1], center), `findCitationRange` (jsdom DOM search: hit returns a Range, miss/empty → null).
- Full web suite: **498 passed**. `tsc` + `vite build` clean.

## Slicing

AI-026: (a) web panel ✅ → **(b) web exact-offset scroll** (this) → (c) mobile sheet → (d) mobile offset scroll.

## Verification

`tsc` + build + 498 unit tests green (incl. the jsdom DOM-search, the riskiest bit). A **live reader browser-check** (ask → click a same-chapter chip scrolls to the passage; a cross-chapter chip navigates then scrolls; a heavily-marked-up passage uses the proportional fallback) needs a running stack — not run here (no local backend; prod-API CORS blocks a localhost dev check).

## Rollback plan

Revert the commit. Pure additive UI behavior on citation click; no API/schema change.

## Notes

- `findTextMatches` matches within a single text node — that's why the snippet is short; the full preview is never passed.
- Snippet match-rate and cross-chapter timing are the real risks, both mitigated (proportional fallback + `loading` render gate). Match-rate can be tuned later if the 026 eval shows misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)