### PR TITLE
feat(ai): Study Buddy agent + 3 tools (AI-035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Phase 6 — Study Buddy agent + 3 tools (2026-06-13)
+
+Phase 6 **AI-035** — the concrete agent on top of the AI-034 loop, plus the three tools it needs. The reader endpoint + SSE step events are AI-037; persistence is AI-036.
+
+- **`StudyBuddyAgent`** (`Application/Agents`, implements `IAgent<StudyBuddyInput, string>`) — a thin layer over `AgentLoop`: owns only the system prompt, the allowed tool set (the new trio + `get_chapter`/`get_chapter_summary`/`search_book`/`get_user_highlights`), and the run budget (≤6 steps, per-step token cap, **$0.05 cost cap**). Goal is built from the highlighted passage + chapter. System prompt: investigate with tools, write a grounded 3–5 sentence explanation, never invent facts.
+- **3 new tools** (`Application/Tools/`, stateless singletons, scoped deps via `ToolContext`):
+  - `find_earlier_definition(term)` — where a concept was first introduced earlier in the book (lowest-numbered chapter that matches, via the AI-023 hybrid retrieval; spoiler-gated to the reader's progress).
+  - `get_chapter_summary(chapter_number)` — a cheap deterministic orientation (title + word count + opening 800 chars), so the agent can scope a chapter without pulling it in full.
+  - `get_user_vocabulary(query?, limit?)` — the user's own saved words (+definition/translation) for the book, so explanations connect to terms they're already learning.
+- Tests: `StudyBuddyAgent` wiring over the real loop + fake LLM (prompt/feature-tag/goal threading, chapter in/out of goal); the three tools' schema validity (happy path / malformed / unknown-prop) and that the assembly scan now finds exactly the 7 Application tools. DB/RAG behaviour exercises in AI-037 + e2e.
+
 ### Phase 6 — agent loop engine (2026-06-13)
 
 Phase 6 **AI-034** — the hand-rolled plan→act→observe loop every agent runs on. Engine only; the concrete Study Buddy agent + its tools are AI-035.

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -87,6 +87,7 @@ builder.Services.AddSingleton<TextStack.Ai.EvalSuite.ToolCallEvalRunner>();
 builder.Services.AddAiTools(typeof(Application.Tools.GetChapterTool).Assembly);
 // Agent loop engine (Phase 6, AI-034). Concrete agents (StudyBuddy, AI-035) build on it.
 TextStack.Ai.Agents.ServiceCollectionExtensions.AddAiAgents(builder.Services);
+builder.Services.AddScoped<Application.Agents.StudyBuddyAgent>();
 builder.Services.AddAuthSettings(builder.Configuration);
 
 var connectionString = builder.Configuration.GetConnectionString("Default")

--- a/backend/src/Application/Agents/StudyBuddyAgent.cs
+++ b/backend/src/Application/Agents/StudyBuddyAgent.cs
@@ -1,0 +1,61 @@
+using TextStack.Ai.Agents;
+using TextStack.Ai.Core;
+
+namespace Application.Agents;
+
+/// <summary>The reader's request: a confusing passage to explain, with its book/chapter for context.</summary>
+public record StudyBuddyInput(string Passage, Guid EditionId, int? ChapterNumber);
+
+/// <summary>
+/// The Study Buddy agent (Phase 6, AI-035): in the reader, a user highlights a confusing paragraph and
+/// asks for help; this agent investigates with tools (chapter context, in-book search, where a term was
+/// first defined, the user's own vocabulary/highlights) and writes a short grounded explanation. A thin
+/// concrete layer over the generic <see cref="AgentLoop"/> — it owns only the system prompt, the allowed
+/// tool set, and the run budget; the plan→act→observe mechanics live in the loop.
+/// </summary>
+public sealed class StudyBuddyAgent(AgentLoop loop) : IAgent<StudyBuddyInput, string>
+{
+    public const string FeatureTag = "studybuddy";
+
+    /// <summary>Bounded per the playbook: ≤6 iterations, a per-step token budget, and a per-run cost cap.</summary>
+    private static readonly AgentLoopOptions Options = new(MaxSteps: 6, MaxTokensPerStep: 1024, CostCapUsd: 0.05m);
+
+    /// <summary>The tools the agent may call — the AI-035 trio plus the relevant Phase 5 book tools.</summary>
+    private static readonly IReadOnlyList<string> AllowedTools =
+    [
+        "get_chapter",
+        "get_chapter_summary",
+        "search_book",
+        "find_earlier_definition",
+        "get_user_vocabulary",
+        "get_user_highlights",
+    ];
+
+    public Task<AgentResult<string>> RunAsync(StudyBuddyInput input, AgentContext ctx, CancellationToken ct)
+    {
+        var agentInput = new AgentInput(
+            UserGoal: BuildGoal(input),
+            SystemPrompt: SystemPrompt,
+            AllowedTools: AllowedTools,
+            FeatureTag: FeatureTag);
+
+        return loop.RunAsync(agentInput, ctx, Options, ct);
+    }
+
+    private static string BuildGoal(StudyBuddyInput input)
+    {
+        var where = input.ChapterNumber is { } n ? $" (Chapter {n})" : string.Empty;
+        return $"Help me understand this confusing passage{where}:\n\n{input.Passage}";
+    }
+
+    public const string SystemPrompt =
+        "You are a study buddy for a developer reading a technical book. " +
+        "Goal: help them understand a confusing passage in at most a few tool-using steps.\n" +
+        "Use the tools to fetch context: the surrounding chapter, in-book search, where a term was first " +
+        "introduced earlier, and the reader's own saved vocabulary and highlights. " +
+        "Call a tool only when it would genuinely help; most passages need one or two lookups at most.\n" +
+        "Once you have enough context, write a clear 3-5 sentence explanation in plain language, " +
+        "connecting it to where concepts were defined earlier when relevant. " +
+        "Never invent facts that are not in the tool results or the passage itself. " +
+        "No preface, no markdown headings.";
+}

--- a/backend/src/Application/Application.csproj
+++ b/backend/src/Application/Application.csproj
@@ -25,5 +25,6 @@
     <ProjectReference Include="..\Ai\TextStack.Ai.Core\TextStack.Ai.Core.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.Llm\TextStack.Ai.Llm.csproj" />
     <ProjectReference Include="..\Ai\TextStack.Ai.Rag\TextStack.Ai.Rag.csproj" />
+    <ProjectReference Include="..\Ai\TextStack.Ai.Agents\TextStack.Ai.Agents.csproj" />
   </ItemGroup>
 </Project>

--- a/backend/src/Application/Tools/FindEarlierDefinitionTool.cs
+++ b/backend/src/Application/Tools/FindEarlierDefinitionTool.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+using TextStack.Ai.Rag;
+
+namespace Application.Tools;
+
+/// <summary>
+/// Study Buddy tool (AI-035): find where a term was introduced EARLIER in the book — the passage from
+/// the lowest-numbered chapter that discusses it — so the agent can explain a confusing passage by
+/// pointing back to where the concept was first defined. Built on the production hybrid retrieval
+/// (AI-023); spoiler-gated to the reader's furthest-read chapter when they have progress.
+/// </summary>
+public sealed class FindEarlierDefinitionTool : ITool
+{
+    /// <summary>Candidates to retrieve before picking the earliest — enough to look past a single near-duplicate.</summary>
+    private const int CandidatePool = 8;
+    private const int SnippetChars = 500;
+
+    private static readonly JsonElement Schema = ToolJson.Schema("""
+        {
+          "type": "object",
+          "properties": {
+            "term": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100,
+              "description": "The term or concept to locate the earliest discussion of"
+            }
+          },
+          "required": ["term"],
+          "additionalProperties": false
+        }
+        """);
+
+    public string Name => "find_earlier_definition";
+
+    public string Description =>
+        "Find where a term or concept was first introduced earlier in the current book, returning that " +
+        "passage and its chapter. Use when a passage assumes a concept the reader may have forgotten.";
+
+    public JsonElement ArgsSchema => Schema;
+
+    public async Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
+    {
+        if (ctx.EditionId is not { } editionId)
+            throw new InvalidOperationException("No edition in context — find_earlier_definition needs a current book.");
+
+        var term = ToolJson.GetString(args, "term")!; // shape guaranteed by schema validation
+
+        var rag = ctx.Services.GetRequiredService<IRagService>();
+        var gate = ctx.UserId is { } userId
+            ? await ResolveLastReadOrdAsync(ctx.Services.GetRequiredService<IAppDbContext>(), userId, editionId, ct)
+            : null;
+
+        var chunks = await rag.RetrieveAsync(editionId, term, CandidatePool, maxChapterOrd: gate, ct);
+        // "Earlier" = the lowest-numbered chapter that matched (where the concept first appears).
+        var earliest = chunks.OrderBy(c => c.ChapterOrd).ThenBy(c => c.Ord).FirstOrDefault();
+
+        if (earliest.Text is null or "")
+            return ToolJson.Result(new { found = false, term, message = $"No earlier discussion of '{term}' found." });
+
+        var (snippet, truncated) = ToolJson.Truncate(earliest.Text, SnippetChars);
+        return ToolJson.Result(new
+        {
+            found = true,
+            term,
+            chapterNumber = earliest.ChapterOrd,
+            snippet,
+            truncated,
+        });
+    }
+
+    /// <summary>Furthest-read chapter (high-water mark) — same spoiler semantics as RagContextService.</summary>
+    private static async Task<int?> ResolveLastReadOrdAsync(
+        IAppDbContext db, Guid userId, Guid editionId, CancellationToken ct)
+    {
+        var row = await db.ReadingProgresses
+            .Where(p => p.UserId == userId && p.EditionId == editionId)
+            .Join(db.Chapters, p => p.ChapterId, c => c.Id,
+                (p, c) => new { p.MaxChapterNumber, c.ChapterNumber })
+            .FirstOrDefaultAsync(ct);
+
+        return row is null ? null : row.MaxChapterNumber ?? row.ChapterNumber;
+    }
+}

--- a/backend/src/Application/Tools/GetChapterSummaryTool.cs
+++ b/backend/src/Application/Tools/GetChapterSummaryTool.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+
+namespace Application.Tools;
+
+/// <summary>
+/// Study Buddy tool (AI-035): a cheap, deterministic "what is this chapter about" snapshot — title,
+/// word count, and the chapter's opening — so the agent can orient a passage without paying to pull
+/// (and the model paying to read) the whole chapter via get_chapter. NOT an LLM-generated summary;
+/// the opening of a well-structured technical chapter states its subject, which is enough to orient.
+/// </summary>
+public sealed class GetChapterSummaryTool : ITool
+{
+    /// <summary>How much of the chapter opening to return — enough to convey the subject, small for the prompt.</summary>
+    public const int OpeningChars = 800;
+
+    private static readonly JsonElement Schema = ToolJson.Schema("""
+        {
+          "type": "object",
+          "properties": {
+            "chapter_number": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based chapter number within the current book"
+            }
+          },
+          "required": ["chapter_number"],
+          "additionalProperties": false
+        }
+        """);
+
+    public string Name => "get_chapter_summary";
+
+    public string Description =>
+        "Get a quick orientation for a chapter of the current book: its title, length, and opening lines. " +
+        "Use to see what a chapter is about before deciding whether to read it in full with get_chapter.";
+
+    public JsonElement ArgsSchema => Schema;
+
+    public async Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
+    {
+        if (ctx.EditionId is not { } editionId)
+            throw new InvalidOperationException("No edition in context — get_chapter_summary needs a current book.");
+
+        var number = ToolJson.GetInt(args, "chapter_number")!.Value; // shape guaranteed by schema validation
+
+        var db = ctx.Services.GetRequiredService<IAppDbContext>();
+        var chapter = await db.Chapters
+            .Where(c => c.EditionId == editionId && c.ChapterNumber == number)
+            .Select(c => new { c.ChapterNumber, c.Title, c.PlainText, c.WordCount })
+            .FirstOrDefaultAsync(ct);
+
+        if (chapter is null)
+            return ToolJson.Result(new { found = false, message = $"Chapter {number} does not exist in this book." });
+
+        var (opening, truncated) = ToolJson.Truncate(chapter.PlainText, OpeningChars);
+        return ToolJson.Result(new
+        {
+            found = true,
+            chapterNumber = chapter.ChapterNumber,
+            title = chapter.Title,
+            wordCount = chapter.WordCount,
+            opening,
+            openingTruncated = truncated,
+        });
+    }
+}

--- a/backend/src/Application/Tools/GetUserVocabularyTool.cs
+++ b/backend/src/Application/Tools/GetUserVocabularyTool.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+
+namespace Application.Tools;
+
+/// <summary>
+/// Study Buddy tool (AI-035): the user's own saved vocabulary for the current book — word + its
+/// definition/translation — so the agent can explain a passage using terms the user has already
+/// chosen to learn, and connect new material to them. Strictly scoped to <see cref="ToolContext.UserId"/>,
+/// optionally substring-filtered, capped to protect the prompt.
+/// </summary>
+public sealed class GetUserVocabularyTool : ITool
+{
+    public const int DefaultLimit = 15;
+    public const int MaxLimit = 30;
+
+    private static readonly JsonElement Schema = ToolJson.Schema("""
+        {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100,
+              "description": "Optional substring to filter the user's saved words by (matches word/definition/translation)"
+            },
+            "limit": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 30,
+              "description": "Max words to return (default 15)"
+            }
+          },
+          "additionalProperties": false
+        }
+        """);
+
+    public string Name => "get_user_vocabulary";
+
+    public string Description =>
+        "Fetch the user's own saved vocabulary words for the current book (word + definition/translation), " +
+        "optionally filtered by a phrase. Use to ground the explanation in terms the user is already learning.";
+
+    public JsonElement ArgsSchema => Schema;
+
+    public async Task<JsonElement> InvokeAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
+    {
+        if (ctx.UserId is not { } userId)
+            throw new InvalidOperationException("No user in context — get_user_vocabulary needs a signed-in user.");
+
+        var query = ToolJson.GetString(args, "query");
+        var limit = Math.Clamp(ToolJson.GetInt(args, "limit") ?? DefaultLimit, 1, MaxLimit);
+
+        var db = ctx.Services.GetRequiredService<IAppDbContext>();
+        var rows = db.VocabularyWords.Where(v => v.UserId == userId);
+        if (ctx.EditionId is { } editionId)
+            rows = rows.Where(v => v.EditionId == editionId);
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            var pattern = $"%{query.Trim()}%";
+            rows = rows.Where(v =>
+                EF.Functions.ILike(v.Word, pattern) ||
+                (v.Definition != null && EF.Functions.ILike(v.Definition, pattern)) ||
+                (v.Translation != null && EF.Functions.ILike(v.Translation, pattern)));
+        }
+
+        var words = await rows
+            .OrderByDescending(v => v.Stage).ThenBy(v => v.Word)
+            .Take(limit)
+            .Select(v => new { word = v.Word, definition = v.Definition, translation = v.Translation })
+            .ToListAsync(ct);
+
+        return ToolJson.Result(new { count = words.Count, words });
+    }
+}

--- a/tests/TextStack.UnitTests/StarterToolsTests.cs
+++ b/tests/TextStack.UnitTests/StarterToolsTests.cs
@@ -29,7 +29,7 @@ public class StarterToolsTests
 
         foreach (var name in ExpectedNames)
             Assert.NotNull(registry.Get(name));
-        Assert.Equal(ExpectedNames.Length, registry.Names.Count); // exactly these — no stray ITool in Application
+        // (The exact total — now also the AI-035 Study Buddy tools — is asserted in StudyBuddyToolsTests.)
     }
 
     [Theory]

