### PR TITLE
feat(web): Study Buddy panel — api, hook, component (AI-038a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Phase 6 — Study Buddy web panel (2026-06-15)
+
+Phase 6 **AI-038, slice a** — the web UI for the agent: an `api` client, a streaming hook, and the panel. Wiring it into the reader's selection toolbar is slice b.
+
+- **`api/studybuddy.ts`** — `runStudyBuddy(editionId, passage, chapter, callbacks)` consumes the AI-037 SSE (`step`/`done`/`error`) via `postSse`; `getStudyBuddyRun(runId)` fetches a persisted run for the "show steps" view.
+- **`useStudyBuddy` hook** — `steps` grow live as the agent works, `answer` lands on `done`, `status` (idle/running/done/error); a new run aborts the in-flight one; 401 surfaces as `error: 'auth'` for a sign-in prompt.
+- **`StudyBuddyPanel`** — right slide-in panel (mirrors `AskPanel`): the passage echoed at the top, the final answer, a spinner while running, and a **collapsible step transcript** (each step summarized: tool name + ok/✗, or the model's text/`Looking up: …`). Auth-gated.
+- **`lib/sse.ts`** — `postSse` now sends `credentials: 'include'` (needed for the authed Study Buddy stream; harmless for the public Explain one) and maps 401 → new `SseUnauthorizedError`.
+- Tests: `useStudyBuddy` (step accumulation → answer on done; terminal error keeps partial steps; 401 → auth; no-op on empty/missing; reset); `postSse` 401 → `SseUnauthorizedError` + credentials sent. Web suite green (517); `tsc` + build clean.
+
 ### Phase 6 — Study Buddy endpoint (SSE + run history) (2026-06-15)
 
 Phase 6 **AI-037, slice b** — the reader can now run the agent and watch it work. The panel UI is AI-038.

--- a/apps/web/src/api/studybuddy.ts
+++ b/apps/web/src/api/studybuddy.ts
@@ -1,0 +1,88 @@
+import { authFetch } from './client'
+import { API_BASE } from './client'
+import { postSse } from '../lib/sse'
+
+// Study Buddy agent (Phase 6, AI-038). Run = SSE stream of the agent's steps; the persisted run is
+// fetched separately for the "show steps" view.
+
+/** One step in the agent's transcript (mirrors the backend AgentStep).  */
+export interface StudyBuddyStep {
+  index: number
+  kind: string // "llm_response" | "tool_result"
+  payload: unknown
+  at: string
+}
+
+/** The terminal `done` event payload.  */
+export interface StudyBuddyDone {
+  runId: string
+  answer: string
+  iterations: number
+  costUsd: number
+}
+
+export interface StudyBuddyRunCallbacks {
+  onStep: (step: StudyBuddyStep) => void
+  onDone: (done: StudyBuddyDone) => void
+  onError: (message: string) => void
+}
+
+/**
+ * Runs the Study Buddy agent on a passage and streams its steps. Resolves when the stream ends;
+ * `onDone` fires on success, `onError` on a terminal error event (or a transport failure).
+ */
+export async function runStudyBuddy(
+  editionId: string,
+  passage: string,
+  chapterNumber: number | null,
+  cb: StudyBuddyRunCallbacks,
+  signal?: AbortSignal,
+): Promise<void> {
+  await postSse(
+    `${API_BASE}/me/books/${editionId}/studybuddy`,
+    { passage, chapterNumber },
+    e => {
+      if (signal?.aborted) return
+      if (e.event === 'step') {
+        try {
+          cb.onStep(JSON.parse(e.data) as StudyBuddyStep)
+        } catch {
+          // malformed step — skip it, the run continues
+        }
+      } else if (e.event === 'done') {
+        try {
+          cb.onDone(JSON.parse(e.data) as StudyBuddyDone)
+        } catch {
+          cb.onError('Malformed response')
+        }
+      } else if (e.event === 'error') {
+        let message = 'Study Buddy failed'
+        try {
+          message = (JSON.parse(e.data) as { error?: string }).error ?? message
+        } catch {
+          // keep the default
+        }
+        cb.onError(message)
+      }
+    },
+    signal,
+  )
+}
+
+/** A persisted run for the "show steps" view (mirrors the backend StudyBuddyRunDto). */
+export interface StudyBuddyRun {
+  id: string
+  agent: string
+  status: string
+  output: string | null
+  steps: StudyBuddyStep[]
+  iterations: number
+  costUsd: number
+  latencyMs: number
+  error: string | null
+  createdAt: string
+}
+
+export function getStudyBuddyRun(runId: string, signal?: AbortSignal): Promise<StudyBuddyRun> {
+  return authFetch<StudyBuddyRun>(`/me/studybuddy/runs/${runId}`, { signal })
+}

--- a/apps/web/src/components/reader/StudyBuddyPanel.tsx
+++ b/apps/web/src/components/reader/StudyBuddyPanel.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import { useTranslation } from '../../hooks/useTranslation'
+import { useStudyBuddy } from '../../hooks/useStudyBuddy'
+import type { StudyBuddyStep } from '../../api/studybuddy'
+
+interface Props {
+  open: boolean
+  editionId: string
+  passage: string
+  chapterNumber: number | null
+  isAuthenticated: boolean
+  onSignIn: () => void
+  onClose: () => void
+}
+
+/** One-line summary of an agent step for the (collapsed-by-default) transcript. */
+function summarizeStep(step: StudyBuddyStep, t: (k: string) => string): string {
+  const p = step.payload as { text?: string; tool?: string; ok?: boolean; toolCalls?: { name: string }[] }
+  if (step.kind === 'tool_result')
+    return `${p.tool ?? 'tool'} ${p.ok === false ? '✗' : '✓'}`
+  if (p.toolCalls && p.toolCalls.length > 0)
+    return `${t('reader.studyBuddy.calling')}: ${p.toolCalls.map(c => c.name).join(', ')}`
+  const text = (p.text ?? '').trim()
+  return text.length > 80 ? text.slice(0, 80) + '…' : text || t('reader.studyBuddy.thinking')
+}
+
+export function StudyBuddyPanel({
+  open,
+  editionId,
+  passage,
+  chapterNumber,
+  isAuthenticated,
+  onSignIn,
+  onClose,
+}: Props) {
+  const { t } = useTranslation()
+  const containerRef = useFocusTrap(open)
+  const { status, steps, answer, error, run, reset } = useStudyBuddy(editionId)
+  const [stepsExpanded, setStepsExpanded] = useState(false)
+
+  // Start a run when the panel opens with a passage; reset when it closes.
+  useEffect(() => {
+    if (open && isAuthenticated && passage.trim()) run(passage, chapterNumber)
+    if (!open) reset()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, passage, chapterNumber, isAuthenticated])
+
+  if (!open) return null
+
+  return (
+    <>
+      <div className="reader-drawer-backdrop" onClick={onClose} />
+      <div
+        className="ask-panel"
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('reader.studyBuddy.title')}
+      >
+        <div className="ask-panel__header">
+          <h3>{t('reader.studyBuddy.title')}</h3>
+          <button onClick={onClose} className="ask-panel__close" aria-label={t('common.close')}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="ask-panel__history">
+          <p className="study-buddy__passage">{passage}</p>
+
+          {!isAuthenticated ? (
+            <div className="ask-panel__composer ask-panel__composer--signin">
+              <p>{t('reader.studyBuddy.signIn')}</p>
+              <button className="ask-panel__send" onClick={onSignIn}>
+                {t('reader.studyBuddy.signInCta')}
+              </button>
+            </div>
+          ) : (
+            <>
+              {answer && <p className="ask-panel__answer study-buddy__answer">{answer}</p>}
+
+              {error && error !== 'auth' && <p className="ask-panel__error">{error}</p>}
+              {error === 'auth' && <p className="ask-panel__error">{t('reader.studyBuddy.signIn')}</p>}
+
+              {status === 'running' && (
+                <div className="ask-panel__loading">
+                  <span className="ask-panel__spinner" />
+                  {t('reader.studyBuddy.thinking')}
+                </div>
+              )}
+
+              {steps.length > 0 && (
+                <div className="study-buddy__steps">
+                  <button
+                    className="study-buddy__steps-toggle"
+                    onClick={() => setStepsExpanded(v => !v)}
+                    aria-expanded={stepsExpanded}
+                  >
+                    {t('reader.studyBuddy.steps')} ({steps.length})
+                  </button>
+                  {stepsExpanded && (
+                    <ol className="study-buddy__step-list">
+                      {steps.map((s, i) => (
+                        <li key={i} className={`study-buddy__step study-buddy__step--${s.kind}`}>
+                          {summarizeStep(s, t)}
+                        </li>
+                      ))}
+                    </ol>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/hooks/useStudyBuddy.test.ts
+++ b/apps/web/src/hooks/useStudyBuddy.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+vi.mock('../api/studybuddy', () => ({ runStudyBuddy: vi.fn() }))
+import { runStudyBuddy, type StudyBuddyRunCallbacks } from '../api/studybuddy'
+import { SseUnauthorizedError } from '../lib/sse'
+import { useStudyBuddy } from './useStudyBuddy'
+
+const mockRun = runStudyBuddy as unknown as ReturnType<typeof vi.fn>
+
+const step = (i: number, kind = 'llm_response', payload: unknown = {}) => ({ index: i, kind, payload, at: '' })
+
+/** Drives the mocked runStudyBuddy by firing the given callbacks in order. */
+function script(fire: (cb: StudyBuddyRunCallbacks) => void) {
+  mockRun.mockImplementationOnce(
+    async (_e: string, _p: string, _c: number | null, cb: StudyBuddyRunCallbacks) => fire(cb),
+  )
+}
+
+describe('useStudyBuddy', () => {
+  beforeEach(() => mockRun.mockReset())
+
+  it('accumulates steps and resolves the answer on done', async () => {
+    script(cb => {
+      cb.onStep(step(0))
+      cb.onStep(step(1, 'tool_result', { tool: 'get_chapter', ok: true }))
+      cb.onDone({ runId: 'r1', answer: 'A grounded explanation.', iterations: 2, costUsd: 0.004 })
+    })
+    const { result } = renderHook(() => useStudyBuddy('ed-1'))
+
+    await act(() => result.current.run('A confusing passage.', 3))
+
+    await waitFor(() => expect(result.current.status).toBe('done'))
+    expect(result.current.steps).toHaveLength(2)
+    expect(result.current.answer).toBe('A grounded explanation.')
+    expect(result.current.error).toBeNull()
+    expect(mockRun).toHaveBeenCalledWith('ed-1', 'A confusing passage.', 3, expect.anything(), expect.anything())
+  })
+
+  it('surfaces a terminal error event', async () => {
+    script(cb => {
+      cb.onStep(step(0))
+      cb.onError('Study Buddy service unavailable')
+    })
+    const { result } = renderHook(() => useStudyBuddy('ed-1'))
+
+    await act(() => result.current.run('passage', null))
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error).toBe('Study Buddy service unavailable')
+    expect(result.current.steps).toHaveLength(1) // partial steps kept
+  })
+
+  it('maps a 401 to the auth error', async () => {
+    mockRun.mockRejectedValueOnce(new SseUnauthorizedError())
+    const { result } = renderHook(() => useStudyBuddy('ed-1'))
+
+    await act(() => result.current.run('passage', null))
+
+    await waitFor(() => expect(result.current.error).toBe('auth'))
+    expect(result.current.status).toBe('error')
+  })
+
+  it('does nothing for an empty passage or missing edition', async () => {
+    const { result } = renderHook(() => useStudyBuddy(undefined))
+    await act(() => result.current.run('passage', null)) // no edition
+    const { result: r2 } = renderHook(() => useStudyBuddy('ed-1'))
+    await act(() => r2.current.run('   ', null)) // blank passage
+
+    expect(mockRun).not.toHaveBeenCalled()
+    expect(result.current.status).toBe('idle')
+    expect(r2.current.status).toBe('idle')
+  })
+
+  it('reset returns to idle', async () => {
+    script(cb => cb.onDone({ runId: 'r', answer: 'x', iterations: 1, costUsd: 0 }))
+    const { result } = renderHook(() => useStudyBuddy('ed-1'))
+    await act(() => result.current.run('p', null))
+    await waitFor(() => expect(result.current.status).toBe('done'))
+
+    act(() => result.current.reset())
+    expect(result.current.status).toBe('idle')
+    expect(result.current.answer).toBeNull()
+  })
+})

--- a/apps/web/src/hooks/useStudyBuddy.ts
+++ b/apps/web/src/hooks/useStudyBuddy.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { runStudyBuddy, type StudyBuddyStep } from '../api/studybuddy'
+import { SseUnauthorizedError } from '../lib/sse'
+
+export type StudyBuddyStatus = 'idle' | 'running' | 'done' | 'error'
+
+interface StudyBuddyState {
+  status: StudyBuddyStatus
+  steps: StudyBuddyStep[]
+  answer: string | null
+  error: string | null // 'auth' when sign-in is required
+}
+
+const INITIAL: StudyBuddyState = { status: 'idle', steps: [], answer: null, error: null }
+
+/**
+ * Streams a Study Buddy run (AI-038): `steps` grows as the agent works, `answer` is set on the
+ * terminal `done`. A new `run` aborts any in-flight one; the controller is also aborted on unmount.
+ * 401 surfaces as `error: 'auth'` so the panel can prompt sign-in.
+ */
+export function useStudyBuddy(editionId: string | undefined) {
+  const [state, setState] = useState<StudyBuddyState>(INITIAL)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => () => abortRef.current?.abort(), [])
+
+  const run = useCallback(
+    async (passage: string, chapterNumber: number | null) => {
+      const text = passage.trim()
+      if (!text || !editionId) return
+
+      abortRef.current?.abort()
+      const ctrl = new AbortController()
+      abortRef.current = ctrl
+      setState({ status: 'running', steps: [], answer: null, error: null })
+
+      try {
+        await runStudyBuddy(
+          editionId,
+          text,
+          chapterNumber,
+          {
+            onStep: step =>
+              setState(prev => (prev.status === 'running' ? { ...prev, steps: [...prev.steps, step] } : prev)),
+            onDone: done =>
+              setState(prev => ({ ...prev, status: 'done', answer: done.answer })),
+            onError: message =>
+              setState(prev => ({ ...prev, status: 'error', error: message })),
+          },
+          ctrl.signal,
+        )
+      } catch (err) {
+        if ((err as { name?: string })?.name === 'AbortError') return
+        if (err instanceof SseUnauthorizedError) {
+          setState(prev => ({ ...prev, status: 'error', error: 'auth' }))
+          return
+        }
+        setState(prev => ({ ...prev, status: 'error', error: err instanceof Error ? err.message : 'Study Buddy failed' }))
+      }
+    },
+    [editionId],
+  )
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort()
+    setState(INITIAL)
+  }, [])
+
+  return { ...state, run, reset }
+}

--- a/apps/web/src/lib/sse.test.ts
+++ b/apps/web/src/lib/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { createSseParser, postSse, SseUnsupportedError, type SseEvent } from './sse'
+import { createSseParser, postSse, SseUnsupportedError, SseUnauthorizedError, type SseEvent } from './sse'
 
 function collect() {
   const events: SseEvent[] = []
@@ -98,5 +98,13 @@ describe('postSse', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(res))
 
     await expect(postSse('/explain', {}, () => {})).rejects.toBeInstanceOf(SseUnsupportedError)
+  })
+
+  it('throws SseUnauthorizedError on 401 and sends credentials', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 401 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(postSse('/me/books/x/studybuddy', {}, () => {})).rejects.toBeInstanceOf(SseUnauthorizedError)
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ credentials: 'include' }))
   })
 })

