### PR TITLE
feat(web): Explain streams visibly (AI-032)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 5 — web Explain streams visibly (2026-06-12)
+
+Phase 5 **AI-032** — the web reader renders explanations token-by-token (perceived latency drops to first-token time).
+
+- **`lib/sse.ts`** — SSE over POST (EventSource can't send a body): a minimal, spec-subset SSE parser (`event`/`data`, multi-line data, CRLF-tolerant, comment/keep-alive lines ignored, arbitrary chunk boundaries) + `postSse()` fetch-stream consumer. Non-OK statuses (429/503/504 are JSON, not SSE) map to readable errors **before** streaming; `SseUnsupportedError` signals environments without a readable body so callers can fall back.
+- **`useExplain` streams** — same external shape (consumers unchanged): `explanation` grows per delta while `isLoading` stays true until `done`; `cached` read from the done payload; a server `error` event keeps any partial text visible alongside the error. Device offline-cache still serves first; no-stream environments fall back to the one-shot JSON request. Local cache written only on a completed stream.
+- **`ExplanationPopup`** — spinner only until the first token; then the text renders and grows in place with a blinking stream caret (CSS) while open.
+- Tests: SSE parser (6 — dispatch, arbitrary split points, multi-line+CRLF, comments/unknown fields, trailing flush, colons in data) + `postSse` (3 — streams events, non-OK mapping, unsupported-body signal) + streaming `useExplain` (6 — delta accumulation, cached flag, server-error with partial text, JSON fallback, offline cache short-circuit, request failure). Full web suite green (511); `tsc` + build clean.
+
 ### Phase 5 — fix: per-tool DI scope + streamed tool calls traced (AI-031b follow-up, 2026-06-12)
 
 Audit follow-up to AI-031b — one real bug, one observability gap.

--- a/apps/web/src/api/explain.ts
+++ b/apps/web/src/api/explain.ts
@@ -1,7 +1,7 @@
 // API_BASE is the host (dev: http://localhost:8080) or `/api` (prod, nginx
 // strips the prefix and proxies the rest to backend). Backend route is
 // `/explain` (no prefix). Don't add `/api/` here or prod gets `/api/api/...`.
-const API_BASE = import.meta.env.VITE_API_URL ?? ''
+export const API_BASE = import.meta.env.VITE_API_URL ?? ''
 
 export interface ExplainRequest {
   word: string

--- a/apps/web/src/components/reader/ExplanationPopup.tsx
+++ b/apps/web/src/components/reader/ExplanationPopup.tsx
@@ -107,15 +107,20 @@ export function ExplanationPopup({
       </div>
 
       <div className="translation-popup__result">
-        {isLoading && (
+        {/* Streaming (AI-032): spinner only until the first token; then the text renders and grows
+            in place, with a cursor while the stream is still open. */}
+        {isLoading && !explanation && (
           <div className="translation-popup__loading">
             <span className="translation-popup__spinner" />
             {t('reader.explanationPopup.loading')}
           </div>
         )}
         {error && <div className="translation-popup__error">{error}</div>}
-        {explanation && !isLoading && !error && (
-          <div className="translation-popup__translated">{explanation}</div>
+        {explanation && !error && (
+          <div className="translation-popup__translated">
+            {explanation}
+            {isLoading && <span className="translation-popup__stream-cursor">▍</span>}
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/hooks/useExplain.test.ts
+++ b/apps/web/src/hooks/useExplain.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+vi.mock('../lib/sse', async importOriginal => {
+  const actual = await importOriginal<typeof import('../lib/sse')>()
+  return { ...actual, postSse: vi.fn() }
+})
+vi.mock('../api/explain', () => ({ explain: vi.fn(), API_BASE: '' }))
+vi.mock('../lib/offlineDb', () => ({
+  getCachedExplain: vi.fn().mockResolvedValue(null),
+  cacheExplain: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { postSse, SseUnsupportedError, type SseEvent } from '../lib/sse'
+import { explain as explainJson } from '../api/explain'
+import { getCachedExplain } from '../lib/offlineDb'
+import { useExplain } from './useExplain'
+
+const mockPostSse = postSse as unknown as ReturnType<typeof vi.fn>
+const mockExplainJson = explainJson as unknown as ReturnType<typeof vi.fn>
+const mockGetCached = getCachedExplain as unknown as ReturnType<typeof vi.fn>
+
+const REQ = { word: 'quorum', sentence: 'A quorum of replicas.', targetLang: 'en' }
+
+/** Makes postSse emit the given events, then resolve. */
+function emit(...events: SseEvent[]) {
+  mockPostSse.mockImplementationOnce(
+    async (_url: string, _body: unknown, onEvent: (e: SseEvent) => void) => {
+      for (const e of events) onEvent(e)
+    },
+  )
+}
+
+describe('useExplain (streaming)', () => {
+  beforeEach(() => {
+    mockPostSse.mockReset()
+    mockExplainJson.mockReset()
+    mockGetCached.mockReset().mockResolvedValue(null)
+  })
+
+  it('accumulates deltas and finishes on done', async () => {
+    emit(
+      { event: 'delta', data: 'A quorum ' },
+      { event: 'delta', data: 'is a majority.' },
+      { event: 'done', data: '{"word":"quorum","cached":false}' },
+    )
+    const { result } = renderHook(() => useExplain())
+
+    await act(() => result.current.explain(REQ))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.explanation).toBe('A quorum is a majority.')
+    expect(result.current.error).toBeNull()
+    expect(result.current.cached).toBe(false)
+  })
+
+  it('marks cached answers from the done payload', async () => {
+    emit(
+      { event: 'delta', data: 'Cached text.' },
+      { event: 'done', data: '{"word":"quorum","cached":true}' },
+    )
+    const { result } = renderHook(() => useExplain())
+
+    await act(() => result.current.explain(REQ))
+
+    await waitFor(() => expect(result.current.cached).toBe(true))
+    expect(result.current.explanation).toBe('Cached text.')
+  })
+
+  it('surfaces a server error event, keeping partial text', async () => {
+    emit(
+      { event: 'delta', data: 'Partial ' },
+      { event: 'error', data: 'Explain service unavailable' },
+    )
+    const { result } = renderHook(() => useExplain())
+
+    await act(() => result.current.explain(REQ))
+
+    await waitFor(() => expect(result.current.error).toBe('Explain service unavailable'))
+    expect(result.current.explanation).toBe('Partial ')
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('falls back to the JSON request when streaming is unsupported', async () => {
+    mockPostSse.mockRejectedValueOnce(new SseUnsupportedError())
+    mockExplainJson.mockResolvedValueOnce({ explanation: 'Plain answer.', cached: false })
+    const { result } = renderHook(() => useExplain())
+
+    await act(() => result.current.explain(REQ))
+
+    await waitFor(() => expect(result.current.explanation).toBe('Plain answer.'))
+    expect(mockExplainJson).toHaveBeenCalledTimes(1)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('serves the local offline cache without any network call', async () => {
+    mockGetCached.mockResolvedValueOnce({ explanation: 'From device cache.' })
+    const { result } = renderHook(() => useExplain())
+
+    await act(() => result.current.explain(REQ))
+
+    await waitFor(() => expect(result.current.explanation).toBe('From device cache.'))
+    expect(result.current.cached).toBe(true)
+    expect(mockPostSse).not.toHaveBeenCalled()
+  })
+
+  it('sets error when the request itself fails (e.g. rate limit)', async () => {
+    mockPostSse.mockRejectedValueOnce(new Error('Too many requests, try again later'))
+    const { result } = renderHook(() => useExplain())
+
+    await act(() => result.current.explain(REQ))
+
+    await waitFor(() => expect(result.current.error).toMatch(/Too many requests/))
+    expect(result.current.explanation).toBeNull()
+  })
+})

--- a/apps/web/src/hooks/useExplain.ts
+++ b/apps/web/src/hooks/useExplain.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react'
-import { explain as explainApi, type ExplainRequest } from '../api/explain'
+import { explain as explainApi, API_BASE, type ExplainRequest } from '../api/explain'
+import { postSse, SseUnsupportedError } from '../lib/sse'
 import { getCachedExplain, cacheExplain } from '../lib/offlineDb'
 
 interface ExplainState {
@@ -16,6 +17,12 @@ const INITIAL: ExplainState = {
   cached: false,
 }
 
+/**
+ * Contextual word explanation, streamed (AI-032): `explanation` grows token-by-token while
+ * `isLoading` stays true until the server's `done` event. Local offline cache is checked first;
+ * environments that can't stream fall back to the JSON request. External shape is unchanged from
+ * the pre-streaming hook, so consumers render incrementally for free.
+ */
 export function useExplain() {
   const [state, setState] = useState<ExplainState>(INITIAL)
   const abortRef = useRef<AbortController | null>(null)
@@ -49,20 +56,66 @@ export function useExplain() {
       return null
     }
 
+    let text = ''
+    let cached = false
+    let serverError: string | null = null
+
     try {
-      const result = await explainApi(req, ctrl.signal)
-      setState({
-        explanation: result.explanation,
-        isLoading: false,
-        error: null,
-        cached: result.cached,
-      })
-      cacheExplain(req.word, req.sentence, req.genre, targetLang, result.explanation).catch(() => {})
-      return result.explanation
+      await postSse(
+        `${API_BASE}/explain`,
+        req,
+        e => {
+          if (ctrl.signal.aborted) return
+          if (e.event === 'delta') {
+            text += e.data
+            setState({ explanation: text, isLoading: true, error: null, cached: false })
+          } else if (e.event === 'done') {
+            try {
+              cached = Boolean((JSON.parse(e.data) as { cached?: boolean }).cached)
+            } catch {
+              // malformed done payload — text already accumulated, treat as uncached
+            }
+          } else if (e.event === 'error') {
+            serverError = e.data || 'Explain failed'
+          }
+        },
+        ctrl.signal,
+      )
+
+      if (serverError || !text) {
+        // Keep any partial text visible alongside the error.
+        setState({
+          explanation: text || null,
+          isLoading: false,
+          error: serverError ?? 'Explain failed',
+          cached: false,
+        })
+        return null
+      }
+
+      setState({ explanation: text, isLoading: false, error: null, cached })
+      cacheExplain(req.word, req.sentence, req.genre, targetLang, text).catch(() => {})
+      return text
     } catch (err) {
       if ((err as { name?: string })?.name === 'AbortError') return null
+
+      // No streaming support (old browser / degraded env) → one-shot JSON request.
+      if (err instanceof SseUnsupportedError) {
+        try {
+          const result = await explainApi(req, ctrl.signal)
+          setState({ explanation: result.explanation, isLoading: false, error: null, cached: result.cached })
+          cacheExplain(req.word, req.sentence, req.genre, targetLang, result.explanation).catch(() => {})
+          return result.explanation
+        } catch (fallbackErr) {
+          if ((fallbackErr as { name?: string })?.name === 'AbortError') return null
+          const error = fallbackErr instanceof Error ? fallbackErr.message : 'Explain failed'
+          setState({ explanation: null, isLoading: false, error, cached: false })
+          return null
+        }
+      }
+
       const error = err instanceof Error ? err.message : 'Explain failed'
-      setState({ explanation: null, isLoading: false, error, cached: false })
+      setState({ explanation: text || null, isLoading: false, error, cached: false })
       return null
     }
   }, [])

--- a/apps/web/src/lib/sse.test.ts
+++ b/apps/web/src/lib/sse.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createSseParser, postSse, SseUnsupportedError, type SseEvent } from './sse'
+
+function collect() {
+  const events: SseEvent[] = []
+  return { events, onEvent: (e: SseEvent) => events.push(e) }
+}
+
+describe('createSseParser', () => {
+  it('parses event + data with blank-line dispatch', () => {
+    const { events, onEvent } = collect()
+    const p = createSseParser(onEvent)
+    p.feed('event: delta\ndata: Hello\n\nevent: done\ndata: {"cached":false}\n\n')
+
+    expect(events).toEqual([
+      { event: 'delta', data: 'Hello' },
+      { event: 'done', data: '{"cached":false}' },
+    ])
+  })
+
+  it('handles chunks split at arbitrary boundaries', () => {
+    const { events, onEvent } = collect()
+    const p = createSseParser(onEvent)
+    for (const ch of 'event: delta\ndata: Hel\n\neve') p.feed(ch)
+    p.feed('nt: delta\ndata: lo\n\n')
+
+    expect(events).toEqual([
+      { event: 'delta', data: 'Hel' },
+      { event: 'delta', data: 'lo' },
+    ])
+  })
+
+  it('joins multi-line data with newline and tolerates CRLF', () => {
+    const { events, onEvent } = collect()
+    const p = createSseParser(onEvent)
+    p.feed('event: delta\r\ndata: line1\r\ndata: line2\r\n\r\n')
+
+    expect(events).toEqual([{ event: 'delta', data: 'line1\nline2' }])
+  })
+
+  it('ignores comments and unknown fields; defaults event type to message', () => {
+    const { events, onEvent } = collect()
+    const p = createSseParser(onEvent)
+    p.feed(': keep-alive\nid: 7\ndata: plain\n\n')
+
+    expect(events).toEqual([{ event: 'message', data: 'plain' }])
+  })
+
+  it('end() flushes a trailing event without a final blank line', () => {
+    const { events, onEvent } = collect()
+    const p = createSseParser(onEvent)
+    p.feed('event: error\ndata: boom')
+    p.end()
+
+    expect(events).toEqual([{ event: 'error', data: 'boom' }])
+  })
+
+  it('preserves data that contains colons', () => {
+    const { events, onEvent } = collect()
+    const p = createSseParser(onEvent)
+    p.feed('data: {"a": "b:c"}\n\n')
+
+    expect(events[0].data).toBe('{"a": "b:c"}')
+  })
+})
+
+describe('postSse', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  function sseResponse(payload: string): Response {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(payload))
+        controller.close()
+      },
+    })
+    return new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+  }
+
+  it('streams events from the response body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      sseResponse('event: delta\ndata: Hi\n\nevent: done\ndata: {"cached":true}\n\n')))
+
+    const { events, onEvent } = collect()
+    await postSse('/explain', { word: 'x' }, onEvent)
+
+    expect(events.map(e => e.event)).toEqual(['delta', 'done'])
+  })
+
+  it('maps non-OK statuses to readable errors before streaming', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 429 })))
+    await expect(postSse('/explain', {}, () => {})).rejects.toThrow(/Too many requests/)
+  })
+
+  it('throws SseUnsupportedError when the body is not streamable', async () => {
+    const res = new Response(null, { status: 200 })
+    Object.defineProperty(res, 'body', { value: null })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(res))
+
+    await expect(postSse('/explain', {}, () => {})).rejects.toBeInstanceOf(SseUnsupportedError)
+  })
+})

--- a/apps/web/src/lib/sse.ts
+++ b/apps/web/src/lib/sse.ts
@@ -1,0 +1,115 @@
+// SSE over POST (Phase 5, AI-032). EventSource can't POST a body, so streaming endpoints
+// (POST /explain with `Accept: text/event-stream`) are consumed via fetch + ReadableStream,
+// parsed with a minimal SSE parser (event/data fields, multi-line data, CRLF-tolerant).
+
+export interface SseEvent {
+  event: string
+  data: string
+}
+
+/**
+ * Stateful SSE parser: feed it raw text chunks (any split points), it dispatches complete events.
+ * Subset of the SSE spec sufficient for our endpoints: `event:`/`data:` fields, blank-line dispatch,
+ * multi-line data joined with \n, comment lines (:) ignored. Call `end()` to flush a trailing event
+ * from a stream that closed without a final blank line.
+ */
+export function createSseParser(onEvent: (e: SseEvent) => void) {
+  let buffer = ''
+  let eventType = 'message'
+  let dataLines: string[] = []
+
+  const dispatch = () => {
+    if (dataLines.length > 0) onEvent({ event: eventType, data: dataLines.join('\n') })
+    eventType = 'message'
+    dataLines = []
+  }
+
+  const processLine = (line: string) => {
+    if (line === '') return dispatch()
+    if (line.startsWith(':')) return // comment / keep-alive
+    const colon = line.indexOf(':')
+    const field = colon === -1 ? line : line.slice(0, colon)
+    // Per spec a single space after the colon is stripped, further spaces are data.
+    let value = colon === -1 ? '' : line.slice(colon + 1)
+    if (value.startsWith(' ')) value = value.slice(1)
+    if (field === 'event') eventType = value
+    else if (field === 'data') dataLines.push(value)
+    // id/retry/unknown fields ignored
+  }
+
+  return {
+    feed(chunk: string) {
+      buffer += chunk
+      let nl: number
+      while ((nl = buffer.indexOf('\n')) !== -1) {
+        let line = buffer.slice(0, nl)
+        if (line.endsWith('\r')) line = line.slice(0, -1)
+        buffer = buffer.slice(nl + 1)
+        processLine(line)
+      }
+    },
+    end() {
+      if (buffer.length > 0) processLine(buffer.endsWith('\r') ? buffer.slice(0, -1) : buffer)
+      buffer = ''
+      dispatch()
+    },
+  }
+}
+
+/**
+ * POSTs JSON and consumes the SSE response, invoking `onEvent` per event. Maps non-OK statuses to
+ * readable errors BEFORE streaming (rate-limit/unavailable responses are JSON, not SSE). Throws
+ * `SseUnsupportedError` when the environment can't stream (no body reader) so callers can fall back
+ * to a plain JSON request.
+ */
+export class SseUnsupportedError extends Error {
+  constructor() {
+    super('Streaming not supported')
+  }
+}
+
+export async function postSse(
+  url: string,
+  body: unknown,
+  onEvent: (e: SseEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream' },
+    body: JSON.stringify(body),
+    signal,
+  })
+
+  if (!res.ok) {
+    if (res.status === 503) throw new Error('Service unavailable')
+    if (res.status === 504) throw new Error('Request timed out')
+    if (res.status === 429) throw new Error('Too many requests, try again later')
+    const text = await res.text()
+    let error = `Request failed: ${res.status}`
+    try {
+      const json = JSON.parse(text)
+      if (json.detail) error = json.detail
+    } catch {
+      // non-JSON error body — keep the status message
+    }
+    throw new Error(error)
+  }
+
+  if (!res.body) throw new SseUnsupportedError()
+
+  const parser = createSseParser(onEvent)
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      parser.feed(decoder.decode(value, { stream: true }))
+    }
+    parser.feed(decoder.decode()) // flush any trailing multi-byte sequence
+    parser.end()
+  } finally {
+    reader.releaseLock()
+  }
+}

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -1243,6 +1243,20 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
   gap: 6px;
 }
 
