### PR TITLE
feat(ai): function-calling — Explain can use tools (AI-031b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Phase 5 — function-calling: Explain can use tools (2026-06-12)
+
+Phase 5 **AI-031, slice b** — the model can now call the AI-030 tools. Explain grounds its answers in the book (chapter fetch, in-book search, the user's highlights, dictionary) via one validated tool round.
+
+- **`OpenAiLlmClient` function-calling** — `LlmRequest.Tools` → `ChatTool.CreateFunctionTool` (schema as-is); `CompleteAsync` parses `tool_calls` into `LlmResponse.ToolCalls`; `StreamAsync` accumulates streamed tool-call fragments per index and emits each **complete** call as a `ToolCallDelta` after the provider stream ends (partial tool-call streaming is out of Phase 5 scope). Message mapping grew the round-2 shapes: assistant turn carrying its tool calls, and `tool` role results keyed by call id. Empty content on a tool-call turn no longer warns.
+- **`ToolCallingSession`** (`Ai.Tools`) — ONE round of function-calling over any `ILlmService`: stream round 1 re-yielding text (the no-tool case stays fully streaming, tool deltas are not client-visible); if tools were requested → validated parallel dispatch (`ToolDispatcher`, failures fed back as data) → round 2 **without** tool schemas streams the final answer. Multi-step loops are Phase 6's `AgentLoop`.
+- **Explain wiring** — both SSE and JSON paths run through the session. Tool set per request: `lookup_dictionary` always; + `get_chapter`/`search_book` with a book in context; + `get_user_highlights` when signed in. System prompt gains the playbook tool-guidance block only when tools ride along. Kill switch: `Explain:ToolsEnabled` (default on).
+- **Cache safety (QA find)** — tool-grounded answers can be user-specific (highlights; progress-gated search), so they are **never written to the shared explain cache** (`onToolRound`/`UsedTools` signal); direct answers cache as before.
+- Tests: `ToolCallingSession` (6) over a scripted LLM — single-round passthrough; tool round dispatches and streams the follow-up (assistant+tool messages, no schemas in round 2, plumbing invisible to the client); unknown tool error fed back as data; complete-variant flags `UsedTools`; result serialization. Caught in-suite: duplicate fake-tool name across test classes broke the assembly-scan test — renamed (the scan's fail-fast working as intended).
+
 ### Phase 5 — Explain streams over SSE (2026-06-12)
 
 Phase 5 **AI-031, slice a** — the Explain endpoint streams token-by-token. Function-calling wiring (tools handed to the model) is slice b.

--- a/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
@@ -1,4 +1,6 @@
 using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using OpenAI;
@@ -58,7 +60,17 @@ public sealed class OpenAiLlmClient : ILlmService
         {
             messages.Add(m.Role.ToLowerInvariant() switch
             {
+                // An assistant turn that requested tool calls (function-calling round 2 sends the
+                // model its own calls back, then the tool results below).
+                "assistant" when m.ToolCalls is { Count: > 0 } =>
+                    new AssistantChatMessage(m.ToolCalls.Select(ToChatToolCall)),
                 "assistant" => new AssistantChatMessage(m.Content),
+                // A tool result: Content is the tool's JSON output; ToolCalls[0] carries the call id.
+                "tool" => new ToolChatMessage(
+                    m.ToolCalls is { Count: > 0 }
+                        ? m.ToolCalls[0].Id
+                        : throw new InvalidOperationException("A 'tool' message must carry its ToolCall (for the call id)."),
+                    m.Content),
                 "system" => new SystemChatMessage(m.Content),
                 _ => new UserChatMessage(m.Content),
             });
@@ -66,22 +78,52 @@ public sealed class OpenAiLlmClient : ILlmService
         return messages;
     }
 
+    private ChatCompletionOptions BuildOptions(LlmRequest request)
+    {
+        var options = new ChatCompletionOptions
+        {
+            MaxOutputTokenCount = request.MaxOutputTokens + _reasoningBudget, // +512 padding quirk
+        };
+        if (request.Tools is { Count: > 0 })
+        {
+            foreach (var tool in request.Tools)
+            {
+                options.Tools.Add(ChatTool.CreateFunctionTool(
+                    tool.Name, tool.Description, BinaryData.FromString(tool.ArgsSchema.GetRawText())));
+            }
+        }
+        return options;
+    }
+
+    private static ChatToolCall ToChatToolCall(ToolCall call) =>
+        ChatToolCall.CreateFunctionToolCall(call.Id, call.ToolName, BinaryData.FromString(call.Arguments.GetRawText()));
+
+    /// <summary>Parses a function-call's arguments JSON ("" → empty object) into a detached element.</summary>
+    private static JsonElement ParseArgs(string argumentsJson)
+    {
+        using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson);
+        return doc.RootElement.Clone();
+    }
+
     public async Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
     {
         var messages = BuildMessages(request);
-
-        var maxTokens = request.MaxOutputTokens + _reasoningBudget; // +512 padding quirk
-        var options = new ChatCompletionOptions { MaxOutputTokenCount = maxTokens };
+        var options = BuildOptions(request);
 
         var result = await _client.CompleteChatAsync(messages, options, ct);
         var completion = result.Value;
 
+        var toolCalls = completion.ToolCalls
+            .Select(tc => new ToolCall(tc.Id, tc.FunctionName, ParseArgs(tc.FunctionArguments.ToString())))
+            .ToList();
+
         var text = completion.Content.FirstOrDefault()?.Text ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(text))
+        // Empty content is normal on a tool-call turn — only warn when the model produced nothing at all.
+        if (string.IsNullOrWhiteSpace(text) && toolCalls.Count == 0)
         {
             _logger.LogWarning(
                 "OpenAI returned empty content (finish={Finish}, maxOutputTokens={Max})",
-                completion.FinishReason, maxTokens);
+                completion.FinishReason, options.MaxOutputTokenCount);
         }
 
         var inputTokens = completion.Usage?.InputTokenCount ?? 0;
@@ -91,22 +133,22 @@ public sealed class OpenAiLlmClient : ILlmService
 
         var usage = new LlmUsage(inputTokens, outputTokens, ModelPricing.CostUsd(_model, inputTokens, outputTokens));
 
-        // ToolCalls left empty: function-calling is not ported in AI-002 (legacy
-        // was text-only). request.Tools is ignored for now.
-        // TODO(AI-0xx): map tool definitions + tool_calls when agents land.
-        return new LlmResponse(text.Trim(), [], usage, _model, Guid.NewGuid());
+        return new LlmResponse(text.Trim(), toolCalls, usage, _model, Guid.NewGuid());
     }
 
     public async IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, [EnumeratorCancellation] CancellationToken ct)
     {
         var messages = BuildMessages(request);
-        var maxTokens = request.MaxOutputTokens + _reasoningBudget; // +512 padding quirk (same as CompleteAsync)
-        var options = new ChatCompletionOptions { MaxOutputTokenCount = maxTokens };
+        var options = BuildOptions(request);
 
-        // Real token streaming: yield each content fragment as it arrives, then a terminal usage delta.
-        // The SDK surfaces token usage on the final update (it requests stream_options.include_usage);
-        // if absent (older endpoints), usage falls back to 0 — text + latency are still traced.
+        // Real token streaming: yield each content fragment as it arrives. Tool calls stream as
+        // fragments (id/name on the first update for an index, then argument chunks) — accumulate per
+        // index and emit each COMPLETE call as a ToolCallDelta after the provider stream ends (partial
+        // tool-call streaming is out of Phase 5 scope). The SDK surfaces token usage on the final
+        // update; if absent, usage falls back to 0 — text + latency are still traced.
         ChatTokenUsage? usage = null;
+        var pendingCalls = new SortedDictionary<int, (string Id, string Name, StringBuilder Args)>();
+
         await foreach (var update in _client.CompleteChatStreamingAsync(messages, options, ct))
         {
             foreach (var part in update.ContentUpdate)
@@ -114,9 +156,23 @@ public sealed class OpenAiLlmClient : ILlmService
                 if (!string.IsNullOrEmpty(part.Text))
                     yield return new LlmDelta(TextDelta: part.Text);
             }
+            foreach (var tc in update.ToolCallUpdates)
+            {
+                if (!pendingCalls.TryGetValue(tc.Index, out var entry))
+                    pendingCalls[tc.Index] = entry = (tc.ToolCallId ?? string.Empty, tc.FunctionName ?? string.Empty, new StringBuilder());
+                if (!string.IsNullOrEmpty(tc.ToolCallId) && entry.Id.Length == 0)
+                    pendingCalls[tc.Index] = entry = (tc.ToolCallId, entry.Name, entry.Args);
+                if (!string.IsNullOrEmpty(tc.FunctionName) && entry.Name.Length == 0)
+                    pendingCalls[tc.Index] = entry = (entry.Id, tc.FunctionName, entry.Args);
+                if (tc.FunctionArgumentsUpdate is not null)
+                    entry.Args.Append(tc.FunctionArgumentsUpdate.ToString());
+            }
             if (update.Usage is not null)
                 usage = update.Usage;
         }
