### PR TITLE
feat(ai): agent run persistence (AI-036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Phase 6 — agent run persistence (2026-06-14)
+
+Phase 6 **AI-036** — agent runs are saved so the reader UI can replay an agent's steps (AI-038) and runs are observable. Persistence mechanics only; the endpoint that calls it is AI-037.
+
+- **`agent_run` table** (`AddAgentRun` migration) + `AgentRun` entity + `DbSet` on `IAppDbContext`/`AppDbContext` (`AppDbContext.Agents.cs`). Columns: agent / user / edition / goal / status / output / **`steps_json` (jsonb)** / iterations / tokens / cost / latency / error / created_at. Optional FK→users `ON DELETE SET NULL` (a deleted user doesn't erase history); partial index on `(user_id, created_at)`.
+- **`IAgentRunWriter`** (`Ai.Core`) + **`DbAgentRunWriter`** (`Application/Ai`, scoped, mirrors `DbLlmTraceWriter`): flattens the framework-free `AgentRunRecord` into the entity, serializing the step transcript to jsonb. Awaited by the caller (the run is already finished — no latency to hide).
+- **`AgentRunRecord` + `AgentRunRecordFactory`** (`Ai.Core` / `Ai.Agents`): `Completed` / `BudgetExhausted` / `Failed` build a persistable record uniformly across outcomes.
+- **Budget-exhausted runs keep their transcript**: `AgentBudgetExhaustedException` now carries the partial `Steps` + `Usage` accumulated before the cap (the run you most want to inspect is the one that ran out of budget); `AgentLoop` throws with them at both the cost-cap and max-steps exits.
+- Tests: `AgentRunRecordFactory` (completed/budget-exhausted-keeps-transcript/failed); `AgentLoop` budget exhaustion now asserts the exception carries the partial transcript + usage. Migration applied locally + jsonb roundtrip/FK/index verified on Postgres.
+
 ### Phase 6 — cleanup: shared spoiler-gate resolver + robust tool-set test (AI-035 follow-up, 2026-06-14)
 
 Audit follow-up to AI-035 — clean-architecture tidy, no behaviour change.

--- a/backend/src/Ai/TextStack.Ai.Agents/AgentLoop.cs
+++ b/backend/src/Ai/TextStack.Ai.Agents/AgentLoop.cs
@@ -69,11 +69,15 @@ public sealed class AgentLoop(ILlmService llm, IToolRegistry tools, ToolDispatch
             // Cost cap is checked AFTER the step completes, so a useful partial transcript is kept.
             if (options.CostCapUsd is { } cap && cost >= cap)
                 throw new AgentBudgetExhaustedException(
-                    $"Agent cost cap ${cap} exceeded after {iteration + 1} iteration(s) (${cost}).");
+                    $"Agent cost cap ${cap} exceeded after {iteration + 1} iteration(s) (${cost}).",
+                    steps,
+                    new AgentUsage(iteration + 1, inputTokens, outputTokens, cost, (int)sw.ElapsedMilliseconds));
         }
 
         throw new AgentBudgetExhaustedException(
-            $"Agent reached MaxSteps={options.MaxSteps} without a final answer.");
+            $"Agent reached MaxSteps={options.MaxSteps} without a final answer.",
+            steps,
+            new AgentUsage(options.MaxSteps, inputTokens, outputTokens, cost, (int)sw.ElapsedMilliseconds));
     }
 
     private static AgentStep Step(int iteration, string kind, JsonElement payload) =>

