### PR TITLE
fix(ai): prod streaming failure with tools (AI-032 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 5 — fix: prod streaming failure with tools (2026-06-12)
+
+Prod verification of the Explain SSE path caught a real failure: with tools attached, the **streamed** OpenAI call died before the first token — the trace (admin /ai-quality, error always sampled) showed `Value cannot be null. (Parameter 'bytes')` from inside the SDK streaming path, while the one-shot JSON path worked. Three-part fix:
+
+- **OpenAI SDK 2.2.0 → 2.10.0** — picks up the upstream streaming/tool-call fixes between 2.2 and 2.10 (likely root cause). Full solution + suites green on the new SDK.
+- **Defensive fragment accumulation** — guard `FunctionArgumentsUpdate.ToMemory().IsEmpty` before `ToString()` (same check the SDK's own streaming example uses): the first id+name chunk can carry an empty/degenerate arguments payload.
+- **The swallowed stream exception is now logged** — `StreamEventsAsync` gains an `onException` hook wired to `logger.LogError`, so the next mid-stream failure leaves a stack trace, not just the trace row's message (this gap is what made diagnosis indirect).
+- Verified during the same pass: SSE through Cloudflare works (correct `text/event-stream`, terminal `error` event, no aborted stream — the AI-031a hardening did its job); JSON path + cache behave on prod.
+
 ### Phase 5 — web Explain streams visibly (2026-06-12)
 
 Phase 5 **AI-032** — the web reader renders explanations token-by-token (perceived latency drops to first-token time).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <!-- LLM -->
-    <PackageVersion Include="OpenAI" Version="2.2.0" />
+    <PackageVersion Include="OpenAI" Version="2.10.0" />
     <!-- Tool-args validation (AI-030): real JSON Schema draft 2020-12 evaluation before dispatch -->
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
     <!-- AI eval framework (MEAI.Evaluation). Stable 10.6.0 — IChatClient seam +

--- a/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/OpenAiLlmClient.cs
@@ -164,7 +164,10 @@ public sealed class OpenAiLlmClient : ILlmService
                     pendingCalls[tc.Index] = entry = (tc.ToolCallId, entry.Name, entry.Args);
                 if (!string.IsNullOrEmpty(tc.FunctionName) && entry.Name.Length == 0)
                     pendingCalls[tc.Index] = entry = (entry.Id, tc.FunctionName, entry.Args);
-                if (tc.FunctionArgumentsUpdate is not null)
+                // Guard ToMemory().IsEmpty like the SDK's own streaming example: a fragment's
+                // arguments BinaryData can be empty/degenerate on the first (id+name) chunk, and
+                // ToString() on such instances has thrown ("Parameter 'bytes'") on prod.
+                if (tc.FunctionArgumentsUpdate is not null && !tc.FunctionArgumentsUpdate.ToMemory().IsEmpty)
                     entry.Args.Append(tc.FunctionArgumentsUpdate.ToString());
             }
             if (update.Usage is not null)

--- a/backend/src/Api/Endpoints/ExplainEndpoints.cs
+++ b/backend/src/Api/Endpoints/ExplainEndpoints.cs
@@ -79,7 +79,7 @@ public static class ExplainEndpoints
             v is not null && v.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase));
 
         return wantsSse
-            ? ExplainSse(request.Word, systemPrompt, userPrompt, cache, cacheKey, llm, toolSession, tools, toolCtx, httpContext)
+            ? ExplainSse(request.Word, systemPrompt, userPrompt, cache, cacheKey, llm, toolSession, tools, toolCtx, httpContext, logger)
             : await ExplainJson(request.Word, systemPrompt, userPrompt, cache, cacheKey, llm, toolSession, tools, toolCtx, logger, ct);
     }
 
@@ -153,7 +153,7 @@ public static class ExplainEndpoints
         string word, string systemPrompt, string userPrompt,
         ExplainCache cache, string cacheKey, ILlmService llm,
         ToolCallingSession toolSession, IReadOnlyList<ToolSchema> tools, ToolContext toolCtx,
