### PR TITLE
fix(ai): per-tool DI scope + streamed tool calls traced (AI-031b follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Phase 5 — fix: per-tool DI scope + streamed tool calls traced (AI-031b follow-up, 2026-06-12)
+
+Audit follow-up to AI-031b — one real bug, one observability gap.
+
+- **Bug (P1): parallel dispatch shared one scoped DbContext.** `DispatchAllAsync` runs tools concurrently, but every tool resolved its scoped services (EF `DbContext`) from the same request scope — `get_chapter` + `get_user_highlights` in one tool round would throw EF's "second operation on this context". The dispatcher now creates a **fresh DI scope per invocation** (`ctx with { Services = scope.ServiceProvider }`). Test: two parallel calls observe different scoped instances.
+- **Observability: streamed tool calls now land in `llm_traces.tool_calls_json`.** `TracingDecorator.StreamAsync` accumulates `ToolCallDelta`s into the trace (one-shot calls already had this), so a streamed function-calling round is inspectable on /ai-quality. Test: streamed tool call appears in the persisted trace JSON.
+- Known limitation (documented, not fixed): a model that emits both round-1 text AND tool calls produces concatenated round1+round2 output for the client. Rare for nano; the shared cache is unaffected (tool-grounded answers aren't written).
+
 ### Phase 5 — function-calling: Explain can use tools (2026-06-12)
 
 Phase 5 **AI-031, slice b** — the model can now call the AI-030 tools. Explain grounds its answers in the book (chapter fetch, in-book search, the user's highlights, dictionary) via one validated tool round.

--- a/backend/src/Ai/TextStack.Ai.Llm/TracingDecorator.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/TracingDecorator.cs
@@ -57,6 +57,7 @@ public sealed class TracingDecorator(
     {
         var sw = Stopwatch.StartNew();
         var text = new StringBuilder();
+        var toolCalls = new List<ToolCall>();
         LlmUsage? usage = null;
         string? modelId = null;
         var traceId = Guid.NewGuid();
@@ -81,13 +82,14 @@ public sealed class TracingDecorator(
             {
                 sw.Stop();
                 TryPersist(
-                    BuildTrace(request, BuildStreamedResponse(text.ToString(), usage, modelId, traceId),
+                    BuildTrace(request, BuildStreamedResponse(text.ToString(), toolCalls, usage, modelId, traceId),
                         sw.ElapsedMilliseconds, error: ex.Message),
                     isError: true);
                 throw;
             }
 
             if (delta.TextDelta is not null) text.Append(delta.TextDelta);
+            if (delta.ToolCallDelta is not null) toolCalls.Add(delta.ToolCallDelta);
             if (delta.FinalUsage is not null) usage = delta.FinalUsage;
             if (delta.ModelId is not null) modelId = delta.ModelId;
             yield return delta;
@@ -95,15 +97,18 @@ public sealed class TracingDecorator(
 
         sw.Stop();
         TryPersist(
-            BuildTrace(request, BuildStreamedResponse(text.ToString(), usage, modelId, traceId),
+            BuildTrace(request, BuildStreamedResponse(text.ToString(), toolCalls, usage, modelId, traceId),
                 sw.ElapsedMilliseconds, error: null),
             isError: false);
     }
 
-    /// <summary>Assembles the accumulated stream into an <see cref="LlmResponse"/> for tracing
-    /// (usage/model default to the same "unknown"/zeros a failed one-shot call records).</summary>
-    public static LlmResponse BuildStreamedResponse(string text, LlmUsage? usage, string? modelId, Guid traceId) =>
-        new(text, [], usage ?? new LlmUsage(0, 0, 0m), modelId ?? "unknown", traceId);
+    /// <summary>Assembles the accumulated stream into an <see cref="LlmResponse"/> for tracing —
+    /// including any tool calls the model streamed, so <c>tool_calls_json</c> is populated for
+    /// streamed function-calling rounds exactly like one-shot ones (AI-031b). Usage/model default
+    /// to the same "unknown"/zeros a failed one-shot call records.</summary>
+    public static LlmResponse BuildStreamedResponse(
+        string text, IReadOnlyList<ToolCall> toolCalls, LlmUsage? usage, string? modelId, Guid traceId) =>
+        new(text, toolCalls, usage ?? new LlmUsage(0, 0, 0m), modelId ?? "unknown", traceId);
 
     private void TryPersist(LlmTrace trace, bool isError)
     {

--- a/backend/src/Ai/TextStack.Ai.Tools/ToolDispatcher.cs
+++ b/backend/src/Ai/TextStack.Ai.Tools/ToolDispatcher.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.Schema;
+using Microsoft.Extensions.DependencyInjection;
 using TextStack.Ai.Core;
 
 namespace TextStack.Ai.Tools;
@@ -41,7 +42,11 @@ public sealed class ToolDispatcher(IToolRegistry registry)
 
         try
         {
-            var result = await tool.InvokeAsync(call.Arguments, ctx, ct);
+            // Each invocation gets its OWN DI scope: tools resolve scoped services (e.g. the EF
+            // DbContext) from ToolContext.Services, and DispatchAllAsync runs calls in parallel —
+            // sharing the request scope would make two tools hit one DbContext concurrently.
+            using var scope = ctx.Services.CreateScope();
+            var result = await tool.InvokeAsync(call.Arguments, ctx with { Services = scope.ServiceProvider }, ct);
             return ToolResult.Success(call, result);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/tests/TextStack.UnitTests/ToolDispatcherTests.cs
+++ b/tests/TextStack.UnitTests/ToolDispatcherTests.cs
@@ -102,6 +102,45 @@ public class ToolDispatcherTests
         Assert.False(results[2].Ok);
     }
 
+    // ---- per-invocation DI scope (parallel tools must not share scoped services, e.g. DbContext) ----
+
+    private sealed class ScopedMarker
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private sealed class ScopeProbeTool : ITool
+    {
+        public string Name => "scope-probe";
+        public string Description => "returns the scoped marker's id";
+        public JsonElement ArgsSchema => JsonDocument.Parse("""{"type":"object"}""").RootElement;
+
+        public Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
+        {
+            var marker = ctx.Services.GetRequiredService<ScopedMarker>();
+            return Task.FromResult(JsonDocument.Parse($"\"{marker.Id}\"").RootElement);
+        }
+    }
+
+    [Fact]
+    public async Task DispatchAll_ParallelCalls_GetIsolatedScopes()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<ScopedMarker>();
+        using var root = services.BuildServiceProvider();
+        using var requestScope = root.CreateScope(); // simulates the HTTP request scope tools run in
+        var ctx = new ToolContext(null, null, Guid.NewGuid(), requestScope.ServiceProvider);
+
+        var dispatcher = Dispatcher(new ScopeProbeTool());
+        var results = await dispatcher.DispatchAllAsync(
+            [Call("scope-probe", "{}"), new ToolCall("call-2", "scope-probe", JsonDocument.Parse("{}").RootElement)],
+            ctx, TestContext.Current.CancellationToken);
+
+        Assert.All(results, r => Assert.True(r.Ok));
+        // Different scope per invocation → different scoped instances (no shared DbContext hazard).
+        Assert.NotEqual(results[0].Result!.Value.GetString(), results[1].Result!.Value.GetString());
+    }
+
     [Fact]
     public void ValidateArgs_Valid_ReturnsNull()
         => Assert.Null(ToolDispatcher.ValidateArgs(EchoSchema, JsonDocument.Parse("""{"text":"x"}""").RootElement));

--- a/tests/TextStack.UnitTests/TracingDecoratorTests.cs
+++ b/tests/TextStack.UnitTests/TracingDecoratorTests.cs
@@ -130,7 +130,8 @@ public class TracingDecoratorTests
     public void BuildStreamedResponse_AssemblesAccumulatedStream()
     {
         var id = Guid.NewGuid();
-        var resp = TracingDecorator.BuildStreamedResponse("Hello world", new LlmUsage(7, 3, 0.002m), "gpt-4.1-nano", id);
+        var resp = TracingDecorator.BuildStreamedResponse(
+            "Hello world", [], new LlmUsage(7, 3, 0.002m), "gpt-4.1-nano", id);
 
         Assert.Equal("Hello world", resp.Text);
         Assert.Equal(7, resp.Usage.InputTokens);
@@ -142,7 +143,7 @@ public class TracingDecoratorTests
     [Fact]
     public void BuildStreamedResponse_NullUsageAndModel_DefaultsLikeFailedCall()
     {
-        var resp = TracingDecorator.BuildStreamedResponse("", usage: null, modelId: null, Guid.NewGuid());
+        var resp = TracingDecorator.BuildStreamedResponse("", [], usage: null, modelId: null, Guid.NewGuid());
         Assert.Equal("unknown", resp.ModelId);
         Assert.Equal(0, resp.Usage.OutputTokens);
         Assert.Equal(0m, resp.Usage.CostUsd);
@@ -190,6 +191,25 @@ public class TracingDecoratorTests
         Assert.Equal(2, trace.TokensOut);
         Assert.Equal(0.001m, trace.CostUsd);
         Assert.Null(trace.Error);
+    }
+
+    [Fact]
+    public async Task StreamAsync_ToolCallDeltas_LandInTraceToolCallsJson()
+    {
+        var deltas = new[]
+        {
+            new LlmDelta(ToolCallDelta: new ToolCall(
+                "call-1", "search_book", System.Text.Json.JsonDocument.Parse("""{"query":"lsm"}""").RootElement)),
+            new LlmDelta(FinalUsage: new LlmUsage(5, 2, 0.001m), ModelId: "gpt-4.1-nano"),
+        };
+        var writer = new CapturingWriter();
+        var decorator = Decorator(new StreamingStub(deltas), writer);
+
+        await foreach (var _ in decorator.StreamAsync(Req(), TestContext.Current.CancellationToken)) { }
+
+        var trace = await writer.Captured.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.NotNull(trace.ToolCallsJson);
+        Assert.Contains("search_book", trace.ToolCallsJson);
     }
 
     // ---- cancellation is not an error (SSE disconnects must not pollute the error rate) ----


### PR DESCRIPTION
Audit follow-up to AI-031b (#313) — one real bug, one observability gap.

## Bug (P1): parallel dispatch shared one scoped DbContext
`DispatchAllAsync` runs tool calls concurrently, but every tool resolved its scoped services (EF `DbContext`) from the same request scope (`ToolContext.Services`). A tool round invoking `get_chapter` + `get_user_highlights` together would throw EF's *"A second operation was started on this context"*. **Fix:** the dispatcher creates a fresh DI scope per invocation and hands the tool `ctx with { Services = scope.ServiceProvider }`.

## Observability (P2): streamed tool calls now traced
`TracingDecorator.StreamAsync` accumulated only text/usage — a streamed function-calling round left `llm_traces.tool_calls_json` empty (one-shot calls already persisted them). Now `ToolCallDelta`s accumulate into the trace, so tool use is inspectable on /ai-quality for streamed rounds too.

## Also audited, no action
- Round-1 text + tool calls both emitted → concatenated client output. Rare for nano; cache unaffected (tool-grounded answers aren't written). Documented as a known limitation.
- Cache-read for tool-eligible requests returns the generic cached answer — intended (cost saving, same word/sentence).
- Ollama ignores `request.Tools` — fine; explain routes to OpenAI, and the non-streaming Ollama stance is documented.

## Tests
- Two parallel `scope-probe` dispatches observe **different** scoped instances (no shared-DbContext hazard).
- A streamed tool call appears in the persisted trace's `ToolCallsJson`.
- `BuildStreamedResponse` signature updated. Full `TextStack.UnitTests` green (238); `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)