### PR TITLE
fix(ai): lexical tool triggers in Explain prompt (AI-033 follow-up 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Phase 5 — lexical tool triggers in Explain prompt (AI-033 follow-up 3, 2026-06-12)
+
+Third eval iteration (0.33 → 0.50 → **0.73**). Dropping the dictionary fixed over-calling completely (no-tool 15/15), but the "RARELY needed" framing over-corrected into **under-calling**: `search_book` 1/5, `get_chapter` 5/8 — nano now answered directly even when the sentence said "as we discussed earlier" or named a chapter.
+
+- **Prompt v3**: each tool keyed to an explicit **lexical trigger in the sentence** with imperative ALWAYS — chapter number → `get_chapter`; "earlier/before/previously" without a number → `search_book`; user mentions own highlights/notes → `get_user_highlights` — plus the rule that tool choice depends only on the sentence's wording, never on the word itself, and the no-signal → no-tool default.
+- Re-run on prod after deploy: need 27/30 (≥0.9); have 22.
+
 ### Phase 5 — drop lookup_dictionary from Explain (AI-033 follow-up 2, 2026-06-12)
 
 Second eval iteration. Prompt tightening moved accuracy 0.33 → **0.50**, but per-case output showed the same single attractor: nano still reached for `lookup_dictionary` on technical words (10 of 15 misses). Rather than keep fighting the model's prior, the tool is **removed from the Explain set** (product call, not just an eval dodge: a dictionary inside an explainer is circular for the technical-reader audience — the same reasoning mobile used when it dropped the dictionary from its reader; the tool stays in the registry for agents/MCP).

--- a/backend/src/Application/Ai/ExplainPrompt.cs
+++ b/backend/src/Application/Ai/ExplainPrompt.cs
@@ -19,20 +19,25 @@ public static class ExplainPrompt
             "one concrete analogy. No preface, no quotes around the answer, no markdown.";
 
         // Phase 5 function-calling (AI-031b): appended only when the request actually carries tools.
-        // Tightened after the AI-033 eval (tools as the exception, explicit no-tool default);
-        // lookup_dictionary was dropped from the Explain set entirely — nano reached for it on
-        // every word, and a dictionary inside an explainer is circular for this audience.
+        // Iterated against the AI-033 eval (0.33 → 0.50 → 0.73 → …): v1 made nano call the dictionary
+        // on every word; v2's "RARELY needed" framing over-corrected into under-calling. v3 keys each
+        // tool to an explicit LEXICAL trigger in the sentence (chapter number / "earlier-before" /
+        // "my highlights") with imperative ALWAYS, and keeps the no-signal → no-tool default.
+        // lookup_dictionary was dropped from the Explain set entirely (circular for this audience).
         if (withTools)
         {
             prompt +=
-                "\n\nYou have access to tools, but they are RARELY needed. " +
-                "Default: answer directly from the sentence with NO tool call. " +
-                "Words and terms never need a tool by themselves - explain them from context.\n" +
-                "Call a tool ONLY in these specific situations:\n" +
-                "- The sentence explicitly references a numbered chapter (\"see Chapter 5\", \"Chapter 9 examines\") -> get_chapter with that number\n" +
-                "- The sentence explicitly says the topic was discussed earlier/before in the book, without a chapter number -> search_book\n" +
-                "- The user explicitly mentions their own saved highlights or notes -> get_user_highlights\n" +
-                "If none of these apply, do NOT call any tool. " +
+                "\n\nYou have access to tools. Whether to call one depends ONLY on the sentence's wording, " +
+                "never on the word being explained:\n" +
+                "- The sentence mentions a chapter NUMBER (\"Chapter 5\", \"see Chapter 9\", \"Chapter 11 turns to\") " +
+                "-> ALWAYS call get_chapter with that number.\n" +
+                "- The sentence says the topic was covered earlier/before/previously in the book " +
+                "(\"as we discussed earlier\", \"mentioned before\", \"covered earlier\") and gives no chapter number " +
+                "-> ALWAYS call search_book for that topic.\n" +
+                "- The sentence mentions the user's own highlights, notes, or things they marked/saved " +
+                "-> ALWAYS call get_user_highlights.\n" +
+                "If the sentence contains NONE of these signals, do NOT call any tool - answer directly from the " +
+                "sentence; a word being technical or unfamiliar is never by itself a reason to call a tool. " +
                 "After using tools, give the same 2-3 sentence explanation, citing tool results when used.";
         }
 


### PR DESCRIPTION
Third AI-033 eval iteration: **0.33 → 0.50 → 0.73**. Dropping the dictionary (#319) fixed over-calling completely (no-tool **15/15**), but the "RARELY needed" framing over-corrected into **under-calling**: `search_book` 1/5, `get_chapter` 5/8 — nano answered directly even when the sentence said "as we discussed earlier" or named a chapter.

## Prompt v3
Each tool keyed to an explicit **lexical trigger in the sentence**, imperative ALWAYS:
- chapter NUMBER in the sentence → `get_chapter` with that number;
- "earlier/before/previously … in the book" without a number → `search_book`;
- user mentions their own highlights/notes → `get_user_highlights`;
- plus: tool choice depends ONLY on the sentence's wording, never on the word being explained; no signal → no tool.

## Verification
Suites green (249 + 22), format clean. After deploy: re-run the prod eval — need 27/30 (≥0.9), have 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)