### PR TITLE
fix(ai): don't trace caller-cancellation as an error (AI-028 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Phase 5 — fix: caller-cancellation isn't a model error (AI-028 follow-up, 2026-06-11)
+
+Audit follow-up to AI-028. `TracingDecorator` caught a broad `Exception` and recorded an **error trace on cancellation** — so an SSE client disconnecting (which cancels the token, a *normal* end to a stream, and the common case once AI-031 lands) would count against the /ai-quality error rate. Both `CompleteAsync` and `StreamAsync` now rethrow a caller-initiated `OperationCanceledException` **untraced** (`when (ct.IsCancellationRequested)`); genuine model errors still persist an error trace. Tests: caller-cancel rethrows without tracing (one-shot + stream); a real model error still persists `error="boom"`.
+
 ### Phase 5 — real token streaming on the LLM seam (2026-06-11)
 
 Phase 5 **AI-028**, slice 1 — the LLM providers actually stream now (the `StreamAsync` placeholder yielded one full delta). Provider + decorator only; the SSE endpoint (AI-031) and incremental UI (AI-032) build on this.

--- a/backend/src/Ai/TextStack.Ai.Llm/TracingDecorator.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/TracingDecorator.cs
@@ -35,6 +35,12 @@ public sealed class TracingDecorator(
             TryPersist(BuildTrace(request, response, sw.ElapsedMilliseconds, error: null), isError: false);
             return response;
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller abandoned the call (e.g. the HTTP client disconnected) — not a model error.
+            // Recording it would pollute the dashboard's error rate, so rethrow untraced.
+            throw;
+        }
         catch (Exception ex)
         {
             sw.Stop();
@@ -64,6 +70,12 @@ public sealed class TracingDecorator(
                 if (!await e.MoveNextAsync())
                     break;
                 delta = e.Current;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // SSE client disconnected (a normal end to a stream) — not a model error. Rethrow
+                // untraced so a cancelled stream doesn't count against the dashboard's error rate.
+                throw;
             }
             catch (Exception ex)
             {

--- a/tests/TextStack.UnitTests/TracingDecoratorTests.cs
+++ b/tests/TextStack.UnitTests/TracingDecoratorTests.cs
@@ -192,6 +192,48 @@ public class TracingDecoratorTests
         Assert.Null(trace.Error);
     }
 
+    // ---- cancellation is not an error (SSE disconnects must not pollute the error rate) ----
+
+    [Fact]
+    public async Task CompleteAsync_CallerCancels_RethrowsWithoutTracing()
+    {
+        var writer = new CapturingWriter();
+        var decorator = Decorator(new ThrowingLlm(ct => throw new OperationCanceledException(ct)), writer);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => decorator.CompleteAsync(Req(), cts.Token));
+        Assert.False(writer.Captured.Task.IsCompleted); // no trace scheduled for a caller cancel
+    }
+
+    [Fact]
+    public async Task CompleteAsync_ModelError_PersistsErrorTrace()
+    {
+        var writer = new CapturingWriter();
+        var decorator = Decorator(new ThrowingLlm(_ => throw new InvalidOperationException("boom")), writer);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => decorator.CompleteAsync(Req(), TestContext.Current.CancellationToken));
+
+        var trace = await writer.Captured.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.Equal("boom", trace.Error);
+    }
+
+    [Fact]
+    public async Task StreamAsync_CallerCancels_RethrowsWithoutTracing()
+    {
+        var writer = new CapturingWriter();
+        var decorator = Decorator(new ThrowingLlm(ct => throw new OperationCanceledException(ct)), writer);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in decorator.StreamAsync(Req(), cts.Token)) { }
+        });
+        Assert.False(writer.Captured.Task.IsCompleted); // no error trace for a stream the client abandoned
+    }
+
     private static TracingDecorator Decorator(ILlmService inner, ILlmTraceWriter writer)
     {
         var services = new ServiceCollection();
@@ -231,6 +273,22 @@ public class TracingDecoratorTests
     private sealed class NoOpWriter : ILlmTraceWriter
     {
         public Task WriteAsync(LlmTrace trace, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    /// <summary>Throws whatever <paramref name="throw"/> produces, from both the one-shot and the stream path.</summary>
+    private sealed class ThrowingLlm(Func<CancellationToken, Exception> @throw) : ILlmService
+    {
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct) => throw @throw(ct);
+
+        public async IAsyncEnumerable<LlmDelta> StreamAsync(
+            LlmRequest request, [EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.Yield();
+            throw @throw(ct);
+#pragma warning disable CS0162 // unreachable — needed so the method is an iterator
+            yield break;
+#pragma warning restore CS0162
+        }
     }
 
     private sealed class CapturingWriter : ILlmTraceWriter


### PR DESCRIPTION
Audit follow-up to AI-028 (#308).

## Bug (root cause)
`TracingDecorator` caught a broad `catch (Exception)` and recorded an **error trace on cancellation**. When an SSE client disconnects it cancels the request token — a *normal* end to a stream, and the common case once the AI-031 SSE endpoint lands — so every disconnect would count against the /ai-quality **error rate**. The same latent defect existed in `CompleteAsync`.

## Fix
Both `CompleteAsync` and `StreamAsync` now rethrow a caller-initiated `OperationCanceledException` **untraced** via `catch (OperationCanceledException) when (ct.IsCancellationRequested)`. Genuine model errors still persist an error trace.

## Audit — also checked, no bug
- OpenAI SDK 2.2.0 auto-injects `stream_options.include_usage` (`s_includeUsageStreamOptions`), so `update.Usage` populates the terminal delta → streamed cost is correct.
- `LlmServiceChatClient` already skips non-text deltas → usage-only terminal delta is handled.
- `BuildMessages` refactor is behaviour-identical to the old inline message build.

## Tests
- Caller-cancel rethrows **without** tracing — one-shot (`CompleteAsync`) and stream (`StreamAsync`).
- A real model error still persists `error="boom"`.
- Full `TracingDecorator` suite green (18); `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)