### PR TITLE
feat(ai): agent loop engine (AI-034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Phase 6 — agent loop engine (2026-06-13)
+
+Phase 6 **AI-034** — the hand-rolled plan→act→observe loop every agent runs on. Engine only; the concrete Study Buddy agent + its tools are AI-035.
+
+- **New project `TextStack.Ai.Agents`** + **`AgentLoop`**: each iteration asks the model with the agent's allowed tool schemas; no tool call → that's the final answer; otherwise dispatch the requested tools (via the Phase 5 `ToolDispatcher` — validated, parallel, failures returned as data so the agent recovers instead of throwing) and feed results back. The assistant tool-call turn is threaded before the tool results (OpenAI ordering). Every turn is recorded as an `AgentStep` for a transparent, persistable transcript; `AgentResult` carries the output + steps + accumulated `AgentUsage`.
+- **Bounded two ways**: a hard `MaxSteps` cap and an optional cumulative `CostCapUsd` — exhausting either throws `AgentBudgetExhaustedException` (can't loop forever / burn budget). `AgentLoopOptions` passed per-run, so one engine serves agents with different caps.
+- Reuses the `Ai.Core` agent contracts that shipped in Phase 2 (`AgentStep`/`AgentResult`/`AgentContext`/`AgentUsage`/`AgentInput`/`AgentLoopOptions`). Registered via `AddAiAgents()` (singleton; per-run state on the stack, scoped tool services via `AgentContext.Services`).
+- Tests (6, scripted LLM): direct answer (1 iteration); tool round → answer (message threading + step kinds `llm_response`/`tool_result`/`llm_response`); usage accumulates across iterations; MaxSteps without a final answer throws; cost cap trips mid-run; unknown tool fed back as data and the loop recovers.
+
 ### Phase 5 — deterministic tool pre-router (AI-033 follow-up 4, 2026-06-12)
 
 Eval history: 0.33 → 0.50 → 0.73 → **0.53**. The v3 ALWAYS-trigger prompt made the trigger goldens near-perfect (chapter 8/8, search 4/5, highlights 2/2) but re-infected the no-tool side (2/15) — nano demonstrably can't hold both directions of the decision in-prompt; every iteration sacrificed one side.

--- a/backend/src/Ai/TextStack.Ai.Agents/AgentLoop.cs
+++ b/backend/src/Ai/TextStack.Ai.Agents/AgentLoop.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+using System.Text.Json;
+using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
+
+namespace TextStack.Ai.Agents;
+
+/// <summary>
+/// The hand-rolled plan → act → observe loop (Phase 6, AI-034) every concrete agent runs on. Each
+/// iteration: ask the model (with the agent's allowed tool schemas); if it answers without a tool
+/// call, that's the final answer; otherwise dispatch the requested tools (validated, in parallel,
+/// failures returned as data so the agent can recover) and feed the results back for the next turn.
+/// Bounded by <see cref="AgentLoopOptions"/> — a hard iteration cap AND an optional cumulative cost
+/// cap — so it can never loop forever or burn the budget; exhausting either throws
+/// <see cref="AgentBudgetExhaustedException"/>. Every turn is recorded as an <see cref="AgentStep"/>
+/// for a transparent, persistable transcript. Generic over any <see cref="ILlmService"/> + tool set;
+/// concrete agents (e.g. StudyBuddy, AI-035) just supply the prompt, allowed tools and options.
+/// </summary>
+public sealed class AgentLoop(ILlmService llm, IToolRegistry tools, ToolDispatcher dispatcher)
+{
+    public async Task<AgentResult<string>> RunAsync(
+        AgentInput input, AgentContext ctx, AgentLoopOptions options, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        var steps = new List<AgentStep>();
+        var messages = new List<LlmMessage> { new("user", input.UserGoal) };
+        var toolSchemas = tools.SchemasFor(input.AllowedTools);
+        var toolCtx = new ToolContext(ctx.UserId, ctx.EditionId, ctx.AgentRunId, ctx.Services);
+
+        int inputTokens = 0, outputTokens = 0;
+        decimal cost = 0m;
+
+        for (var iteration = 0; iteration < options.MaxSteps; iteration++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var request = new LlmRequest(
+                input.SystemPrompt, messages, options.MaxTokensPerStep,
+                Tools: toolSchemas.Count > 0 ? toolSchemas : null, FeatureTag: input.FeatureTag);
+
+            var response = await llm.CompleteAsync(request, ct);
+            inputTokens += response.Usage.InputTokens;
+            outputTokens += response.Usage.OutputTokens;
+            cost += response.Usage.CostUsd;
+            steps.Add(Step(iteration, "llm_response", SerializeResponse(response)));
+
+            // No tool calls → the model has produced its final answer.
+            if (response.ToolCalls.Count == 0)
+            {
+                sw.Stop();
+                return new AgentResult<string>(
+                    response.Text, steps,
+                    new AgentUsage(iteration + 1, inputTokens, outputTokens, cost, (int)sw.ElapsedMilliseconds));
+            }
+
+            // The assistant's tool-call turn must precede the tool results (OpenAI message ordering).
+            messages.Add(new LlmMessage("assistant", response.Text, response.ToolCalls));
+
+            var results = await dispatcher.DispatchAllAsync(response.ToolCalls, toolCtx, ct);
+            for (var j = 0; j < response.ToolCalls.Count; j++)
+            {
+                var call = response.ToolCalls[j];
+                var result = results[j];
+                steps.Add(Step(iteration, "tool_result", SerializeResult(call, result)));
+                // Errors come back as data (ToolCallingSession serialization) so the model can recover.
+                messages.Add(new LlmMessage("tool", ToolCallingSession.SerializeResult(result), [call]));
+            }
+
+            // Cost cap is checked AFTER the step completes, so a useful partial transcript is kept.
+            if (options.CostCapUsd is { } cap && cost >= cap)
+                throw new AgentBudgetExhaustedException(
+                    $"Agent cost cap ${cap} exceeded after {iteration + 1} iteration(s) (${cost}).");
+        }
+
+        throw new AgentBudgetExhaustedException(
+            $"Agent reached MaxSteps={options.MaxSteps} without a final answer.");
+    }
+
+    private static AgentStep Step(int iteration, string kind, JsonElement payload) =>
+        new(iteration, kind, payload, DateTimeOffset.UtcNow);
+
+    /// <summary>Compact JSON view of one model turn for the step transcript (text + requested calls).</summary>
+    private static JsonElement SerializeResponse(LlmResponse response) =>
+        JsonSerializer.SerializeToElement(new
+        {
+            text = response.Text,
+            toolCalls = response.ToolCalls.Select(c => new { name = c.ToolName, args = c.Arguments }),
+        });
+
+    /// <summary>Compact JSON view of one tool outcome for the step transcript.</summary>
+    private static JsonElement SerializeResult(ToolCall call, ToolResult result) =>
+        JsonSerializer.SerializeToElement(new
+        {
+            tool = call.ToolName,
+            args = call.Arguments,
+            ok = result.Ok,
+            result = result.Result,
+            error = result.Error,
+        });
+}

--- a/backend/src/Ai/TextStack.Ai.Agents/ServiceCollectionExtensions.cs
+++ b/backend/src/Ai/TextStack.Ai.Agents/ServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace TextStack.Ai.Agents;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the generic <see cref="AgentLoop"/> engine (Phase 6). Singleton — it is stateless;
+    /// per-run state (messages, steps, usage) lives on the stack of <see cref="AgentLoop.RunAsync"/>,
+    /// and scoped tool services arrive via <c>AgentContext.Services</c>. Requires the tool registry +
+    /// dispatcher (<c>AddAiTools</c>) and an <c>ILlmService</c> to be registered.
+    /// </summary>
+    public static IServiceCollection AddAiAgents(this IServiceCollection services)
+    {
+        services.TryAddSingleton<AgentLoop>();
+        return services;
+    }
+}

--- a/backend/src/Ai/TextStack.Ai.Agents/TextStack.Ai.Agents.csproj
+++ b/backend/src/Ai/TextStack.Ai.Agents/TextStack.Ai.Agents.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>TextStack.Ai.Agents</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TextStack.Ai.Core\TextStack.Ai.Core.csproj" />
+    <ProjectReference Include="..\TextStack.Ai.Tools\TextStack.Ai.Tools.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+</Project>

--- a/backend/src/Api/Api.csproj
+++ b/backend/src/Api/Api.csproj
@@ -26,5 +26,6 @@
     <ProjectReference Include="..\Ai\TextStack.Ai.EvalSuite\TextStack.Ai.EvalSuite.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.Tools\TextStack.Ai.Tools.csproj" />
+    <ProjectReference Include="..\Ai\TextStack.Ai.Agents\TextStack.Ai.Agents.csproj" />
   </ItemGroup>
 </Project>

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -85,6 +85,8 @@ builder.Services.AddSingleton<TextStack.Ai.EvalSuite.RagEvalRunner>();
 builder.Services.AddSingleton<TextStack.Ai.EvalSuite.ToolCallEvalRunner>();
 // Tool catalogue (AI-029/030): scans Application for ITool impls; dispatch is schema-validated.
 builder.Services.AddAiTools(typeof(Application.Tools.GetChapterTool).Assembly);
+// Agent loop engine (Phase 6, AI-034). Concrete agents (StudyBuddy, AI-035) build on it.
+TextStack.Ai.Agents.ServiceCollectionExtensions.AddAiAgents(builder.Services);
 builder.Services.AddAuthSettings(builder.Configuration);
 
 var connectionString = builder.Configuration.GetConnectionString("Default")

--- a/tests/TextStack.UnitTests/AgentLoopTests.cs
+++ b/tests/TextStack.UnitTests/AgentLoopTests.cs
@@ -1,0 +1,145 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Agents;
+using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// AI-034 — the generic plan→act→observe loop, driven by a scripted fake LLM: direct answer,
+/// tool round then answer, message threading, usage accumulation, iteration cap, cost cap, and
+/// tool failures fed back as data (loop recovers rather than throwing).
+/// </summary>
+public class AgentLoopTests
+{
+    private static readonly JsonElement AnySchema = JsonDocument.Parse("""{"type":"object"}""").RootElement;
+
+    private static JsonElement Json(string json) => JsonDocument.Parse(json).RootElement;
+
+    private sealed class EchoTool : ITool
+    {
+        public string Name => "agent-echo";
+        public string Description => "echoes";
+        public JsonElement ArgsSchema => AnySchema;
+        public Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct) =>
+            Task.FromResult(Json("""{"echoed":true}"""));
+    }
+
+    /// <summary>Each CompleteAsync consumes the next script turn; requests are recorded.</summary>
+    private sealed class ScriptedLlm(params object[][] turns) : ILlmService
+    {
+        private int _turn;
+        public List<LlmRequest> Requests { get; } = [];
+
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
+        {
+            Requests.Add(request);
+            var entries = _turn < turns.Length ? turns[_turn] : ["fallback final"];
+            _turn++;
+            var text = string.Concat(entries.OfType<string>());
+            var calls = entries.OfType<ToolCall>().ToList();
+            return Task.FromResult(new LlmResponse(text, calls, new LlmUsage(10, 5, 0.001m), "m", Guid.NewGuid()));
+        }
+
+        public IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
+
+    private static AgentLoop Loop(ILlmService llm, params ITool[] tools) =>
+        new(llm, new ToolRegistry(tools), new ToolDispatcher(new ToolRegistry(tools)));
+
+    private static AgentContext Ctx() =>
+        new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), new ServiceCollection().BuildServiceProvider());
+
+    private static AgentInput Input() =>
+        new("Explain this passage.", "You are a study buddy.", ["agent-echo"], "studybuddy");
+
+    private static ToolCall Call(string name = "agent-echo", string args = "{}") => new("call-1", name, Json(args));
+
+    [Fact]
+    public async Task Run_DirectAnswer_OneIteration()
+    {
+        var llm = new ScriptedLlm(["The answer."]);
+        var result = await Loop(llm, new EchoTool()).RunAsync(
+            Input(), Ctx(), new AgentLoopOptions(), TestContext.Current.CancellationToken);
+
+        Assert.Equal("The answer.", result.Output);
+        Assert.Equal(1, result.Usage.Iterations);
+        Assert.Single(llm.Requests);
+        Assert.Single(result.Steps);
+        Assert.Equal("llm_response", result.Steps[0].Kind);
+    }
+
+    [Fact]
+    public async Task Run_ToolThenAnswer_ThreadsMessagesAndRecordsSteps()
+    {
+        var llm = new ScriptedLlm(
+            [Call(args: """{"x":1}""")], // turn 1: request a tool
+            ["Grounded answer."]);        // turn 2: final
+        var result = await Loop(llm, new EchoTool()).RunAsync(
+            Input(), Ctx(), new AgentLoopOptions(), TestContext.Current.CancellationToken);
+
+        Assert.Equal("Grounded answer.", result.Output);
+        Assert.Equal(2, result.Usage.Iterations);
+        Assert.Equal(["llm_response", "tool_result", "llm_response"], result.Steps.Select(s => s.Kind));
+
+        // Turn 2's request carries the user goal, the assistant tool-call turn, and the tool result.
+        var followUp = llm.Requests[1];
+        Assert.Equal("user", followUp.Messages[0].Role);
+        Assert.Equal("assistant", followUp.Messages[1].Role);
+        Assert.Equal("tool", followUp.Messages[2].Role);
+        Assert.Equal("call-1", followUp.Messages[2].ToolCalls![0].Id);
+        Assert.Contains("echoed", followUp.Messages[2].Content);
+    }
+
+    [Fact]
+    public async Task Run_AccumulatesUsageAcrossIterations()
+    {
+        var llm = new ScriptedLlm([Call()], ["done"]);
+        var result = await Loop(llm, new EchoTool()).RunAsync(
+            Input(), Ctx(), new AgentLoopOptions(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.Usage.Iterations);
+        Assert.Equal(20, result.Usage.InputTokensTotal);   // 10 * 2
+        Assert.Equal(10, result.Usage.OutputTokensTotal);  // 5 * 2
+        Assert.Equal(0.002m, result.Usage.CostUsdTotal);   // 0.001 * 2
+    }
+
+    [Fact]
+    public async Task Run_MaxStepsWithoutFinal_ThrowsBudgetExhausted()
+    {
+        // Every turn requests a tool → never terminates on its own.
+        var llm = new ScriptedLlm([Call()], [Call()], [Call()]);
+        await Assert.ThrowsAsync<AgentBudgetExhaustedException>(() =>
+            Loop(llm, new EchoTool()).RunAsync(
+                Input(), Ctx(), new AgentLoopOptions(MaxSteps: 3), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Run_CostCapExceeded_ThrowsBudgetExhausted()
+    {
+        var llm = new ScriptedLlm([Call()], [Call()], [Call()], [Call()], [Call()], ["late"]);
+        // Each iteration costs 0.001; cap 0.0015 trips after the 2nd.
+        await Assert.ThrowsAsync<AgentBudgetExhaustedException>(() =>
+            Loop(llm, new EchoTool()).RunAsync(
+                Input(), Ctx(), new AgentLoopOptions(MaxSteps: 6, CostCapUsd: 0.0015m),
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Run_UnknownTool_FedBackAsData_LoopRecovers()
+    {
+        var llm = new ScriptedLlm(
+            [Call("missing")],   // model asks for a tool that doesn't exist
+            ["Recovered answer."]);
+        var result = await Loop(llm, new EchoTool()).RunAsync(
+            Input(), Ctx(), new AgentLoopOptions(), TestContext.Current.CancellationToken);
+
+        Assert.Equal("Recovered answer.", result.Output);
+        var toolMsg = llm.Requests[1].Messages[2];
+        Assert.Equal("tool", toolMsg.Role);
+        Assert.Contains("Unknown tool", toolMsg.Content); // error surfaced to the model, not thrown
+    }
+}

--- a/tests/TextStack.UnitTests/TextStack.UnitTests.csproj
+++ b/tests/TextStack.UnitTests/TextStack.UnitTests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\backend\src\Ai\TextStack.Ai.Llm\TextStack.Ai.Llm.csproj" />
     <ProjectReference Include="..\..\backend\src\Ai\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj" />
     <ProjectReference Include="..\..\backend\src\Ai\TextStack.Ai.Tools\TextStack.Ai.Tools.csproj" />
+    <ProjectReference Include="..\..\backend\src\Ai\TextStack.Ai.Agents\TextStack.Ai.Agents.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/textstack.sln
+++ b/textstack.sln
@@ -163,6 +163,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextStack.Ai.Rag", "backend
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextStack.Ai.Tools", "backend\src\Ai\TextStack.Ai.Tools\TextStack.Ai.Tools.csproj", "{1AF63AF3-8BF0-462A-869D-5B898B03D976}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextStack.Ai.Agents", "backend\src\Ai\TextStack.Ai.Agents\TextStack.Ai.Agents.csproj", "{AE675856-0D0A-4672-A820-8FEEE39AB55F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -437,6 +439,18 @@ Global
 		{1AF63AF3-8BF0-462A-869D-5B898B03D976}.Release|x64.Build.0 = Release|Any CPU
 		{1AF63AF3-8BF0-462A-869D-5B898B03D976}.Release|x86.ActiveCfg = Release|Any CPU
 		{1AF63AF3-8BF0-462A-869D-5B898B03D976}.Release|x86.Build.0 = Release|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Debug|x64.Build.0 = Debug|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Debug|x86.Build.0 = Debug|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Release|x64.ActiveCfg = Release|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Release|x64.Build.0 = Release|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Release|x86.ActiveCfg = Release|Any CPU
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -478,5 +492,6 @@ Global
 		{FBBD7C9B-97DA-46EB-BDB8-54ED5C0A0B92} = {1D9F3A7C-AABB-CCDD-EEFF-A10001000001}
 		{2EA08B22-EAB6-48E8-B201-CDF5E7D245BE} = {1D9F3A7C-AABB-CCDD-EEFF-A10001000001}
 		{1AF63AF3-8BF0-462A-869D-5B898B03D976} = {1D9F3A7C-AABB-CCDD-EEFF-A10001000001}
+		{AE675856-0D0A-4672-A820-8FEEE39AB55F} = {1D9F3A7C-AABB-CCDD-EEFF-A10001000001}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Phase 6 **AI-034** — the hand-rolled plan→act→observe loop every agent runs on. **Engine only**; the concrete Study Buddy agent + its 3 new tools + system prompt are AI-035.

## Changes
- **New project `TextStack.Ai.Agents`** + **`AgentLoop`** (~80 lines): each iteration asks the model with the agent's allowed tool schemas; **no tool call → final answer**; otherwise dispatch the requested tools via the Phase 5 `ToolDispatcher` (validated, parallel, **failures returned as data** so the agent recovers instead of throwing — unlike the playbook sketch's `throw on unknown tool`) and feed results back. The assistant tool-call turn is threaded before the tool results (OpenAI message ordering). Every turn → an `AgentStep` (transparent, persistable transcript); `AgentResult` carries output + steps + accumulated `AgentUsage`.
- **Bounded two ways**: hard `MaxSteps` cap + optional cumulative `CostCapUsd` → `AgentBudgetExhaustedException` (can't loop forever / burn budget). `AgentLoopOptions` is per-run, so one engine serves agents with different caps.
- Reuses the `Ai.Core` agent contracts already shipped in Phase 2. `AddAiAgents()` registers it as a singleton (stateless; per-run state on the stack, scoped tool services via `AgentContext.Services`).

## Design note
`AgentLoopOptions` moved from the sketch's constructor to a per-run parameter (one shared engine, many agents), and tool dispatch routes through `ToolDispatcher`/`ToolCallingSession.SerializeResult` for consistency with Explain's function-calling rather than re-implementing raw `tool.InvokeAsync`.

## Verification
6 scripted-LLM tests: direct answer (1 iteration); tool round → answer (message threading + step-kind sequence); usage accumulation; MaxSteps-without-final throws; cost cap trips mid-run; unknown tool fed back as data and the loop recovers. Full `TextStack.UnitTests` (255) + `TextStack.AiEvals` (28) green; `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)