-        HttpContext httpContext)
+        HttpContext httpContext, ILogger logger)
     {
         // Cloudflare/nginx must not buffer the stream (playbook Phase 5 risk).
         httpContext.Response.Headers["X-Accel-Buffering"] = "no";
@@ -172,7 +172,8 @@ public static class ExplainEndpoints
                 (await llm.CompleteAsync(BuildRequest(systemPrompt, userPrompt, RetryOutputTokens), ct)).Text,
             readCache: ct => cache.TryReadAsync(cacheKey, ct),
             persist: (text, ct) => usedTools ? Task.CompletedTask : cache.WriteAsync(cacheKey, text, ct),
-            httpContext.RequestAborted));
+            onException: ex => logger.LogError(ex, "Explain stream failed"),
+            ct: httpContext.RequestAborted));
     }
 
     /// <summary>
@@ -187,7 +188,8 @@ public static class ExplainEndpoints
         Func<CancellationToken, Task<string>> fallback,
         Func<CancellationToken, Task<string?>> readCache,
         Func<string, CancellationToken, Task> persist,
-        [EnumeratorCancellation] CancellationToken ct)
+        Action<Exception>? onException = null,
+        [EnumeratorCancellation] CancellationToken ct = default)
     {
         if (await readCache(ct) is { } cachedText)
         {
@@ -206,8 +208,9 @@ public static class ExplainEndpoints
         {
             stream = primary(ct);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            onException?.Invoke(ex);
             error = "Explain service unavailable";
         }
 
@@ -227,8 +230,9 @@ public static class ExplainEndpoints
                 {
                     throw; // client disconnected — nothing to emit
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    onException?.Invoke(ex);
                     error = "Explain service unavailable";
                     break;
                 }
@@ -259,8 +263,9 @@ public static class ExplainEndpoints
             {
                 throw;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                onException?.Invoke(ex);
                 error = "Explain service unavailable";
             }
 

--- a/tests/TextStack.UnitTests/ExplainSseTests.cs
+++ b/tests/TextStack.UnitTests/ExplainSseTests.cs
@@ -40,7 +40,8 @@ public class ExplainSseTests
             fallback ?? (_ => Task.FromResult(string.Empty)),
             _ => Task.FromResult(cached),
             (text, _) => { onPersist?.Invoke(text); return Task.CompletedTask; },
-            TestContext.Current.CancellationToken))
+            onException: null,
+            ct: TestContext.Current.CancellationToken))
         {
             items.Add(item);
         }


### PR DESCRIPTION
Prod verification of Explain SSE (the step before AI-033) caught a real failure.

## Symptom
`POST /explain` with `Accept: text/event-stream` on prod → terminal `error` event, zero tokens. The one-shot JSON path worked. The error trace (admin /ai-quality → Traces; errors are always sampled) showed **`Value cannot be null. (Parameter 'bytes')`** from inside the OpenAI SDK streaming path — i.e. the streamed call with tools attached died before the first token.

## Fix (three parts)
1. **OpenAI SDK 2.2.0 → 2.10.0** — picks up the upstream streaming/tool-call fixes shipped between 2.2 and 2.10 (likely root cause). Whole solution + suites green on the new SDK.
2. **Defensive fragment accumulation** (`OpenAiLlmClient.StreamAsync`) — guard `FunctionArgumentsUpdate.ToMemory().IsEmpty` before `ToString()`, the same check the SDK's own function-calling-streaming example performs: the first id+name chunk can carry an empty/degenerate arguments payload.
3. **Stop swallowing the stream exception** — `StreamEventsAsync` gains an `onException` hook wired to `logger.LogError("Explain stream failed")`. The missing stack trace is what made this diagnosis indirect; next time it's one log line away.

## Verified on prod during the same pass
- SSE transits Cloudflare correctly: `text/event-stream`, terminal `error` event, no aborted stream (the AI-031a hardening worked as designed).
- JSON path + tool round + cache behave.
- After this deploys: re-run `curl -N` SSE check + browser check of visible token streaming in the reader (then AI-033).

## Tests
Full `TextStack.UnitTests` (238) + `TextStack.AiEvals` green on SDK 2.10.0; `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)