--- a/apps/web/src/lib/sse.ts
+++ b/apps/web/src/lib/sse.ts
@@ -68,6 +68,13 @@ export class SseUnsupportedError extends Error {
   }
 }
 
+/** The SSE request was rejected with 401 — the caller should prompt sign-in. */
+export class SseUnauthorizedError extends Error {
+  constructor() {
+    super('Unauthorized')
+  }
+}
+
 export async function postSse(
   url: string,
   body: unknown,
@@ -78,10 +85,12 @@ export async function postSse(
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream' },
     body: JSON.stringify(body),
+    credentials: 'include', // send the auth cookie (needed for authed SSE; harmless for public ones)
     signal,
   })
 
   if (!res.ok) {
+    if (res.status === 401) throw new SseUnauthorizedError()
     if (res.status === 503) throw new Error('Service unavailable')
     if (res.status === 504) throw new Error('Request timed out')
     if (res.status === 429) throw new Error('Too many requests, try again later')

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -197,6 +197,14 @@
       "signInCta": "Sign in",
       "citation": "ch.{{ch}}"
     },
+    "studyBuddy": {
+      "title": "Help me understand this",
+      "thinking": "Investigating…",
+      "calling": "Looking up",
+      "steps": "Steps",
+      "signIn": "Sign in to get help understanding passages.",
+      "signInCta": "Sign in"
+    },
     "wordPopup": {
       "known": "Known",
       "ignore": "Ignore",

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -2169,6 +2169,49 @@ html[data-theme="dark"] .vocab-translation-overlay__item {
   line-height: 1.55;
   white-space: pre-wrap;
 }
+
+/* Study Buddy panel (AI-038): passage echo, answer at top, collapsible step transcript. */
+.study-buddy__passage {
+  margin: 0 0 12px;
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--reader-text-muted, #6b7280);
+  border-left: 3px solid var(--reader-accent, #2563eb);
+  background: var(--reader-surface-2, rgba(37, 99, 235, 0.06));
+  border-radius: 0 6px 6px 0;
+  white-space: pre-wrap;
+}
+.study-buddy__answer {
+  margin-bottom: 12px;
+}
+.study-buddy__steps {
+  margin-top: 12px;
+  border-top: 1px solid var(--reader-border, rgba(0, 0, 0, 0.08));
+  padding-top: 8px;
+}
+.study-buddy__steps-toggle {
+  background: none;
+  border: none;
+  padding: 4px 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--reader-text-muted, #6b7280);
+  cursor: pointer;
+}
+.study-buddy__step-list {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--reader-text-muted, #6b7280);
+}
+.study-buddy__step {
+  margin-bottom: 2px;
+}
+.study-buddy__step--tool_result {
+  color: var(--reader-accent, #2563eb);
+}
 .ask-panel__citations {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Phase 6 **AI-038, slice a** — the web UI for the agent: an api client, a streaming hook, and the panel. **Wiring it into the reader's selection toolbar is slice b** (touches the complex `ReaderPage`/`ReaderHighlights`, kept separate for a reviewable diff).

## Changes
- **`api/studybuddy.ts`** — `runStudyBuddy(editionId, passage, chapter, callbacks)` consumes the AI-037 SSE (`step` / `done` / `error`) via `postSse`; `getStudyBuddyRun(runId)` fetches a persisted run for the "show steps" view.
- **`useStudyBuddy` hook** — `steps` grow live as the agent works, `answer` lands on `done`, `status` (idle/running/done/error); a new run aborts the in-flight one (and on unmount); 401 surfaces as `error: 'auth'`.
- **`StudyBuddyPanel`** — right slide-in panel (mirrors `AskPanel`): passage echoed at top, final answer, a spinner while running, and a **collapsible step transcript** (each step summarized — tool name + ✓/✗, or the model's text / `Looking up: …`). Auth-gated with a sign-in CTA.
- **`lib/sse.ts`** — `postSse` now sends `credentials: 'include'` (needed for the authed Study Buddy stream; harmless for the public Explain one) and maps 401 → new `SseUnauthorizedError`.

## Verification
- `useStudyBuddy`: step accumulation → answer on done; terminal error keeps the partial steps; 401 → `auth`; no-op on empty passage / missing edition; reset.
- `postSse`: 401 → `SseUnauthorizedError` and `credentials: 'include'` sent.
- Full web suite green (517); `tsc --noEmit` + `pnpm build` clean. The panel renders end-to-end once wired (AI-038b); a live run is exercised on prod / AI-039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)