### PR TITLE
feat(rag): mobile scroll to cited passage (AI-026d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — mobile citation scroll (2026-06-11)
+
+Phase 4 **AI-026, slice 4 of 4** — completes "Ask this book" (web + mobile, panel + exact scroll). Mobile citation chips now land on the cited **passage**, not just the chapter.
+
+- **In-WebView `window.__textstackScrollToCitation(snippet, charStart)`** (`apps/mobile/src/lib/readerHtml.ts`) — same strategy as web (the chunk offsets are into PlainText, not the rendered DOM): a self-contained `TreeWalker` search for a short snippet of the chunk (skipping vocab/overlay decorations) → `scrollTo` centered + a brief flash via the CSS Custom Highlight API; else a proportional scroll by `charStart / textLength`.
+- **`ReaderShell`** orchestrates: same-chapter citations inject the scroll immediately; cross-chapter ones navigate, then `onLoadEnd` injects the scroll once the new chapter renders (after scroll-restore). `AskSheet` now hands the citation up (`onCitation`) and `ReaderShell` owns the slug/snippet resolution.
+- **`makeSnippet` moved to `@textstack/shared`** (used by web + mobile; web's `citationScroll` imports it). Tests moved with it.
+- Verified: shared unit tests (incl. `makeSnippet`), mobile `tsc`, web `tsc`/build/tests.
+
 ### Phase 4 RAG — mobile AskSheet (2026-06-10)
 
 Phase 4 **AI-026, slice 3 of 4**. "Ask this book" comes to the **mobile** reader (React Native).

--- a/apps/mobile/src/components/AskSheet.tsx
+++ b/apps/mobile/src/components/AskSheet.tsx
@@ -3,7 +3,7 @@ import {
   View, Text, Modal, TouchableOpacity, TextInput, StyleSheet, ActivityIndicator, ScrollView,
 } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
-import { ragApi, citationChapterSlug, type AskCitation } from '@textstack/shared'
+import { ragApi, type AskCitation } from '@textstack/shared'
 import { useTheme } from '../context/ThemeContext'
 import { useLanguage } from '../context/LanguageContext'
 import { fonts } from '../theme/typography'
@@ -18,15 +18,14 @@ interface AskTurn {
 interface AskSheetProps {
   visible: boolean
   editionId?: string
-  chapters: { slug: string; chapterNumber?: number }[]
   isAuthenticated: boolean
-  onNavigateChapter: (slug: string) => void
+  onCitation: (citation: AskCitation) => void
   onSignIn: () => void
   onClose: () => void
 }
 
 export function AskSheet({
-  visible, editionId, chapters, isAuthenticated, onNavigateChapter, onSignIn, onClose,
+  visible, editionId, isAuthenticated, onCitation, onSignIn, onClose,
 }: AskSheetProps) {
   const { colors } = useTheme()
   const { t } = useLanguage()
@@ -62,12 +61,9 @@ export function AskSheet({
     }
   }, [input, editionId, loading])
 
-  const onCitation = (c: AskCitation) => {
-    const slug = citationChapterSlug(chapters, c.chapterOrd)
-    if (slug) {
-      onNavigateChapter(slug)
-      onClose()
-    }
+  const onCitationTap = (c: AskCitation) => {
+    onCitation(c)
+    onClose()
   }
 
   return (
@@ -97,7 +93,7 @@ export function AskSheet({
                     {turn.citations.map(c => (
                       <TouchableOpacity
                         key={c.chunkId}
-                        onPress={() => onCitation(c)}
+                        onPress={() => onCitationTap(c)}
                         style={[styles.chip, { borderColor: colors.border }]}
                         accessibilityRole="button"
                       >

--- a/apps/mobile/src/components/reader/ReaderShell.tsx
+++ b/apps/mobile/src/components/reader/ReaderShell.tsx
@@ -3,8 +3,8 @@ import type { MutableRefObject, RefObject } from 'react'
 import { View, Text, StyleSheet, TouchableOpacity, Animated, Linking } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { useRouter, Stack } from 'expo-router'
-import { t, computeBookProgress } from '@textstack/shared'
-import type { Chapter, BookmarkDto } from '@textstack/shared'
+import { t, computeBookProgress, citationChapterSlug, makeSnippet } from '@textstack/shared'
+import type { Chapter, BookmarkDto, AskCitation } from '@textstack/shared'
 import { buildReaderHtml } from '../../lib/readerHtml'
 import { useAuth } from '../../context/AuthContext'
 import { useReaderSettings } from '../../hooks/useReaderSettings'
@@ -322,7 +322,24 @@ export function ReaderShell(props: ReaderShellProps) {
     onNavigateChapter(slug)
   }
 
+  // RAG citation (AI-026d): scroll the WebView to the cited passage.
+  const pendingCitationRef = useRef<{ slug: string; snippet: string; charStart: number } | null>(null)
+  const scrollToCitation = (snippet: string, charStart: number) =>
+    injectJs(`window.__textstackScrollToCitation && window.__textstackScrollToCitation(${JSON.stringify(snippet)}, ${charStart})`)
+
   const activeSlug = visibleChapterSlug ?? chapterSlug
+  // Same chapter → scroll now; other chapter → navigate, then onLoadEnd injects once it renders.
+  const handleCitation = (c: AskCitation) => {
+    const slug = citationChapterSlug(chapters, c.chapterOrd)
+    if (!slug) return
+    const snippet = makeSnippet(c.preview)
+    if (slug === activeSlug) {
+      scrollToCitation(snippet, c.charStart)
+    } else {
+      pendingCitationRef.current = { slug, snippet, charStart: c.charStart }
+      navigateChapter(slug)
+    }
+  }
   const activeChapter = chapters.find(c => c.slug === activeSlug)
   const isCurrentBookmarked = bookmarks.some(b => bookmarkChapterSlug(b) === activeSlug)
   const isMultiWord = !!(selection && selection.mode === 'drag' && selection.text.includes(' '))
@@ -396,6 +413,13 @@ export function ReaderShell(props: ReaderShellProps) {
             // Scroll-restore is owned by useReaderPersistence — it coordinates
             // this signal with the async saved-position fetch (no race).
             onWebViewLoaded()
+            // A cross-chapter citation jump (AI-026d): once the cited chapter has rendered, scroll
+            // to the passage — after restore (delay) so the explicit jump wins.
+            const pc = pendingCitationRef.current
+            if (pc && pc.slug === activeSlug) {
+              pendingCitationRef.current = null
+              setTimeout(() => scrollToCitation(pc.snippet, pc.charStart), 120)
+            }
           }}
           originWhitelist={['*']}
           scrollEnabled
@@ -554,9 +578,8 @@ export function ReaderShell(props: ReaderShellProps) {
           <AskSheet
             visible={askOpen}
             editionId={explainBookId}
-            chapters={chapters}
             isAuthenticated={isAuthenticated}
-            onNavigateChapter={navigateChapter}
+            onCitation={handleCitation}
             onSignIn={() => { setAskOpen(false); router.push('/(auth)/login') }}
             onClose={() => setAskOpen(false)}
           />

--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -142,6 +142,7 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
     ::highlight(vocab-context) { text-decoration: underline; text-decoration-thickness: 2px; text-decoration-skip-ink: all; text-underline-offset: 0.18em; text-decoration-color: rgba(34,197,94,0.4); }
     ::highlight(vocab-mastered) { text-decoration: underline; text-decoration-thickness: 2px; text-decoration-skip-ink: all; text-underline-offset: 0.18em; text-decoration-color: rgba(34,197,94,0.25); }
     ::highlight(vocab-active) { text-decoration: underline; text-decoration-thickness: 2px; text-decoration-skip-ink: all; text-underline-offset: 0.18em; text-decoration-color: rgba(59,130,246,0.7); }
+    ::highlight(rag-citation) { background-color: rgba(37,99,235,0.25); border-radius: 2px; }
 
     .vocab-translation-overlay { position: absolute; top: 0; left: 0; width: 0; height: 0; pointer-events: none; z-index: 1; }
     .vocab-translation-overlay__item { position: absolute; top: 0; left: 0; transform: translate3d(0,0,0); white-space: nowrap; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif; font-size: 0.42em; font-style: italic; font-weight: 400; letter-spacing: 0.015em; color: #6b6b6b; opacity: 0.85; line-height: 1; pointer-events: none; user-select: none; max-width: 160px; overflow: hidden; text-overflow: ellipsis; will-change: transform; }
@@ -219,6 +220,45 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
         requestAnimationFrame(function() {
           window.scrollTo(0, target);
         });
+      } catch (e) {}
+    };
+
+    // Scroll to a RAG citation (AI-026d): find a short snippet of the chunk in the rendered text
+    // (offsets are into PlainText, not this DOM, so we locate by text) and center it; else scroll
+    // proportionally by the char offset. Mirror of the web citationScroll strategy, in-WebView.
+    window.__textstackScrollToCitation = function(snippet, charStart) {
+      try {
+        var range = null;
+        if (snippet) {
+          var needle = String(snippet).toLowerCase();
+          var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+          var node;
+          while ((node = walker.nextNode())) {
+            var p = node.parentElement, skip = false;
+            while (p) {
+              if (p.classList && (p.classList.contains('vocab-inline-translation') || p.hasAttribute('data-vocab-overlay'))) { skip = true; break; }
+              p = p.parentElement;
+            }
+            if (skip) continue;
+            var idx = (node.nodeValue || '').toLowerCase().indexOf(needle);
+            if (idx >= 0) { range = document.createRange(); range.setStart(node, idx); range.setEnd(node, idx + needle.length); break; }
+          }
+        }
+        if (range) {
+          var rect = range.getBoundingClientRect();
+          var top = window.scrollY + rect.top - window.innerHeight / 2 + rect.height / 2;
+          window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+          if (window.Highlight && window.CSS && CSS.highlights) {
+            try {
+              CSS.highlights.set('rag-citation', new Highlight(range));
+              setTimeout(function() { CSS.highlights.delete('rag-citation'); }, 2400);
+            } catch (e) {}
+          }
+          return;
+        }
+        var len = (document.body.textContent || '').length || 1;
+        var frac = Math.min(1, Math.max(0, (Number(charStart) || 0) / len));
+        window.scrollTo({ top: Math.round(document.documentElement.scrollHeight * frac), behavior: 'smooth' });
       } catch (e) {}
     };
 

--- a/apps/web/src/lib/citationScroll.test.ts
+++ b/apps/web/src/lib/citationScroll.test.ts
@@ -1,23 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { makeSnippet, proportionalTop, findCitationRange } from './citationScroll'
-
-describe('makeSnippet', () => {
-  it('returns the whole string when short enough (and collapses whitespace)', () => {
-    expect(makeSnippet('  the   quick brown  ')).toBe('the quick brown')
-  })
-
-  it('cuts a long preview at a word boundary', () => {
-    const s = makeSnippet('Replication keeps a copy of the same data on multiple machines for fault tolerance')
-    expect(s.length).toBeLessThanOrEqual(40)
-    expect(s).not.toMatch(/\s$/)
-    expect('Replication keeps a copy of the same data on multiple machines for fault tolerance').toContain(s)
-  })
-
-  it('returns empty for too-short input', () => {
-    expect(makeSnippet('short')).toBe('')
-    expect(makeSnippet('   ')).toBe('')
-  })
-})
+import { proportionalTop, findCitationRange } from './citationScroll'
+// makeSnippet now lives in @textstack/shared (used by web + mobile); tested there.
 
 describe('proportionalTop', () => {
   it('clamps the fraction to [0,1] and centers in the viewport', () => {

--- a/apps/web/src/lib/citationScroll.ts
+++ b/apps/web/src/lib/citationScroll.ts
@@ -1,23 +1,8 @@
 import { findTextMatches } from '@textstack/reader-overlay'
+import { makeSnippet } from '@textstack/shared'
 import type { AskCitation } from '../api/ask'
 
-const SNIPPET_MAX = 40
-const SNIPPET_MIN = 12
-
-/**
- * A short, distinctive prefix of a citation's preview, cut at a word boundary. Kept short so it's
- * likely to sit within a single DOM text node — `findTextMatches` matches within one node, and the
- * RAG offsets are into PlainText (not the rendered DOM), so we locate by text, not by offset.
- * Returns '' when there isn't enough to be distinctive.
- */
-export function makeSnippet(preview: string): string {
-  const text = preview.replace(/\s+/g, ' ').trim()
-  if (text.length < SNIPPET_MIN) return ''
-  if (text.length <= SNIPPET_MAX) return text
-  const cut = text.slice(0, SNIPPET_MAX)
-  const lastSpace = cut.lastIndexOf(' ')
-  return lastSpace >= SNIPPET_MIN ? cut.slice(0, lastSpace) : cut
-}
+export { makeSnippet }
 
 /** True if the node sits inside a reader decoration (vocab gloss / overlay), not the book text. */
 function isInsideDecoration(node: Node): boolean {

--- a/packages/shared/src/reader/citation.test.ts
+++ b/packages/shared/src/reader/citation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { citationChapterSlug } from './citation'
+import { citationChapterSlug, makeSnippet } from './citation'
 
 const chapters = [
   { chapterNumber: 1, slug: 'intro' },
@@ -15,5 +15,24 @@ describe('citationChapterSlug', () => {
   it('returns undefined when no chapter matches', () => {
     expect(citationChapterSlug(chapters, 99)).toBeUndefined()
     expect(citationChapterSlug([], 1)).toBeUndefined()
+  })
+})
+
+describe('makeSnippet', () => {
+  it('returns the whole string when short enough (and collapses whitespace)', () => {
+    expect(makeSnippet('  the   quick brown  ')).toBe('the quick brown')
+  })
+
+  it('cuts a long preview at a word boundary', () => {
+    const long = 'Replication keeps a copy of the same data on multiple machines for fault tolerance'
+    const s = makeSnippet(long)
+    expect(s.length).toBeLessThanOrEqual(40)
+    expect(s).not.toMatch(/\s$/)
+    expect(long).toContain(s)
+  })
+
+  it('returns empty for too-short input', () => {
+    expect(makeSnippet('short')).toBe('')
+    expect(makeSnippet('   ')).toBe('')
   })
 })

--- a/packages/shared/src/reader/citation.ts
+++ b/packages/shared/src/reader/citation.ts
@@ -8,3 +8,21 @@ export function citationChapterSlug(
 ): string | undefined {
   return chapters.find(c => c.chapterNumber === chapterOrd)?.slug
 }
+
+const SNIPPET_MAX = 40
+const SNIPPET_MIN = 12
+
+/**
+ * A short, distinctive prefix of a citation's preview, cut at a word boundary. Kept short so it's
+ * likely to sit within a single DOM text node — citation scroll locates the passage by searching the
+ * rendered text for this snippet (the chunk offsets are into PlainText, not the rendered DOM). Both
+ * web (AI-026b) and the mobile WebView (AI-026d) use it. Returns '' when there isn't enough to match on.
+ */
+export function makeSnippet(preview: string): string {
+  const text = preview.replace(/\s+/g, ' ').trim()
+  if (text.length < SNIPPET_MIN) return ''
+  if (text.length <= SNIPPET_MAX) return text
+  const cut = text.slice(0, SNIPPET_MAX)
+  const lastSpace = cut.lastIndexOf(' ')
+  return lastSpace >= SNIPPET_MIN ? cut.slice(0, lastSpace) : cut
+}


### PR DESCRIPTION
## Summary

Phase 4 **AI-026, slice 4 of 4** — **completes "Ask this book"** (web + mobile, panel + exact scroll). Mobile citation chips now land on the cited **passage**, not just the chapter (the mobile counterpart of 026b).

## Approach

The chunk offsets are into `PlainText` (≠ the rendered DOM), so — same as web — we locate by **text, not offset**, but it runs as **JS injected into the native WebView** (`textWalker`/`findTextMatches` aren't bundled there):

- **`window.__textstackScrollToCitation(snippet, charStart)`** added to the WebView bootstrap (`readerHtml.ts`, next to `__textstackRestoreScroll`): a self-contained `TreeWalker` snippet search (skipping `.vocab-inline-translation` / `[data-vocab-overlay]`) → build a `Range` → `scrollTo` centered + a brief flash via the CSS Custom Highlight API (already used in the WebView for vocab); else a **proportional** scroll by `charStart / textLength`.
- **`ReaderShell`** orchestrates: same-chapter citations inject the scroll immediately; cross-chapter ones navigate, then `onLoadEnd` (after `onWebViewLoaded()` / scroll-restore) injects the scroll once the new chapter renders. `AskSheet` now hands the citation up via `onCitation` and `ReaderShell` owns slug+snippet resolution.
- **`makeSnippet` moved to `@textstack/shared`** (`reader/citation.ts`) so web (026b) and mobile share one implementation; web's `citationScroll` imports it; the tests moved too.

## Slicing — AI-026 complete

(a) web panel ✅ → (b) web exact-scroll ✅ → (c) mobile sheet ✅ → **(d) mobile exact-scroll** (this). "Ask this book" is now live on both platforms end to end.

## Tests / verification

- Shared unit tests **149 passed** (incl. moved `makeSnippet`).
- `cd apps/mobile && npx tsc --noEmit` — clean.
- Web unaffected: `tsc` clean, `vite build` clean, **496 tests** (3 `makeSnippet` tests moved to shared).
- Device check (tap a current-chapter chip → WebView scrolls to the passage + flash; cross-chapter → navigate then scroll; marked-up passage → proportional fallback) needs an emulator + stack — not run here.

## Rollback plan

Revert the commit. Additive: a new in-WebView function + citation orchestration; no schema/API change.

## Notes

- **Cross-chapter remount:** if `router.replace` re-mounts `ReaderShell`, `pendingCitationRef` is lost and the cross-chapter scroll degrades to chapter-level (still navigates). Expo Router usually keeps the screen mounted on a param change — verify on device; harden with a URL param only if needed.
- **Fire-and-forget injection** — no found/not-found ack; the in-WebView fn silently falls back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)