### PR TITLE
ci(health): tolerate deploy-window restarts (no false alarms)

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -8,28 +8,33 @@ on:
 # Opt JS actions into Node 24 ahead of June 2026 forced cutover.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  # Shared retry policy: a deploy restarts the API container (and rebuilds SSG), so a scheduled
+  # check landing inside the ~25-min deploy window briefly sees connection-refused / 5xx. These
+  # flags ride that out (up to 5 * 15s ≈ 75s) instead of false-alarming. --retry-all-errors retries
+  # on any HTTP error, --retry-connrefused on a restarting container.
+  CURL_RETRY: '--retry 5 --retry-delay 15 --retry-all-errors --retry-connrefused'
 
 jobs:
   health:
     runs-on: ubuntu-latest
     steps:
       - name: Check textstack.app API
-        run: curl -sf --retry 3 --retry-delay 10 https://textstack.app/health
+        run: curl -sf $CURL_RETRY https://textstack.app/health
 
       - name: Check textstack.dev API
-        run: curl -sf --retry 3 --retry-delay 10 https://textstack.dev/health
+        run: curl -sf $CURL_RETRY https://textstack.dev/health
 
       - name: Check frontends
         run: |
-          curl -sf --retry 2 https://textstack.app/ -o /dev/null
-          curl -sf --retry 2 https://textstack.dev/ -o /dev/null
+          curl -sf $CURL_RETRY https://textstack.app/ -o /dev/null
+          curl -sf $CURL_RETRY https://textstack.dev/ -o /dev/null
 
       - name: Smoke — book listing
         run: |
-          body=$(curl -sf --retry 2 "https://textstack.app/api/books?lang=en&limit=1")
+          body=$(curl -sf $CURL_RETRY "https://textstack.app/api/books?lang=en&limit=1")
           echo "$body" | grep -q '"id"' || { echo "books endpoint returned no items"; echo "$body"; exit 1; }
 
       - name: Smoke — search
         run: |
-          body=$(curl -sf --retry 2 "https://textstack.app/api/search?q=the&lang=en&limit=1")
+          body=$(curl -sf $CURL_RETRY "https://textstack.app/api/search?q=the&lang=en&limit=1")
           echo "$body" | grep -q '"' || { echo "search endpoint returned empty body"; echo "$body"; exit 1; }


### PR DESCRIPTION
## Symptom
The **Health Check** scheduled run at 00:10 UTC failed on `Smoke — book listing` (`curl -sf` exit 22 = HTTP ≥400 on `/api/books`). The runs before (23:42) and after were green.

## Root cause — not a prod outage
The failure landed **inside the deploy window of #326** (23:52 → ~00:18): a deploy restarts the API container and rebuilds SSG, so the API is briefly connection-refused / 5xx. The `/health` checks already retried for ~30s (`--retry 3 --retry-delay 10`), but the **smoke checks** used only `--retry 2` with no delay (~3s of retry) and couldn't ride out the restart. Prod was verified healthy at fix time (`/api/books` 200 with data, `/health` 200, explain 200).

## Fix
One shared, tolerant retry policy for every check via a `CURL_RETRY` env: `--retry 5 --retry-delay 15 --retry-all-errors --retry-connrefused` (~75s window). A deploy-window restart is now ridden out instead of paging; a genuine multi-minute outage still fails (the next scheduled run, or sustained downtime beyond the window, trips it).

No application change.