### PR TITLE
fix(ai): drop lookup_dictionary from Explain tool set (AI-033 follow-up 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 5 — drop lookup_dictionary from Explain (AI-033 follow-up 2, 2026-06-12)
+
+Second eval iteration. Prompt tightening moved accuracy 0.33 → **0.50**, but per-case output showed the same single attractor: nano still reached for `lookup_dictionary` on technical words (10 of 15 misses). Rather than keep fighting the model's prior, the tool is **removed from the Explain set** (product call, not just an eval dodge: a dictionary inside an explainer is circular for the technical-reader audience — the same reasoning mobile used when it dropped the dictionary from its reader; the tool stays in the registry for agents/MCP).
+
+- `ExplainEndpoints.ResolveTools`: book in context → `get_chapter`/`search_book` (+`get_user_highlights` signed-in); **no book → no tools at all** (plain streaming explain).
+- `ExplainPrompt`: dictionary bullet removed; "words never need a tool by themselves" added.
+- Eval updated: runner offers the 3 Explain tools; the 3 dictionary goldens re-labelled no-tool (now 15 no-tool / 8 chapter / 5 search / 2 highlights).
+- Re-run on prod after deploy targets ≥0.9.
+
 ### Phase 5 — prompt tuning: stop over-eager tool calls (AI-033 follow-up, 2026-06-12)
 
 First prod run of the AI-033 tool-call eval scored **0.33** (10/30): gpt-4.1-nano called `lookup_dictionary` on **every** word — all 12 no-tool goldens failed, and half the chapter goldens were swallowed by the dictionary too. The original playbook guidance ("the word has a precise dictionary meaning relevant to the explanation") reads as "always" to nano.

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/Datasets/toolcalls.json
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/Datasets/toolcalls.json
@@ -27,9 +27,9 @@
   { "word": "leader election", "sentence": "Leader election, covered earlier in this book, decides which replica accepts writes.", "expectedTool": "search_book", "expectedArgFragments": { "query": "leader election" } },
   { "word": "skew", "sentence": "We touched on skew earlier — some partitions receive far more load than others.", "expectedTool": "search_book", "expectedArgFragments": { "query": "skew" } },
 
-  { "word": "ephemeral", "sentence": "ZooKeeper stores membership in ephemeral nodes that vanish when a session ends.", "expectedTool": "lookup_dictionary", "expectedArgFragments": { "word": "ephemeral" } },
-  { "word": "monotonic", "sentence": "A monotonic clock always moves forward, unlike a time-of-day clock.", "expectedTool": "lookup_dictionary", "expectedArgFragments": { "word": "monotonic" } },
-  { "word": "byzantine", "sentence": "A byzantine fault means a node may behave arbitrarily, even maliciously.", "expectedTool": "lookup_dictionary", "expectedArgFragments": { "word": "byzantine" } },
+  { "word": "ephemeral", "sentence": "ZooKeeper stores membership in ephemeral nodes that vanish when a session ends.", "expectedTool": null },
+  { "word": "monotonic", "sentence": "A monotonic clock always moves forward, unlike a time-of-day clock.", "expectedTool": null },
+  { "word": "byzantine", "sentence": "A byzantine fault means a node may behave arbitrarily, even maliciously.", "expectedTool": null },
 
   { "word": "vector clock", "sentence": "I highlighted the definition of vector clock somewhere in my notes earlier in this book.", "expectedTool": "get_user_highlights" },
   { "word": "gossip protocol", "sentence": "Check my saved highlights — I marked an explanation of the gossip protocol a few chapters back.", "expectedTool": "get_user_highlights" }

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/ToolCallEvalRunner.cs
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/ToolCallEvalRunner.cs
@@ -26,9 +26,10 @@ public sealed class ToolCallEvalRunner(ILogger<ToolCallEvalRunner> logger)
     private const string Feature = "explain.toolcall";
     private const int MaxOutputTokens = 500; // matches the Explain endpoint's round-1 budget
 
-    /// <summary>The four Explain tools, as a signed-in reader with a book in context gets them.</summary>
+    /// <summary>The Explain tools, as a signed-in reader with a book in context gets them
+    /// (lookup_dictionary was dropped from Explain after the first eval run — see AI-033).</summary>
     private static readonly string[] ExplainToolNames =
-        ["lookup_dictionary", "get_chapter", "search_book", "get_user_highlights"];
+        ["get_chapter", "search_book", "get_user_highlights"];
 
     public async Task<ToolCallEvalResult> RunAsync(
         ILlmService llm,

--- a/backend/src/Api/Endpoints/ExplainEndpoints.cs
+++ b/backend/src/Api/Endpoints/ExplainEndpoints.cs
@@ -90,14 +90,16 @@ public static class ExplainEndpoints
         if (!config.GetValue("Explain:ToolsEnabled", true))
             return [];
 
-        var names = new List<string> { "lookup_dictionary" };
-        if (editionId is not null)
-        {
-            names.Add("get_chapter");
-            names.Add("search_book");
-            if (userId is not null)
-                names.Add("get_user_highlights");
-        }
+        // No lookup_dictionary here (AI-033): the eval showed nano reaching for it on every word
+        // (0.33 → 0.50 even after prompt tightening), and a dictionary inside an explainer is
+        // circular for the technical-reader audience — same call mobile made when it dropped the
+        // dictionary from its reader. The tool stays in the registry for agents/MCP.
+        if (editionId is null)
+            return []; // no book in context → nothing tool-worthy; plain streaming explain
+
+        var names = new List<string> { "get_chapter", "search_book" };
+        if (userId is not null)
+            names.Add("get_user_highlights");
         return registry.SchemasFor(names);
     }
 

--- a/backend/src/Application/Ai/ExplainPrompt.cs
+++ b/backend/src/Application/Ai/ExplainPrompt.cs
@@ -19,20 +19,19 @@ public static class ExplainPrompt
             "one concrete analogy. No preface, no quotes around the answer, no markdown.";
 
         // Phase 5 function-calling (AI-031b): appended only when the request actually carries tools.
-        // Tightened after the AI-033 eval: the original "precise dictionary meaning" guidance made
-        // gpt-4.1-nano call lookup_dictionary on EVERY word (accuracy 0.33). Tools are now framed as
-        // the exception with an explicit default-to-no-tools rule.
+        // Tightened after the AI-033 eval (tools as the exception, explicit no-tool default);
+        // lookup_dictionary was dropped from the Explain set entirely — nano reached for it on
+        // every word, and a dictionary inside an explainer is circular for this audience.
         if (withTools)
         {
             prompt +=
                 "\n\nYou have access to tools, but they are RARELY needed. " +
                 "Default: answer directly from the sentence with NO tool call. " +
-                "Technical terms (e.g. replication, cache, latency) never need a tool - explain them from context.\n" +
+                "Words and terms never need a tool by themselves - explain them from context.\n" +
                 "Call a tool ONLY in these specific situations:\n" +
                 "- The sentence explicitly references a numbered chapter (\"see Chapter 5\", \"Chapter 9 examines\") -> get_chapter with that number\n" +
                 "- The sentence explicitly says the topic was discussed earlier/before in the book, without a chapter number -> search_book\n" +
                 "- The user explicitly mentions their own saved highlights or notes -> get_user_highlights\n" +
-                "- The word is rare, archaic or non-technical (e.g. ephemeral, byzantine) and its general meaning is genuinely unclear -> lookup_dictionary\n" +
                 "If none of these apply, do NOT call any tool. " +
                 "After using tools, give the same 2-3 sentence explanation, citing tool results when used.";
         }

--- a/tests/TextStack.AiEvals/ToolCallEvalRunnerTests.cs
+++ b/tests/TextStack.AiEvals/ToolCallEvalRunnerTests.cs
@@ -29,8 +29,7 @@ public class ToolCallEvalRunnerTests
 
     private static IToolRegistry Registry() => new ToolRegistry(
     [
-        new SchemaTool("lookup_dictionary"), new SchemaTool("get_chapter"),
-        new SchemaTool("search_book"), new SchemaTool("get_user_highlights"),
+        new SchemaTool("get_chapter"), new SchemaTool("search_book"), new SchemaTool("get_user_highlights"),
     ]);
 
     /// <summary>Answers each golden EXACTLY as expected (right tool + expected fragments, or no tool).</summary>
@@ -93,7 +92,7 @@ public class ToolCallEvalRunnerTests
         Assert.All(llm.Requests, r =>
         {
             Assert.NotNull(r.Tools);
-            Assert.Equal(4, r.Tools!.Count);
+            Assert.Equal(3, r.Tools!.Count);
             Assert.Contains("You have access to tools", r.SystemPrompt);
         });
     }
