### PR TITLE
feat(ai): real token streaming on LLM seam (AI-028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Phase 5 — real token streaming on the LLM seam (2026-06-11)
+
+Phase 5 **AI-028**, slice 1 — the LLM providers actually stream now (the `StreamAsync` placeholder yielded one full delta). Provider + decorator only; the SSE endpoint (AI-031) and incremental UI (AI-032) build on this.
+
+- **`OpenAiLlmClient.StreamAsync`** — real token streaming via `CompleteChatStreamingAsync`: each content fragment yields a `TextDelta` as it arrives, then a terminal usage delta (tokens + `ModelPricing` cost; falls back to 0 if the endpoint omits usage). Message-building shared with `CompleteAsync`; the reasoning-budget padding is preserved.
+- **`LlmDelta` += `ModelId`** — the terminal usage delta carries the model id so the decorator can attribute a streamed call (deltas have no `TraceId`).
+- **`TracingDecorator.StreamAsync`** — streamed calls are now observed like one-shot ones: it accumulates the text + terminal usage/model, then persists one sampled `LlmTrace` when the stream ends (or errors mid-flight), re-yielding every delta unchanged so real-time streaming is untouched.
+- **`OllamaLlmClient`** — intentionally **not** streamed (it only serves one-shot SRS-distractor + eval-judge features, never a user stream): completes once and emits a text delta + terminal usage delta, satisfying the contract. Relabelled from a TODO to an intentional decision.
+- Tests: `BuildStreamedResponse` (assembly + null-usage/model defaults); `StreamAsync` re-yields all deltas in order and persists a trace with the accumulated text + tokens + cost + model. Provider streaming itself (needs a key) is verified in staging before AI-031.
+
 ### Phase 4 RAG — citation-correctness judge — Phase 4 complete (2026-06-11)
 
 Phase 4 **AI-027, slice 2 of 2** — the last DoD metric: cited excerpts actually support the claim (LLM-as-judge ≥0.9). **This closes Phase 4** ("Ask this book" is complete end to end: hybrid retrieval → spoiler-safe answer with citations → reader scroll → eval gate).

--- a/backend/src/Ai/TextStack.Ai.Core/Llm.cs
+++ b/backend/src/Ai/TextStack.Ai.Core/Llm.cs
@@ -25,11 +25,14 @@ public record LlmUsage(int InputTokens, int OutputTokens, decimal CostUsd);
 public record LlmMessage(string Role, string Content, IReadOnlyList<ToolCall>? ToolCalls = null);
 
 /// <summary>
-/// One streaming chunk from <see cref="ILlmService.StreamAsync"/>. Either <see cref="TextDelta"/> carries a
-/// partial text fragment, <see cref="ToolCallDelta"/> carries a partial tool-call, or <see cref="FinalUsage"/>
-/// signals the stream's terminal usage row. Exactly one field is non-null per delta.
+/// One streaming chunk from <see cref="ILlmService.StreamAsync"/>. A <see cref="TextDelta"/> carries a
+/// partial text fragment, a <see cref="ToolCallDelta"/> a partial tool-call, or the terminal delta carries
+/// <see cref="FinalUsage"/> + <see cref="ModelId"/> (the usage row that closes the stream). Text and tool
+/// deltas are mutually exclusive; the terminal usage delta sets <see cref="FinalUsage"/> and
+/// <see cref="ModelId"/> together so <c>TracingDecorator</c> can attribute the streamed call (AI-028).
 /// </summary>
 public record LlmDelta(
     string? TextDelta = null,
     ToolCall? ToolCallDelta = null,
-    LlmUsage? FinalUsage = null);
+    LlmUsage? FinalUsage = null,
+    string? ModelId = null);

--- a/backend/src/Ai/TextStack.Ai.Llm/OllamaLlmClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/OllamaLlmClient.cs
@@ -90,10 +90,13 @@ public sealed class OllamaLlmClient : ILlmService
 
     public async IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, [EnumeratorCancellation] CancellationToken ct)
     {
-        // TODO(AI-028): real token streaming. For now yield the full response
-        // as a single delta after CompleteAsync.
+        // Intentional non-streaming (AI-028): Ollama is never streamed to a user — it serves only the
+        // one-shot SRS distractor + eval-judge features. We complete once and emit the result as a text
+        // delta followed by the terminal usage delta, so the contract (and TracingDecorator) still holds.
         var resp = await CompleteAsync(request, ct);
-        yield return new LlmDelta(TextDelta: resp.Text, FinalUsage: resp.Usage);
+        if (!string.IsNullOrEmpty(resp.Text))
+            yield return new LlmDelta(TextDelta: resp.Text);
+        yield return new LlmDelta(FinalUsage: resp.Usage, ModelId: resp.ModelId);
     }
 
     private sealed class OllamaResponse