--- a/backend/src/Ai/TextStack.Ai.Agents/AgentRunRecordFactory.cs
+++ b/backend/src/Ai/TextStack.Ai.Agents/AgentRunRecordFactory.cs
@@ -1,0 +1,34 @@
+using TextStack.Ai.Core;
+
+namespace TextStack.Ai.Agents;
+
+/// <summary>
+/// Builds an <see cref="AgentRunRecord"/> from a run's outcome (AI-036), so the endpoint (AI-037) can
+/// persist completed, budget-exhausted and errored runs uniformly. Pure — unit-tested directly.
+/// </summary>
+public static class AgentRunRecordFactory
+{
+    public const string StatusCompleted = "completed";
+    public const string StatusBudgetExhausted = "budget_exhausted";
+    public const string StatusError = "error";
+
+    private static readonly AgentUsage NoUsage = new(0, 0, 0, 0m, 0);
+
+    /// <summary>A run that produced a final answer.</summary>
+    public static AgentRunRecord Completed(
+        Guid id, string agent, Guid? userId, Guid? editionId, string goal, AgentResult<string> result) =>
+        new(id, agent, userId, editionId, goal, StatusCompleted,
+            result.Output, result.Steps, result.Usage, Error: null, DateTimeOffset.UtcNow);
+
+    /// <summary>A run that hit its iteration / cost cap — keeps the partial transcript the exception carries.</summary>
+    public static AgentRunRecord BudgetExhausted(
+        Guid id, string agent, Guid? userId, Guid? editionId, string goal, AgentBudgetExhaustedException ex) =>
+        new(id, agent, userId, editionId, goal, StatusBudgetExhausted,
+            Output: null, ex.Steps, ex.Usage, ex.Message, DateTimeOffset.UtcNow);
+
+    /// <summary>A run that failed for any other reason (no transcript available).</summary>
+    public static AgentRunRecord Failed(
+        Guid id, string agent, Guid? userId, Guid? editionId, string goal, Exception ex) =>
+        new(id, agent, userId, editionId, goal, StatusError,
+            Output: null, Steps: [], NoUsage, ex.Message, DateTimeOffset.UtcNow);
+}

--- a/backend/src/Ai/TextStack.Ai.Core/Agents.cs
+++ b/backend/src/Ai/TextStack.Ai.Core/Agents.cs
@@ -43,10 +43,65 @@ public record AgentLoopOptions(
     int MaxTokensPerStep = 1024,
     decimal? CostCapUsd = null);
 
-/// <summary>Thrown when an agent reaches <see cref="AgentLoopOptions.MaxSteps"/> or its cost cap without terminating.</summary>
+/// <summary>
+/// Thrown when an agent reaches <see cref="AgentLoopOptions.MaxSteps"/> or its cost cap without
+/// terminating. Carries the partial <see cref="Steps"/> transcript and <see cref="Usage"/> accumulated
+/// before the budget ran out — a budget-exhausted run is exactly the one worth inspecting, so it can be
+/// persisted (AI-036) instead of lost. The legacy constructors default these to empty.
+/// </summary>
 public sealed class AgentBudgetExhaustedException : Exception
 {
-    public AgentBudgetExhaustedException() : base("Agent budget exhausted.") { }
-    public AgentBudgetExhaustedException(string message) : base(message) { }
-    public AgentBudgetExhaustedException(string message, Exception innerException) : base(message, innerException) { }
+    private static readonly AgentUsage EmptyUsage = new(0, 0, 0, 0m, 0);
+
+    public IReadOnlyList<AgentStep> Steps { get; }
+    public AgentUsage Usage { get; }
+
+    public AgentBudgetExhaustedException(string message, IReadOnlyList<AgentStep> steps, AgentUsage usage)
+        : base(message)
+    {
+        Steps = steps;
+        Usage = usage;
+    }
+
+    public AgentBudgetExhaustedException() : base("Agent budget exhausted.")
+    {
+        Steps = [];
+        Usage = EmptyUsage;
+    }
+
+    public AgentBudgetExhaustedException(string message) : base(message)
+    {
+        Steps = [];
+        Usage = EmptyUsage;
+    }
+
+    public AgentBudgetExhaustedException(string message, Exception innerException) : base(message, innerException)
+    {
+        Steps = [];
+        Usage = EmptyUsage;
+    }
+}
+
+/// <summary>
+/// A finished agent run ready to persist (AI-036): identity + who/what it ran for, the terminal
+/// <see cref="Status"/> ("completed" | "budget_exhausted" | "error"), the final answer (if any), the
+/// full step transcript and accumulated usage. Framework-free so the writer interface lives in Core.
+/// </summary>
+public record AgentRunRecord(
+    Guid Id,
+    string Agent,
+    Guid? UserId,
+    Guid? EditionId,
+    string Goal,
+    string Status,
+    string? Output,
+    IReadOnlyList<AgentStep> Steps,
+    AgentUsage Usage,
+    string? Error,
+    DateTimeOffset CreatedAt);
+
+/// <summary>Persists an <see cref="AgentRunRecord"/> (e.g. to Postgres) so the UI can replay the agent's steps.</summary>
+public interface IAgentRunWriter
+{
+    Task WriteAsync(AgentRunRecord run, CancellationToken ct);
 }