@@ -119,7 +118,6 @@ public class ToolCallEvalRunnerTests
         Assert.Contains(Goldens, g => g.ExpectedTool is null);                    // no-tool cases present
         Assert.Contains(Goldens, g => g.ExpectedTool == "get_chapter");
         Assert.Contains(Goldens, g => g.ExpectedTool == "search_book");
-        Assert.Contains(Goldens, g => g.ExpectedTool == "lookup_dictionary");
         Assert.Contains(Goldens, g => g.ExpectedTool == "get_user_highlights");
         Assert.All(Goldens, g => Assert.False(string.IsNullOrWhiteSpace(g.Sentence)));
     }


### PR DESCRIPTION
Second AI-033 eval iteration. Prompt tightening (#318) moved accuracy 0.33 → **0.50**, but the per-case output showed one attractor: nano still reached for `lookup_dictionary` on technical words (10 of 15 misses, across no-tool AND chapter/search goldens).

## Decision (product, not an eval dodge)
Remove `lookup_dictionary` from the **Explain** tool set. A dictionary inside an explainer is circular for the technical-reader audience — the same reasoning mobile used when it dropped the dictionary from its reader (Data Safety note in CLAUDE.md). The tool stays in the registry for Phase 6 agents / MCP.

## Changes
- `ExplainEndpoints.ResolveTools`: book in context → `get_chapter`/`search_book` (+`get_user_highlights` when signed in); **no book → no tools** (plain streaming explain, no tool round).
- `ExplainPrompt`: dictionary bullet removed; "words never need a tool by themselves" added.
- Eval: runner offers the 3 Explain tools; the 3 dictionary goldens re-labelled no-tool (now 15 no-tool / 8 chapter / 5 search / 2 highlights — still 30).

## Verification
- Suites green (249 + 22); format clean.
- After deploy: re-run `POST /admin/ai-quality/evals/toolcalls/run` → target ≥0.9 (history: 0.33 → 0.50 → ?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)