### PR TITLE
feat(ai): 4 starter tools + schema-validated dispatch (AI-030)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Phase 5 — 4 starter tools + schema-validated dispatch (2026-06-11)
+
+Phase 5 **AI-030** — the first concrete tools and the validated dispatch they run through. The Explain SSE refactor (AI-031) will hand these to the model.
+
+- **`ToolDispatcher`** (`Ai.Tools`) — resolve from the registry → evaluate args against the tool's JSON Schema (**draft 2020-12 via JsonSchema.Net** — a real evaluator, not hand-rolled checks) → invoke. Unknown tool / invalid args / tool exceptions come back as failed `ToolResult`s (**errors are data** — fed back to the LLM so it can fix its args and retry, per playbook risk note). Caller-cancellation propagates untraced. `DispatchAllAsync` runs a batch concurrently (parallel tool calls, Phase 5 scope).
+- **4 starter tools** (`Application/Tools/`, stateless singletons; scoped deps via `ToolContext.Services` at invoke):
+  - `get_chapter(chapter_number)` — chapter title + text (4k char cap) of the context edition.
+  - `search_book(query)` — top-5 passages via the production **hybrid retrieval** (AI-023); spoiler-gated to the user's furthest-read chapter when progress exists (same high-water mark as RAG), ungated otherwise (Explain targets text the user is looking at).
+  - `lookup_dictionary(word, lang?)` — Free Dictionary API (same upstream as /dictionary), compacted to phonetic + top meanings; not-found is data, not an error.
+  - `get_user_highlights(query?, limit?)` — the user's own highlights+notes for the book, ILIKE-filtered, capped at 20.
+- All schemas declare `additionalProperties: false` — hallucinated args are caught before dispatch.
+- Wired: `AddAiTools(Application assembly)` in `Program` (registry + dispatcher + scanned tools). `Microsoft.Extensions.Http` added to Application (IHttpClientFactory for the dictionary tool).
+- Tests (21): dispatcher (valid → invoke; unknown tool lists available; missing-required / wrong-type / below-minimum / extra-prop all rejected pre-invoke; tool exception → failure result; batch order), every tool's schema accepts its happy path + rejects malformed & unknown props, assembly scan finds exactly the 4, `ParseEntry` compaction.
+
 ### Phase 5 — tool registry (2026-06-11)
 
 Phase 5 **AI-029** — the shared tool catalogue (ADR-AI-005) that function-calling (AI-030/031), agents (Phase 6) and MCP all dispatch through. No tools yet (those are AI-030); this is the registry + DI wiring.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,8 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <!-- LLM -->
     <PackageVersion Include="OpenAI" Version="2.2.0" />
+    <!-- Tool-args validation (AI-030): real JSON Schema draft 2020-12 evaluation before dispatch -->
+    <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
     <!-- AI eval framework (MEAI.Evaluation). Stable 10.6.0 — IChatClient seam +
          IEvaluator/EvaluationMetric + Reporting (response cache, HTML report).
          Used by tests/TextStack.AiEvals; see docs/eval-migration.md. -->

--- a/backend/src/Ai/TextStack.Ai.Tools/ServiceCollectionExtensions.cs
+++ b/backend/src/Ai/TextStack.Ai.Tools/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
         }
 
         services.TryAddSingleton<IToolRegistry, ToolRegistry>();
+        services.TryAddSingleton<ToolDispatcher>();
         return services;
     }
 

--- a/backend/src/Ai/TextStack.Ai.Tools/TextStack.Ai.Tools.csproj
+++ b/backend/src/Ai/TextStack.Ai.Tools/TextStack.Ai.Tools.csproj
@@ -9,5 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <!-- Real JSON Schema (draft 2020-12) evaluation of tool args before dispatch (AI-030). -->
+    <PackageReference Include="JsonSchema.Net" />
   </ItemGroup>
 </Project>

