### PR TITLE
refactor(ai): shared spoiler-gate resolver + robust tool-set test (AI-035 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Phase 6 — cleanup: shared spoiler-gate resolver + robust tool-set test (AI-035 follow-up, 2026-06-14)
+
+Audit follow-up to AI-035 — clean-architecture tidy, no behaviour change.
+
+- **DRY:** the high-water-mark spoiler-gate resolver (`ResolveLastReadOrdAsync`) was copy-pasted verbatim in `SearchBookTool` and `FindEarlierDefinitionTool`. Extracted to a single `ReadingProgressGate` helper (Application/Tools); both tools call it. (`RagContextService` keeps its own variant — it additionally filters by SiteId for the authenticated RAG path; the difference is now documented in one place.) Orphaned `Microsoft.EntityFrameworkCore` usings removed with the local copies.
+- **Test robustness:** the tool-discovery assertion drifted on a magic count (broke at 4→7) and was split across files. Now one canonical allow-list in `StudyBuddyToolsTests` asserted by **set-equality** against the registry — a missing OR stray tool fails with a readable diff, and adding a tool is a deliberate one-line edit in one place. The duplicate count assertion was already removed from `StarterToolsTests`.
+
 ### Phase 6 — Study Buddy agent + 3 tools (2026-06-13)
 
 Phase 6 **AI-035** — the concrete agent on top of the AI-034 loop, plus the three tools it needs. The reader endpoint + SSE step events are AI-037; persistence is AI-036.

--- a/backend/src/Application/Tools/FindEarlierDefinitionTool.cs
+++ b/backend/src/Application/Tools/FindEarlierDefinitionTool.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Application.Common.Interfaces;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using TextStack.Ai.Core;
 using TextStack.Ai.Rag;
@@ -52,7 +51,7 @@ public sealed class FindEarlierDefinitionTool : ITool
 
         var rag = ctx.Services.GetRequiredService<IRagService>();
         var gate = ctx.UserId is { } userId
-            ? await ResolveLastReadOrdAsync(ctx.Services.GetRequiredService<IAppDbContext>(), userId, editionId, ct)
+            ? await ReadingProgressGate.ResolveLastReadOrdAsync(ctx.Services.GetRequiredService<IAppDbContext>(), userId, editionId, ct)
             : null;
 
         var chunks = await rag.RetrieveAsync(editionId, term, CandidatePool, maxChapterOrd: gate, ct);
@@ -71,18 +70,5 @@ public sealed class FindEarlierDefinitionTool : ITool
             snippet,
             truncated,
         });
-    }
-
-    /// <summary>Furthest-read chapter (high-water mark) — same spoiler semantics as RagContextService.</summary>
-    private static async Task<int?> ResolveLastReadOrdAsync(
-        IAppDbContext db, Guid userId, Guid editionId, CancellationToken ct)
-    {
-        var row = await db.ReadingProgresses
-            .Where(p => p.UserId == userId && p.EditionId == editionId)
-            .Join(db.Chapters, p => p.ChapterId, c => c.Id,
-                (p, c) => new { p.MaxChapterNumber, c.ChapterNumber })
-            .FirstOrDefaultAsync(ct);
-
-        return row is null ? null : row.MaxChapterNumber ?? row.ChapterNumber;
     }
 }

--- a/backend/src/Application/Tools/ReadingProgressGate.cs
+++ b/backend/src/Application/Tools/ReadingProgressGate.cs
@@ -1,0 +1,27 @@
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Tools;
+
+/// <summary>
+/// Shared spoiler-gate resolver for the book tools (AI-030/035): the furthest chapter ordinal a user
+/// has reached in an edition (high-water mark — flipping back doesn't re-hide already-read chapters),
+/// falling back to the current chapter for legacy rows. Null when the user has no progress, so the
+/// caller leaves retrieval ungated. Single-site (ADR-007), so no SiteId filter — that's the one
+/// difference from <c>RagContextService.ResolveLastReadOrdAsync</c>, which gates the authenticated
+/// RAG path and carries the site. Extracted to remove the copy that lived in both search tools.
+/// </summary>
+internal static class ReadingProgressGate
+{
+    public static async Task<int?> ResolveLastReadOrdAsync(
+        IAppDbContext db, Guid userId, Guid editionId, CancellationToken ct)
+    {
+        var row = await db.ReadingProgresses
+            .Where(p => p.UserId == userId && p.EditionId == editionId)
+            .Join(db.Chapters, p => p.ChapterId, c => c.Id,
+                (p, c) => new { p.MaxChapterNumber, c.ChapterNumber })
+            .FirstOrDefaultAsync(ct);
+
+        return row is null ? null : row.MaxChapterNumber ?? row.ChapterNumber;
+    }
+}

--- a/backend/src/Application/Tools/SearchBookTool.cs
+++ b/backend/src/Application/Tools/SearchBookTool.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Application.Common.Interfaces;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using TextStack.Ai.Core;
 using TextStack.Ai.Rag;
@@ -54,7 +53,7 @@ public sealed class SearchBookTool : ITool
 
         var rag = ctx.Services.GetRequiredService<IRagService>();
         var gate = ctx.UserId is { } userId