--- a/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
@@ -51,7 +51,7 @@ public sealed class OpenAiLlmClient : ILlmService
         _client = new OpenAIClient(apiKey).GetChatClient(_model);
     }
 
-    public async Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
+    private static List<ChatMessage> BuildMessages(LlmRequest request)
     {
         var messages = new List<ChatMessage> { new SystemChatMessage(request.SystemPrompt) };
         foreach (var m in request.Messages)
@@ -63,6 +63,12 @@ public sealed class OpenAiLlmClient : ILlmService
                 _ => new UserChatMessage(m.Content),
             });
         }
+        return messages;
+    }
+
+    public async Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
+    {
+        var messages = BuildMessages(request);
 
         var maxTokens = request.MaxOutputTokens + _reasoningBudget; // +512 padding quirk
         var options = new ChatCompletionOptions { MaxOutputTokenCount = maxTokens };
@@ -93,9 +99,32 @@ public sealed class OpenAiLlmClient : ILlmService
 
     public async IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, [EnumeratorCancellation] CancellationToken ct)
     {
-        // TODO(AI-028): real token streaming over SSE. For now we yield the
-        // full response as a single delta after CompleteAsync.
-        var resp = await CompleteAsync(request, ct);
-        yield return new LlmDelta(TextDelta: resp.Text, FinalUsage: resp.Usage);
+        var messages = BuildMessages(request);
+        var maxTokens = request.MaxOutputTokens + _reasoningBudget; // +512 padding quirk (same as CompleteAsync)
+        var options = new ChatCompletionOptions { MaxOutputTokenCount = maxTokens };
+
+        // Real token streaming: yield each content fragment as it arrives, then a terminal usage delta.
+        // The SDK surfaces token usage on the final update (it requests stream_options.include_usage);
+        // if absent (older endpoints), usage falls back to 0 — text + latency are still traced.
+        ChatTokenUsage? usage = null;
+        await foreach (var update in _client.CompleteChatStreamingAsync(messages, options, ct))
+        {
+            foreach (var part in update.ContentUpdate)
+            {
+                if (!string.IsNullOrEmpty(part.Text))
+                    yield return new LlmDelta(TextDelta: part.Text);
+            }
+            if (update.Usage is not null)
+                usage = update.Usage;
+        }
+
+        var inputTokens = usage?.InputTokenCount ?? 0;
+        var outputTokens = usage?.OutputTokenCount ?? 0;
+        if (!ModelPricing.IsPriced(_model))
+            _logger.LogWarning("No pricing entry for OpenAI model {Model}; cost recorded as 0", _model);
+
+        yield return new LlmDelta(
+            FinalUsage: new LlmUsage(inputTokens, outputTokens, ModelPricing.CostUsd(_model, inputTokens, outputTokens)),
+            ModelId: _model);
     }
 }

--- a/backend/src/Ai/TextStack.Ai.Llm/TracingDecorator.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/TracingDecorator.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -42,10 +43,55 @@ public sealed class TracingDecorator(
         }
     }
 