--- a/backend/src/Ai/TextStack.Ai.Tools/ToolDispatcher.cs
+++ b/backend/src/Ai/TextStack.Ai.Tools/ToolDispatcher.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.Schema;
+using TextStack.Ai.Core;
+
+namespace TextStack.Ai.Tools;
+
+/// <summary>
+/// Outcome of one tool dispatch. Failures are DATA, not exceptions — the result (or error) goes back
+/// to the LLM as the tool message so the model can correct its arguments and retry (playbook Phase 5
+/// risk mitigation). <see cref="Error"/> is model-facing: short, factual, no stack traces.
+/// </summary>
+public sealed record ToolResult(string CallId, string ToolName, bool Ok, JsonElement? Result, string? Error)
+{
+    public static ToolResult Success(ToolCall call, JsonElement result) =>
+        new(call.Id, call.ToolName, true, result, null);
+
+    public static ToolResult Failure(ToolCall call, string error) =>
+        new(call.Id, call.ToolName, false, null, error);
+}
+
+/// <summary>
+/// Validated tool dispatch (AI-030): resolves the tool from the <see cref="IToolRegistry"/>, evaluates
+/// the call's arguments against the tool's JSON Schema (draft 2020-12, via JsonSchema.Net) and only
+/// then invokes it. Unknown tool, invalid args, and tool exceptions all come back as failed
+/// <see cref="ToolResult"/>s. Independent calls in a batch run in parallel (playbook scope).
+/// </summary>
+public sealed class ToolDispatcher(IToolRegistry registry)
+{
+    private static readonly EvaluationOptions SchemaOptions = new() { OutputFormat = OutputFormat.List };
+
+    public async Task<ToolResult> DispatchAsync(ToolCall call, ToolContext ctx, CancellationToken ct)
+    {
+        var tool = registry.Get(call.ToolName);
+        if (tool is null)
+            return ToolResult.Failure(call, $"Unknown tool '{call.ToolName}'. Available: {string.Join(", ", registry.Names)}.");
+
+        var validationError = ValidateArgs(tool.ArgsSchema, call.Arguments);
+        if (validationError is not null)
+            return ToolResult.Failure(call, $"Invalid arguments: {validationError}");
+
+        try
+        {
+            var result = await tool.InvokeAsync(call.Arguments, ctx, ct);
+            return ToolResult.Success(call, result);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw; // caller cancelled — propagate, don't feed back to the model
+        }
+        catch (Exception ex)
+        {
+            return ToolResult.Failure(call, $"Tool execution failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>Dispatches a batch concurrently (tools are independent by contract; Phase 5 scope).</summary>
+    public Task<ToolResult[]> DispatchAllAsync(IReadOnlyList<ToolCall> calls, ToolContext ctx, CancellationToken ct) =>
+        Task.WhenAll(calls.Select(c => DispatchAsync(c, ctx, ct)));
+
+    /// <summary>
+    /// Evaluates <paramref name="args"/> against <paramref name="schema"/>; null when valid, else a
+    /// compact, model-readable list of violations ("path: message"). Pure — unit-tested directly.
+    /// </summary>
+    public static string? ValidateArgs(JsonElement schema, JsonElement args)
+    {
+        JsonSchema compiled;
+        try
+        {
+            compiled = JsonSchema.FromText(schema.GetRawText());
+        }
+        catch (Exception ex)
+        {
+            return $"tool schema is invalid: {ex.Message}"; // a wiring bug, surfaced loudly
+        }
+
+        var node = args.ValueKind == JsonValueKind.Undefined ? null : JsonNode.Parse(args.GetRawText());
+        var evaluation = compiled.Evaluate(node, SchemaOptions);
+        if (evaluation.IsValid)
+            return null;
+
+        var violations = evaluation.Details
+            .Where(d => d.HasErrors)
+            .SelectMany(d => d.Errors!.Select(e => $"{Location(d)}: {e.Value}"))
+            .Distinct()
+            .Take(5)
+            .ToList();
+        return violations.Count > 0 ? string.Join("; ", violations) : "arguments do not match the tool schema";
+
+        static string Location(EvaluationResults d) =>
+            d.InstanceLocation.Count == 0 ? "$" : d.InstanceLocation.ToString();
+    }
+}

--- a/backend/src/Api/Api.csproj
+++ b/backend/src/Api/Api.csproj
@@ -25,5 +25,6 @@
     <ProjectReference Include="..\Vocabulary\TextStack.Vocabulary\TextStack.Vocabulary.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.EvalSuite\TextStack.Ai.EvalSuite.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj" />
+    <ProjectReference Include="..\Ai\TextStack.Ai.Tools\TextStack.Ai.Tools.csproj" />
   </ItemGroup>
 </Project>

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -28,6 +28,7 @@ using Application.Auth;
 using Application.Search;
 using OpenTelemetry.Trace;
 using Scalar.AspNetCore;
+using TextStack.Ai.Tools;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -81,6 +82,8 @@ builder.Services.AddOpenApi();
 builder.Services.AddApplication();
 builder.Services.AddSingleton<TextStack.Ai.EvalSuite.EvalSuiteRunner>();
 builder.Services.AddSingleton<TextStack.Ai.EvalSuite.RagEvalRunner>();
+// Tool catalogue (AI-029/030): scans Application for ITool impls; dispatch is schema-validated.
+builder.Services.AddAiTools(typeof(Application.Tools.GetChapterTool).Assembly);
 builder.Services.AddAuthSettings(builder.Configuration);
 
 var connectionString = builder.Configuration.GetConnectionString("Default")

--- a/backend/src/Application/Application.csproj
+++ b/backend/src/Application/Application.csproj
@@ -5,6 +5,8 @@
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <!-- IHttpClientFactory for tools that call external APIs (AI-030 LookupDictionaryTool) -->
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" />

--- a/backend/src/Application/Tools/GetChapterTool.cs
+++ b/backend/src/Application/Tools/GetChapterTool.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+
+namespace Application.Tools;
+
+/// <summary>
+/// Phase 5 starter tool (AI-030): fetches one chapter of the context edition by number, so the LLM can
+/// pull surrounding context ("see chapter 3", "as discussed earlier"). Text is truncated to keep one
+/// call inside the prompt budget. Stateless singleton — the scoped db arrives via
+/// <see cref="ToolContext.Services"/> at invoke time.
+/// </summary>
+public sealed class GetChapterTool : ITool
+{
+    /// <summary>Cap on returned chapter text — enough for context, small enough for the prompt.</summary>
+    public const int MaxChars = 4000;
+
+    private static readonly JsonElement Schema = ToolJson.Schema("""
+        {
+          "type": "object",
+          "properties": {
+            "chapter_number": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based chapter number within the current book"
+            }
+          },
+          "required": ["chapter_number"],
+          "additionalProperties": false
+        }
+        """);
+
+    public string Name => "get_chapter";
+
+    public string Description =>
+        "Fetch a chapter of the current book by its number (1-based). " +
+        "Use when the text references another chapter or earlier discussion.";
+
+    public JsonElement ArgsSchema => Schema;
+
+    public async Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
+    {
+        if (ctx.EditionId is not { } editionId)
+            throw new InvalidOperationException("No edition in context — get_chapter needs a current book.");
+
+        var number = ToolJson.GetInt(args, "chapter_number")!.Value; // shape guaranteed by schema validation
+
+        var db = ctx.Services.GetRequiredService<IAppDbContext>();
+        var chapter = await db.Chapters
+            .Where(c => c.EditionId == editionId && c.ChapterNumber == number)
+            .Select(c => new { c.ChapterNumber, c.Title, c.PlainText })
+            .FirstOrDefaultAsync(ct);
+
+        if (chapter is null)
+            return ToolJson.Result(new { found = false, message = $"Chapter {number} does not exist in this book." });
+
+        var (text, truncated) = ToolJson.Truncate(chapter.PlainText, MaxChars);
+        return ToolJson.Result(new { found = true, chapterNumber = chapter.ChapterNumber, title = chapter.Title, text, truncated });
+    }
+}

--- a/backend/src/Application/Tools/GetUserHighlightsTool.cs
+++ b/backend/src/Application/Tools/GetUserHighlightsTool.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+
+namespace Application.Tools;
+
+/// <summary>
+/// Phase 5 starter tool (AI-030): the invoking user's highlights (with inline notes) for the current
+/// book, optionally filtered by a substring — so the model can ground an explanation in what the user
+/// already marked. Strictly scoped to <see cref="ToolContext.UserId"/>; capped to protect the prompt.
+/// </summary>
+public sealed class GetUserHighlightsTool : ITool
+{
+    public const int DefaultLimit = 10;
+    public const int MaxLimit = 20;
+
+    private static readonly JsonElement Schema = ToolJson.Schema("""
+        {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200,
+              "description": "Optional substring to filter highlights by (matches the highlighted text or its note)"
+            },
+            "limit": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "description": "Max highlights to return (default 10)"
+            }
+          },
+          "additionalProperties": false
+        }
+        """);
+
+    public string Name => "get_user_highlights";
+
+    public string Description =>
+        "Fetch the user's own highlights and notes for the current book, optionally filtered by a phrase. " +
+        "Use when the user may have already marked or annotated the concept being explained.";
+
+    public JsonElement ArgsSchema => Schema;
+
+    public async Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
+    {
+        if (ctx.UserId is not { } userId)
+            throw new InvalidOperationException("No user in context — get_user_highlights needs a signed-in user.");
+        if (ctx.EditionId is not { } editionId)
+            throw new InvalidOperationException("No edition in context — get_user_highlights needs a current book.");
+
+        var query = ToolJson.GetString(args, "query");
+        var limit = Math.Clamp(ToolJson.GetInt(args, "limit") ?? DefaultLimit, 1, MaxLimit);
+
+        var db = ctx.Services.GetRequiredService<IAppDbContext>();
+        var rows = db.Highlights
+            .Where(h => h.UserId == userId && h.EditionId == editionId && h.ChapterId != null);
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            var pattern = $"%{query.Trim()}%";
+            rows = rows.Where(h =>
+                EF.Functions.ILike(h.SelectedText, pattern) ||
+                (h.NoteText != null && EF.Functions.ILike(h.NoteText, pattern)));
+        }
+
+        var highlights = await rows
+            .OrderBy(h => h.Chapter!.ChapterNumber).ThenBy(h => h.CreatedAt)
+            .Take(limit)
+            .Select(h => new { chapterNumber = h.Chapter!.ChapterNumber, text = h.SelectedText, note = h.NoteText })
+            .ToListAsync(ct);
+
+        return ToolJson.Result(new { count = highlights.Count, highlights });
+    }
+}

--- a/backend/src/Application/Tools/LookupDictionaryTool.cs
+++ b/backend/src/Application/Tools/LookupDictionaryTool.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+
+namespace Application.Tools;
+
+/// <summary>
+/// Phase 5 starter tool (AI-030): looks a word up in the Free Dictionary API (the same upstream the
+/// public /dictionary endpoint proxies) and returns a compact entry — phonetic + first few meanings.
+/// "Not found" is data (<c>found:false</c>), not an error, so the model moves on instead of retrying.
+/// </summary>
+public sealed class LookupDictionaryTool : ITool
+{
+    private const int MaxMeanings = 3;
+    private const int MaxDefinitionsPerMeaning = 2;
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    private static readonly JsonElement Schema = ToolJson.Schema("""
+        {
+          "type": "object",
+          "properties": {
+            "word": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100,
+              "description": "The word to look up"
+            },
+            "lang": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 5,
+              "description": "ISO language code of the word (default en)"
+            }
+          },
+          "required": ["word"],
+          "additionalProperties": false
+        }
+        """);
+
+    public string Name => "lookup_dictionary";
+
+    public string Description =>
+        "Look up a word's dictionary definition (with phonetics and parts of speech). " +
+        "Use when the precise dictionary meaning matters for the explanation.";
+
+    public JsonElement ArgsSchema => Schema;
+
+    public async Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
+    {
+        var word = ToolJson.GetString(args, "word")!.Trim(); // shape guaranteed by schema validation
+        var lang = ToolJson.GetString(args, "lang")?.ToLowerInvariant() ?? "en";
+
+        var client = ctx.Services.GetRequiredService<IHttpClientFactory>().CreateClient();
+        client.Timeout = Timeout;
+
+        var url = $"https://api.dictionaryapi.dev/api/v2/entries/{lang}/{Uri.EscapeDataString(word)}";
+        using var response = await client.GetAsync(url, ct);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            return ToolJson.Result(new { found = false, word, message = $"No dictionary entry for '{word}'." });
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Dictionary service returned {(int)response.StatusCode}.");
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+        return ParseEntry(doc.RootElement, word);
+    }
+
+    /// <summary>Compacts the Free Dictionary payload to phonetic + top meanings. Pure — unit-tested.</summary>
+    public static JsonElement ParseEntry(JsonElement payload, string word)
+    {
+        if (payload.ValueKind != JsonValueKind.Array || payload.GetArrayLength() == 0)
+            return ToolJson.Result(new { found = false, word, message = $"No dictionary entry for '{word}'." });
+
+        var entry = payload[0];
+        var phonetic = entry.TryGetProperty("phonetic", out var ph) && ph.ValueKind == JsonValueKind.String
+            ? ph.GetString()
+            : null;
+
+        var meanings = new List<object>();
+        if (entry.TryGetProperty("meanings", out var ms) && ms.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var m in ms.EnumerateArray().Take(MaxMeanings))
+            {
+                var pos = m.TryGetProperty("partOfSpeech", out var p) && p.ValueKind == JsonValueKind.String
+                    ? p.GetString()
+                    : "unknown";
+                var defs = new List<string>();
+                if (m.TryGetProperty("definitions", out var ds) && ds.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var d in ds.EnumerateArray().Take(MaxDefinitionsPerMeaning))
+                    {
+                        if (d.TryGetProperty("definition", out var def) && def.ValueKind == JsonValueKind.String)
+                            defs.Add(def.GetString()!);
+                    }
+                }
+                meanings.Add(new { partOfSpeech = pos, definitions = defs });
+            }
+        }
+
+        return ToolJson.Result(new { found = true, word, phonetic, meanings });
+    }
+}