+
+        foreach (var (_, call) in pendingCalls)
+            yield return new LlmDelta(ToolCallDelta: new ToolCall(call.Id, call.Name, ParseArgs(call.Args.ToString())));
 
         var inputTokens = usage?.InputTokenCount ?? 0;
         var outputTokens = usage?.OutputTokenCount ?? 0;

--- a/backend/src/Ai/TextStack.Ai.Tools/ServiceCollectionExtensions.cs
+++ b/backend/src/Ai/TextStack.Ai.Tools/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<IToolRegistry, ToolRegistry>();
         services.TryAddSingleton<ToolDispatcher>();
+        services.TryAddSingleton<ToolCallingSession>();
         return services;
     }
 

--- a/backend/src/Ai/TextStack.Ai.Tools/ToolCallingSession.cs
+++ b/backend/src/Ai/TextStack.Ai.Tools/ToolCallingSession.cs
@@ -1,0 +1,95 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using TextStack.Ai.Core;
+
+namespace TextStack.Ai.Tools;
+
+/// <summary>
+/// One round of function-calling over any <see cref="ILlmService"/> (Phase 5, AI-031b): send the
+/// request with tool schemas; if the model answers directly, that's the result; if it requests tools,
+/// dispatch them (validated, parallel — failures come back as data) and ask once more WITHOUT tools
+/// for the grounded final answer. Single round by design — the multi-step plan/act/observe loop is
+/// Phase 6's <c>AgentLoop</c>.
+/// </summary>
+public sealed class ToolCallingSession(ToolDispatcher dispatcher)
+{
+    /// <summary>
+    /// Streams the answer. Round-1 text deltas are re-yielded as they arrive (the no-tool case stays
+    /// fully streaming); tool-call deltas are collected, dispatched, and the follow-up round streams
+    /// the final answer. Usage deltas from both rounds pass through (the tracer reads them).
+    /// </summary>
+    /// <param name="onToolRound">
+    /// Fired (before round 2) when the model requested tools — callers use it to mark the answer
+    /// tool-grounded (e.g. Explain must NOT write such answers to its shared cache: tool output can be
+    /// user-specific, so caching it would leak across users).
+    /// </param>
+    public async IAsyncEnumerable<LlmDelta> StreamAsync(
+        ILlmService llm, LlmRequest request, ToolContext ctx,
+        Action? onToolRound = null, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var toolCalls = new List<ToolCall>();
+        var round1Text = string.Empty;
+
+        await foreach (var delta in llm.StreamAsync(request, ct))
+        {
+            if (delta.ToolCallDelta is { } call)
+            {
+                toolCalls.Add(call);
+                continue; // tool plumbing is not client-visible
+            }
+            if (delta.TextDelta is { } text)
+                round1Text += text;
+            yield return delta;
+        }
+
+        if (toolCalls.Count == 0)
+            yield break; // model answered directly
+
+        onToolRound?.Invoke();
+        var followUp = await BuildFollowUpAsync(request, round1Text, toolCalls, ctx, ct);
+        await foreach (var delta in llm.StreamAsync(followUp, ct))
+            yield return delta;
+    }
+
+    /// <summary>One-shot variant (the JSON path): same round semantics, full text back.
+    /// <c>UsedTools</c> tells the caller whether the answer is tool-grounded (→ not cacheable).</summary>
+    public async Task<(LlmResponse Response, bool UsedTools)> CompleteAsync(
+        ILlmService llm, LlmRequest request, ToolContext ctx, CancellationToken ct)
+    {
+        var response = await llm.CompleteAsync(request, ct);
+        if (response.ToolCalls.Count == 0)
+            return (response, false);
+
+        var followUp = await BuildFollowUpAsync(request, response.Text, response.ToolCalls, ctx, ct);
+        return (await llm.CompleteAsync(followUp, ct), true);
+    }
+
+    /// <summary>
+    /// Dispatches the requested calls and builds the round-2 request: original messages + the
+    /// assistant's tool-call turn + one tool-result message per call (failures included, as data).
+    /// Round 2 carries NO tool schemas — it must answer, not call again.
+    /// </summary>
+    private async Task<LlmRequest> BuildFollowUpAsync(
+        LlmRequest request, string assistantText, IReadOnlyList<ToolCall> toolCalls,
+        ToolContext ctx, CancellationToken ct)
+    {
+        var results = await dispatcher.DispatchAllAsync(toolCalls, ctx, ct);
+
+        var messages = new List<LlmMessage>(request.Messages)
+        {
+            new("assistant", assistantText, toolCalls),
+        };
+        for (var i = 0; i < toolCalls.Count; i++)
+        {
+            messages.Add(new LlmMessage("tool", SerializeResult(results[i]), [toolCalls[i]]));
+        }
+
+        return request with { Messages = messages, Tools = null };
+    }
+
+    /// <summary>The payload the model sees for one tool result — the output, or the error as data.</summary>
+    public static string SerializeResult(ToolResult result) =>
+        result.Ok
+            ? result.Result!.Value.GetRawText()
+            : JsonSerializer.Serialize(new { error = result.Error });
+}