--- a/tests/TextStack.UnitTests/StudyBuddyAgentTests.cs
+++ b/tests/TextStack.UnitTests/StudyBuddyAgentTests.cs
@@ -1,0 +1,72 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Application.Agents;
+using TextStack.Ai.Agents;
+using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// AI-035 — the StudyBuddyAgent wiring over the real <see cref="AgentLoop"/> with a fake LLM: it feeds
+/// the loop its system prompt, the allowed tool set, and a goal built from the passage + chapter, and
+/// returns the loop's answer.
+/// </summary>
+public class StudyBuddyAgentTests
+{
+    private sealed class FixedLlm(string reply) : ILlmService
+    {
+        public List<LlmRequest> Requests { get; } = [];
+
+        public Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
+        {
+            Requests.Add(request);
+            return Task.FromResult(new LlmResponse(reply, [], new LlmUsage(1, 1, 0m), "m", Guid.NewGuid()));
+        }
+
+        public IAsyncEnumerable<LlmDelta> StreamAsync(LlmRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
+
+    private static AgentLoop Loop(ILlmService llm)
+    {
+        var registry = new ToolRegistry([]);
+        return new AgentLoop(llm, registry, new ToolDispatcher(registry));
+    }
+
+    private static AgentContext Ctx() =>
+        new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), new ServiceCollection().BuildServiceProvider());
+
+    [Fact]
+    public async Task Run_FeedsPromptAndPassageGoal_ReturnsAnswer()
+    {
+        var llm = new FixedLlm("Here is the explanation.");
+        var agent = new StudyBuddyAgent(Loop(llm));
+
+        var result = await agent.RunAsync(
+            new StudyBuddyInput("A quorum protects reads from stale replicas.", Guid.NewGuid(), ChapterNumber: 3),
+            Ctx(), TestContext.Current.CancellationToken);
+
+        Assert.Equal("Here is the explanation.", result.Output);
+
+        var request = Assert.Single(llm.Requests);
+        Assert.Equal(StudyBuddyAgent.SystemPrompt, request.SystemPrompt);
+        Assert.Equal(StudyBuddyAgent.FeatureTag, request.FeatureTag);
+        Assert.Contains("A quorum protects reads", request.Messages[0].Content);
+        Assert.Contains("Chapter 3", request.Messages[0].Content); // chapter threaded into the goal
+    }
+
+    [Fact]
+    public async Task Run_NoChapter_GoalOmitsChapter()
+    {
+        var llm = new FixedLlm("Explanation.");
+        var agent = new StudyBuddyAgent(Loop(llm));
+
+        await agent.RunAsync(
+            new StudyBuddyInput("Some passage.", Guid.NewGuid(), ChapterNumber: null),
+            Ctx(), TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain("Chapter", llm.Requests[0].Messages[0].Content);
+    }
+}

--- a/tests/TextStack.UnitTests/StudyBuddyToolsTests.cs
+++ b/tests/TextStack.UnitTests/StudyBuddyToolsTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using Application.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using TextStack.Ai.Core;
+using TextStack.Ai.Tools;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// AI-035 — the three Study Buddy tools, at the level testable without a DB: discovery via the
+/// assembly scan (now seven Application tools), and schema validity through the same validator the
+/// dispatcher uses. DB behaviour (EF queries, RAG retrieval) is exercised in AI-037 + e2e.
+/// </summary>
+public class StudyBuddyToolsTests
+{
+    private static readonly string[] AllApplicationTools =
+    [
+        "get_chapter", "search_book", "lookup_dictionary", "get_user_highlights",
+        "find_earlier_definition", "get_chapter_summary", "get_user_vocabulary",
+    ];
+
+    private static JsonElement Args(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void AddAiTools_ScanningApplication_DiscoversAllSevenTools()
+    {
+        var services = new ServiceCollection();
+        services.AddAiTools(typeof(GetChapterTool).Assembly);
+
+        using var sp = services.BuildServiceProvider();
+        var registry = sp.GetRequiredService<IToolRegistry>();
+
+        foreach (var name in AllApplicationTools)
+            Assert.NotNull(registry.Get(name));
+        Assert.Equal(AllApplicationTools.Length, registry.Names.Count);
+    }
+
+    [Theory]
+    [InlineData(typeof(FindEarlierDefinitionTool), """{"term": "quorum"}""", """{}""")]
+    [InlineData(typeof(GetChapterSummaryTool), """{"chapter_number": 5}""", """{"chapter_number": 0}""")]
+    [InlineData(typeof(GetUserVocabularyTool), """{"query": "lsm", "limit": 10}""", """{"limit": 99}""")]
+    public void ArgsSchema_AcceptsHappyPath_RejectsMalformed(Type toolType, string goodArgs, string badArgs)
+    {
+        var tool = (ITool)Activator.CreateInstance(toolType)!;
+
+        Assert.Null(ToolDispatcher.ValidateArgs(tool.ArgsSchema, Args(goodArgs)));
+        Assert.NotNull(ToolDispatcher.ValidateArgs(tool.ArgsSchema, Args(badArgs)));
+    }
+
+    [Theory]
+    [InlineData(typeof(FindEarlierDefinitionTool))]
+    [InlineData(typeof(GetChapterSummaryTool))]
+    [InlineData(typeof(GetUserVocabularyTool))]
+    public void ArgsSchema_RejectsUnknownProperties(Type toolType)
+    {
+        var tool = (ITool)Activator.CreateInstance(toolType)!;
+        Assert.NotNull(ToolDispatcher.ValidateArgs(tool.ArgsSchema, Args("""{"hallucinated_arg": true}""")));
+    }
+}


### PR DESCRIPTION
Phase 6 **AI-035** — the concrete agent on top of the AI-034 loop, plus the three tools it needs. The reader endpoint + SSE step events are **AI-037**; `agent_run` persistence is **AI-036**.

## Changes
- **`StudyBuddyAgent`** (`Application/Agents`, `IAgent<StudyBuddyInput, string>`) — a thin layer over `AgentLoop`: owns only the system prompt, the allowed tool set, and the run budget (≤6 steps, per-step token cap, **$0.05 cost cap**). The goal is built from the highlighted passage + chapter; the system prompt steers it to investigate with tools, write a grounded 3–5 sentence explanation, and never invent facts.
- **3 new tools** (`Application/Tools/`, stateless singletons, scoped deps via `ToolContext`):
  - `find_earlier_definition(term)` — where a concept was first introduced **earlier** in the book (lowest-numbered chapter matching, via the AI-023 hybrid retrieval; spoiler-gated to the reader's progress).
  - `get_chapter_summary(chapter_number)` — a cheap **deterministic** orientation (title + word count + opening 800 chars), so the agent can scope a chapter without pulling it in full (and the model paying to read it).
  - `get_user_vocabulary(query?, limit?)` — the user's own saved words (+definition/translation) for the book, to connect explanations to terms they're already learning.
- Allowed tool set for the agent: the trio above + `get_chapter` / `get_chapter_summary` / `search_book` / `get_user_highlights`. Registered `AddScoped<StudyBuddyAgent>`.

## Verification
- `StudyBuddyAgent` wiring over the **real** `AgentLoop` + fake LLM: system prompt / feature tag / passage+chapter goal threading (chapter in and out).
- The 3 tools' schema validity (happy path / malformed / unknown-prop) via the dispatcher's validator; the assembly scan now finds exactly the **7** Application tools (old 4-count assertion moved here).
- Full `TextStack.UnitTests` (264) + `TextStack.AiEvals` (28) green; `dotnet format` clean. DB/RAG paths (EF queries, retrieval) run in AI-037 + e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)