### PR TITLE
ci: bump checkout/setup-node/setup-dotnet to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -60,13 +60,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -85,7 +85,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Free disk space
         run: |
@@ -120,7 +120,7 @@ jobs:
         run: |
           timeout 120 bash -c 'until curl -s http://localhost:8080/health; do sleep 5; done'
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -136,7 +136,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Free disk space
         run: |
@@ -175,7 +175,7 @@ jobs:
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -44,9 +44,9 @@ jobs:
       run:
         working-directory: apps/mobile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## What the annotations were
The 2 CI warnings ("Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node, actions/setup-dotnet") are GitHub's June 2026 Node 20 deprecation notices — **warnings, not failures** (CI was green). The `@v4` actions still declare `runs.using: node20`; our `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env was already running them on node24, which is exactly the "being forced to run on Node.js 24" phrasing.

## Fix
Bump the three named actions to **v5**, which target node24 natively → the warnings clear.
- `ci.yml` jobs run on `ubuntu-latest` → safe.
- `deploy.yml` is self-hosted but uses **no** `actions/checkout` (it git-pulls on the server) → untouched. (It already runs node24 via the FORCE flag and deploys pass, so the runner is ≥ v2.327.1 regardless.)
- `mobile-release.yml` bumped too for consistency.
- `actions/cache@v4` / `actions/upload-artifact@v4` left as-is — they weren't in the two warnings; the FORCE flag keeps them on node24 until node20 is removed (Sep 16 2026).

Sources: [setup-dotnet@v5](https://github.com/actions/setup-dotnet/tree/v5/) · [setup-node releases](https://github.com/actions/setup-node/releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)