+/* Streaming caret while an explanation is still arriving (AI-032) */
+.translation-popup__stream-cursor {
+  display: inline-block;
+  margin-left: 2px;
+  color: var(--reader-accent, #2563eb);
+  animation: stream-cursor-blink 1s steps(2, start) infinite;
+}
+
+@keyframes stream-cursor-blink {
+  to {
+    visibility: hidden;
+  }
+}
+
 
 /* Word popup (tap-to-translate) */
 @keyframes word-popup-in {


### PR DESCRIPTION
Phase 5 **AI-032** — the web reader renders explanations token-by-token; perceived latency drops to first-token time.

## Changes
- **`lib/sse.ts`** — SSE over POST (EventSource can't send a body): minimal spec-subset parser (`event`/`data` fields, multi-line data, CRLF-tolerant, comments/keep-alives ignored, robust to arbitrary chunk boundaries) + `postSse()` fetch-stream consumer. Non-OK statuses (429/503/504 come back as JSON, not SSE — the AI-031a follow-up note) map to readable errors **before** streaming; `SseUnsupportedError` lets callers fall back when the body isn't streamable.
- **`useExplain` streams** — external shape unchanged (`useExplainPopup`/`ReaderHighlights` untouched): `explanation` grows per `delta` while `isLoading` stays true until `done`; `cached` comes from the done payload; a server `error` event keeps partial text visible alongside the error. Device offline-cache still serves first; no-stream environments fall back to the one-shot JSON request; local cache written only on a completed stream.
- **`ExplanationPopup`** — spinner only until the first token, then the text grows in place with a blinking stream caret (pure CSS).

## Verification
- SSE parser (6): blank-line dispatch, char-by-char chunk splits, multi-line data + CRLF, comment/unknown-field handling, trailing-event flush, colons inside data.
- `postSse` (3): event streaming from a real `ReadableStream` Response; 429 → readable error; null body → `SseUnsupportedError`.
- Streaming `useExplain` (6): delta accumulation → final text; cached flag; server error keeps partial text; JSON fallback path; offline-cache short-circuit (no network); request-failure error.
- Full web suite green (511 tests / 59 files); `tsc --noEmit` + `pnpm build` clean.
- Visual check (stream + caret through Cloudflare) on prod after deploy — the endpoint side already ships (#312).

🤖 Generated with [Claude Code](https://claude.com/claude-code)