### PR TITLE
fix(ai): deterministic tool pre-router for Explain (AI-033 follow-up 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 5 — deterministic tool pre-router (AI-033 follow-up 4, 2026-06-12)
+
+Eval history: 0.33 → 0.50 → 0.73 → **0.53**. The v3 ALWAYS-trigger prompt made the trigger goldens near-perfect (chapter 8/8, search 4/5, highlights 2/2) but re-infected the no-tool side (2/15) — nano demonstrably can't hold both directions of the decision in-prompt; every iteration sacrificed one side.
+
+- **The IF moves into code** (`ExplainToolTriggers`, Application/Ai, pure): compiled regexes detect the lexical signals — chapter number / "discussed-mentioned-covered … earlier-before-previously" / "my highlights-notes". **No signal → the request carries no tool schemas at all** (the model physically cannot over-call; the common case also skips the tool-guidance prompt and stays a plain streamed explain). Signal → only the matching tool(s) ride along, and the v3 prompt steers the now near-trivial choice.
+- `ExplainEndpoints.ResolveTools` and `ToolCallEvalRunner` both route through the same triggers — the eval gate measures the production **pipeline**, not the bare model.
+- **CI now guarantees the deterministic half of the gate**: `ExplainToolTriggersTests` runs the pre-router over the ENTIRE golden set — every no-tool golden triggers nothing (15/15 floor by construction), every tool golden triggers its expected tool; highlights requires a signed-in user; near-miss sentences ("a long chapter", "earlier adopters") trigger nothing.
+- Re-run on prod after deploy: expected ≥0.9 (model only decides the remaining offered-tool → right-args step, which it did at 14/15 in run 4).
+
 ### Phase 5 — lexical tool triggers in Explain prompt (AI-033 follow-up 3, 2026-06-12)
 
 Third eval iteration (0.33 → 0.50 → **0.73**). Dropping the dictionary fixed over-calling completely (no-tool 15/15), but the "RARELY needed" framing over-corrected into **under-calling**: `search_book` 1/5, `get_chapter` 5/8 — nano now answered directly even when the sentence said "as we discussed earlier" or named a chapter.

--- a/backend/src/Ai/TextStack.Ai.EvalSuite/ToolCallEvalRunner.cs
+++ b/backend/src/Ai/TextStack.Ai.EvalSuite/ToolCallEvalRunner.cs
@@ -26,11 +26,6 @@ public sealed class ToolCallEvalRunner(ILogger<ToolCallEvalRunner> logger)
     private const string Feature = "explain.toolcall";
     private const int MaxOutputTokens = 500; // matches the Explain endpoint's round-1 budget
 
-    /// <summary>The Explain tools, as a signed-in reader with a book in context gets them
-    /// (lookup_dictionary was dropped from Explain after the first eval run — see AI-033).</summary>
-    private static readonly string[] ExplainToolNames =
-        ["get_chapter", "search_book", "get_user_highlights"];
-
     public async Task<ToolCallEvalResult> RunAsync(
         ILlmService llm,
         IToolRegistry registry,
@@ -40,14 +35,21 @@ public sealed class ToolCallEvalRunner(ILogger<ToolCallEvalRunner> logger)
         CancellationToken ct)
     {
         var goldens = ToolCallGoldenSet.Load();
-        var tools = registry.SchemasFor(ExplainToolNames);
-        var systemPrompt = ExplainPrompt.BuildSystemPrompt(genre: null, targetLang: "en", withTools: true);
 
         var cases = new List<ToolCallCase>();
         string? modelId = null;
         foreach (var g in goldens)
         {
             ct.ThrowIfCancellationRequested();
+
+            // Mirror production exactly (the gate measures the PIPELINE, not the bare model): the
+            // deterministic pre-router decides which tools — if any — ride along for this sentence;
+            // a no-signal sentence carries no schemas, so the model cannot over-call (AI-033).
+            var names = ExplainToolTriggers.TriggeredTools(g.Sentence, hasUser: true);
+            var tools = names.Count == 0 ? null : registry.SchemasFor(names);
+            var systemPrompt = ExplainPrompt.BuildSystemPrompt(
+                genre: null, targetLang: "en", withTools: tools is { Count: > 0 });
+
             var request = new LlmRequest(
                 systemPrompt,
                 [new LlmMessage("user", ExplainPrompt.BuildUserPrompt(g.Word, g.Sentence))],

--- a/backend/src/Api/Endpoints/ExplainEndpoints.cs
+++ b/backend/src/Api/Endpoints/ExplainEndpoints.cs
@@ -69,7 +69,7 @@ public static class ExplainEndpoints
         Guid? editionId = !string.IsNullOrWhiteSpace(request.BookId) && Guid.TryParse(request.BookId, out var parsed)
             ? parsed
             : null;
-        var tools = ResolveTools(toolRegistry, config, editionId, userId);
+        var tools = ResolveTools(toolRegistry, config, request.Sentence, editionId, userId);
         var toolCtx = new ToolContext(userId, editionId, AgentRunId: Guid.NewGuid(), httpContext.RequestServices);
 
         var systemPrompt = ExplainPrompt.BuildSystemPrompt(genre, targetLang, withTools: tools.Count > 0);
@@ -85,22 +85,21 @@ public static class ExplainEndpoints
 
     /// <summary>The tool schemas this request is allowed to call (empty = plain completion).</summary>
     private static IReadOnlyList<ToolSchema> ResolveTools(
-        IToolRegistry registry, IConfiguration config, Guid? editionId, Guid? userId)
+        IToolRegistry registry, IConfiguration config, string sentence, Guid? editionId, Guid? userId)
     {
         if (!config.GetValue("Explain:ToolsEnabled", true))
             return [];
 
-        // No lookup_dictionary here (AI-033): the eval showed nano reaching for it on every word
-        // (0.33 → 0.50 even after prompt tightening), and a dictionary inside an explainer is
-        // circular for the technical-reader audience — same call mobile made when it dropped the
-        // dictionary from its reader. The tool stays in the registry for agents/MCP.
+        // Deterministic pre-routing (AI-033): tools are offered ONLY when the sentence's wording
+        // contains a matching lexical signal (chapter number / "discussed earlier" / "my highlights").
+        // The eval showed nano can't hold both sides of this decision in-prompt — code decides IF,
+        // the prompt steers WHICH. No book in context → no book to fetch from → no tools at all.
+        // (lookup_dictionary was dropped from Explain entirely; it stays in the registry for agents/MCP.)
         if (editionId is null)
-            return []; // no book in context → nothing tool-worthy; plain streaming explain
+            return [];
 
-        var names = new List<string> { "get_chapter", "search_book" };
-        if (userId is not null)
-            names.Add("get_user_highlights");
-        return registry.SchemasFor(names);
+        var names = ExplainToolTriggers.TriggeredTools(sentence, hasUser: userId is not null);
+        return names.Count == 0 ? [] : registry.SchemasFor(names);
     }
 
     // ---- JSON path (original contract; mobile + non-streaming clients) ----

--- a/backend/src/Application/Ai/ExplainToolTriggers.cs
+++ b/backend/src/Application/Ai/ExplainToolTriggers.cs
@@ -1,0 +1,49 @@
+using System.Text.RegularExpressions;
+
+namespace Application.Ai;
+
+/// <summary>
+/// Deterministic pre-router for Explain's tools (AI-033). The eval showed gpt-4.1-nano can't hold
+/// both directions of the tool decision at once (prompt iterations swung 0.33 → 0.50 → 0.73 → 0.53,
+/// always sacrificing one side): so the LEXICAL part of the decision — does the sentence even
+/// contain a tool-worthy signal? — moves into code. No signal → the request carries no tool schemas
+/// and the model physically cannot over-call; a signal → only the matching tool is offered and the
+/// prompt's trigger guidance steers the (now near-trivial) choice. Pure; unit-tested over the golden
+/// set. Compiled regexes, not [GeneratedRegex] (repo ARM64 SIGILL caveat).
+/// </summary>
+public static class ExplainToolTriggers
+{
+    // "Chapter 5", "chapter 11" — a numbered chapter reference.
+    private static readonly Regex ChapterRef =
+        new(@"\bchapters?\s+\d+\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // "discussed/mentioned/covered/saw/introduced ... earlier/before/previously" (either order),
+    // or "earlier in this book/chapter".
+    private static readonly Regex EarlierRef = new(
+        @"\b(discussed|mentioned|covered|saw|introduced|touched\s+on)\b[^.!?]*\b(earlier|before|previously)\b" +
+        @"|\b(earlier|previously)\b[^.!?]*\b(discussed|mentioned|covered|saw|introduced)\b" +
+        @"|\bearlier\s+in\s+this\s+(book|chapter)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // "my highlights", "I highlighted/marked/saved", "my notes".
+    private static readonly Regex HighlightsRef = new(
+        @"\bmy\s+(saved\s+)?(highlights?|notes?)\b|\bI\s+(highlighted|marked|saved|noted)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The tool names this sentence's wording justifies offering, in stable order. Empty when the
+    /// sentence carries no tool-worthy signal — the common case, which then skips the tool round
+    /// entirely. <paramref name="hasUser"/> gates the highlights tool (needs a signed-in user).
+    /// </summary>
+    public static IReadOnlyList<string> TriggeredTools(string sentence, bool hasUser)
+    {
+        var tools = new List<string>();
+        if (ChapterRef.IsMatch(sentence))
+            tools.Add("get_chapter");
+        if (EarlierRef.IsMatch(sentence))
+            tools.Add("search_book");
+        if (hasUser && HighlightsRef.IsMatch(sentence))
+            tools.Add("get_user_highlights");
+        return tools;
+    }
+}

--- a/tests/TextStack.AiEvals/ExplainToolTriggersTests.cs
+++ b/tests/TextStack.AiEvals/ExplainToolTriggersTests.cs
@@ -1,0 +1,49 @@
+using Application.Ai;
+using TextStack.Ai.EvalSuite;
+
+namespace TextStack.AiEvals;
+
+/// <summary>
+/// AI-033 — the deterministic pre-router, validated against the ENTIRE golden set in CI: every
+/// no-tool golden must trigger nothing (so production physically cannot over-call on them — that
+/// floor is 15/15 by construction), and every tool golden must have its expected tool among the
+/// triggered set. This is the deterministic half of the accuracy gate; the model only decides the
+/// remainder (offered-tool → call it with the right args).
+/// </summary>
+public class ExplainToolTriggersTests
+{
+    private static readonly IReadOnlyList<ToolCallGolden> Goldens = ToolCallGoldenSet.Load();
+
+    [Fact]
+    public void NoToolGoldens_TriggerNothing()
+    {
+        var noTool = Goldens.Where(g => g.ExpectedTool is null).ToList();
+        Assert.NotEmpty(noTool);
+        Assert.All(noTool, g =>
+            Assert.Empty(ExplainToolTriggers.TriggeredTools(g.Sentence, hasUser: true)));
+    }
+
+    [Fact]
+    public void ToolGoldens_TriggerTheirExpectedTool()
+    {
+        var withTool = Goldens.Where(g => g.ExpectedTool is not null).ToList();
+        Assert.NotEmpty(withTool);
+        Assert.All(withTool, g =>
+            Assert.Contains(g.ExpectedTool!, ExplainToolTriggers.TriggeredTools(g.Sentence, hasUser: true)));
+    }
+
+    [Fact]
+    public void HighlightsTrigger_RequiresSignedInUser()
+    {
+        var highlightGolden = Goldens.First(g => g.ExpectedTool == "get_user_highlights");
+        Assert.DoesNotContain("get_user_highlights",
+            ExplainToolTriggers.TriggeredTools(highlightGolden.Sentence, hasUser: false));
+    }
+
+    [Theory]
+    [InlineData("Replication keeps a copy of the same data on multiple machines.")]
+    [InlineData("This was a long chapter about many things.")] // "chapter" without a number
+    [InlineData("Earlier adopters of NoSQL hit this problem.")] // "earlier" without discussed/mentioned
+    public void PlainSentences_TriggerNothing(string sentence)
+        => Assert.Empty(ExplainToolTriggers.TriggeredTools(sentence, hasUser: true));
+}

--- a/tests/TextStack.AiEvals/ToolCallEvalRunnerTests.cs
+++ b/tests/TextStack.AiEvals/ToolCallEvalRunnerTests.cs
@@ -88,12 +88,23 @@ public class ToolCallEvalRunnerTests
         Assert.Equal(1.0, result.Accuracy, 12);
         Assert.All(result.Cases, c => Assert.True(c.Hit));
 
-        // Every request carried the production tool schemas + the tool-guidance prompt.
+        // Pre-router semantics (mirrors production): no-signal sentences carry NO schemas and a
+        // plain prompt; triggered sentences carry their expected tool + the tool-guidance prompt.
+        var byWord = Goldens.ToDictionary(g => g.Word);
         Assert.All(llm.Requests, r =>
         {
-            Assert.NotNull(r.Tools);
-            Assert.Equal(3, r.Tools!.Count);
-            Assert.Contains("You have access to tools", r.SystemPrompt);
+            var word = r.Messages[0].Content.Split('\n')[0]["Word: ".Length..];
+            if (byWord[word].ExpectedTool is null)
+            {
+                Assert.Null(r.Tools);
+                Assert.DoesNotContain("You have access to tools", r.SystemPrompt);
+            }
+            else
+            {
+                Assert.NotNull(r.Tools);
+                Assert.Contains(r.Tools!, t => t.Name == byWord[word].ExpectedTool);
+                Assert.Contains("You have access to tools", r.SystemPrompt);
+            }
         });
     }
 


### PR DESCRIPTION
Eval history: **0.33 → 0.50 → 0.73 → 0.53.** The v3 ALWAYS-trigger prompt made trigger goldens near-perfect (chapter 8/8, search 4/5, highlights 2/2) but re-infected the no-tool side (2/15). Conclusion after four runs: nano demonstrably cannot hold both directions of the decision in-prompt — every iteration sacrificed one side.

## Fix — don't ask the model what code can decide
- **`ExplainToolTriggers`** (Application/Ai, pure, compiled regexes — ARM64 caveat respected): detects the lexical signals — chapter number / "discussed-mentioned-covered … earlier-before-previously" / "my highlights-notes".
- **No signal → the request carries no tool schemas at all**: the model physically cannot over-call, and the common case skips the tool-guidance prompt entirely (stays a plain streamed explain — slightly cheaper too).
- **Signal → only the matching tool(s) ride along**; the v3 prompt steers the now near-trivial choice.
- `ExplainEndpoints.ResolveTools` and `ToolCallEvalRunner` route through the SAME triggers — the gate measures the production **pipeline**, not the bare model.

## CI guarantees the deterministic half
`ExplainToolTriggersTests` runs the pre-router over the ENTIRE golden set: every no-tool golden triggers nothing (**15/15 floor by construction**), every tool golden triggers its expected tool, highlights requires a signed-in user, near-miss sentences ("a long chapter", "earlier adopters") trigger nothing.

## Verification
- Suites green (249 + 28); format clean.
- After deploy: re-run the prod eval — expected ≥0.9 (the model only decides the offered-tool → right-args remainder, which it did at 14/15 in run 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)