-    // TODO(AI-028): trace streamed calls once real token streaming exists. The
-    // current StreamAsync is a single-delta placeholder, so pass through untraced.
-    public IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, CancellationToken ct)
-        => inner.StreamAsync(request, ct);
+    // Streamed calls are traced like one-shot ones (AI-028): accumulate the text deltas + terminal
+    // usage/model, then persist one trace when the stream ends (or errors mid-flight). Re-yields every
+    // delta unchanged so the caller still streams in real time.
+    public async IAsyncEnumerable<LlmDelta> StreamAsync(
+        LlmRequest request, [EnumeratorCancellation] CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        var text = new StringBuilder();
+        LlmUsage? usage = null;
+        string? modelId = null;
+        var traceId = Guid.NewGuid();
+
+        await using var e = inner.StreamAsync(request, ct).GetAsyncEnumerator(ct);
+        while (true)
+        {
+            LlmDelta delta;
+            try
+            {
+                if (!await e.MoveNextAsync())
+                    break;
+                delta = e.Current;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                TryPersist(
+                    BuildTrace(request, BuildStreamedResponse(text.ToString(), usage, modelId, traceId),
+                        sw.ElapsedMilliseconds, error: ex.Message),
+                    isError: true);
+                throw;
+            }
+
+            if (delta.TextDelta is not null) text.Append(delta.TextDelta);
+            if (delta.FinalUsage is not null) usage = delta.FinalUsage;
+            if (delta.ModelId is not null) modelId = delta.ModelId;
+            yield return delta;
+        }
+
+        sw.Stop();
+        TryPersist(
+            BuildTrace(request, BuildStreamedResponse(text.ToString(), usage, modelId, traceId),
+                sw.ElapsedMilliseconds, error: null),
+            isError: false);
+    }
+
+    /// <summary>Assembles the accumulated stream into an <see cref="LlmResponse"/> for tracing
+    /// (usage/model default to the same "unknown"/zeros a failed one-shot call records).</summary>
+    public static LlmResponse BuildStreamedResponse(string text, LlmUsage? usage, string? modelId, Guid traceId) =>
+        new(text, [], usage ?? new LlmUsage(0, 0, 0m), modelId ?? "unknown", traceId);
 
     private void TryPersist(LlmTrace trace, bool isError)
     {

--- a/tests/TextStack.UnitTests/TracingDecoratorTests.cs
+++ b/tests/TextStack.UnitTests/TracingDecoratorTests.cs
@@ -124,6 +124,84 @@ public class TracingDecoratorTests
         Assert.Equal(resp.Usage.InputTokens, result.Usage.InputTokens);
     }
 
+    // ---- BuildStreamedResponse (stream → traceable response) ----
+
+    [Fact]
+    public void BuildStreamedResponse_AssemblesAccumulatedStream()
+    {
+        var id = Guid.NewGuid();
+        var resp = TracingDecorator.BuildStreamedResponse("Hello world", new LlmUsage(7, 3, 0.002m), "gpt-4.1-nano", id);
+
+        Assert.Equal("Hello world", resp.Text);
+        Assert.Equal(7, resp.Usage.InputTokens);
+        Assert.Equal("gpt-4.1-nano", resp.ModelId);
+        Assert.Equal(id, resp.TraceId);
+        Assert.Empty(resp.ToolCalls);
+    }
+
+    [Fact]
+    public void BuildStreamedResponse_NullUsageAndModel_DefaultsLikeFailedCall()
+    {
+        var resp = TracingDecorator.BuildStreamedResponse("", usage: null, modelId: null, Guid.NewGuid());
+        Assert.Equal("unknown", resp.ModelId);
+        Assert.Equal(0, resp.Usage.OutputTokens);
+        Assert.Equal(0m, resp.Usage.CostUsd);
+    }
+
+    // ---- StreamAsync (re-yields every delta; persists one trace on completion) ----
+
+    [Fact]
+    public async Task StreamAsync_ReYieldsAllDeltasInOrder()
+    {
+        var deltas = new[]
+        {
+            new LlmDelta(TextDelta: "Hel"),
+            new LlmDelta(TextDelta: "lo"),
+            new LlmDelta(FinalUsage: new LlmUsage(5, 2, 0.001m), ModelId: "gpt-4.1-nano"),
+        };
+        var decorator = Decorator(new StreamingStub(deltas), new NoOpWriter());
+
+        var seen = new List<LlmDelta>();
+        await foreach (var d in decorator.StreamAsync(Req(), TestContext.Current.CancellationToken))
+            seen.Add(d);
+
+        Assert.Equal(deltas, seen);
+    }
+
+    [Fact]
+    public async Task StreamAsync_PersistsTraceWithAccumulatedTextAndUsage()
+    {
+        var deltas = new[]
+        {
+            new LlmDelta(TextDelta: "Hel"),
+            new LlmDelta(TextDelta: "lo world"),
+            new LlmDelta(FinalUsage: new LlmUsage(5, 2, 0.001m), ModelId: "gpt-4.1-nano"),
+        };
+        var writer = new CapturingWriter();
+        var decorator = Decorator(new StreamingStub(deltas), writer);
+
+        var ct = TestContext.Current.CancellationToken;
+        await foreach (var _ in decorator.StreamAsync(Req(), ct)) { }
+
+        var trace = await writer.Captured.Task.WaitAsync(TimeSpan.FromSeconds(5), ct);
+        Assert.Equal("Hello world", trace.ResponseText);
+        Assert.Equal("gpt-4.1-nano", trace.ModelId);
+        Assert.Equal(5, trace.TokensIn);
+        Assert.Equal(2, trace.TokensOut);
+        Assert.Equal(0.001m, trace.CostUsd);
+        Assert.Null(trace.Error);
+    }
+
+    private static TracingDecorator Decorator(ILlmService inner, ILlmTraceWriter writer)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => writer);
+        var sp = services.BuildServiceProvider();
+        return new TracingDecorator(
+            inner, sp.GetRequiredService<IServiceScopeFactory>(),
+            new TracingOptions(), NullLogger<TracingDecorator>.Instance);
+    }
+
     private sealed class StubLlm(LlmResponse resp) : ILlmService
     {
         public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct) => Task.FromResult(resp);