--- a/backend/src/Application/Tools/SearchBookTool.cs
+++ b/backend/src/Application/Tools/SearchBookTool.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+using TextStack.Ai.Rag;
+
+namespace Application.Tools;
+
+/// <summary>
+/// Phase 5 starter tool (AI-030): searches the current book via the production hybrid retrieval
+/// (vector + lexical + RRF, AI-023) and returns the top passages with their chapter numbers. When the
+/// invoking user has reading progress, results are spoiler-gated to their furthest-read chapter (same
+/// high-water mark as RAG); without progress the search is ungated — the Explain flow targets text the
+/// user is actively looking at.
+/// </summary>
+public sealed class SearchBookTool : ITool
+{
+    public const int TopK = 5;
+
+    /// <summary>Snippet cap per passage — five of these stay comfortably inside the prompt budget.</summary>
+    public const int SnippetChars = 400;
+
+    private static readonly JsonElement Schema = ToolJson.Schema("""
+        {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 300,
+              "description": "What to look for in the book (a phrase, term, or question)"
+            }
+          },
+          "required": ["query"],
+          "additionalProperties": false
+        }
+        """);
+
+    public string Name => "search_book";
+
+    public string Description =>
+        "Search the current book for passages relevant to a phrase or question. " +
+        "Use when the explanation needs where/how the book discusses something.";
+
+    public JsonElement ArgsSchema => Schema;
+
+    public async Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
+    {
+        if (ctx.EditionId is not { } editionId)
+            throw new InvalidOperationException("No edition in context — search_book needs a current book.");
+
+        var query = ToolJson.GetString(args, "query")!; // shape guaranteed by schema validation
+
+        var rag = ctx.Services.GetRequiredService<IRagService>();
+        var gate = ctx.UserId is { } userId
+            ? await ResolveLastReadOrdAsync(ctx.Services.GetRequiredService<IAppDbContext>(), userId, editionId, ct)
+            : null;
+
+        var chunks = await rag.RetrieveAsync(editionId, query, TopK, maxChapterOrd: gate, ct);
+
+        var passages = chunks.Select(c =>
+        {
+            var (snippet, truncated) = ToolJson.Truncate(c.Text, SnippetChars);
+            return new { chapterNumber = c.ChapterOrd, snippet, truncated };
+        }).ToList();
+
+        return ToolJson.Result(new { query, passages });
+    }
+
+    /// <summary>
+    /// The user's furthest-read chapter in this edition (high-water mark, falling back to the current
+    /// chapter for legacy rows) — same semantics as RagContextService, minus the site filter
+    /// (single-site, ADR-007; ToolContext carries no SiteId). Null = no progress → ungated.
+    /// </summary>
+    private static async Task<int?> ResolveLastReadOrdAsync(
+        IAppDbContext db, Guid userId, Guid editionId, CancellationToken ct)
+    {
+        var row = await db.ReadingProgresses
+            .Where(p => p.UserId == userId && p.EditionId == editionId)
+            .Join(db.Chapters, p => p.ChapterId, c => c.Id,
+                (p, c) => new { p.MaxChapterNumber, c.ChapterNumber })
+            .FirstOrDefaultAsync(ct);
+
+        return row is null ? null : row.MaxChapterNumber ?? row.ChapterNumber;
+    }
+}