--- a/backend/src/Application/Ai/DbAgentRunWriter.cs
+++ b/backend/src/Application/Ai/DbAgentRunWriter.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Application.Common.Interfaces;
+using Domain.Entities;
+
+namespace Application.Ai;
+
+/// <summary>
+/// Persists agent runs (AI-036) to Postgres via <see cref="IAppDbContext"/>. Scoped (owns a
+/// per-request DbContext); the endpoint awaits it after the agent finishes (the run is already done,
+/// so there is no latency to hide). The Core <see cref="global::TextStack.Ai.Core.AgentRunRecord"/> is
+/// flattened into the EF <see cref="AgentRun"/> entity, with the step transcript serialized to jsonb.
+/// Written as global:: to avoid the Application.* vs TextStack.* namespace clash.
+/// </summary>
+public sealed class DbAgentRunWriter(IAppDbContext db) : global::TextStack.Ai.Core.IAgentRunWriter
+{
+    public async Task WriteAsync(global::TextStack.Ai.Core.AgentRunRecord run, CancellationToken ct)
+    {
+        db.AgentRuns.Add(new AgentRun
+        {
+            Id = run.Id,
+            Agent = run.Agent,
+            UserId = run.UserId,
+            EditionId = run.EditionId,
+            Goal = run.Goal,
+            Status = run.Status,
+            Output = run.Output,
+            StepsJson = JsonSerializer.Serialize(run.Steps),
+            Iterations = run.Usage.Iterations,
+            TokensIn = run.Usage.InputTokensTotal,
+            TokensOut = run.Usage.OutputTokensTotal,
+            CostUsd = run.Usage.CostUsdTotal,
+            LatencyMs = run.Usage.LatencyMs,
+            Error = run.Error,
+            CreatedAt = run.CreatedAt,
+        });
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/backend/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/backend/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -59,6 +59,7 @@ public interface IAppDbContext
     DbSet<BookCollection> BookCollections { get; }
     DbSet<LlmTrace> LlmTraces { get; }
     DbSet<EvalRun> EvalRuns { get; }
+    DbSet<AgentRun> AgentRuns { get; }
     DbSet<PodcastGenerationJob> PodcastGenerationJobs { get; }
 
     Task<int> SaveChangesAsync(CancellationToken ct = default);

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -53,6 +53,7 @@ public static class DependencyInjection
         // Trace writer: scoped (per-request DbContext); the singleton
         // TracingDecorator resolves it per-write via a fresh scope.
         services.AddScoped<global::TextStack.Ai.Core.ILlmTraceWriter, Ai.DbLlmTraceWriter>();
+        services.AddScoped<global::TextStack.Ai.Core.IAgentRunWriter, Ai.DbAgentRunWriter>();
 
         // Sampling policy (Ai:Tracing:Sampling). Errors always sampled regardless.
         services.AddSingleton(sp =>

--- a/backend/src/Domain/Entities/AgentRun.cs
+++ b/backend/src/Domain/Entities/AgentRun.cs
@@ -1,0 +1,43 @@
+namespace Domain.Entities;
+
+/// <summary>
+/// Persisted record of one agent run (table <c>agent_run</c>, Phase 6 / AI-036). Written after a
+/// Study Buddy (or future) agent finishes so the reader UI can replay its steps and so runs are
+/// observable (cost / iterations / status). <see cref="StepsJson"/> holds the full transcript as
+/// jsonb — read whole for "show steps", not queried per field. Plain POCO; EF mapping in
+/// AppDbContext.Agents.cs.
+/// </summary>
+public class AgentRun
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Which agent ran, e.g. "studybuddy".</summary>
+    public required string Agent { get; set; }
+
+    public Guid? UserId { get; set; }
+    public Guid? EditionId { get; set; }
+
+    /// <summary>The user goal the agent was given (the highlighted passage).</summary>
+    public required string Goal { get; set; }
+
+    /// <summary>Terminal status: "completed" | "budget_exhausted" | "error".</summary>
+    public required string Status { get; set; }
+
+    /// <summary>Final answer, when the run completed.</summary>
+    public string? Output { get; set; }
+
+    /// <summary>Full step transcript as a JSON array (jsonb).</summary>
+    public required string StepsJson { get; set; }
+
+    public int Iterations { get; set; }
+    public int TokensIn { get; set; }
+    public int TokensOut { get; set; }
+    public decimal CostUsd { get; set; }
+    public int LatencyMs { get; set; }
+
+    public string? Error { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+
+    // Optional FK → users; ON DELETE SET NULL (a deleted user shouldn't erase the run history).
+    public User? User { get; set; }
+}

--- a/backend/src/Infrastructure/Migrations/20260614220552_AddAgentRun.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260614220552_AddAgentRun.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260614220552_AddAgentRun")]
+    partial class AddAgentRun
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260614220552_AddAgentRun.cs
+++ b/backend/src/Infrastructure/Migrations/20260614220552_AddAgentRun.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAgentRun : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "agent_run",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    agent = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    edition_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    goal = table.Column<string>(type: "text", nullable: false),
+                    status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    output = table.Column<string>(type: "text", nullable: true),
+                    steps_json = table.Column<string>(type: "jsonb", nullable: false),
+                    iterations = table.Column<int>(type: "integer", nullable: false),
+                    tokens_in = table.Column<int>(type: "integer", nullable: false),
+                    tokens_out = table.Column<int>(type: "integer", nullable: false),
+                    cost_usd = table.Column<decimal>(type: "numeric(10,6)", nullable: false),
+                    latency_ms = table.Column<int>(type: "integer", nullable: false),
+                    error = table.Column<string>(type: "text", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_agent_run", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_agent_run_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_agent_run_user_id_created_at",
+                table: "agent_run",
+                columns: new[] { "user_id", "created_at" },
+                filter: "user_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "agent_run");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Agents.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Agents.cs
@@ -1,0 +1,34 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Persistence;
+
+/// <summary>
+/// Agent persistence (Phase 6 / AI-036). <see cref="AgentRun"/> (table <c>agent_run</c>) — one row per
+/// finished agent run (Study Buddy and future agents) so the reader UI can replay its steps and runs
+/// are observable. snake_case names come from the global convention (OnConfiguring).
+/// </summary>
+public partial class AppDbContext
+{
+    private static void ConfigureAgents(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<AgentRun>(e =>
+        {
+            e.ToTable("agent_run");
+
+            // Hot query: a user's recent runs (the "my Study Buddy runs" lookup).
+            e.HasIndex(x => new { x.UserId, x.CreatedAt }).HasFilter("user_id IS NOT NULL");
+
+            e.Property(x => x.Agent).HasMaxLength(64);
+            e.Property(x => x.Status).HasMaxLength(32);
+            e.Property(x => x.StepsJson).HasColumnType("jsonb");
+            e.Property(x => x.CostUsd).HasColumnType("numeric(10,6)");
+
+            // Optional FK → users; a deleted user nulls the column but keeps the run.
+            e.HasOne(x => x.User)
+                .WithMany()
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.SetNull);
+        });
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -80,6 +80,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
     public DbSet<BookCollection> BookCollections => Set<BookCollection>();
     public DbSet<LlmTrace> LlmTraces => Set<LlmTrace>();
     public DbSet<EvalRun> EvalRuns => Set<EvalRun>();
+    public DbSet<AgentRun> AgentRuns => Set<AgentRun>();
     public DbSet<PodcastGenerationJob> PodcastGenerationJobs => Set<PodcastGenerationJob>();
 
     // Phase 4 RAG. Intentionally not on IAppDbContext — retrieval uses raw Npgsql.
@@ -101,6 +102,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
         ConfigureSeo(modelBuilder);
         ConfigureCollections(modelBuilder);
         ConfigureAi(modelBuilder);
+        ConfigureAgents(modelBuilder);
         ConfigurePodcasts(modelBuilder);
         ConfigureRag(modelBuilder);
     }

--- a/tests/TextStack.UnitTests/AgentLoopTests.cs
+++ b/tests/TextStack.UnitTests/AgentLoopTests.cs
@@ -108,13 +108,18 @@ public class AgentLoopTests
     }
 
     [Fact]
-    public async Task Run_MaxStepsWithoutFinal_ThrowsBudgetExhausted()
+    public async Task Run_MaxStepsWithoutFinal_ThrowsBudgetExhaustedWithTranscript()
     {
         // Every turn requests a tool → never terminates on its own.
         var llm = new ScriptedLlm([Call()], [Call()], [Call()]);
-        await Assert.ThrowsAsync<AgentBudgetExhaustedException>(() =>
+        var ex = await Assert.ThrowsAsync<AgentBudgetExhaustedException>(() =>
             Loop(llm, new EchoTool()).RunAsync(
                 Input(), Ctx(), new AgentLoopOptions(MaxSteps: 3), TestContext.Current.CancellationToken));
+
+        // The exception carries the partial transcript + usage so the run can still be persisted (AI-036).
+        Assert.Equal(3, ex.Usage.Iterations);
+        Assert.NotEmpty(ex.Steps);
+        Assert.Equal(0.003m, ex.Usage.CostUsdTotal); // 3 iterations * 0.001
     }
 
     [Fact]

--- a/tests/TextStack.UnitTests/AgentRunRecordFactoryTests.cs
+++ b/tests/TextStack.UnitTests/AgentRunRecordFactoryTests.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using TextStack.Ai.Agents;
+using TextStack.Ai.Core;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// AI-036 — the pure factory that turns a run outcome into a persistable <see cref="AgentRunRecord"/>:
+/// completed, budget-exhausted (keeps the partial transcript), and errored.
+/// </summary>
+public class AgentRunRecordFactoryTests
+{
+    private static AgentStep Step(int i, string kind) =>
+        new(i, kind, JsonDocument.Parse("""{"x":1}""").RootElement, DateTimeOffset.UtcNow);
+
+    private static readonly Guid Id = Guid.NewGuid();
+    private static readonly Guid User = Guid.NewGuid();
+    private static readonly Guid Edition = Guid.NewGuid();
+
+    [Fact]
+    public void Completed_CarriesOutputStepsAndUsage()
+    {
+        var result = new AgentResult<string>(
+            "Final answer.", [Step(0, "llm_response")], new AgentUsage(2, 30, 12, 0.004m, 850));
+
+        var record = AgentRunRecordFactory.Completed(Id, "studybuddy", User, Edition, "passage", result);
+
+        Assert.Equal("completed", record.Status);
+        Assert.Equal("Final answer.", record.Output);
+        Assert.Null(record.Error);
+        Assert.Single(record.Steps);
+        Assert.Equal(2, record.Usage.Iterations);
+        Assert.Equal(0.004m, record.Usage.CostUsdTotal);
+        Assert.Equal(Id, record.Id);
+        Assert.NotEqual(default, record.CreatedAt);
+    }
+
+    [Fact]
+    public void BudgetExhausted_KeepsPartialTranscriptAndUsage_NoOutput()
+    {
+        var ex = new AgentBudgetExhaustedException(
+            "cap exceeded",
+            [Step(0, "llm_response"), Step(0, "tool_result")],
+            new AgentUsage(1, 50, 20, 0.05m, 1200));
+
+        var record = AgentRunRecordFactory.BudgetExhausted(Id, "studybuddy", User, Edition, "passage", ex);
+
+        Assert.Equal("budget_exhausted", record.Status);
+        Assert.Null(record.Output);
+        Assert.Equal("cap exceeded", record.Error);
+        Assert.Equal(2, record.Steps.Count);          // partial transcript preserved
+        Assert.Equal(0.05m, record.Usage.CostUsdTotal);
+    }
+
+    [Fact]
+    public void Failed_EmptyTranscriptZeroUsage_WithError()
+    {
+        var record = AgentRunRecordFactory.Failed(
+            Id, "studybuddy", User, Edition, "passage", new InvalidOperationException("boom"));
+
+        Assert.Equal("error", record.Status);
+        Assert.Null(record.Output);
+        Assert.Equal("boom", record.Error);
+        Assert.Empty(record.Steps);
+        Assert.Equal(0, record.Usage.Iterations);
+    }
+}


### PR DESCRIPTION
Phase 6 **AI-036** — agent runs are saved so the reader UI can replay an agent's steps (**AI-038**) and runs are observable. **Persistence mechanics only**; the endpoint that calls the writer is **AI-037**.

## Changes
- **`agent_run` table** (`AddAgentRun` migration) + `AgentRun` entity + `DbSet` on `IAppDbContext`/`AppDbContext` (`AppDbContext.Agents.cs`). Columns: agent / user / edition / goal / status / output / **`steps_json` (jsonb)** / iterations / tokens / cost / latency / error / created_at. Optional FK→users `ON DELETE SET NULL` (a deleted user doesn't erase history); partial index on `(user_id, created_at)`.
- **`IAgentRunWriter`** (`Ai.Core`) + **`DbAgentRunWriter`** (`Application/Ai`, scoped — mirrors `DbLlmTraceWriter`): flattens the framework-free `AgentRunRecord` into the entity, serializing the step transcript to jsonb. Awaited by the caller (the run is already finished — no latency to hide, recommendation #3).
- **`AgentRunRecord`** (`Ai.Core`) + **`AgentRunRecordFactory`** (`Ai.Agents`): `Completed` / `BudgetExhausted` / `Failed` build a persistable record uniformly across outcomes.
- **Budget-exhausted runs keep their transcript** (recommendation #1): `AgentBudgetExhaustedException` now carries the partial `Steps` + `Usage` accumulated before the cap — the run you most want to inspect is the one that ran out of budget. `AgentLoop` throws with them at both the cost-cap and max-steps exits (additive; AI-034 tests still pass).
- `steps_json` is a single jsonb column (recommendation #2) — read whole for "show steps", not queried per field.

## Verification
- `AgentRunRecordFactory` tests (completed / budget-exhausted-keeps-transcript / failed); `AgentLoop` budget-exhaustion test now asserts the exception carries the partial transcript + usage.
- Migration applied locally; `\d agent_run` + a jsonb insert/read roundtrip + FK + partial index verified on Postgres.
- Full `TextStack.UnitTests` (267) + `TextStack.AiEvals` (28) green; `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)