### PR TITLE
fix(ops): backup verify uses pgvector image (restore failing 6 days)

### DIFF
--- a/infra/scripts/backup-verify.sh
+++ b/infra/scripts/backup-verify.sh
@@ -32,7 +32,7 @@ docker run -d --rm \
   -e POSTGRES_PASSWORD="$PG_PASS" \
   -e POSTGRES_DB="$PG_DB" \
   -p "$PORT:5432" \
-  postgres:16 >/dev/null
+  pgvector/pgvector:pg16 >/dev/null  # prod schema uses CREATE EXTENSION vector (pgvector); vanilla postgres:16 fails restore
 
 echo "[verify] waiting for postgres to accept connections ..."
 for i in {1..30}; do


### PR DESCRIPTION
## Backups have been red since 2026-06-12

The daily `backup.yml` workflow does: dump → **verify** (restore the dump into a throwaway Postgres + run sanity queries). The verify container was vanilla `postgres:16`. Since the pgvector work (Phase 4 embeddings, `chapter_chunk` vectors), the schema dump contains `CREATE EXTENSION vector`, which vanilla `postgres:16` can't load:

```
ERROR:  extension "vector" is not available
DETAIL: Could not open extension control file ".../vector.control": No such file or directory.
[verify] FAIL: restore aborted on error
```

→ the verify gate failed **every night for 6 days**, marking the whole backup workflow failed.

## Fix
`infra/scripts/backup-verify.sh` — the throwaway verify container now uses **`pgvector/pgvector:pg16`** (the same image prod runs) instead of `postgres:16`, so the dump (with `CREATE EXTENSION vector`) restores cleanly. One-line image swap.

`bash -n` clean. After merge I'll trigger `backup.yml` via `workflow_dispatch` to confirm it goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)