### PR TITLE
feat(ai): tool-call golden set + eval — Phase 5 complete (AI-033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Phase 5 — tool-call golden set + eval — Phase 5 complete (2026-06-12)
+
+Phase 5 **AI-033** — the last DoD metric: tool-call accuracy ≥0.9 on a 30-example set (right tool, right args). **This closes Phase 5** (streaming + function-calling: token streams end-to-end, 4 validated tools, visible web streaming, eval gate).
+
+- **`ToolCallMetrics`** (`Ai.Tools`, pure) — `IsHit`: expected tool must be among the round-1 calls with every expected argument fragment present (case-insensitive substring — args are model-phrased); a **no-tool golden passes only when nothing was called** (over-calling is as much a failure as under-calling); extra parallel calls don't fail a case. `Accuracy` over the set. CI-tested.
+- **Golden set** `toolcalls.json` (embedded, 30 cases): 12 no-tool (plain technical words), 8 `get_chapter` ("see Chapter N"), 5 `search_book` ("as we discussed earlier"), 3 `lookup_dictionary` (precise-meaning words), 2 `get_user_highlights` (user references own notes).
+- **`ToolCallEvalRunner`** (`Ai.EvalSuite`) — per golden: the REAL Explain round-1 (production `ExplainPrompt` with tool guidance + the registry's schemas) → score the model's tool choice. Round-1 only: tools are never executed → no edition/user needed, one nano call per case. Persists `explain.toolcall` `EvalRun` (score 0–1).
+- **`POST /admin/ai-quality/evals/toolcalls/run`** — sync admin trigger (~30 nano calls), 503 when keyless; per-case expected/actual detail in the response.
+- Tests: `ToolCallMetrics` (11 — no-tool both ways, right/wrong/missing tool, extra parallel call, string + number fragments, missing arg, accuracy math); `ToolCallEvalRunner` with an oracle LLM (accuracy 1.0; every request carries the 4 schemas + tool-guidance prompt) and an over-eager dictionary-happy LLM (only dictionary goldens hit; no-tool goldens all miss); dataset shape guard (≥30, all tools represented).
+
 ### Phase 5 — fix: prod streaming failure with tools (2026-06-12)
 
 Prod verification of the Explain SSE path caught a real failure: with tools attached, the **streamed** OpenAI call died before the first token — the trace (admin /ai-quality, error always sampled) showed `Value cannot be null. (Parameter 'bytes')` from inside the SDK streaming path, while the one-shot JSON path worked. Three-part fix:

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/Datasets/toolcalls.json
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/Datasets/toolcalls.json
@@ -1,0 +1,36 @@
+[
+  { "word": "replication", "sentence": "Replication keeps a copy of the same data on multiple machines connected via a network.", "expectedTool": null },
+  { "word": "partitioning", "sentence": "Partitioning splits a large dataset into smaller subsets assigned to different nodes.", "expectedTool": null },
+  { "word": "throughput", "sentence": "The system sustained a throughput of 10,000 requests per second under load.", "expectedTool": null },
+  { "word": "idempotent", "sentence": "Retrying an idempotent operation is safe because applying it twice has the same effect as once.", "expectedTool": null },
+  { "word": "latency", "sentence": "Tail latency matters more than the average when users issue many requests per page.", "expectedTool": null },
+  { "word": "bottleneck", "sentence": "The single leader became a bottleneck once write volume doubled.", "expectedTool": null },
+  { "word": "schema", "sentence": "Document databases let you write data without first declaring a schema.", "expectedTool": null },
+  { "word": "rollback", "sentence": "If any statement fails, the database performs a rollback of the whole transaction.", "expectedTool": null },
+  { "word": "cache", "sentence": "A cache stores the result of an expensive computation for faster reads later.", "expectedTool": null },
+  { "word": "denormalization", "sentence": "Denormalization duplicates data to avoid expensive joins at read time.", "expectedTool": null },
+  { "word": "failover", "sentence": "Automatic failover promotes a follower to leader when the old leader dies.", "expectedTool": null },
+  { "word": "backpressure", "sentence": "Backpressure lets a slow consumer signal the producer to stop sending so fast.", "expectedTool": null },
+
+  { "word": "quorum", "sentence": "As we saw in Chapter 5, a quorum protects reads from stale replicas.", "expectedTool": "get_chapter", "expectedArgFragments": { "chapter_number": "5" } },
+  { "word": "compaction", "sentence": "Compaction was covered in detail in Chapter 3, where SSTables merge in the background.", "expectedTool": "get_chapter", "expectedArgFragments": { "chapter_number": "3" } },
+  { "word": "serializability", "sentence": "See Chapter 7 for why serializability is the strongest isolation level.", "expectedTool": "get_chapter", "expectedArgFragments": { "chapter_number": "7" } },
+  { "word": "rebalancing", "sentence": "Chapter 6 describes rebalancing, the process of moving partitions between nodes.", "expectedTool": "get_chapter", "expectedArgFragments": { "chapter_number": "6" } },
+  { "word": "linearizability", "sentence": "We will define linearizability precisely in Chapter 9; for now think of it as single-copy behavior.", "expectedTool": "get_chapter", "expectedArgFragments": { "chapter_number": "9" } },
+  { "word": "hinted handoff", "sentence": "Recall the hinted handoff mechanism introduced in Chapter 5 for sloppy quorums.", "expectedTool": "get_chapter", "expectedArgFragments": { "chapter_number": "5" } },
+  { "word": "two-phase commit", "sentence": "Two-phase commit, which Chapter 9 examines closely, coordinates atomic commits across nodes.", "expectedTool": "get_chapter", "expectedArgFragments": { "chapter_number": "9" } },
+  { "word": "stream processing", "sentence": "Chapter 11 turns to stream processing, where inputs are unbounded and arrive over time.", "expectedTool": "get_chapter", "expectedArgFragments": { "chapter_number": "11" } },
+
+  { "word": "write amplification", "sentence": "As we discussed earlier, write amplification is one effect of repeated compaction.", "expectedTool": "search_book", "expectedArgFragments": { "query": "write amplification" } },
+  { "word": "read repair", "sentence": "Read repair, mentioned before, fixes stale values during reads.", "expectedTool": "search_book", "expectedArgFragments": { "query": "read repair" } },
+  { "word": "split brain", "sentence": "Earlier we discussed split brain, where two nodes both believe they are the leader.", "expectedTool": "search_book", "expectedArgFragments": { "query": "split brain" } },
+  { "word": "leader election", "sentence": "Leader election, covered earlier in this book, decides which replica accepts writes.", "expectedTool": "search_book", "expectedArgFragments": { "query": "leader election" } },
+  { "word": "skew", "sentence": "We touched on skew earlier — some partitions receive far more load than others.", "expectedTool": "search_book", "expectedArgFragments": { "query": "skew" } },
+
+  { "word": "ephemeral", "sentence": "ZooKeeper stores membership in ephemeral nodes that vanish when a session ends.", "expectedTool": "lookup_dictionary", "expectedArgFragments": { "word": "ephemeral" } },
+  { "word": "monotonic", "sentence": "A monotonic clock always moves forward, unlike a time-of-day clock.", "expectedTool": "lookup_dictionary", "expectedArgFragments": { "word": "monotonic" } },
+  { "word": "byzantine", "sentence": "A byzantine fault means a node may behave arbitrarily, even maliciously.", "expectedTool": "lookup_dictionary", "expectedArgFragments": { "word": "byzantine" } },
+
+  { "word": "vector clock", "sentence": "I highlighted the definition of vector clock somewhere in my notes earlier in this book.", "expectedTool": "get_user_highlights" },
+  { "word": "gossip protocol", "sentence": "Check my saved highlights — I marked an explanation of the gossip protocol a few chapters back.", "expectedTool": "get_user_highlights" }
+]

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/TextStack.Ai.EvalSuite.csproj
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/TextStack.Ai.EvalSuite.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\TextStack.Ai.Llm\TextStack.Ai.Llm.csproj" />
     <ProjectReference Include="..\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj" />
     <ProjectReference Include="..\..\Application\Application.csproj" />
+    <ProjectReference Include="..\TextStack.Ai.Tools\TextStack.Ai.Tools.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/ToolCallEvalRunner.cs
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/ToolCallEvalRunner.cs
@@ -1,0 +1,86 @@
+using Application.Ai;
+using Application.Common.Interfaces;
+using Domain.Entities;
+using Microsoft.Extensions.Logging;
+using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
+
+namespace TextStack.Ai.EvalSuite;
+
+/// <summary>One golden's outcome — what the model actually called, for the admin UI.</summary>
+public sealed record ToolCallCase(string Word, string? ExpectedTool, IReadOnlyList<string> ActualTools, bool Hit);
+
+/// <summary>Result of a tool-call eval run (AI-033). DoD: accuracy ≥ 0.9 over the 30-case set.</summary>
+public sealed record ToolCallEvalResult(double Accuracy, int N, IReadOnlyList<ToolCallCase> Cases);
+
+/// <summary>
+/// Runs the Phase 5 tool-call eval (AI-033): for each golden, issue the REAL Explain round-1 — the
+/// production prompt (<see cref="ExplainPrompt"/> with tool guidance) + the registry's tool schemas —
+/// and score the model's tool choice with the pure <see cref="ToolCallMetrics"/> (right tool, right
+/// args, or correctly NO tool). Round 1 only: tools are never executed, so the eval needs no edition,
+/// no user, and costs one nano call per case. Persists an <c>explain.toolcall</c>
+/// <see cref="EvalRun"/> (score 0–1) so /ai-quality tracks it like every other feature.
+/// </summary>
+public sealed class ToolCallEvalRunner(ILogger<ToolCallEvalRunner> logger)
+{
+    private const string Feature = "explain.toolcall";
+    private const int MaxOutputTokens = 500; // matches the Explain endpoint's round-1 budget
+
+    /// <summary>The four Explain tools, as a signed-in reader with a book in context gets them.</summary>
+    private static readonly string[] ExplainToolNames =
+        ["lookup_dictionary", "get_chapter", "search_book", "get_user_highlights"];
+
+    public async Task<ToolCallEvalResult> RunAsync(
+        ILlmService llm,
+        IToolRegistry registry,
+        bool persist,
+        IAppDbContext? db,
+        string? gitSha,
+        CancellationToken ct)
+    {
+        var goldens = ToolCallGoldenSet.Load();
+        var tools = registry.SchemasFor(ExplainToolNames);
+        var systemPrompt = ExplainPrompt.BuildSystemPrompt(genre: null, targetLang: "en", withTools: true);
+
+        var cases = new List<ToolCallCase>();
+        string? modelId = null;
+        foreach (var g in goldens)
+        {
+            ct.ThrowIfCancellationRequested();
+            var request = new LlmRequest(
+                systemPrompt,
+                [new LlmMessage("user", ExplainPrompt.BuildUserPrompt(g.Word, g.Sentence))],
+                MaxOutputTokens, Tools: tools, FeatureTag: Feature);
+
+            var response = await llm.CompleteAsync(request, ct);
+            modelId ??= response.ModelId;
+
+            var hit = ToolCallMetrics.IsHit(response.ToolCalls, g.ExpectedTool, g.ExpectedArgFragments);
+            cases.Add(new ToolCallCase(
+                g.Word, g.ExpectedTool, response.ToolCalls.Select(c => c.ToolName).ToList(), hit));
+        }
+
+        var accuracy = ToolCallMetrics.Accuracy(cases.Select(c => c.Hit).ToList());
+        logger.LogInformation("Tool-call eval: accuracy={Accuracy:0.00} (N={N})", accuracy, cases.Count);
+
+        if (persist && db is not null)
+        {
+            db.EvalRuns.Add(new EvalRun
+            {
+                Id = Guid.NewGuid(),
+                Feature = Feature,
+                ModelId = modelId ?? "unknown",
+                JudgeModelId = "n/a", // deterministic comparison, no judge
+                Score = Math.Round((decimal)accuracy, 3),
+                N = cases.Count,
+                BreakdownJson =
+                    $"{{\"hits\":{cases.Count(c => c.Hit)},\"noToolCases\":{cases.Count(c => c.ExpectedTool is null)}}}",
+                GitSha = gitSha,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+            await db.SaveChangesAsync(ct);
+        }
+
+        return new ToolCallEvalResult(accuracy, cases.Count, cases);
+    }
+}

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/ToolCallGolden.cs
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/ToolCallGolden.cs
@@ -1,0 +1,20 @@
+namespace TextStack.Ai.EvalSuite;
+
+/// <summary>
+/// One tool-call golden case (AI-033): an Explain input plus the round-1 behaviour a correct model
+/// shows. <see cref="ExpectedTool"/> null = the model must answer directly (no tool) — most words
+/// need none, and over-calling is as much a failure as under-calling.
+/// <see cref="ExpectedArgFragments"/> maps argument name → substring the model's argument must
+/// contain (case-insensitive; model-phrased args make exact matching brittle).
+/// </summary>
+public record ToolCallGolden(
+    string Word,
+    string Sentence,
+    string? ExpectedTool,
+    IReadOnlyDictionary<string, string>? ExpectedArgFragments);
+
+/// <summary>Loads the embedded tool-call golden set (<c>toolcalls.json</c>).</summary>
+public static class ToolCallGoldenSet
+{
+    public static IReadOnlyList<ToolCallGolden> Load() => GoldenLoader.Load<ToolCallGolden>("toolcalls.json");
+}

--- a/backend/src/Ai/TextStack.Ai.Tools/ToolCallMetrics.cs
+++ b/backend/src/Ai/TextStack.Ai.Tools/ToolCallMetrics.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using TextStack.Ai.Core;
+
+namespace TextStack.Ai.Tools;
+
+/// <summary>
+/// Pure tool-call accuracy scoring for the Phase 5 eval (AI-033). A case passes when the model's
+/// round-1 behaviour matches the golden: called the expected tool with the expected argument
+/// fragments — or, for a no-tool golden, called nothing. Deterministic, no LLM, unit-tested in CI;
+/// the real model runs offline via the admin eval.
+/// </summary>
+public static class ToolCallMetrics
+{
+    /// <summary>
+    /// True when <paramref name="actual"/> matches the golden expectation.
+    /// <paramref name="expectedTool"/> null/empty = the model must call NO tool. Otherwise exactly
+    /// that tool must be among the calls (extra parallel calls don't fail the case — the target
+    /// behaviour is "did it reach for the right tool"), and for each entry in
+    /// <paramref name="expectedArgFragments"/> the named argument must exist and contain the
+    /// fragment (case-insensitive substring — args are model-phrased, exact match is brittle).
+    /// </summary>
+    public static bool IsHit(
+        IReadOnlyList<ToolCall> actual,
+        string? expectedTool,
+        IReadOnlyDictionary<string, string>? expectedArgFragments)
+    {
+        if (string.IsNullOrEmpty(expectedTool))
+            return actual.Count == 0;
+
+        var call = actual.FirstOrDefault(c => c.ToolName == expectedTool);
+        if (call is null)
+            return false;
+
+        if (expectedArgFragments is null || expectedArgFragments.Count == 0)
+            return true;
+
+        foreach (var (arg, fragment) in expectedArgFragments)
+        {
+            if (call.Arguments.ValueKind != JsonValueKind.Object
+                || !call.Arguments.TryGetProperty(arg, out var value))
+                return false;
+
+            var text = value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString() ?? string.Empty,
+                _ => value.GetRawText(),
+            };
+            if (!text.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>Accuracy over the golden set: fraction of cases that hit. Empty set → 1.0 (N is reported).</summary>
+    public static double Accuracy(IReadOnlyList<bool> hits) =>
+        hits.Count == 0 ? 1.0 : (double)hits.Count(h => h) / hits.Count;
+}

--- a/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using TextStack.Ai.Core;
 using TextStack.Ai.EvalSuite;
+using TextStack.Ai.Tools;
 
 namespace Api.Endpoints;
 
@@ -26,6 +27,43 @@ public static class AdminAiQualityEndpoints
         group.MapGet("/evals", GetEvals);
         group.MapPost("/evals/run", RunEvals);
         group.MapGet("/evals/status", GetEvalStatus);
+        group.MapPost("/evals/toolcalls/run", RunToolCallEval);
+    }
+
+    // Phase 5 DoD gate (AI-033): deterministic tool-call accuracy over the embedded golden set.
+    // Round-1 only (tools are never executed) → no edition/user needed; ~30 nano calls, run sync.
+    private static async Task<IResult> RunToolCallEval(
+        IServiceProvider services,
+        ToolCallEvalRunner runner,
+        IToolRegistry registry,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        ILlmService llm;
+        try
+        {
+            llm = services.GetRequiredService<ILlmService>();
+        }
+        catch (InvalidOperationException)
+        {
+            return Results.Problem("LLM gateway is not configured (no OpenAI key).", statusCode: 503);
+        }
+
+        var gitSha = Environment.GetEnvironmentVariable("GIT_SHA");
+        var result = await runner.RunAsync(llm, registry, persist: true, db, gitSha, ct);
+
+        return Results.Ok(new
+        {
+            accuracy = Math.Round(result.Accuracy, 4),
+            n = result.N,
+            cases = result.Cases.Select(c => new
+            {
+                c.Word,
+                expected = c.ExpectedTool ?? "(no tool)",
+                actual = c.ActualTools,
+                c.Hit,
+            }),
+        });
     }
 
     // In-app eval runner state (one run at a time). Triggered from the admin Evals tab.

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -82,6 +82,7 @@ builder.Services.AddOpenApi();
 builder.Services.AddApplication();
 builder.Services.AddSingleton<TextStack.Ai.EvalSuite.EvalSuiteRunner>();
 builder.Services.AddSingleton<TextStack.Ai.EvalSuite.RagEvalRunner>();
+builder.Services.AddSingleton<TextStack.Ai.EvalSuite.ToolCallEvalRunner>();
 // Tool catalogue (AI-029/030): scans Application for ITool impls; dispatch is schema-validated.
 builder.Services.AddAiTools(typeof(Application.Tools.GetChapterTool).Assembly);
 builder.Services.AddAuthSettings(builder.Configuration);

--- a/tests/TextStack.AiEvals/ToolCallEvalRunnerTests.cs
+++ b/tests/TextStack.AiEvals/ToolCallEvalRunnerTests.cs
@@ -1,0 +1,126 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using TextStack.Ai.Core;
+using TextStack.Ai.EvalSuite;
+using TextStack.Ai.Tools;
+
+namespace TextStack.AiEvals;
+
+/// <summary>
+/// Deterministic coverage for <see cref="ToolCallEvalRunner"/> (AI-033) with a fake LLM: load the
+/// embedded goldens → issue round-1 per case with the production prompt + tool schemas → score.
+/// Counts come from the dataset so the test survives the set growing.
+/// </summary>
+public class ToolCallEvalRunnerTests
+{
+    private static readonly IReadOnlyList<ToolCallGolden> Goldens = ToolCallGoldenSet.Load();
+    private static readonly JsonElement AnySchema = JsonDocument.Parse("""{"type":"object"}""").RootElement;
+
+    /// <summary>A registry stub exposing the four Explain tool names (schemas only — never invoked).</summary>
+    private sealed class SchemaTool(string name) : ITool
+    {
+        public string Name => name;
+        public string Description => name;
+        public JsonElement ArgsSchema => AnySchema;
+        public Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct) =>
+            throw new NotSupportedException("eval never executes tools");
+    }
+
+    private static IToolRegistry Registry() => new ToolRegistry(
+    [
+        new SchemaTool("lookup_dictionary"), new SchemaTool("get_chapter"),
+        new SchemaTool("search_book"), new SchemaTool("get_user_highlights"),
+    ]);
+
+    /// <summary>Answers each golden EXACTLY as expected (right tool + expected fragments, or no tool).</summary>
+    private sealed class OracleLlm : ILlmService
+    {
+        public List<LlmRequest> Requests { get; } = [];
+
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
+        {
+            Requests.Add(request);
+            // The user prompt is "Word: {word}\nSentence: {sentence}" — recover the golden by word.
+            var word = request.Messages[0].Content.Split('\n')[0]["Word: ".Length..];
+            var g = Goldens.First(x => x.Word == word);
+
+            var calls = new List<ToolCall>();
+            if (g.ExpectedTool is not null)
+            {
+                var args = g.ExpectedArgFragments is null
+                    ? "{}"
+                    : JsonSerializer.Serialize(g.ExpectedArgFragments.ToDictionary(kv => kv.Key, kv => (object)kv.Value));
+                calls.Add(new ToolCall("c1", g.ExpectedTool, JsonDocument.Parse(args).RootElement));
+            }
+            return Task.FromResult(new LlmResponse(
+                calls.Count == 0 ? "A direct answer." : "", calls, new LlmUsage(1, 1, 0m), "oracle", Guid.NewGuid()));
+        }
+
+        public IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
+
+    /// <summary>Always calls lookup_dictionary — wrong for every golden except the dictionary ones.</summary>
+    private sealed class DictionaryHappyLlm : ILlmService
+    {
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
+        {
+            var word = request.Messages[0].Content.Split('\n')[0]["Word: ".Length..];
+            var call = new ToolCall("c1", "lookup_dictionary",
+                JsonDocument.Parse($"{{\"word\":\"{word}\"}}").RootElement);
+            return Task.FromResult(new LlmResponse("", [call], new LlmUsage(1, 1, 0m), "happy", Guid.NewGuid()));
+        }
+
+        public IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task RunAsync_OracleModel_PerfectAccuracy()
+    {
+        var llm = new OracleLlm();
+        var runner = new ToolCallEvalRunner(NullLogger<ToolCallEvalRunner>.Instance);
+
+        var result = await runner.RunAsync(llm, Registry(), persist: false, db: null, gitSha: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(Goldens.Count, result.N);
+        Assert.Equal(1.0, result.Accuracy, 12);
+        Assert.All(result.Cases, c => Assert.True(c.Hit));
+
+        // Every request carried the production tool schemas + the tool-guidance prompt.
+        Assert.All(llm.Requests, r =>
+        {
+            Assert.NotNull(r.Tools);
+            Assert.Equal(4, r.Tools!.Count);
+            Assert.Contains("You have access to tools", r.SystemPrompt);
+        });
+    }
+
+    [Fact]
+    public async Task RunAsync_OverEagerToolCaller_ScoresOnlyDictionaryCases()
+    {
+        var runner = new ToolCallEvalRunner(NullLogger<ToolCallEvalRunner>.Instance);
+
+        var result = await runner.RunAsync(new DictionaryHappyLlm(), Registry(), persist: false, db: null,
+            gitSha: null, TestContext.Current.CancellationToken);
+
+        var expectedHits = Goldens.Count(g => g.ExpectedTool == "lookup_dictionary");
+        Assert.Equal((double)expectedHits / Goldens.Count, result.Accuracy, 12);
+        // No-tool goldens must be misses for an over-eager caller (over-calling is a failure).
+        Assert.All(result.Cases.Where(c => c.ExpectedTool is null), c => Assert.False(c.Hit));
+    }
+
+    [Fact]
+    public void GoldenSet_LoadsWithSaneShape()
+    {
+        Assert.True(Goldens.Count >= 30, $"DoD wants a 30-example set; got {Goldens.Count}");
+        Assert.Contains(Goldens, g => g.ExpectedTool is null);                    // no-tool cases present
+        Assert.Contains(Goldens, g => g.ExpectedTool == "get_chapter");
+        Assert.Contains(Goldens, g => g.ExpectedTool == "search_book");
+        Assert.Contains(Goldens, g => g.ExpectedTool == "lookup_dictionary");
+        Assert.Contains(Goldens, g => g.ExpectedTool == "get_user_highlights");
+        Assert.All(Goldens, g => Assert.False(string.IsNullOrWhiteSpace(g.Sentence)));
+    }
+}

--- a/tests/TextStack.UnitTests/ToolCallMetricsTests.cs
+++ b/tests/TextStack.UnitTests/ToolCallMetricsTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
+
+namespace TextStack.UnitTests;
+
+public class ToolCallMetricsTests
+{
+    private static ToolCall Call(string name, string argsJson = "{}") =>
+        new("c1", name, JsonDocument.Parse(argsJson).RootElement);
+
+    private static Dictionary<string, string> Frag(string arg, string fragment) => new() { [arg] = fragment };
+
+    [Fact]
+    public void IsHit_NoToolExpected_NoCalls_True()
+        => Assert.True(ToolCallMetrics.IsHit([], expectedTool: null, expectedArgFragments: null));
+
+    [Fact]
+    public void IsHit_NoToolExpected_ButCalled_False()
+        => Assert.False(ToolCallMetrics.IsHit([Call("lookup_dictionary")], null, null));
+
+    [Fact]
+    public void IsHit_ExpectedTool_Called_True()
+        => Assert.True(ToolCallMetrics.IsHit([Call("get_chapter")], "get_chapter", null));
+
+    [Fact]
+    public void IsHit_ExpectedTool_NotCalled_False()
+        => Assert.False(ToolCallMetrics.IsHit([], "get_chapter", null));
+
+    [Fact]
+    public void IsHit_WrongTool_False()
+        => Assert.False(ToolCallMetrics.IsHit([Call("search_book")], "get_chapter", null));
+
+    [Fact]
+    public void IsHit_ExtraParallelCall_StillHits()
+        => Assert.True(ToolCallMetrics.IsHit(
+            [Call("lookup_dictionary"), Call("get_chapter", """{"chapter_number":5}""")],
+            "get_chapter", Frag("chapter_number", "5")));
+
+    [Fact]
+    public void IsHit_ArgFragment_StringContains_CaseInsensitive()
+        => Assert.True(ToolCallMetrics.IsHit(
+            [Call("search_book", """{"query":"the Write Amplification effect"}""")],
+            "search_book", Frag("query", "write amplification")));
+
+    [Fact]
+    public void IsHit_ArgFragment_NumberMatchedViaRawText()
+        => Assert.True(ToolCallMetrics.IsHit(
+            [Call("get_chapter", """{"chapter_number":7}""")],
+            "get_chapter", Frag("chapter_number", "7")));
+
+    [Fact]
+    public void IsHit_ArgFragment_Missing_False()
+        => Assert.False(ToolCallMetrics.IsHit(
+            [Call("search_book", """{"query":"something else"}""")],
+            "search_book", Frag("query", "read repair")));
+
+    [Fact]
+    public void IsHit_ArgProperty_Absent_False()
+        => Assert.False(ToolCallMetrics.IsHit(
+            [Call("get_chapter", "{}")],
+            "get_chapter", Frag("chapter_number", "5")));
+
+    [Fact]
+    public void Accuracy_Fraction_And_EmptyVacuouslyOne()
+    {
+        Assert.Equal(0.75, ToolCallMetrics.Accuracy([true, true, true, false]), 12);
+        Assert.Equal(1.0, ToolCallMetrics.Accuracy([]));
+    }
+}


### PR DESCRIPTION
Phase 5 **AI-033** — the last DoD metric: tool-call accuracy ≥0.9 on a 30-example set (right tool, right args). **This closes Phase 5**: token streaming end-to-end (C# `IAsyncEnumerable` → SSE → React), 4 schema-validated tools, visible web streaming, and now the eval gate.

## Changes
- **`ToolCallMetrics`** (`Ai.Tools`, pure) — `IsHit`: the expected tool must be among the round-1 calls, with every expected argument fragment present (case-insensitive substring — args are model-phrased, exact match is brittle). A **no-tool golden passes only when nothing was called** — over-calling is as much a failure as under-calling. Extra parallel calls don't fail a case. `Accuracy` over the set.
- **Golden set** `toolcalls.json` (embedded, 30): 12 no-tool (plain technical words — the majority case per the prompt's own guidance), 8 `get_chapter` ("see Chapter N"), 5 `search_book` ("as we discussed earlier"), 3 `lookup_dictionary`, 2 `get_user_highlights`.
- **`ToolCallEvalRunner`** (`Ai.EvalSuite`) — per golden: the REAL Explain round-1 (production `ExplainPrompt` with tool guidance + the registry's schemas) → deterministic scoring. **Round-1 only — tools are never executed**, so the eval needs no edition/user and costs one nano call per case. Persists `explain.toolcall` `EvalRun` (score 0–1, no judge).
- **`POST /admin/ai-quality/evals/toolcalls/run`** — sync admin trigger (~30 nano calls), 503 when keyless, per-case expected/actual detail in the response.

## Verification
- `ToolCallMetrics` (11): no-tool both directions, right/wrong/missing tool, extra parallel call tolerated, string + number fragments, missing arg property, accuracy math + empty-set edge.
- `ToolCallEvalRunner` (3, fake LLMs): oracle model → accuracy 1.0 and every request carries the 4 schemas + tool-guidance prompt; an over-eager dictionary-happy model scores exactly the dictionary-golden fraction with all no-tool goldens missed; dataset shape guard (≥30 cases, all five behaviours represented).
- Full `TextStack.UnitTests` (249) + `TextStack.AiEvals` green; `dotnet format` clean.

## After merge (closes the phase)
Run the admin eval on prod (key + nano live there) → confirm **accuracy ≥0.9**. Streaming-in-production was already verified live this session (59-delta SSE through Cloudflare, popup renders incrementally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)