### PR TITLE
fix(ai): stop over-eager tool calls in Explain prompt (AI-033 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Phase 5 — prompt tuning: stop over-eager tool calls (AI-033 follow-up, 2026-06-12)
+
+First prod run of the AI-033 tool-call eval scored **0.33** (10/30): gpt-4.1-nano called `lookup_dictionary` on **every** word — all 12 no-tool goldens failed, and half the chapter goldens were swallowed by the dictionary too. The original playbook guidance ("the word has a precise dictionary meaning relevant to the explanation") reads as "always" to nano.
+
+- **`ExplainPrompt` tool-guidance rewritten**: tools framed as the exception ("RARELY needed"), an explicit default ("answer directly with NO tool call"), technical terms named as never needing a tool, each tool gated on an *explicit* textual trigger (numbered chapter / "discussed earlier" / user mentions own highlights / rare-archaic word), and a closing "if none apply, do NOT call any tool".
+- The eval gate did exactly its job: deterministic per-case output made the failure mode obvious in one read. Re-run on prod after deploy targets ≥0.9.
+
 ### Phase 5 — tool-call golden set + eval — Phase 5 complete (2026-06-12)
 
 Phase 5 **AI-033** — the last DoD metric: tool-call accuracy ≥0.9 on a 30-example set (right tool, right args). **This closes Phase 5** (streaming + function-calling: token streams end-to-end, 4 validated tools, visible web streaming, eval gate).

--- a/backend/src/Application/Ai/ExplainPrompt.cs
+++ b/backend/src/Application/Ai/ExplainPrompt.cs
@@ -19,14 +19,21 @@ public static class ExplainPrompt
             "one concrete analogy. No preface, no quotes around the answer, no markdown.";
 
         // Phase 5 function-calling (AI-031b): appended only when the request actually carries tools.
+        // Tightened after the AI-033 eval: the original "precise dictionary meaning" guidance made
+        // gpt-4.1-nano call lookup_dictionary on EVERY word (accuracy 0.33). Tools are now framed as
+        // the exception with an explicit default-to-no-tools rule.
         if (withTools)
         {
             prompt +=
-                "\n\nYou have access to tools. Use them when:\n" +
-                "- The sentence references \"see chapter X\" or \"earlier we discussed\" -> call get_chapter or search_book\n" +
-                "- The word may be defined elsewhere in the user's saved highlights -> call get_user_highlights\n" +
-                "- The word has a precise dictionary meaning relevant to the explanation -> call lookup_dictionary\n" +
-                "Most words need NO tools - answer directly. " +
+                "\n\nYou have access to tools, but they are RARELY needed. " +
+                "Default: answer directly from the sentence with NO tool call. " +
+                "Technical terms (e.g. replication, cache, latency) never need a tool - explain them from context.\n" +
+                "Call a tool ONLY in these specific situations:\n" +
+                "- The sentence explicitly references a numbered chapter (\"see Chapter 5\", \"Chapter 9 examines\") -> get_chapter with that number\n" +
+                "- The sentence explicitly says the topic was discussed earlier/before in the book, without a chapter number -> search_book\n" +
+                "- The user explicitly mentions their own saved highlights or notes -> get_user_highlights\n" +
+                "- The word is rare, archaic or non-technical (e.g. ephemeral, byzantine) and its general meaning is genuinely unclear -> lookup_dictionary\n" +
+                "If none of these apply, do NOT call any tool. " +
                 "After using tools, give the same 2-3 sentence explanation, citing tool results when used.";
         }
 


### PR DESCRIPTION
First prod run of the AI-033 tool-call eval scored **0.33** (10/30): gpt-4.1-nano called `lookup_dictionary` on **every** word — all 12 no-tool goldens failed, half the chapter goldens were swallowed by the dictionary too. The playbook's original guidance ("the word has a precise dictionary meaning relevant to the explanation") reads as "always" to nano.

## Fix — prompt engineering only
`ExplainPrompt` tool-guidance rewritten:
- Tools framed as the exception ("RARELY needed") with an explicit default: answer directly, NO tool call.
- Technical terms named as never needing a tool (with examples).
- Each tool gated on an **explicit textual trigger**: numbered chapter → `get_chapter`; "discussed earlier" without a number → `search_book`; user mentions own highlights → `get_user_highlights`; rare/archaic word → `lookup_dictionary`.
- Closing rule: "If none of these apply, do NOT call any tool."

## Verification
- Suites green (249 + 22); format clean. (The eval itself is the test — deterministic per-case output made the failure mode obvious in one read.)
- After deploy: re-run `POST /admin/ai-quality/evals/toolcalls/run` on prod → target ≥0.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)