--- a/backend/src/Api/Endpoints/ExplainEndpoints.cs
+++ b/backend/src/Api/Endpoints/ExplainEndpoints.cs
@@ -3,11 +3,14 @@ using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Api.Extensions;
 using Application.Ai;
+using Application.Auth;
 using Application.Common.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
 
 namespace Api.Endpoints;
 
@@ -36,6 +39,9 @@ public static class ExplainEndpoints
         IConfiguration config,
         ILlmService llm,
         IAppDbContext db,
+        AuthService authService,
+        IToolRegistry toolRegistry,
+        ToolCallingSession toolSession,
         ILogger<Program> logger,
         CancellationToken ct)
     {
@@ -56,32 +62,64 @@ public static class ExplainEndpoints
         var cache = new ExplainCache(config, logger);
         var cacheKey = ComputeCacheKey(request.Word, request.Sentence, genre, targetLang);
 
-        var systemPrompt = ExplainPrompt.BuildSystemPrompt(genre, targetLang);
+        // Function-calling (AI-031b): which tools this request may use. Book tools need an edition in
+        // context; the highlights tool additionally needs a signed-in user. Kill switch:
+        // Explain:ToolsEnabled.
+        var userId = httpContext.GetUserId(authService);
+        Guid? editionId = !string.IsNullOrWhiteSpace(request.BookId) && Guid.TryParse(request.BookId, out var parsed)
+            ? parsed
+            : null;
+        var tools = ResolveTools(toolRegistry, config, editionId, userId);
+        var toolCtx = new ToolContext(userId, editionId, AgentRunId: Guid.NewGuid(), httpContext.RequestServices);
+
+        var systemPrompt = ExplainPrompt.BuildSystemPrompt(genre, targetLang, withTools: tools.Count > 0);
         var userPrompt = ExplainPrompt.BuildUserPrompt(request.Word, request.Sentence);
 
         var wantsSse = httpContext.Request.Headers.Accept.Any(v =>
             v is not null && v.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase));
 
         return wantsSse
