### PR TITLE
feat(ai): Explain streams over SSE (AI-031a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Phase 5 — Explain streams over SSE (2026-06-12)
+
+Phase 5 **AI-031, slice a** — the Explain endpoint streams token-by-token. Function-calling wiring (tools handed to the model) is slice b.
+
+- **Content negotiation, mobile-safe**: `Accept: text/event-stream` → SSE (`delta`* → `done` | `error`, via .NET 10 `TypedResults.ServerSentEvents`); any other request keeps the **original JSON contract** — the shared mobile client works unchanged. Web switches to the stream in AI-032.
+- **Migrated off the legacy seam**: Explain now calls the `ILlmService` gateway directly (FeatureTag `explain` — routed + traced, streamed calls included per AI-028) instead of `ILlmServiceFactory`.
+- **Cache preserved**: SHA256 file cache hit → one `delta` with the full text + `done(cached:true)` immediately; miss → stream, then persist the accumulated text. Empty-stream (reasoning-budget) retry preserved as a `CompleteAsync` fallback at doubled budget.
+- **Robust SSE termination**: mid-stream provider failure and keyless-host provider-resolution failure both emit a terminal `error` event (never an aborted stream); client disconnect propagates untraced (AI-028 follow-up behaviour).
+- **Cloudflare/nginx**: `X-Accel-Buffering: no` + `Cache-Control: no-cache` on the SSE response (playbook Phase 5 risk).
+- Tests: `StreamEventsAsync` unit-tested over fake delegates (cache hit; per-fragment deltas + persist; empty→fallback delta; fallback empty/throws → error; mid-stream failure → partial deltas + terminal error, nothing persisted). Live-API integration: 400 regardless of Accept; JSON contract intact without the header; SSE content-type + guaranteed terminal event with it (skip when provider unavailable).
+
 ### Phase 5 — 4 starter tools + schema-validated dispatch (2026-06-11)
 
 Phase 5 **AI-030** — the first concrete tools and the validated dispatch they run through. The Explain SSE refactor (AI-031) will hand these to the model.

--- a/backend/src/Api/Endpoints/ExplainEndpoints.cs
+++ b/backend/src/Api/Endpoints/ExplainEndpoints.cs
@@ -1,16 +1,29 @@
+using System.Net.ServerSentEvents;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Application.Ai;
 using Application.Common.Interfaces;
-using Domain.LLM;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using TextStack.Ai.Core;
 
 namespace Api.Endpoints;
 
+/// <summary>
+/// Contextual word explanation (Phase 5: streams). Content-negotiated (AI-031a): an
+/// <c>Accept: text/event-stream</c> request gets token-by-token SSE (<c>delta</c> events, then
+/// <c>done</c>); anything else gets the original JSON shape — the mobile client keeps working
+/// unchanged. Both paths share validation, genre resolution, the SHA256 file cache, and the
+/// <see cref="ILlmService"/> gateway seam (FeatureTag <c>explain</c> — traced, routed).
+/// </summary>
 public static class ExplainEndpoints
 {
+    private const string FeatureTag = "explain";
+    private const int MaxOutputTokens = 500;
+    private const int RetryOutputTokens = 1000;
+
     public static void MapExplainEndpoints(this WebApplication app)
     {
         var group = app.MapGroup("/explain").WithTags("Explain");
@@ -19,16 +32,15 @@ public static class ExplainEndpoints
 
     private static async Task<IResult> Explain(
         [FromBody] ExplainRequest request,
+        HttpContext httpContext,
         IConfiguration config,
-        ILlmServiceFactory llmFactory,
+        ILlmService llm,
         IAppDbContext db,
         ILogger<Program> logger,
         CancellationToken ct)
     {
         var maxWordLength = config.GetValue("Explain:MaxWordLength", 100);
         var maxSentenceLength = config.GetValue("Explain:MaxSentenceLength", 800);
-        var cachePath = config.GetValue<string>("Explain:CachePath") ?? "/tmp/explain-cache";
-        var cacheTtlDays = config.GetValue("Explain:CacheTtlDays", 30);
 
         if (string.IsNullOrWhiteSpace(request.Word))
             return Results.BadRequest("Word is required");
@@ -40,92 +52,48 @@ public static class ExplainEndpoints
             return Results.BadRequest($"Sentence exceeds {maxSentenceLength} chars");
 
         var targetLang = string.IsNullOrWhiteSpace(request.TargetLang) ? "en" : request.TargetLang.Split('-')[0];
-
-        var genre = request.Genre;
-        if (string.IsNullOrWhiteSpace(genre) && !string.IsNullOrWhiteSpace(request.BookId)
-            && Guid.TryParse(request.BookId, out var bookId))
-        {
-            try
-            {
-                genre = await db.Editions
-                    .Where(e => e.Id == bookId)
-                    .SelectMany(e => e.Genres.Select(g => g.Name))
-                    .FirstOrDefaultAsync(ct);
-                if (string.IsNullOrWhiteSpace(genre))
-                {
-                    genre = await db.UserBooks
-                        .Where(ub => ub.Id == bookId)
-                        .Select(ub => ub.Genre)
-                        .FirstOrDefaultAsync(ct);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Explain genre lookup failed, using 'general' domain");
-            }
-        }
-
+        var genre = await ResolveGenreAsync(request, db, logger, ct);
+        var cache = new ExplainCache(config, logger);
         var cacheKey = ComputeCacheKey(request.Word, request.Sentence, genre, targetLang);
-        var cacheFile = Path.Combine(cachePath, cacheKey + ".json");
-
-        try
-        {
-            Directory.CreateDirectory(cachePath);
-            if (File.Exists(cacheFile))
-            {
-                var info = new FileInfo(cacheFile);
-                if (info.LastWriteTimeUtc > DateTime.UtcNow.AddDays(-cacheTtlDays))
-                {
-                    var cached = await File.ReadAllTextAsync(cacheFile, ct);
-                    var cachedResp = JsonSerializer.Deserialize<ExplainResponse>(cached);
-                    if (cachedResp != null && !string.IsNullOrWhiteSpace(cachedResp.Explanation))
-                        return Results.Ok(cachedResp with { Cached = true });
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Explain cache read failed, falling through to LLM");
-        }
 
         var systemPrompt = ExplainPrompt.BuildSystemPrompt(genre, targetLang);
         var userPrompt = ExplainPrompt.BuildUserPrompt(request.Word, request.Sentence);
 
+        var wantsSse = httpContext.Request.Headers.Accept.Any(v =>
+            v is not null && v.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase));
+
+        return wantsSse
+            ? ExplainSse(request.Word, systemPrompt, userPrompt, cache, cacheKey, llm, httpContext)
+            : await ExplainJson(request.Word, systemPrompt, userPrompt, cache, cacheKey, llm, logger, ct);
+    }
+
+    // ---- JSON path (original contract; mobile + non-streaming clients) ----
+
+    private static async Task<IResult> ExplainJson(
+        string word, string systemPrompt, string userPrompt,
+        ExplainCache cache, string cacheKey, ILlmService llm, ILogger logger, CancellationToken ct)
+    {
+        if (await cache.TryReadAsync(cacheKey, ct) is { } cachedText)
+            return Results.Ok(new ExplainResponse(cachedText, word, Cached: true));
+
         try
         {
-            var llm = llmFactory.Get("Explain");
-            var text = await llm.CompleteAsync(
-                systemPrompt,
-                userPrompt,
-                maxOutputTokens: 500,
-                ct);
+            var text = (await llm.CompleteAsync(BuildRequest(systemPrompt, userPrompt, MaxOutputTokens), ct)).Text;
 
             // Reasoning models can exhaust the visible budget on internal reasoning
             // and return empty. Retry once with doubled budget before giving up.
             if (string.IsNullOrWhiteSpace(text))
             {
-                logger.LogWarning("Explain got empty result at 500 tokens, retrying with 1000");
-                text = await llm.CompleteAsync(systemPrompt, userPrompt, maxOutputTokens: 1000, ct);
+                logger.LogWarning("Explain got empty result at {Max} tokens, retrying with {Retry}",
+                    MaxOutputTokens, RetryOutputTokens);
+                text = (await llm.CompleteAsync(BuildRequest(systemPrompt, userPrompt, RetryOutputTokens), ct)).Text;
             }
 
             if (string.IsNullOrWhiteSpace(text))
                 return Results.Problem("LLM returned empty explanation", statusCode: 502);
 
-            var resp = new ExplainResponse(text, request.Word, false);
-
-            try
-            {
-                await File.WriteAllTextAsync(
-                    cacheFile,
-                    JsonSerializer.Serialize(resp),
-                    ct);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Explain cache write failed");
-            }
-
-            return Results.Ok(resp);
+            await cache.WriteAsync(cacheKey, text, ct);
+            return Results.Ok(new ExplainResponse(text, word, Cached: false));
         }
         catch (TaskCanceledException)
         {
@@ -134,9 +102,170 @@ public static class ExplainEndpoints
         catch (Exception ex)
         {
             logger.LogError(ex, "Explain LLM call failed");
-            return Results.Problem(
-                detail: "Explain service unavailable",
-                statusCode: 503);
+            return Results.Problem(detail: "Explain service unavailable", statusCode: 503);
+        }
+    }
+
+    // ---- SSE path (AI-031a): delta* -> done | error ----
+
+    private static IResult ExplainSse(
+        string word, string systemPrompt, string userPrompt,
+        ExplainCache cache, string cacheKey, ILlmService llm, HttpContext httpContext)
+    {
+        // Cloudflare/nginx must not buffer the stream (playbook Phase 5 risk).
+        httpContext.Response.Headers["X-Accel-Buffering"] = "no";
+        httpContext.Response.Headers.CacheControl = "no-cache";
+
+        return TypedResults.ServerSentEvents(StreamEventsAsync(
+            word,
+            primary: ct => llm.StreamAsync(BuildRequest(systemPrompt, userPrompt, MaxOutputTokens), ct),
+            fallback: async ct =>
+                (await llm.CompleteAsync(BuildRequest(systemPrompt, userPrompt, RetryOutputTokens), ct)).Text,
+            readCache: ct => cache.TryReadAsync(cacheKey, ct),
+            persist: (text, ct) => cache.WriteAsync(cacheKey, text, ct),
+            httpContext.RequestAborted));
+    }
+
+    /// <summary>
+    /// The Explain SSE event stream: cache hit → one <c>delta</c> + <c>done(cached)</c>; miss → a
+    /// <c>delta</c> per token from <paramref name="primary"/>, then persist + <c>done</c>. An empty
+    /// stream falls back to <paramref name="fallback"/> (the empty-reasoning retry); a mid-stream
+    /// failure emits <c>error</c> as the terminal event. Pure over its delegates — unit-tested directly.
+    /// </summary>
+    public static async IAsyncEnumerable<SseItem<string>> StreamEventsAsync(
+        string word,
+        Func<CancellationToken, IAsyncEnumerable<LlmDelta>> primary,
+        Func<CancellationToken, Task<string>> fallback,
+        Func<CancellationToken, Task<string?>> readCache,
+        Func<string, CancellationToken, Task> persist,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        if (await readCache(ct) is { } cachedText)
+        {
+            yield return new SseItem<string>(cachedText, "delta");
+            yield return Done(word, cached: true);
+            yield break;
+        }
+
+        var text = new StringBuilder();
+        string? error = null;
+
+        // Provider resolution happens inside primary() (gateway → keyed provider ctor) and can throw
+        // on a keyless host — that must surface as an SSE error event, not a broken stream.
+        IAsyncEnumerable<LlmDelta>? stream = null;
+        try
+        {
+            stream = primary(ct);
+        }
+        catch (Exception)
+        {
+            error = "Explain service unavailable";
+        }
+
+        if (error is null)
+        {
+            await using var e = stream!.GetAsyncEnumerator(ct);
+            while (true)
+            {
+                LlmDelta delta;
+                try
+                {
+                    if (!await e.MoveNextAsync())
+                        break;
+                    delta = e.Current;
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw; // client disconnected — nothing to emit
+                }
+                catch (Exception)
+                {
+                    error = "Explain service unavailable";
+                    break;
+                }
+
+                if (delta.TextDelta is { Length: > 0 } fragment)
+                {
+                    text.Append(fragment);
+                    yield return new SseItem<string>(fragment, "delta");
+                }
+            }
+        }
+
+        if (error is not null)
+        {
+            yield return new SseItem<string>(error, "error");
+            yield break;
+        }
+
+        // Empty stream (reasoning budget exhausted) → one-shot retry with a doubled budget.
+        if (text.Length == 0)
+        {
+            string? retried = null;
+            try
+            {
+                retried = await fallback(ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                error = "Explain service unavailable";
+            }
+
+            if (error is null && string.IsNullOrWhiteSpace(retried))
+                error = "LLM returned empty explanation";
+            if (error is not null)
+            {
+                yield return new SseItem<string>(error, "error");
+                yield break;
+            }
+
+            text.Append(retried);
+            yield return new SseItem<string>(retried!, "delta");
+        }
+
+        await persist(text.ToString(), ct);
+        yield return Done(word, cached: false);
+    }
+
+    private static SseItem<string> Done(string word, bool cached) =>
+        new(JsonSerializer.Serialize(new { word, cached }), "done");
+
+    // ---- shared pieces ----
+
+    private static LlmRequest BuildRequest(string systemPrompt, string userPrompt, int maxTokens) =>
+        new(systemPrompt, [new LlmMessage("user", userPrompt)], maxTokens, FeatureTag: FeatureTag);
+
+    private static async Task<string?> ResolveGenreAsync(
+        ExplainRequest request, IAppDbContext db, ILogger logger, CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(request.Genre))
+            return request.Genre;
+        if (string.IsNullOrWhiteSpace(request.BookId) || !Guid.TryParse(request.BookId, out var bookId))
+            return null;
+
+        try
+        {
+            var genre = await db.Editions
+                .Where(e => e.Id == bookId)
+                .SelectMany(e => e.Genres.Select(g => g.Name))
+                .FirstOrDefaultAsync(ct);
+            if (string.IsNullOrWhiteSpace(genre))
+            {
+                genre = await db.UserBooks
+                    .Where(ub => ub.Id == bookId)
+                    .Select(ub => ub.Genre)
+                    .FirstOrDefaultAsync(ct);
+            }
+            return genre;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Explain genre lookup failed, using 'general' domain");
+            return null;
         }
     }
 
@@ -146,6 +275,48 @@ public static class ExplainEndpoints
         var bytes = Encoding.UTF8.GetBytes(payload);
         var hash = SHA256.HashData(bytes);
         return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    /// <summary>The SHA256-keyed file cache (unchanged semantics: TTL days, best-effort IO).</summary>
+    private sealed class ExplainCache(IConfiguration config, ILogger logger)
+    {
+        private readonly string _path = config.GetValue<string>("Explain:CachePath") ?? "/tmp/explain-cache";
+        private readonly int _ttlDays = config.GetValue("Explain:CacheTtlDays", 30);
+
+        public async Task<string?> TryReadAsync(string key, CancellationToken ct)
+        {
+            try
+            {
+                var file = Path.Combine(_path, key + ".json");
+                if (!File.Exists(file))
+                    return null;
+                if (new FileInfo(file).LastWriteTimeUtc <= DateTime.UtcNow.AddDays(-_ttlDays))
+                    return null;
+                var cached = JsonSerializer.Deserialize<ExplainResponse>(await File.ReadAllTextAsync(file, ct));
+                return string.IsNullOrWhiteSpace(cached?.Explanation) ? null : cached.Explanation;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Explain cache read failed, falling through to LLM");
+                return null;
+            }
+        }
+
+        public async Task WriteAsync(string key, string explanation, CancellationToken ct)
+        {
+            try
+            {
+                Directory.CreateDirectory(_path);
+                var file = Path.Combine(_path, key + ".json");
+                // Word/Cached mirror what the JSON path historically persisted; readers flip Cached on hit.
+                await File.WriteAllTextAsync(
+                    file, JsonSerializer.Serialize(new ExplainResponse(explanation, "", false)), ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Explain cache write failed");
+            }
+        }
     }
 }
 

--- a/tests/TextStack.IntegrationTests/ExplainSseEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/ExplainSseEndpointTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// AI-031a — content negotiation on POST /explain against the live API. Without an
+/// <c>Accept: text/event-stream</c> header the original JSON contract must hold (the mobile client
+/// depends on it); with it the response must be an SSE stream. LLM-touching outcomes skip when the
+/// backing provider isn't available (no key / 5xx), like the other live-API suites.
+/// </summary>
+public class ExplainSseEndpointTests : IClassFixture<LiveApiFixture>
+{
+    private readonly LiveApiFixture _fixture;
+
+    public ExplainSseEndpointTests(LiveApiFixture fixture) => _fixture = fixture;
+
+    private static readonly object ValidBody = new
+    {
+        word = "quorum",
+        sentence = "The write succeeds once a quorum of replicas acknowledges it.",
+        targetLang = "en",
+    };
+
+    private HttpRequestMessage Request(bool sse)
+    {
+        var request = _fixture.CreateRequest(HttpMethod.Post, "/explain");
+        request.Content = JsonContent.Create(ValidBody);
+        if (sse)
+            request.Headers.Accept.ParseAdd("text/event-stream");
+        return request;
+    }
+
+    // 429 = rate-limited (explain is throttled); 5xx = no provider/key behind the endpoint.
+    private static bool NotReachable(HttpResponseMessage r) =>
+        IntegrationSkip.Unavailable(r)
+        || r.StatusCode is HttpStatusCode.TooManyRequests
+            or HttpStatusCode.BadGateway
+            or HttpStatusCode.ServiceUnavailable
+            or HttpStatusCode.GatewayTimeout;
+
+    [Fact]
+    public async Task Explain_InvalidBody_Returns400_RegardlessOfAccept()
+    {
+        var request = Request(sse: true);
+        request.Content = JsonContent.Create(new { word = "", sentence = "" });
+
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "explain endpoint not deployed");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Explain_WithoutSseAccept_KeepsJsonContract()
+    {
+        var response = await _fixture.Client.SendAsync(Request(sse: false), TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(NotReachable(response), "explain backend unavailable (no key / throttled)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("explanation").GetString()));
+    }
+
+    [Fact]
+    public async Task Explain_WithSseAccept_StreamsEventStream()
+    {
+        var response = await _fixture.Client.SendAsync(
+            Request(sse: true), HttpCompletionOption.ResponseHeadersRead, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(NotReachable(response), "explain backend unavailable (no key / throttled)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/event-stream", response.Content.Headers.ContentType?.MediaType);
+
+        // The stream must terminate with done (success) or error (e.g. keyless host) — never hang
+        // and never abort mid-stream.
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(
+            body.Contains("event: done") || body.Contains("event: error"),
+            $"SSE stream ended without a terminal event:\n{body}");
+        if (body.Contains("event: done"))
+            Assert.Contains("event: delta", body); // success implies at least one text delta
+    }
+}

--- a/tests/TextStack.UnitTests/ExplainSseTests.cs
+++ b/tests/TextStack.UnitTests/ExplainSseTests.cs
@@ -1,0 +1,121 @@
+using System.Net.ServerSentEvents;
+using Api.Endpoints;
+using TextStack.Ai.Core;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// AI-031a — the Explain SSE event stream (<see cref="ExplainEndpoints.StreamEventsAsync"/>), driven
+/// through fake delegates: cache hit, token streaming + persist, empty-stream fallback, and error
+/// terminal events.
+/// </summary>
+public class ExplainSseTests
+{
+    private static async IAsyncEnumerable<LlmDelta> Deltas(params LlmDelta[] deltas)
+    {
+        foreach (var d in deltas)
+        {
+            await Task.Yield();
+            yield return d;
+        }
+    }
+
+    private static async IAsyncEnumerable<LlmDelta> Boom()
+    {
+        await Task.Yield();
+        yield return new LlmDelta(TextDelta: "par");
+        throw new InvalidOperationException("provider died");
+    }
+
+    private async Task<List<SseItem<string>>> CollectEvents(
+        Func<CancellationToken, IAsyncEnumerable<LlmDelta>> primary,
+        Func<CancellationToken, Task<string>>? fallback = null,
+        string? cached = null,
+        Action<string>? onPersist = null)
+    {
+        var items = new List<SseItem<string>>();
+        await foreach (var item in ExplainEndpoints.StreamEventsAsync(
+            "quorum",
+            primary,
+            fallback ?? (_ => Task.FromResult(string.Empty)),
+            _ => Task.FromResult(cached),
+            (text, _) => { onPersist?.Invoke(text); return Task.CompletedTask; },
+            TestContext.Current.CancellationToken))
+        {
+            items.Add(item);
+        }
+        return items;
+    }
+
+    [Fact]
+    public async Task CacheHit_EmitsSingleDeltaAndCachedDone()
+    {
+        var events = await CollectEvents(_ => Deltas(), cached: "A cached explanation.");
+
+        Assert.Equal(["delta", "done"], events.Select(e => e.EventType));
+        Assert.Equal("A cached explanation.", events[0].Data);
+        Assert.Contains("\"cached\":true", events[1].Data);
+    }
+
+    [Fact]
+    public async Task Stream_EmitsDeltaPerFragment_PersistsFullText_ThenDone()
+    {
+        string? persisted = null;
+        var events = await CollectEvents(
+            _ => Deltas(
+                new LlmDelta(TextDelta: "Hel"),
+                new LlmDelta(TextDelta: "lo"),
+                new LlmDelta(FinalUsage: new LlmUsage(5, 2, 0.001m), ModelId: "m")), // usage delta → no SSE event
+            onPersist: t => persisted = t);
+
+        Assert.Equal(["delta", "delta", "done"], events.Select(e => e.EventType));
+        Assert.Equal("Hello", persisted);
+        Assert.Contains("\"cached\":false", events[^1].Data);
+    }
+
+    [Fact]
+    public async Task EmptyStream_FallsBackToRetry_EmitsRetriedTextAsDelta()
+    {
+        string? persisted = null;
+        var events = await CollectEvents(
+            _ => Deltas(new LlmDelta(FinalUsage: new LlmUsage(0, 0, 0m), ModelId: "m")), // no text at all
+            fallback: _ => Task.FromResult("Retried explanation."),
+            onPersist: t => persisted = t);
+
+        Assert.Equal(["delta", "done"], events.Select(e => e.EventType));
+        Assert.Equal("Retried explanation.", events[0].Data);
+        Assert.Equal("Retried explanation.", persisted);
+    }
+
+    [Fact]
+    public async Task EmptyStream_FallbackAlsoEmpty_EmitsErrorNotDone()
+    {
+        var events = await CollectEvents(
+            _ => Deltas(),
+            fallback: _ => Task.FromResult(string.Empty));
+
+        var item = Assert.Single(events);
+        Assert.Equal("error", item.EventType);
+    }
+
+    [Fact]
+    public async Task MidStreamFailure_EmitsErrorAsTerminalEvent_NothingPersisted()
+    {
+        var persisted = false;
+        var events = await CollectEvents(_ => Boom(), onPersist: _ => persisted = true);
+
+        Assert.Equal(["delta", "error"], events.Select(e => e.EventType)); // partial text then error
+        Assert.False(persisted);
+    }
+
+    [Fact]
+    public async Task FallbackThrows_EmitsError()
+    {
+        var events = await CollectEvents(
+            _ => Deltas(),
+            fallback: _ => throw new InvalidOperationException("retry died"));
+
+        var item = Assert.Single(events);
+        Assert.Equal("error", item.EventType);
+    }
+}


### PR DESCRIPTION
Phase 5 **AI-031, slice a** — the Explain endpoint streams token-by-token. Function-calling wiring (handing the AI-030 tools to the model) is **slice b**.

## Changes
- **Content negotiation, mobile-safe**: `Accept: text/event-stream` → SSE (`delta`* → `done` | `error`, via .NET 10 `TypedResults.ServerSentEvents`); any other request keeps the **original JSON contract** — the shared mobile client keeps working unchanged. Web switches to the stream in AI-032.
- **Migrated off the legacy seam**: Explain now calls the `ILlmService` gateway directly (FeatureTag `explain` — routed + traced, streamed calls included per AI-028) instead of `ILlmServiceFactory`. Validation, genre resolution and the empty-reasoning retry are unchanged.
- **Cache preserved**: SHA256 file-cache hit → one `delta` (full text) + `done(cached:true)` immediately; miss → stream, then persist the accumulated text on completion.
- **Robust SSE termination** (QA find during implementation): provider resolution happens lazily inside the stream — on a keyless host the keyed-provider ctor throws *after* SSE headers are sent. Both that and a mid-stream provider failure now emit a terminal `error` **event** instead of aborting the stream. Client disconnect propagates untraced (#309 behaviour).
- **Cloudflare/nginx**: `X-Accel-Buffering: no` + `Cache-Control: no-cache` on the SSE response (playbook Phase 5 risk).

## Verification
- `StreamEventsAsync` unit-tested over fake delegates (6): cache hit → single delta + cached done; per-fragment deltas + full-text persist (usage delta emits nothing); empty stream → fallback delta; fallback empty / throws → terminal error; mid-stream failure → partial deltas + terminal error, nothing persisted.
- Live-API integration (3, skip-when-unavailable): 400 regardless of Accept; JSON contract intact without the header; SSE content-type + guaranteed terminal event with it.
- Full `TextStack.UnitTests` green (230); `dotnet format` clean.
- TTFT + real streaming through the Cloudflare tunnel: verify on prod after deploy (`curl -N -H 'Accept: text/event-stream' …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)