### PR TITLE
feat(rag): citation-correctness judge — Phase 4 complete (AI-027b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 4 RAG — citation-correctness judge — Phase 4 complete (2026-06-11)
+
+Phase 4 **AI-027, slice 2 of 2** — the last DoD metric: cited excerpts actually support the claim (LLM-as-judge ≥0.9). **This closes Phase 4** ("Ask this book" is complete end to end: hybrid retrieval → spoiler-safe answer with citations → reader scroll → eval gate).
+
+- **`RagAskService` → `IRagAskService`** + extracted `AskFromChunksAsync` — generates the grounded, cited answer from an already-retrieved chunk set (no reading user), so the eval drives the **real production prompt + citation parsing** rather than a reimplementation. `AskAsync` now delegates to it.
+- **`RagEvalRunner` citation phase** — per retrieval golden: generate an answer over its chunks, then judge **each citation against the full text of its cited excerpt** (answer + excerpt as evidence) with the same MEAI `RubricEvaluator` the rest of the suite uses. Rubric axes: support / relevance / faithfulness. Reports the 1–5 mean and the **support rate** (citations scored ≥4 on support = the DoD ≥0.9 metric); persists a `rag.citation` `EvalRun`.
+- **Judge selection** — `POST /admin/rag/{id}/eval?judge=openai|ollama|none`. Default **openai** (the stronger `Eval:JudgeModel`, independent of the nano generator → no self-judging bias); `ollama` free; `none` keeps the run retrieval-only.
+- Tests: `RagEvalRunner` with a fake `IRagAskService` + fixed judge — full support (D1=5 → support rate 1.0) and a failing support axis (D1=2 → support rate 0.0); retrieval-only path still returns a null citation summary. Retrieval/spoiler tests updated for the new signature.
+
 ### Phase 4 RAG — retrieval eval + golden set (2026-06-11)
 
 Phase 4 **AI-027, slice 1 of 2** — the deterministic half of the DoD gate: retrieval quality (recall@8) and spoiler-safety (leak rate), scored with no LLM so the math is CI-tested. Citation-correctness (LLM judge) is 027b, which closes the phase.

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/RagEvalRunner.cs
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/RagEvalRunner.cs
@@ -196,15 +196,15 @@ public sealed class RagEvalRunner(ILogger<RagEvalRunner> logger)
 
     private static EvalRun MakeRun(
         string feature, string modelId, string judgeModelId, decimal score, int n, string? gitSha, string breakdown) => new()
-    {
-        Id = Guid.NewGuid(),
-        Feature = feature,
-        ModelId = modelId,
-        JudgeModelId = judgeModelId,
-        Score = Math.Round(score, 3),
-        N = n,
-        BreakdownJson = breakdown,
-        GitSha = gitSha,
-        CreatedAt = DateTimeOffset.UtcNow,
-    };
+        {
+            Id = Guid.NewGuid(),
+            Feature = feature,
+            ModelId = modelId,
+            JudgeModelId = judgeModelId,
+            Score = Math.Round(score, 3),
+            N = n,
+            BreakdownJson = breakdown,
+            GitSha = gitSha,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
 }

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/RagEvalRunner.cs
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/RagEvalRunner.cs
@@ -1,6 +1,12 @@
 using Application.Common.Interfaces;
+using Application.Rag;
 using Domain.Entities;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
 using Microsoft.Extensions.Logging;
+using TextStack.Ai.Core;
+using TextStack.Ai.Evals;
+using TextStack.Ai.Llm;
 using TextStack.Ai.Rag;
 
 namespace TextStack.Ai.EvalSuite;
@@ -12,8 +18,14 @@ public sealed record RagRecallCase(string Question, int ExpectedChapterOrd, bool
 public sealed record RagSpoilerCase(string Question, int GateChapterOrd, int LeakCount);
 
 /// <summary>
-/// Result of a RAG retrieval eval (AI-027a): recall@k over the retrieval goldens and the spoiler-leak
-/// rate over the adversarial set, plus per-case detail. Citation-correctness (LLM judge) is AI-027b.
+/// Citation-correctness summary (AI-027b): the 1–5 judge mean over every cited excerpt plus the
+/// support rate (fraction of citations the judge scored ≥4 on the "support" axis — the DoD ≥0.9 metric).
+/// </summary>
+public sealed record RagCitationSummary(double Score, double SupportRate, int CitationsJudged, int AnswersGenerated);
+
+/// <summary>
+/// Result of a RAG eval (AI-027): recall@k + spoiler-leak over the goldens, and — when a judge is
+/// supplied (AI-027b) — citation correctness. <see cref="Citation"/> is null for a retrieval-only run.
 /// </summary>
 public sealed record RagEvalResult(
     double Recall,
@@ -21,23 +33,39 @@ public sealed record RagEvalResult(
     double SpoilerLeakRate,
     int SpoilerN,
     IReadOnlyList<RagRecallCase> RecallCases,
-    IReadOnlyList<RagSpoilerCase> SpoilerCases);
+    IReadOnlyList<RagSpoilerCase> SpoilerCases,
+    RagCitationSummary? Citation);
 
 /// <summary>
-/// Runs the deterministic half of the Phase 4 RAG eval against a real edition (AI-027a): it drives the
+/// Runs the Phase 4 RAG eval against a real edition (AI-027). The deterministic half (027a) drives the
 /// production <see cref="IRagService"/> (hybrid retrieval, AI-023) over the embedded golden sets and
-/// scores the results with the pure <see cref="RetrievalMetrics"/> — no LLM. DoD targets: recall@8
-/// ≥0.85, spoiler-leak = 0. Persists two <see cref="EvalRun"/> rows (<c>rag.retrieval</c>,
-/// <c>rag.spoiler</c>) so the /ai-quality Evals tab tracks them like every other feature.
+/// scores it with the pure <see cref="RetrievalMetrics"/> — recall@8, spoiler-leak, no LLM. The judged
+/// half (027b) generates a real grounded answer per question via <see cref="IRagAskService"/> and scores
+/// each citation against its cited excerpt with the same MEAI <see cref="RubricEvaluator"/> the rest of
+/// the eval suite uses. Persists <c>rag.retrieval</c> / <c>rag.spoiler</c> (and <c>rag.citation</c> when
+/// judged) <see cref="EvalRun"/> rows. DoD: recall@8 ≥0.85, spoiler-leak = 0, citation support ≥0.9.
 /// </summary>
 public sealed class RagEvalRunner(ILogger<RagEvalRunner> logger)
 {
     // Retrieval scores 0–1 (recall / 1−leak), unlike the 1–5 judged features — the feature key disambiguates.
     private const string RetrievalModelId = "hybrid-retrieval";
     private const string NoJudge = "n/a";
+    private const int SupportPassThreshold = 4; // judge ≥4/5 on the support axis = a correct citation
+    private const string CitationFeature = "rag.citation";
+
+    // The "support" axis MUST stay Dim1 — SupportRate reads JudgeScore.D1.
+    private static readonly Rubric CitationRubric = new(
+        "support: does the cited excerpt actually contain or directly imply the specific claim it is attached to?",
+        "relevance: is the excerpt genuinely on-topic for the answer, not a loosely-related passage?",
+        "faithfulness: does the answer avoid asserting anything the cited excerpts do not support (no outside knowledge)?");
+
+    private static readonly ChatMessage[] JudgePlaceholderMessages = [new ChatMessage(ChatRole.User, string.Empty)];
 
     public async Task<RagEvalResult> RunAsync(
         IRagService rag,
+        IRagAskService? ask,
+        ILlmService? judge,
+        string? judgeModelId,
         Guid editionId,
         int k,
         bool persist,
@@ -49,8 +77,10 @@ public sealed class RagEvalRunner(ILogger<RagEvalRunner> logger)
         var spoilerGoldens = RagGoldenSet.LoadSpoiler();
 
         // Recall: retrieve UNGATED (we measure raw retrieval quality), score chapter+phrase hits.
+        // Keep each question's chunks — the citation phase reuses them as the answer's context.
         var recallCases = new List<(IReadOnlyList<RetrievedChunk>, int, IReadOnlyList<string>)>();
         var recallDetail = new List<RagRecallCase>();
+        var retrievedByQuestion = new List<(string Question, IReadOnlyList<RetrievedChunk> Chunks)>();
         foreach (var g in retrievalGoldens)
         {
             ct.ThrowIfCancellationRequested();
@@ -59,6 +89,7 @@ public sealed class RagEvalRunner(ILogger<RagEvalRunner> logger)
             recallDetail.Add(new RagRecallCase(
                 g.Question, g.ExpectedChapterOrd,
                 RetrievalMetrics.IsHit(chunks, g.ExpectedChapterOrd, g.ExpectedPhrases)));
+            retrievedByQuestion.Add((g.Question, chunks));
         }
 
         // Spoiler: retrieve GATED at the reader's supposed position; nothing past it may surface.
@@ -75,28 +106,101 @@ public sealed class RagEvalRunner(ILogger<RagEvalRunner> logger)
 
         var recall = RetrievalMetrics.Recall(recallCases);
         var leakRate = RetrievalMetrics.LeakRate(spoilerCases);
+
+        // Citation correctness (027b) — only when a generator + judge are supplied.
+        RagCitationSummary? citation = null;
+        if (ask is not null && judge is not null)
+            citation = await JudgeCitationsAsync(ask, judge, retrievedByQuestion, ct);
+
         logger.LogInformation(
-            "RAG eval edition={Edition} recall@{K}={Recall:0.00} (N={RecallN}) spoilerLeakRate={Leak:0.00} (N={SpoilerN})",
-            editionId, k, recall, recallCases.Count, leakRate, spoilerCases.Count);
+            "RAG eval edition={Edition} recall@{K}={Recall:0.00} (N={RecallN}) spoilerLeakRate={Leak:0.00} (N={SpoilerN}) citation={Cit}",
+            editionId, k, recall, recallCases.Count, leakRate, spoilerCases.Count,
+            citation is null ? "(skipped)" : $"{citation.Score:0.00}/support {citation.SupportRate:0.00}");
 
         if (persist && db is not null)
         {
-            db.EvalRuns.Add(MakeRun("rag.retrieval", (decimal)recall, recallCases.Count, gitSha,
+            db.EvalRuns.Add(MakeRun("rag.retrieval", RetrievalModelId, NoJudge, (decimal)recall, recallCases.Count, gitSha,
                 $"{{\"recallAtK\":{recall:0.000},\"k\":{k},\"hits\":{recallDetail.Count(c => c.Hit)}}}"));
-            db.EvalRuns.Add(MakeRun("rag.spoiler", (decimal)(1.0 - leakRate), spoilerCases.Count, gitSha,
+            db.EvalRuns.Add(MakeRun("rag.spoiler", RetrievalModelId, NoJudge, (decimal)(1.0 - leakRate), spoilerCases.Count, gitSha,
                 $"{{\"leakRate\":{leakRate:0.000},\"leakingCases\":{spoilerDetail.Count(c => c.LeakCount > 0)}}}"));
+            if (citation is not null)
+                db.EvalRuns.Add(MakeRun(CitationFeature, RagAskService.FeatureTag, judgeModelId ?? NoJudge,
+                    (decimal)citation.Score, citation.CitationsJudged, gitSha,
+                    $"{{\"supportRate\":{citation.SupportRate:0.000},\"answers\":{citation.AnswersGenerated}}}"));
             await db.SaveChangesAsync(ct);
         }
 
-        return new RagEvalResult(recall, recallCases.Count, leakRate, spoilerCases.Count, recallDetail, spoilerDetail);
+        return new RagEvalResult(recall, recallCases.Count, leakRate, spoilerCases.Count, recallDetail, spoilerDetail, citation);
     }
 
-    private static EvalRun MakeRun(string feature, decimal score, int n, string? gitSha, string breakdown) => new()
+    /// <summary>
+    /// Generates a grounded answer per question (over its already-retrieved chunks) and judges each
+    /// citation against the FULL text of the excerpt it points to. Returns the mean 1–5 score and the
+    /// support rate (citations scored ≥<see cref="SupportPassThreshold"/> on the support axis).
+    /// </summary>
+    private async Task<RagCitationSummary> JudgeCitationsAsync(
+        IRagAskService ask,
+        ILlmService judge,
+        IReadOnlyList<(string Question, IReadOnlyList<RetrievedChunk> Chunks)> retrieved,
+        CancellationToken ct)
+    {
+        var chatConfig = new ChatConfiguration(new LlmServiceChatClient(judge, defaultFeatureTag: "eval.judge"));
+        var scores = new List<JudgeScore>();
+        var supported = 0;
+        var answersGenerated = 0;
+
+        foreach (var (question, chunks) in retrieved)
+        {
+            ct.ThrowIfCancellationRequested();
+            // lastReadOrd is irrelevant here — chunks are supplied directly (no user gating).
+            var answer = await ask.AskFromChunksAsync(question, chunks, [], lastReadOrd: int.MaxValue, ct);
+            if (answer.Insufficient || answer.Citations.Count == 0)
+                continue;
+            answersGenerated++;
+
+            foreach (var cited in answer.Citations)
+            {
+                ct.ThrowIfCancellationRequested();
+                var evidence =
+                    $"Question: {question}\n\nAnswer:\n{answer.Answer}\n\n" +
+                    $"Cited excerpt [{cited.Marker}] (the answer attributes a claim to this passage):\n{cited.Chunk.Text}";
+
+                var evaluator = new RubricEvaluator(CitationFeature, CitationRubric);
+                var result = await evaluator.EvaluateAsync(
+                    JudgePlaceholderMessages,
+                    new ChatResponse(new ChatMessage(ChatRole.Assistant, answer.Answer)),
+                    chatConfig, [new RubricEvidenceContext(evidence)], ct);
+
+                var score = new JudgeScore(
+                    ReadAxis(result, CitationRubric.Dim1),
+                    ReadAxis(result, CitationRubric.Dim2),
+                    ReadAxis(result, CitationRubric.Dim3),
+                    string.Empty);
+                scores.Add(score);
+                if (score.D1 >= SupportPassThreshold)
+                    supported++;
+            }
+        }
+
+        if (scores.Count == 0)
+            return new RagCitationSummary(0, 0, 0, answersGenerated);
+
+        var summary = JudgeRunner.Aggregate(scores);
+        var supportRate = (double)supported / scores.Count;
+        return new RagCitationSummary(summary.MeanOverall, supportRate, scores.Count, answersGenerated);
+    }
+
+    // RubricEvaluator names each axis "{feature}.{label}" (label = text before ':').
+    private static int ReadAxis(EvaluationResult result, string dim) =>
+        (int)Math.Round(result.Get<NumericMetric>($"{CitationFeature}.{dim.Split(':')[0].Trim()}").Value ?? 0);
+
+    private static EvalRun MakeRun(
+        string feature, string modelId, string judgeModelId, decimal score, int n, string? gitSha, string breakdown) => new()
     {
         Id = Guid.NewGuid(),
         Feature = feature,
-        ModelId = RetrievalModelId,
-        JudgeModelId = NoJudge,
+        ModelId = modelId,
+        JudgeModelId = judgeModelId,
         Score = Math.Round(score, 3),
         N = n,
         BreakdownJson = breakdown,

--- a/backend/src/Api/Endpoints/AdminRagEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminRagEndpoints.cs
@@ -4,6 +4,7 @@ using Application.Rag;
 using Contracts.Admin;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
 using TextStack.Ai.EvalSuite;
 using TextStack.Ai.Rag;
 
@@ -28,13 +29,17 @@ public static class AdminRagEndpoints
         group.MapPost("/{editionId:guid}/eval", RunEval);
     }
 
-    // Phase 4 DoD gate (AI-027a): runs the retrieval eval (recall@k + spoiler-leak) against a real,
-    // embedded edition. Deterministic (no LLM) — citation-correctness judging is AI-027b. Persists
-    // rag.retrieval / rag.spoiler EvalRun rows. DDIA is the intended target.
+    // Phase 4 DoD gate (AI-027): runs the RAG eval against a real, embedded edition. Retrieval
+    // (recall@k + spoiler-leak) is deterministic (no LLM); citation-correctness (AI-027b) generates a
+    // grounded answer per question and judges each citation. `judge` selects the LLM judge —
+    // openai (default, stronger + independent of the nano generator) | ollama (free) | none
+    // (retrieval-only). Persists rag.retrieval / rag.spoiler / rag.citation EvalRun rows.
     private static async Task<IResult> RunEval(
         Guid editionId,
         [FromQuery] int? k,
+        [FromQuery] string? judge,
         IServiceProvider services,
+        IConfiguration config,
         RagEvalRunner runner,
         IAppDbContext db,
         CancellationToken ct)
@@ -44,7 +49,33 @@ public static class AdminRagEndpoints
 
         var limit = Math.Clamp(k ?? IRagService.DefaultK, 1, MaxK);
         var gitSha = Environment.GetEnvironmentVariable("GIT_SHA");
-        var result = await runner.RunAsync(rag, editionId, limit, persist: true, db, gitSha, ct);
+
+        // Resolve the judge unless explicitly disabled. openai-judge runs the stronger Eval:JudgeModel.
+        IRagAskService? ask = null;
+        ILlmService? judgeClient = null;
+        string? judgeModelId = null;
+        var judgeChoice = (judge ?? "openai").Trim().ToLowerInvariant();
+        if (judgeChoice != "none")
+        {
+            var useOllama = judgeChoice == "ollama";
+            var judgeKey = useOllama ? "ollama" : "openai-judge";
+            judgeModelId = useOllama
+                ? config["Ollama:Model"] ?? "gemma4:e4b"
+                : config["Eval:JudgeModel"] ?? "gpt-4.1";
+            ask = services.GetRequiredService<IRagAskService>();
+            judgeClient = services.GetRequiredKeyedService<ILlmService>(judgeKey);
+        }
+
+        var result = await runner.RunAsync(
+            rag, ask, judgeClient, judgeModelId, editionId, limit, persist: true, db, gitSha, ct);
+
+        var citation = result.Citation is null
+            ? null
+            : new RagCitationDto(
+                Math.Round(result.Citation.Score, 3),
+                Math.Round(result.Citation.SupportRate, 4),
+                result.Citation.CitationsJudged,
+                result.Citation.AnswersGenerated);
 
         return Results.Ok(new RagEvalDto(
             limit,
@@ -52,6 +83,7 @@ public static class AdminRagEndpoints
             result.RecallN,
             Math.Round(result.SpoilerLeakRate, 4),
             result.SpoilerN,
+            citation,
             result.RecallCases.Select(c => new RagRecallCaseDto(c.Question, c.ExpectedChapterOrd, c.Hit)).ToList(),
             result.SpoilerCases.Select(c => new RagSpoilerCaseDto(c.Question, c.GateChapterOrd, c.LeakCount)).ToList()));
     }

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -115,6 +115,7 @@ builder.Services.AddRagRetrieval(_ => () => new NpgsqlConnection(connectionStrin
 builder.Services.AddScoped<Application.Rag.RagContextService>();
 // "Ask this book" orchestration (AI-025): context + LLM gateway → grounded answer with citations.
 builder.Services.AddScoped<Application.Rag.RagAskService>();
+builder.Services.AddScoped<Application.Rag.IRagAskService>(sp => sp.GetRequiredService<Application.Rag.RagAskService>());
 
 // Reindex service (used by CLI)
 builder.Services.AddScoped<SearchReindexService>();

--- a/backend/src/Application/Rag/RagAskService.cs
+++ b/backend/src/Application/Rag/RagAskService.cs
@@ -18,11 +18,29 @@ public record AskAnswer(
     bool Insufficient);
 
 /// <summary>
+/// "Ask this book" (Phase 4 RAG, AI-025). Interface so the AI-027 citation eval can drive generation
+/// against pre-retrieved chunks (no reading user) and tests can fake it.
+/// </summary>
+public interface IRagAskService
+{
+    /// <summary>Spoiler-safe ask for a real reader: gates context by their reading progress.</summary>
+    Task<AskAnswer> AskAsync(Guid userId, Guid siteId, Guid editionId, string question, int k, CancellationToken ct);
+
+    /// <summary>
+    /// Generate a grounded, cited answer from an already-retrieved chunk set — bypasses user-progress
+    /// gating (the caller supplies the chunks). Used by the AI-027 citation eval over the golden set.
+    /// </summary>
+    Task<AskAnswer> AskFromChunksAsync(
+        string question, IReadOnlyList<RetrievedChunk> chunks, IReadOnlyList<string> noteTexts,
+        int lastReadOrd, CancellationToken ct);
+}
+
+/// <summary>
 /// "Ask this book" (Phase 4 RAG, AI-025): retrieves spoiler-safe context via
 /// <see cref="RagContextService"/>, generates a grounded 2-4 sentence answer with citations via the
 /// LLM gateway (FeatureTag <c>rag.ask</c>), and resolves the cited excerpts. Reused by the AI-027 eval.
 /// </summary>
-public sealed class RagAskService(RagContextService context, ILlmService llm)
+public sealed class RagAskService(RagContextService context, ILlmService llm) : IRagAskService
 {
     public const string FeatureTag = "rag.ask";
     private const int MaxOutputTokens = 320;
@@ -34,23 +52,29 @@ public sealed class RagAskService(RagContextService context, ILlmService llm)
         Guid userId, Guid siteId, Guid editionId, string question, int k, CancellationToken ct)
     {
         var ctx = await context.BuildAsync(userId, siteId, editionId, question, k, ct);
-
-        // No readable context → answer plainly without spending an LLM call.
-        if (ctx.Chunks.Count == 0)
-            return new AskAnswer(InsufficientMessage, [], ctx.LastReadOrd, Insufficient: true);
-
         var noteTexts = ctx.Notes.Select(n => n.Text).ToList();
+        return await AskFromChunksAsync(question, ctx.Chunks, noteTexts, ctx.LastReadOrd, ct);
+    }
+
+    public async Task<AskAnswer> AskFromChunksAsync(
+        string question, IReadOnlyList<RetrievedChunk> chunks, IReadOnlyList<string> noteTexts,
+        int lastReadOrd, CancellationToken ct)
+    {
+        // No readable context → answer plainly without spending an LLM call.
+        if (chunks.Count == 0)
+            return new AskAnswer(InsufficientMessage, [], lastReadOrd, Insufficient: true);
+
         var request = new LlmRequest(
             SystemPrompt: RagAskPrompt.BuildSystemPrompt(),
-            Messages: [new LlmMessage("user", RagAskPrompt.BuildUserPrompt(question, ctx.Chunks, noteTexts))],
+            Messages: [new LlmMessage("user", RagAskPrompt.BuildUserPrompt(question, chunks, noteTexts))],
             MaxOutputTokens: MaxOutputTokens,
             FeatureTag: FeatureTag);
 
         var response = await llm.CompleteAsync(request, ct);
 
-        var markers = RagAskPrompt.ParseCitations(response.Text, ctx.Chunks.Count);
-        var citations = markers.Select(n => new AskCitationSource(n, ctx.Chunks[n - 1])).ToList();
+        var markers = RagAskPrompt.ParseCitations(response.Text, chunks.Count);
+        var citations = markers.Select(n => new AskCitationSource(n, chunks[n - 1])).ToList();
 
-        return new AskAnswer(response.Text, citations, ctx.LastReadOrd, Insufficient: false);
+        return new AskAnswer(response.Text, citations, lastReadOrd, Insufficient: false);
     }
 }

--- a/backend/src/Contracts/Admin/RagDtos.cs
+++ b/backend/src/Contracts/Admin/RagDtos.cs
@@ -33,8 +33,14 @@ public record RagRecallCaseDto(string Question, int ExpectedChapterOrd, bool Hit
 public record RagSpoilerCaseDto(string Question, int GateChapterOrd, int LeakCount);
 
 /// <summary>
-/// Result of the admin RAG retrieval eval (AI-027a): recall@k over the retrieval goldens and the
-/// spoiler-leak rate over the adversarial set (DoD: recall ≥0.85, leak rate = 0), plus per-case detail.
+/// Citation-correctness summary (AI-027b): the 1–5 judge mean over cited excerpts and the support rate
+/// (fraction the judge scored ≥4 on "support" — the DoD ≥0.9 metric). Null on a retrieval-only run.
+/// </summary>
+public record RagCitationDto(double Score, double SupportRate, int CitationsJudged, int AnswersGenerated);
+
+/// <summary>
+/// Result of the admin RAG eval (AI-027): recall@k + spoiler-leak rate (DoD: recall ≥0.85, leak = 0)
+/// and, when judged (027b), citation correctness — plus per-case detail.
 /// </summary>
 public record RagEvalDto(
     int K,
@@ -42,5 +48,6 @@ public record RagEvalDto(
     int RecallN,
     double SpoilerLeakRate,
     int SpoilerN,
+    RagCitationDto? Citation,
     IReadOnlyList<RagRecallCaseDto> RecallCases,
     IReadOnlyList<RagSpoilerCaseDto> SpoilerCases);

--- a/tests/TextStack.AiEvals/RagEvalRunnerTests.cs
+++ b/tests/TextStack.AiEvals/RagEvalRunnerTests.cs
@@ -1,4 +1,6 @@
+using Application.Rag;
 using Microsoft.Extensions.Logging.Abstractions;
+using TextStack.Ai.Core;
 using TextStack.Ai.EvalSuite;
 using TextStack.Ai.Rag;
 
@@ -51,13 +53,41 @@ public class RagEvalRunnerTests
         }
     }
 
+    /// <summary>Echoes back a one-citation answer pointing at the first supplied chunk.</summary>
+    private sealed class FakeAsk : IRagAskService
+    {
+        public Task<AskAnswer> AskAsync(Guid u, Guid s, Guid e, string q, int k, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<AskAnswer> AskFromChunksAsync(
+            string question, IReadOnlyList<RetrievedChunk> chunks, IReadOnlyList<string> notes, int lastReadOrd, CancellationToken ct)
+        {
+            var citations = chunks.Count == 0
+                ? Array.Empty<AskCitationSource>()
+                : [new AskCitationSource(1, chunks[0])];
+            return Task.FromResult(new AskAnswer($"Grounded answer [1]. ({question})", citations, lastReadOrd, Insufficient: chunks.Count == 0));
+        }
+    }
+
+    /// <summary>A judge that always returns the same rubric verdict (support/relevance/faithfulness).</summary>
+    private sealed class FixedJudge(int d1, int d2, int d3) : ILlmService
+    {
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct) =>
+            Task.FromResult(new LlmResponse(
+                $"{{\"d1\": {d1}, \"d2\": {d2}, \"d3\": {d3}, \"rationale\": \"ok\"}}",
+                [], new LlmUsage(0, 0, 0m), "judge-fake", Guid.NewGuid()));
+
+        public IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
+
     [Fact]
     public async Task RunAsync_PerfectRetriever_FullRecallNoLeak()
     {
         var runner = new RagEvalRunner(NullLogger<RagEvalRunner>.Instance);
         var result = await runner.RunAsync(
-            new PerfectRag(), Guid.NewGuid(), k: 8, persist: false, db: null, gitSha: null,
-            TestContext.Current.CancellationToken);
+            new PerfectRag(), ask: null, judge: null, judgeModelId: null, Guid.NewGuid(), k: 8,
+            persist: false, db: null, gitSha: null, TestContext.Current.CancellationToken);
 
         Assert.Equal(1.0, result.Recall, 12);
         Assert.Equal(0.0, result.SpoilerLeakRate, 12);
@@ -65,6 +95,7 @@ public class RagEvalRunnerTests
         Assert.Equal(SpoilerN, result.SpoilerN);
         Assert.All(result.RecallCases, c => Assert.True(c.Hit));
         Assert.All(result.SpoilerCases, c => Assert.Equal(0, c.LeakCount));
+        Assert.Null(result.Citation); // no judge supplied → retrieval-only
     }
 
     [Fact]
@@ -72,11 +103,38 @@ public class RagEvalRunnerTests
     {
         var runner = new RagEvalRunner(NullLogger<RagEvalRunner>.Instance);
         var result = await runner.RunAsync(
-            new LeakyRag(), Guid.NewGuid(), k: 8, persist: false, db: null, gitSha: null,
-            TestContext.Current.CancellationToken);
+            new LeakyRag(), ask: null, judge: null, judgeModelId: null, Guid.NewGuid(), k: 8,
+            persist: false, db: null, gitSha: null, TestContext.Current.CancellationToken);
 
         Assert.Equal(0.0, result.Recall, 12);
         Assert.Equal(1.0, result.SpoilerLeakRate, 12);
         Assert.All(result.SpoilerCases, c => Assert.True(c.LeakCount > 0));
+    }
+
+    [Fact]
+    public async Task RunAsync_WithJudge_ScoresCitations()
+    {
+        var runner = new RagEvalRunner(NullLogger<RagEvalRunner>.Instance);
+        var result = await runner.RunAsync(
+            new PerfectRag(), new FakeAsk(), new FixedJudge(5, 4, 5), judgeModelId: "judge-fake",
+            Guid.NewGuid(), k: 8, persist: false, db: null, gitSha: null, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result.Citation);
+        Assert.Equal((5 + 4 + 5) / 3.0, result.Citation!.Score, 3); // rubric mean
+        Assert.Equal(1.0, result.Citation.SupportRate, 12);          // D1=5 ≥4 for every citation
+        Assert.Equal(RetrievalN, result.Citation.CitationsJudged);   // one citation per golden answer
+        Assert.Equal(RetrievalN, result.Citation.AnswersGenerated);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithJudge_LowSupportAxis_ZeroSupportRate()
+    {
+        var runner = new RagEvalRunner(NullLogger<RagEvalRunner>.Instance);
+        var result = await runner.RunAsync(
+            new PerfectRag(), new FakeAsk(), new FixedJudge(2, 5, 5), judgeModelId: "judge-fake",
+            Guid.NewGuid(), k: 8, persist: false, db: null, gitSha: null, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result.Citation);
+        Assert.Equal(0.0, result.Citation!.SupportRate, 12); // D1=2 < 4 → no citation counts as supported
     }
 }


### PR DESCRIPTION
Phase 4 **AI-027, slice 2 of 2** — the last DoD metric: cited excerpts actually support the claim (LLM-as-judge ≥0.9). **This closes Phase 4** — "Ask this book" is complete end to end: hybrid retrieval → spoiler-safe answer with citations → reader scroll → eval gate.

## Changes
- **`RagAskService` → `IRagAskService`** + extracted **`AskFromChunksAsync`** — generates the grounded, cited answer from an already-retrieved chunk set (no reading user), so the eval drives the **real production prompt + citation parsing**, not a reimplementation. `AskAsync` delegates to it.
- **`RagEvalRunner` citation phase** — per retrieval golden: generate an answer over its chunks, then judge **each citation against the FULL text of its cited excerpt** (answer + excerpt as evidence) via the same MEAI `RubricEvaluator` the rest of the suite uses. Rubric: support / relevance / faithfulness. Reports the 1–5 mean and the **support rate** (citations ≥4 on support = the DoD ≥0.9 metric); persists a `rag.citation` `EvalRun`.
- **Judge selection** — `POST /admin/rag/{id}/eval?judge=openai|ollama|none`. Default **openai** (stronger `Eval:JudgeModel`, independent of the nano generator → no self-judging bias); `ollama` free; `none` keeps it retrieval-only.

## Best-practice decisions (delegated)
1. Evidence = **full cited chunk text** (already carried in `RetrievedChunk.Text`; the 160-char preview is DTO-only) — judge against the real source.
2. Judge default **openai** — independence from the nano generator avoids self-judging bias on a quality gate.
3. Evidence form = **answer + cited excerpt** (RAGAS-style faithfulness) — cutting the exact sentence at a marker is brittle.

## Verification
- `RagEvalRunner` with a fake `IRagAskService` + fixed judge: full support (D1=5 → support rate 1.0, mean (5+4+5)/3); failing support axis (D1=2 → support rate 0.0); retrieval-only path returns a null citation summary. Retrieval/spoiler tests updated for the new signature. Full `TextStack.AiEvals` + `TextStack.UnitTests` green.
- The real scored run is admin-triggered on prod (where DDIA is embedded + keys configured), like the other golden evals.

## Follow-up (owner)
Curate the 12 starter retrieval goldens to the DoD's 50 against the live DDIA edition (align `expectedChapterOrd` to its numbering), then run the admin eval and confirm recall@8 ≥0.85 · spoiler-leak = 0 · citation support ≥0.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)