@@ -135,8 +213,35 @@ public class TracingDecoratorTests
         }
     }
 
+    private sealed class StreamingStub(IReadOnlyList<LlmDelta> deltas) : ILlmService
+    {
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public async IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, [EnumeratorCancellation] CancellationToken ct)
+        {
+            foreach (var d in deltas)
+            {
+                await Task.Yield();
+                yield return d;
+            }
+        }
+    }
+
     private sealed class NoOpWriter : ILlmTraceWriter
     {
         public Task WriteAsync(LlmTrace trace, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class CapturingWriter : ILlmTraceWriter
+    {
+        public TaskCompletionSource<LlmTrace> Captured { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WriteAsync(LlmTrace trace, CancellationToken ct)
+        {
+            Captured.TrySetResult(trace);
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
Phase 5 **AI-028**, slice 1 — the LLM providers actually stream now (the `StreamAsync` placeholder yielded one full delta after `CompleteAsync`). **Provider + decorator only**; the SSE endpoint (AI-031) and incremental UI (AI-032) build on this.

## Changes
- **`OpenAiLlmClient.StreamAsync`** — real token streaming via `CompleteChatStreamingAsync`: each content fragment yields a `TextDelta` as it arrives, then a terminal usage delta (tokens + `ModelPricing` cost; falls back to 0 if the endpoint omits usage). Message-building factored out and shared with `CompleteAsync`; reasoning-budget padding preserved.
- **`LlmDelta` += `ModelId`** — the terminal usage delta carries the model id so the decorator can attribute a streamed call (deltas carry no `TraceId`). Nullable, backward-compatible.
- **`TracingDecorator.StreamAsync`** — streamed calls are now observed like one-shot ones: accumulate text + terminal usage/model, persist one sampled `LlmTrace` on completion (or error mid-flight), re-yielding every delta unchanged so real-time streaming is untouched.
- **`OllamaLlmClient`** — intentionally **not** streamed (serves only one-shot SRS-distractor + eval-judge features, never a user stream): completes once, emits a text delta + terminal usage delta. Relabelled from TODO to an intentional decision.

## Decisions (delegated — "best practice + why")
1. `LlmDelta.ModelId` — the decorator is the single tracing seam; without a model id on the terminal delta a streamed call can't be attributed. Minimal nullable add beats a separate terminal type.
2. Sample stream traces like `CompleteAsync` (same `ShouldSample`) — one observability policy, no blind spot.
3. Keep Ollama non-streaming — never user-streamed; real NDJSON = code + failure surface for zero value (YAGNI).
4. Small PR (providers+decorator, no endpoint/UI) — independently testable, de-risks the visible AI-031/032 work; nothing breaks since the interface already existed.

## Verification
- `BuildStreamedResponse` (assembly + null usage/model defaults); `StreamAsync` re-yields all deltas in order and persists a trace with accumulated text + tokens + cost + model. Full `TextStack.UnitTests` (192) + `TextStack.AiEvals` green; `dotnet format` clean.
- Provider streaming itself (needs an OpenAI key, like `CompleteAsync`) is verified in staging before the AI-031 SSE endpoint lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)