-            ? await ResolveLastReadOrdAsync(ctx.Services.GetRequiredService<IAppDbContext>(), userId, editionId, ct)
+            ? await ReadingProgressGate.ResolveLastReadOrdAsync(ctx.Services.GetRequiredService<IAppDbContext>(), userId, editionId, ct)
             : null;
 
         var chunks = await rag.RetrieveAsync(editionId, query, TopK, maxChapterOrd: gate, ct);
@@ -66,22 +65,5 @@ public sealed class SearchBookTool : ITool
         }).ToList();
 
         return ToolJson.Result(new { query, passages });
-    }
-
-    /// <summary>
-    /// The user's furthest-read chapter in this edition (high-water mark, falling back to the current
-    /// chapter for legacy rows) — same semantics as RagContextService, minus the site filter
-    /// (single-site, ADR-007; ToolContext carries no SiteId). Null = no progress → ungated.
-    /// </summary>
-    private static async Task<int?> ResolveLastReadOrdAsync(
-        IAppDbContext db, Guid userId, Guid editionId, CancellationToken ct)
-    {
-        var row = await db.ReadingProgresses
-            .Where(p => p.UserId == userId && p.EditionId == editionId)
-            .Join(db.Chapters, p => p.ChapterId, c => c.Id,
-                (p, c) => new { p.MaxChapterNumber, c.ChapterNumber })
-            .FirstOrDefaultAsync(ct);
-
-        return row is null ? null : row.MaxChapterNumber ?? row.ChapterNumber;
     }
 }

--- a/tests/TextStack.UnitTests/StudyBuddyToolsTests.cs
+++ b/tests/TextStack.UnitTests/StudyBuddyToolsTests.cs
@@ -7,12 +7,18 @@ using TextStack.Ai.Tools;
 namespace TextStack.UnitTests;
 
 /// <summary>
-/// AI-035 — the three Study Buddy tools, at the level testable without a DB: discovery via the
-/// assembly scan (now seven Application tools), and schema validity through the same validator the
-/// dispatcher uses. DB behaviour (EF queries, RAG retrieval) is exercised in AI-037 + e2e.
+/// AI-035 — the three Study Buddy tools, at the level testable without a DB: schema validity through
+/// the same validator the dispatcher uses, and the single canonical assertion that the assembly scan
+/// registers EXACTLY the expected Application tool set. DB behaviour (EF queries, RAG retrieval) is
+/// exercised in AI-037 + e2e.
 /// </summary>
 public class StudyBuddyToolsTests
 {
+    /// <summary>
+    /// The one place that lists every tool the Application assembly is expected to register. Adding a
+    /// tool is a deliberate change to this allow-list; the set-equality assertion below then catches
+    /// both a missing tool AND a stray one, with a readable diff — no magic count to drift.
+    /// </summary>
     private static readonly string[] AllApplicationTools =
     [
         "get_chapter", "search_book", "lookup_dictionary", "get_user_highlights",
@@ -22,7 +28,7 @@ public class StudyBuddyToolsTests
     private static JsonElement Args(string json) => JsonDocument.Parse(json).RootElement;
 
     [Fact]
-    public void AddAiTools_ScanningApplication_DiscoversAllSevenTools()
+    public void AddAiTools_ScanningApplication_RegistersExactlyTheExpectedTools()
     {
         var services = new ServiceCollection();
         services.AddAiTools(typeof(GetChapterTool).Assembly);
@@ -30,9 +36,9 @@ public class StudyBuddyToolsTests
         using var sp = services.BuildServiceProvider();
         var registry = sp.GetRequiredService<IToolRegistry>();
 
-        foreach (var name in AllApplicationTools)
-            Assert.NotNull(registry.Get(name));
-        Assert.Equal(AllApplicationTools.Length, registry.Names.Count);
+        Assert.Equal(
+            AllApplicationTools.OrderBy(n => n),
+            registry.Names.OrderBy(n => n)); // missing or stray tool → readable diff
     }
 
     [Theory]


### PR DESCRIPTION
Audit follow-up to AI-035 (#323) — clean-architecture tidy, **no behaviour change**.

## DRY: shared spoiler-gate resolver
`ResolveLastReadOrdAsync` (the high-water-mark "furthest chapter the reader reached" used to spoiler-gate retrieval) was copy-pasted **verbatim** in `SearchBookTool` and `FindEarlierDefinitionTool`. Extracted to a single `ReadingProgressGate` helper (Application/Tools); both tools call it. `RagContextService` keeps its own variant deliberately — it additionally filters by `SiteId` for the authenticated RAG path — and that one difference is now documented in one place. Orphaned `Microsoft.EntityFrameworkCore` usings removed alongside the local copies (build is 0-warning, confirming they were dead).

## Test robustness
The tool-discovery assertion relied on a magic count (`== 4`, then `== 7`) and had drifted across two test files. Replaced with **one canonical allow-list** in `StudyBuddyToolsTests`, asserted by **set-equality** against the registry: a missing OR stray tool now fails with a readable diff, and adding a tool is a deliberate one-line edit in a single place.

## Verification
Full `TextStack.UnitTests` (264) green; `dotnet format` clean; build 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)