--- a/backend/src/Application/Tools/ToolJson.cs
+++ b/backend/src/Application/Tools/ToolJson.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+
+namespace Application.Tools;
+
+/// <summary>
+/// Small shared helpers for the Phase 5 tools (AI-030): parse a schema string once into the
+/// <see cref="JsonElement"/> the <c>ITool.ArgsSchema</c> contract wants, read already-validated
+/// arguments, and serialize results. Argument SHAPE is guaranteed by the dispatcher's JSON-Schema
+/// validation — these readers only extract.
+/// </summary>
+internal static class ToolJson
+{
+    /// <summary>Parses a JSON-Schema literal into a detached, reusable element (held in a static).</summary>
+    public static JsonElement Schema(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    public static string? GetString(JsonElement args, string name) =>
+        args.ValueKind == JsonValueKind.Object && args.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    public static int? GetInt(JsonElement args, string name) =>
+        args.ValueKind == JsonValueKind.Object && args.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+            ? v.GetInt32()
+            : null;
+
+    public static JsonElement Result<T>(T value) => JsonSerializer.SerializeToElement(value, JsonOpts);
+
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    /// <summary>Truncates tool output text so one tool call can't blow the prompt budget.</summary>
+    public static (string Text, bool Truncated) Truncate(string text, int maxChars) =>
+        text.Length <= maxChars ? (text, false) : (text[..maxChars], true);
+}

--- a/tests/TextStack.UnitTests/StarterToolsTests.cs
+++ b/tests/TextStack.UnitTests/StarterToolsTests.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using Application.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// AI-030 starter tools — the parts testable without a DB/network: discovery via the assembly scan,
+/// schema validity (each tool's ArgsSchema accepts its happy path and rejects malformed args through
+/// the same validator the dispatcher uses), and the dictionary payload parser.
+/// </summary>
+public class StarterToolsTests
+{
+    private static readonly string[] ExpectedNames =
+        ["get_chapter", "search_book", "lookup_dictionary", "get_user_highlights"];
+
+    private static JsonElement Args(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void AddAiTools_ScanningApplication_DiscoversAllFourStarterTools()
+    {
+        var services = new ServiceCollection();
+        services.AddAiTools(typeof(GetChapterTool).Assembly);
+
+        using var sp = services.BuildServiceProvider();
+        var registry = sp.GetRequiredService<IToolRegistry>();
+
+        foreach (var name in ExpectedNames)
+            Assert.NotNull(registry.Get(name));
+        Assert.Equal(ExpectedNames.Length, registry.Names.Count); // exactly these — no stray ITool in Application
+    }
+
+    [Theory]
+    [InlineData(typeof(GetChapterTool), """{"chapter_number": 3}""", """{"chapter_number": 0}""")]
+    [InlineData(typeof(SearchBookTool), """{"query": "replication lag"}""", """{"query": "x"}""")]
+    [InlineData(typeof(LookupDictionaryTool), """{"word": "quorum", "lang": "en"}""", """{"lang": "en"}""")]
+    [InlineData(typeof(GetUserHighlightsTool), """{"query": "lsm", "limit": 5}""", """{"limit": 99}""")]
+    public void ArgsSchema_AcceptsHappyPath_RejectsMalformed(Type toolType, string goodArgs, string badArgs)
+    {
+        var tool = (ITool)Activator.CreateInstance(toolType)!;
+
+        Assert.Null(ToolDispatcher.ValidateArgs(tool.ArgsSchema, Args(goodArgs)));
+        Assert.NotNull(ToolDispatcher.ValidateArgs(tool.ArgsSchema, Args(badArgs)));
+    }
+
+    [Theory]
+    [InlineData(typeof(GetChapterTool))]
+    [InlineData(typeof(SearchBookTool))]
+    [InlineData(typeof(LookupDictionaryTool))]
+    [InlineData(typeof(GetUserHighlightsTool))]
+    public void ArgsSchema_RejectsUnknownProperties(Type toolType)
+    {
+        var tool = (ITool)Activator.CreateInstance(toolType)!;
+        Assert.NotNull(ToolDispatcher.ValidateArgs(tool.ArgsSchema, Args("""{"hallucinated_arg": true}""")));
+    }
+
+    // ---- LookupDictionaryTool.ParseEntry (pure) ----
+
+    [Fact]
+    public void ParseEntry_CompactsPhoneticAndMeanings()
+    {
+        var payload = Args("""
+            [{
+              "word": "quorum",
+              "phonetic": "/ˈkwɔːɹəm/",
+              "meanings": [
+                { "partOfSpeech": "noun",
+                  "definitions": [ {"definition": "The minimum number of members required."},
+                                   {"definition": "A select group."},
+                                   {"definition": "A third definition that should be cut."} ] }
+              ]
+            }]
+            """);
+
+        var result = LookupDictionaryTool.ParseEntry(payload, "quorum");
+
+        Assert.True(result.GetProperty("found").GetBoolean());
+        Assert.Equal("/ˈkwɔːɹəm/", result.GetProperty("phonetic").GetString());
+        var meaning = result.GetProperty("meanings")[0];
+        Assert.Equal("noun", meaning.GetProperty("partOfSpeech").GetString());
+        Assert.Equal(2, meaning.GetProperty("definitions").GetArrayLength()); // capped at 2 per meaning
+    }
+
+    [Fact]
+    public void ParseEntry_EmptyPayload_NotFound()
+    {
+        var result = LookupDictionaryTool.ParseEntry(Args("[]"), "ghost");
+        Assert.False(result.GetProperty("found").GetBoolean());
+    }
+}

--- a/tests/TextStack.UnitTests/ToolDispatcherTests.cs
+++ b/tests/TextStack.UnitTests/ToolDispatcherTests.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
+
+namespace TextStack.UnitTests;
+
+public class ToolDispatcherTests
+{
+    private static readonly JsonElement EchoSchema = JsonDocument.Parse("""
+        {
+          "type": "object",
+          "properties": { "text": { "type": "string" }, "count": { "type": "integer", "minimum": 1 } },
+          "required": ["text"],
+          "additionalProperties": false
+        }
+        """).RootElement;
+
+    private sealed class EchoTool : ITool
+    {
+        public string Name => "echo";
+        public string Description => "echoes";
+        public JsonElement ArgsSchema => EchoSchema;
+        public Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct) =>
+            Task.FromResult(args);
+    }
+
+    private sealed class BoomTool : ITool
+    {
+        public string Name => "boom";
+        public string Description => "always fails";
+        public JsonElement ArgsSchema => JsonDocument.Parse("""{"type":"object"}""").RootElement;
+        public Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct) =>
+            throw new InvalidOperationException("kaput");
+    }
+
+    private static ToolDispatcher Dispatcher(params ITool[] tools) => new(new ToolRegistry(tools));
+
+    private static ToolContext Ctx() =>
+        new(UserId: null, EditionId: null, AgentRunId: Guid.NewGuid(), new ServiceCollection().BuildServiceProvider());
+
+    private static ToolCall Call(string tool, string argsJson) =>
+        new("call-1", tool, JsonDocument.Parse(argsJson).RootElement);
+
+    [Fact]
+    public async Task Dispatch_ValidArgs_InvokesAndSucceeds()
+    {
+        var result = await Dispatcher(new EchoTool())
+            .DispatchAsync(Call("echo", """{"text":"hi","count":2}"""), Ctx(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Ok);
+        Assert.Equal("hi", result.Result!.Value.GetProperty("text").GetString());
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task Dispatch_UnknownTool_FailsAndListsAvailable()
+    {
+        var result = await Dispatcher(new EchoTool())
+            .DispatchAsync(Call("nope", "{}"), Ctx(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.Ok);
+        Assert.Contains("Unknown tool 'nope'", result.Error);
+        Assert.Contains("echo", result.Error); // tells the model what IS available
+    }
+
+    [Theory]
+    [InlineData("{}")]                          // missing required "text"
+    [InlineData("""{"text": 42}""")]            // wrong type
+    [InlineData("""{"text":"hi","count":0}""")] // below minimum
+    [InlineData("""{"text":"hi","extra":1}""")] // additionalProperties: false
+    public async Task Dispatch_InvalidArgs_FailsWithoutInvoking(string argsJson)
+    {
+        var result = await Dispatcher(new EchoTool())
+            .DispatchAsync(Call("echo", argsJson), Ctx(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.Ok);
+        Assert.StartsWith("Invalid arguments", result.Error);
+    }
+
+    [Fact]
+    public async Task Dispatch_ToolThrows_BecomesFailureResult()
+    {
+        var result = await Dispatcher(new BoomTool())
+            .DispatchAsync(Call("boom", "{}"), Ctx(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.Ok);
+        Assert.Contains("kaput", result.Error);
+    }
+
+    [Fact]
+    public async Task DispatchAll_RunsEveryCall_PreservesOrder()
+    {
+        var dispatcher = Dispatcher(new EchoTool(), new BoomTool());
+        var results = await dispatcher.DispatchAllAsync(
+            [Call("echo", """{"text":"a"}"""), Call("boom", "{}"), Call("missing", "{}")],
+            Ctx(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, results.Length);
+        Assert.True(results[0].Ok);
+        Assert.False(results[1].Ok);
+        Assert.False(results[2].Ok);
+    }
+
+    [Fact]
+    public void ValidateArgs_Valid_ReturnsNull()
+        => Assert.Null(ToolDispatcher.ValidateArgs(EchoSchema, JsonDocument.Parse("""{"text":"x"}""").RootElement));
+
+    [Fact]
+    public void ValidateArgs_Invalid_ReturnsReadableViolations()
+    {
+        var error = ToolDispatcher.ValidateArgs(EchoSchema, JsonDocument.Parse("{}").RootElement);
+        Assert.NotNull(error);
+        Assert.Contains("text", error); // names the offending property/requirement
+    }
+}


### PR DESCRIPTION
Phase 5 **AI-030** — the first concrete tools and the validated dispatch they run through. The Explain SSE refactor (**AI-031**) will hand these to the model.

## Changes
- **`ToolDispatcher`** (`Ai.Tools`) — registry lookup → evaluate args against the tool's JSON Schema (**draft 2020-12 via JsonSchema.Net**, a real evaluator, not hand-rolled checks) → invoke. Unknown tool / invalid args / tool exceptions return as failed `ToolResult`s — **errors are data**, fed back to the LLM so it can fix its args and retry (playbook risk mitigation). Caller-cancellation propagates. `DispatchAllAsync` runs a batch concurrently (parallel tool calls, Phase 5 scope).
- **4 starter tools** (`Application/Tools/`, stateless singletons; scoped deps resolved from `ToolContext.Services` at invoke — no captive dependencies):
  - `get_chapter(chapter_number)` — chapter title + text (4k char cap) of the context edition.
  - `search_book(query)` — top-5 passages via the production **hybrid retrieval** (AI-023); **spoiler-gated** to the user's furthest-read chapter when progress exists (same high-water mark as RAG), ungated otherwise (Explain targets text the user is actively viewing).
  - `lookup_dictionary(word, lang?)` — Free Dictionary API (same upstream as the public /dictionary), compacted to phonetic + top meanings; not-found is data (`found:false`), not an error.
  - `get_user_highlights(query?, limit?)` — the user's own highlights+notes for the book, ILIKE-filtered, capped at 20. Strictly scoped to `ToolContext.UserId`.
- All schemas declare **`additionalProperties: false`** — hallucinated args are rejected before dispatch.
- Wiring: `AddAiTools(Application assembly)` in `Program` (scan finds exactly the 4); dispatcher registered alongside the registry. `Microsoft.Extensions.Http` added to Application (`IHttpClientFactory` for the dictionary tool). New central package: `JsonSchema.Net 7.3.4`.

## Verification (21 new tests)
- Dispatcher: valid args → invoke; unknown tool fails and lists what's available; missing-required / wrong-type / below-minimum / extra-property all rejected **pre-invoke**; tool exception → failure result with message; batch preserves order.
- Every tool's schema accepts its happy path and rejects malformed args + unknown props via the same validator the dispatcher uses.
- Assembly scan discovers exactly the 4 starter tools.
- `LookupDictionaryTool.ParseEntry` compaction (caps, not-found).
- Full solution builds; `TextStack.UnitTests` green (224); `dotnet format` clean. DB/network paths (EF queries, dictionary HTTP) exercise in AI-031 + e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)