-            ? ExplainSse(request.Word, systemPrompt, userPrompt, cache, cacheKey, llm, httpContext)
-            : await ExplainJson(request.Word, systemPrompt, userPrompt, cache, cacheKey, llm, logger, ct);
+            ? ExplainSse(request.Word, systemPrompt, userPrompt, cache, cacheKey, llm, toolSession, tools, toolCtx, httpContext)
+            : await ExplainJson(request.Word, systemPrompt, userPrompt, cache, cacheKey, llm, toolSession, tools, toolCtx, logger, ct);
+    }
+
+    /// <summary>The tool schemas this request is allowed to call (empty = plain completion).</summary>
+    private static IReadOnlyList<ToolSchema> ResolveTools(
+        IToolRegistry registry, IConfiguration config, Guid? editionId, Guid? userId)
+    {
+        if (!config.GetValue("Explain:ToolsEnabled", true))
+            return [];
+
+        var names = new List<string> { "lookup_dictionary" };
+        if (editionId is not null)
+        {
+            names.Add("get_chapter");
+            names.Add("search_book");
+            if (userId is not null)
+                names.Add("get_user_highlights");
+        }
+        return registry.SchemasFor(names);
     }
 
     // ---- JSON path (original contract; mobile + non-streaming clients) ----
 
     private static async Task<IResult> ExplainJson(
         string word, string systemPrompt, string userPrompt,
-        ExplainCache cache, string cacheKey, ILlmService llm, ILogger logger, CancellationToken ct)
+        ExplainCache cache, string cacheKey, ILlmService llm,
+        ToolCallingSession toolSession, IReadOnlyList<ToolSchema> tools, ToolContext toolCtx,
+        ILogger logger, CancellationToken ct)
     {
         if (await cache.TryReadAsync(cacheKey, ct) is { } cachedText)
             return Results.Ok(new ExplainResponse(cachedText, word, Cached: true));
 
         try
         {
-            var text = (await llm.CompleteAsync(BuildRequest(systemPrompt, userPrompt, MaxOutputTokens), ct)).Text;
+            var (response, usedTools) = await toolSession.CompleteAsync(
+                llm, BuildRequest(systemPrompt, userPrompt, MaxOutputTokens, tools), toolCtx, ct);
+            var text = response.Text;
 
             // Reasoning models can exhaust the visible budget on internal reasoning
-            // and return empty. Retry once with doubled budget before giving up.
+            // and return empty. Retry once with doubled budget (no tools) before giving up.
             if (string.IsNullOrWhiteSpace(text))
             {
                 logger.LogWarning("Explain got empty result at {Max} tokens, retrying with {Retry}",
@@ -92,7 +130,10 @@ public static class ExplainEndpoints
             if (string.IsNullOrWhiteSpace(text))
                 return Results.Problem("LLM returned empty explanation", statusCode: 502);
 
-            await cache.WriteAsync(cacheKey, text, ct);
+            // Tool-grounded answers can be user-specific (highlights, progress-gated search) —
+            // never write them to the shared cache.
+            if (!usedTools)
+                await cache.WriteAsync(cacheKey, text, ct);
             return Results.Ok(new ExplainResponse(text, word, Cached: false));
         }
         catch (TaskCanceledException)
@@ -110,19 +151,27 @@ public static class ExplainEndpoints
 
     private static IResult ExplainSse(
         string word, string systemPrompt, string userPrompt,
-        ExplainCache cache, string cacheKey, ILlmService llm, HttpContext httpContext)
+        ExplainCache cache, string cacheKey, ILlmService llm,
+        ToolCallingSession toolSession, IReadOnlyList<ToolSchema> tools, ToolContext toolCtx,
+        HttpContext httpContext)
     {
         // Cloudflare/nginx must not buffer the stream (playbook Phase 5 risk).
         httpContext.Response.Headers["X-Accel-Buffering"] = "no";
         httpContext.Response.Headers.CacheControl = "no-cache";
 
+        // Tool-grounded answers can be user-specific — skip the shared-cache write for them.
+        // The flag is set before round 2 streams, so it's final by the time persist runs.
+        var usedTools = false;
+
         return TypedResults.ServerSentEvents(StreamEventsAsync(
             word,
-            primary: ct => llm.StreamAsync(BuildRequest(systemPrompt, userPrompt, MaxOutputTokens), ct),
+            primary: ct => toolSession.StreamAsync(
+                llm, BuildRequest(systemPrompt, userPrompt, MaxOutputTokens, tools), toolCtx,
+                onToolRound: () => usedTools = true, ct),
             fallback: async ct =>
                 (await llm.CompleteAsync(BuildRequest(systemPrompt, userPrompt, RetryOutputTokens), ct)).Text,
             readCache: ct => cache.TryReadAsync(cacheKey, ct),
-            persist: (text, ct) => cache.WriteAsync(cacheKey, text, ct),
+            persist: (text, ct) => usedTools ? Task.CompletedTask : cache.WriteAsync(cacheKey, text, ct),
             httpContext.RequestAborted));
     }
 
@@ -236,8 +285,10 @@ public static class ExplainEndpoints
 
     // ---- shared pieces ----
 
-    private static LlmRequest BuildRequest(string systemPrompt, string userPrompt, int maxTokens) =>
-        new(systemPrompt, [new LlmMessage("user", userPrompt)], maxTokens, FeatureTag: FeatureTag);
+    private static LlmRequest BuildRequest(
+        string systemPrompt, string userPrompt, int maxTokens, IReadOnlyList<ToolSchema>? tools = null) =>
+        new(systemPrompt, [new LlmMessage("user", userPrompt)], maxTokens,
+            Tools: tools is { Count: > 0 } ? tools : null, FeatureTag: FeatureTag);
 
     private static async Task<string?> ResolveGenreAsync(
         ExplainRequest request, IAppDbContext db, ILogger logger, CancellationToken ct)

--- a/backend/src/Application/Ai/ExplainPrompt.cs
+++ b/backend/src/Application/Ai/ExplainPrompt.cs
@@ -7,16 +7,30 @@ namespace Application.Ai;
 /// </summary>
 public static class ExplainPrompt
 {
-    public static string BuildSystemPrompt(string? genre, string targetLang)
+    public static string BuildSystemPrompt(string? genre, string targetLang, bool withTools = false)
     {
         var domain = string.IsNullOrWhiteSpace(genre) ? "general" : genre.Trim();
-        return
+        var prompt =
             $"You explain unfamiliar words or phrases to a reader in context. " +
             $"Domain hint: {domain}. " +
             $"Respond in {targetLang}. " +
             "Write 2-3 sentences. Focus on how the word is used IN THIS SENTENCE, " +
             "not a dictionary definition. If it is a technical term, give the meaning and " +
             "one concrete analogy. No preface, no quotes around the answer, no markdown.";
+
+        // Phase 5 function-calling (AI-031b): appended only when the request actually carries tools.
+        if (withTools)
+        {
+            prompt +=
+                "\n\nYou have access to tools. Use them when:\n" +
+                "- The sentence references \"see chapter X\" or \"earlier we discussed\" -> call get_chapter or search_book\n" +
+                "- The word may be defined elsewhere in the user's saved highlights -> call get_user_highlights\n" +
+                "- The word has a precise dictionary meaning relevant to the explanation -> call lookup_dictionary\n" +
+                "Most words need NO tools - answer directly. " +
+                "After using tools, give the same 2-3 sentence explanation, citing tool results when used.";
+        }
+
+        return prompt;
     }
 
     public static string BuildUserPrompt(string word, string sentence) =>

--- a/tests/TextStack.UnitTests/ToolCallingSessionTests.cs
+++ b/tests/TextStack.UnitTests/ToolCallingSessionTests.cs
@@ -1,0 +1,174 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// AI-031b — the one-round function-calling session: passthrough when the model answers directly,
+/// dispatch + follow-up round when it requests tools, tool failures fed back as data.
+/// </summary>
+public class ToolCallingSessionTests
+{
+    private static readonly JsonElement AnySchema = JsonDocument.Parse("""{"type":"object"}""").RootElement;
+
+    private static JsonElement Json(string json) => JsonDocument.Parse(json).RootElement;
+
+    private sealed class EchoTool : ITool
+    {
+        public string Name => "session-echo";
+        public string Description => "echoes";
+        public JsonElement ArgsSchema => AnySchema;
+        public Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct) =>
+            Task.FromResult(Json("""{"echoed":true}"""));
+    }
+
+    /// <summary>Scripted LLM: each call (stream or complete) consumes the next script entry; requests are recorded.</summary>
+    private sealed class ScriptedLlm(params object[][] script) : ILlmService
+    {
+        private int _call;
+        public List<LlmRequest> Requests { get; } = [];
+
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
+        {
+            Requests.Add(request);
+            var entries = script[_call++];
+            var text = string.Concat(entries.OfType<string>());
+            var calls = entries.OfType<ToolCall>().ToList();
+            return Task.FromResult(new LlmResponse(text, calls, new LlmUsage(1, 1, 0m), "m", Guid.NewGuid()));
+        }
+
+        public async IAsyncEnumerable<LlmDelta> StreamAsync(
+            LlmRequest request, [EnumeratorCancellation] CancellationToken ct)
+        {
+            Requests.Add(request);
+            foreach (var entry in script[_call++])
+            {
+                await Task.Yield();
+                yield return entry switch
+                {
+                    string s => new LlmDelta(TextDelta: s),
+                    ToolCall c => new LlmDelta(ToolCallDelta: c),
+                    _ => throw new InvalidOperationException(),
+                };
+            }
+            yield return new LlmDelta(FinalUsage: new LlmUsage(1, 1, 0m), ModelId: "m");
+        }
+    }
+
+    private static ToolCallingSession Session(params ITool[] tools) =>
+        new(new ToolDispatcher(new ToolRegistry(tools)));
+
+    private static ToolContext Ctx() =>
+        new(null, null, Guid.NewGuid(), new ServiceCollection().BuildServiceProvider());
+
+    private static ToolCall Call(string name, string args = "{}") => new("call-1", name, Json(args));
+
+    private static async Task<List<LlmDelta>> Drain(IAsyncEnumerable<LlmDelta> stream)
+    {
+        var list = new List<LlmDelta>();
+        await foreach (var d in stream) list.Add(d);
+        return list;
+    }
+
+    [Fact]
+    public async Task Stream_NoToolCalls_PassesThroughSingleRound()
+    {
+        var llm = new ScriptedLlm(["Hello ", "world"]);
+        var fired = false;
+
+        var deltas = await Drain(Session(new EchoTool()).StreamAsync(
+            llm, Req(tools: true), Ctx(), () => fired = true, TestContext.Current.CancellationToken));
+
+        Assert.Single(llm.Requests); // no second round
+        Assert.False(fired);
+        Assert.Equal("Hello world", string.Concat(deltas.Where(d => d.TextDelta != null).Select(d => d.TextDelta)));
+    }
+
+    [Fact]
+    public async Task Stream_ToolCalls_DispatchesAndStreamsFollowUp()
+    {
+        var llm = new ScriptedLlm(
+            [Call("session-echo", """{"x":1}""")],   // round 1: model requests a tool
+            ["Grounded ", "answer"]);        // round 2: final answer
+        var fired = false;
+
+        var deltas = await Drain(Session(new EchoTool()).StreamAsync(
+            llm, Req(tools: true), Ctx(), () => fired = true, TestContext.Current.CancellationToken));
+
+        Assert.True(fired);
+        Assert.Equal(2, llm.Requests.Count);
+        // Tool plumbing is not client-visible — only text (+usage) deltas flow out.
+        Assert.DoesNotContain(deltas, d => d.ToolCallDelta is not null);
+        Assert.Equal("Grounded answer", string.Concat(deltas.Where(d => d.TextDelta != null).Select(d => d.TextDelta)));
+
+        // Round 2 carries the assistant tool-call turn + the tool result, and NO tool schemas.
+        var followUp = llm.Requests[1];
+        Assert.Null(followUp.Tools);
+        Assert.Equal("assistant", followUp.Messages[^2].Role);
+        Assert.Equal("tool", followUp.Messages[^1].Role);
+        Assert.Contains("echoed", followUp.Messages[^1].Content);
+        Assert.Equal("call-1", followUp.Messages[^1].ToolCalls![0].Id);
+    }
+
+    [Fact]
+    public async Task Stream_UnknownTool_FeedsErrorBackAsData()
+    {
+        var llm = new ScriptedLlm(
+            [Call("nope")],
+            ["Recovered"]);
+
+        await Drain(Session(new EchoTool()).StreamAsync(
+            llm, Req(tools: true), Ctx(), null, TestContext.Current.CancellationToken));
+
+        var toolMsg = llm.Requests[1].Messages[^1];
+        Assert.Equal("tool", toolMsg.Role);
+        Assert.Contains("error", toolMsg.Content);
+        Assert.Contains("Unknown tool", toolMsg.Content);
+    }
+
+    [Fact]
+    public async Task Complete_NoToolCalls_ReturnsDirectAnswer()
+    {
+        var llm = new ScriptedLlm(["Direct answer"]);
+
+        var (response, usedTools) = await Session(new EchoTool()).CompleteAsync(
+            llm, Req(tools: true), Ctx(), TestContext.Current.CancellationToken);
+
+        Assert.False(usedTools);
+        Assert.Equal("Direct answer", response.Text);
+        Assert.Single(llm.Requests);
+    }
+
+    [Fact]
+    public async Task Complete_ToolCalls_RunsFollowUpAndFlagsUsedTools()
+    {
+        var llm = new ScriptedLlm(
+            [Call("session-echo")],
+            ["Grounded answer"]);
+
+        var (response, usedTools) = await Session(new EchoTool()).CompleteAsync(
+            llm, Req(tools: true), Ctx(), TestContext.Current.CancellationToken);
+
+        Assert.True(usedTools);
+        Assert.Equal("Grounded answer", response.Text);
+        Assert.Null(llm.Requests[1].Tools);
+    }
+
+    [Fact]
+    public void SerializeResult_OkRawJson_FailureErrorEnvelope()
+    {
+        var call = Call("session-echo");
+        Assert.Equal("""{"a":1}""", ToolCallingSession.SerializeResult(
+            ToolResult.Success(call, Json("""{"a":1}"""))));
+        Assert.Contains("\"error\"", ToolCallingSession.SerializeResult(
+            ToolResult.Failure(call, "boom")));
+    }
+
+    private static LlmRequest Req(bool tools) =>
+        new("system", [new LlmMessage("user", "explain quorum")], 500,
+            Tools: tools ? [new ToolSchema("session-echo", "echoes", AnySchema)] : null,
+            FeatureTag: "explain");
+}


### PR DESCRIPTION
Phase 5 **AI-031, slice b** — the model can now call the AI-030 tools. Explain grounds its answers in the book (chapter fetch, in-book search, the user's highlights, dictionary) via **one validated tool round**.

## Changes
- **`OpenAiLlmClient` function-calling**
  - `LlmRequest.Tools` → `ChatTool.CreateFunctionTool` (JSON Schema passed as-is).
  - `CompleteAsync` parses `tool_calls` → `LlmResponse.ToolCalls` (empty content on a tool-call turn no longer warns).
  - `StreamAsync` accumulates streamed tool-call fragments per index and emits each **complete** call as a `ToolCallDelta` after the provider stream ends (partial tool-call streaming is out of Phase 5 scope).
  - Message mapping grows the round-2 shapes: assistant turn carrying its tool calls + `tool`-role results keyed by call id.
- **`ToolCallingSession`** (`Ai.Tools`) — ONE round over any `ILlmService`: round-1 text deltas stream through (the common no-tool case stays fully streaming; tool plumbing is never client-visible); if tools were requested → validated **parallel** dispatch (failures fed back as data so the model can recover) → round 2 **without** schemas streams the final answer. Multi-step loops are Phase 6's `AgentLoop`.
- **Explain wiring (SSE + JSON)** — tool set per request: `lookup_dictionary` always; + `get_chapter`/`search_book` with a book in context; + `get_user_highlights` when signed in. System prompt gains the playbook tool-guidance block only when tools ride along. Kill switch: `Explain:ToolsEnabled` (default on).
- **Cache safety (QA find)** — tool-grounded answers can be user-specific (highlights; progress-gated search), so they're **never written to the shared explain cache** (`UsedTools` signal); direct answers cache as before.

## Verification
- `ToolCallingSession` (6 tests, scripted LLM): single-round passthrough (no second call, callback not fired); tool round → parallel dispatch → follow-up streams (assistant+tool messages, schemas stripped in round 2, tool deltas invisible); unknown tool error fed back as data; complete-variant flags `UsedTools`; result serialization.
- In-suite catch: a duplicate fake-tool name across test classes tripped the assembly-scan fail-fast — renamed (the guard doing its job).
- Full `TextStack.UnitTests` green (236); solution builds; `dotnet format` clean.
- Real model behaviour (does nano call tools sensibly?) is measured by the AI-033 tool-call golden set; staging spot-check before AI-032 UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)