### PR TITLE
docs+code: sync LLM model names to reality (gpt-4.1-nano + gemma4:e2b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ Upload EPUB/PDF/FB2 → BookFile (stored) → IngestionJob (queued)
 - **Review entity**: `VocabularyReview` — tracks each answer (isCorrect, responseTimeMs, reviewMode)
 - **5 SRS stages**: New(0) → Recognition(1) → Recall(2) → Context(3) → Mastered(4). Logic in `Application/Vocabulary/SrsEngine.cs`
 - **2 review modes**: `multiple_choice` (all stages, Blitz + Context Cloze), `classic` (flashcard with self-assessment). Typing mode removed.
-- **MC distractors + hint + explanation**: Ollama LLM (`gemma4:e4b`) generates 5 distractors + hint + 2-3 sentence explanation (in native language) per word at save time. Stored in `Distractors` (JSON), `Hint` (varchar 500), `Explanation` (varchar 1000). Fallback: random words from user's vocab pool + hardcoded list. Generator: `Vocabulary/TextStack.Vocabulary/DistractorGenerator.cs`
+- **MC distractors + hint + explanation**: Ollama LLM (`gemma4:e2b`) generates 5 distractors + hint + 2-3 sentence explanation (in native language) per word at save time. Stored in `Distractors` (JSON), `Hint` (varchar 500), `Explanation` (varchar 1000). Fallback: random words from user's vocab pool + hardcoded list. Generator: `Vocabulary/TextStack.Vocabulary/DistractorGenerator.cs`
 - **Ollama**: Docker service (`ollama/ollama`), config: `Ollama:BaseUrl`, `Ollama:Model`, `Ollama:TimeoutSeconds` (default 30s). Fire-and-forget generation via `IServiceScopeFactory` after word save
 - **MC fallback cascade**: definition → translation → blank sentence (if LLM distractors exist) → downgrade to context/typed_recall
 - **Frontend**: `VocabularyPage.tsx` (word list, filters, search, stats), `VocabularyReviewPage.tsx` (review session), components in `components/vocabulary/`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ domain.** Tap "attention" in an ML book and you get *увага (механіз�
 нейромережах)* in Ukrainian or *внимание (механизм в нейросетях)* in
 Russian — not the everyday meaning of the word. Explanation mode (no
 translation) is also available for native English readers who want the
-term clarified instead of translated. Powered by OpenAI `gpt-5-mini`,
+term clarified instead of translated. Powered by OpenAI `gpt-4.1-nano`,
 swap-in friendly — any `ILlmService` impl works. 18+ target languages
 supported, with Russian and Ukrainian as the focus during current
 development.
@@ -80,7 +80,7 @@ out; only technical vocabulary gets surfaced.
   keyboard shortcuts
 - **Explain** — select any technical phrase → 2-3 sentence explanation in
   your native language, aware of the book's domain. Uses OpenAI
-  `gpt-5-mini`. Includes a concrete analogy when the term is technical
+  `gpt-4.1-nano`. Includes a concrete analogy when the term is technical
   (see GIF above).
 - Text selection extras — contextual translation in 18+ languages,
   dictionary fallback (Free Dictionary API), highlights
@@ -125,7 +125,7 @@ out; only technical vocabulary gets surfaced.
 | Search | PostgreSQL FTS |
 | Web | React 19, Vite, pnpm |
 | Mobile | React Native (Expo 55) |
-| LLM | OpenAI `gpt-5-mini` (explanations + translation) + Ollama `gemma4:e4b` (distractors, local) |
+| LLM | OpenAI `gpt-4.1-nano` (explanations + translation) + Ollama `gemma4:e4b` (distractors, local) |
 | TTS | Edge TTS (WebSocket, no API key) |
 | SSG | Puppeteer prerender, nginx serves static first |
 | Telemetry | OpenTelemetry → Aspire Dashboard |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ out; only technical vocabulary gets surfaced.
 - Auto-added while reading — sentence context, definition, translation
 - 5 stages (New → Recognition → Recall → Context → Mastered)
 - Capped weekly queue + LLM-generated distractors and hints (Ollama
-  `gemma4:e4b`)
+  `gemma4:e2b`)
 - Review modes: multiple choice, classic flashcard
 
 **Library**
@@ -125,7 +125,7 @@ out; only technical vocabulary gets surfaced.
 | Search | PostgreSQL FTS |
 | Web | React 19, Vite, pnpm |
 | Mobile | React Native (Expo 55) |
-| LLM | OpenAI `gpt-4.1-nano` (explanations + translation) + Ollama `gemma4:e4b` (distractors, local) |
+| LLM | OpenAI `gpt-4.1-nano` (explanations + translation) + Ollama `gemma4:e2b` (distractors, local) |
 | TTS | Edge TTS (WebSocket, no API key) |
 | SSG | Puppeteer prerender, nginx serves static first |
 | Telemetry | OpenTelemetry → Aspire Dashboard |

--- a/backend/src/Ai/TextStack.Ai.Llm/OllamaLlmClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/OllamaLlmClient.cs
@@ -30,7 +30,7 @@ public sealed class OllamaLlmClient : ILlmService
             ?? "http://localhost:11434";
         _model = config["Ollama:Model"]
             ?? Environment.GetEnvironmentVariable("OLLAMA_MODEL")
-            ?? "gemma4:e4b";
+            ?? "gemma4:e2b";
         _timeoutSeconds = int.TryParse(config["Ollama:TimeoutSeconds"], out var t) ? t : 30;
     }
 

--- a/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
@@ -156,7 +156,7 @@ public static class AdminAiQualityEndpoints
 
         var useOllama = string.Equals(judge, "ollama", StringComparison.OrdinalIgnoreCase);
         var judgeKey = useOllama ? "ollama" : "openai-judge";
-        var judgeModelId = useOllama ? config["Ollama:Model"] ?? "gemma4:e4b" : config["Eval:JudgeModel"] ?? "gpt-4.1";
+        var judgeModelId = useOllama ? config["Ollama:Model"] ?? "gemma4:e2b" : config["Eval:JudgeModel"] ?? "gpt-4.1";
 
         ILlmService judgeClient;
         try
@@ -257,7 +257,7 @@ public static class AdminAiQualityEndpoints
         var judgeKey = useOpenAiJudge ? "openai-judge" : "ollama";
         var judgeModelId = useOpenAiJudge
             ? config["Eval:JudgeModel"] ?? "gpt-4.1"
-            : config["Ollama:Model"] ?? "gemma4:e4b";
+            : config["Ollama:Model"] ?? "gemma4:e2b";
         var gitSha = Environment.GetEnvironmentVariable("GIT_SHA");
         var features = body?.Features;
 

--- a/backend/src/Api/Endpoints/AdminRagEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminRagEndpoints.cs
@@ -60,7 +60,7 @@ public static class AdminRagEndpoints
             var useOllama = judgeChoice == "ollama";
             var judgeKey = useOllama ? "ollama" : "openai-judge";
             judgeModelId = useOllama
-                ? config["Ollama:Model"] ?? "gemma4:e4b"
+                ? config["Ollama:Model"] ?? "gemma4:e2b"
                 : config["Eval:JudgeModel"] ?? "gpt-4.1";
             ask = services.GetRequiredService<IRagAskService>();
             judgeClient = services.GetRequiredKeyedService<ILlmService>(judgeKey);

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -153,7 +153,7 @@ builder.Services.AddScoped<SearchReindexService>();
 builder.Services.AddTextStackVocabulary(options =>
 {
     options.OllamaBaseUrl = builder.Configuration["Ollama:BaseUrl"] ?? "http://localhost:11434";
-    options.OllamaModel = builder.Configuration["Ollama:Model"] ?? "gemma4:e4b";
+    options.OllamaModel = builder.Configuration["Ollama:Model"] ?? "gemma4:e2b";
     options.OllamaTimeoutSeconds = builder.Configuration.GetValue("Ollama:TimeoutSeconds", 30);
 });
 

--- a/backend/src/Vocabulary/TextStack.Vocabulary/VocabularyOptions.cs
+++ b/backend/src/Vocabulary/TextStack.Vocabulary/VocabularyOptions.cs
@@ -3,6 +3,6 @@ namespace TextStack.Vocabulary;
 public class VocabularyOptions
 {
     public string OllamaBaseUrl { get; set; } = "http://localhost:11434";
-    public string OllamaModel { get; set; } = "gemma4:e4b";
+    public string OllamaModel { get; set; } = "gemma4:e2b";
     public int OllamaTimeoutSeconds { get; set; } = 30;
 }

--- a/backend/src/Worker/Services/MetadataBackfillWorker.cs
+++ b/backend/src/Worker/Services/MetadataBackfillWorker.cs
@@ -27,7 +27,7 @@ public class MetadataBackfillWorker(
     ILogger<MetadataBackfillWorker> logger) : BackgroundService
 {
     // Defer the run a bit so the rest of the system is up (Ollama may still
-    // be loading the gemma4:e4b model into memory on a fresh deploy).
+    // be loading the gemma4:e2b model into memory on a fresh deploy).
     private static readonly TimeSpan StartDelay = TimeSpan.FromMinutes(2);
     // Tight cap so a misbehaving Ollama can't burn forever on startup.
     private const int MaxPerRun = 50;

--- a/docs/01-architecture/README.md
+++ b/docs/01-architecture/README.md
@@ -28,7 +28,7 @@ Modular monolith: single API + Worker, layered architecture, PostgreSQL.
                     ▼               │
             ┌───────────────┐       │     ┌───────────────┐
             │   Storage     │◄──────┘     │    Ollama     │
-            │ (bind mount)  │             │  gemma4:e4b   │
+            │ (bind mount)  │             │  gemma4:e2b   │
             └───────────────┘             └───────────────┘
                                           ┌───────────────┐
                                           │LibreTranslate │

--- a/docs/02-system/database.md
+++ b/docs/02-system/database.md
@@ -200,7 +200,7 @@ All services: API :8080 | Web :5173 | Admin :81 | DB :5432
 │                                                                             │
 │   SRS: New(0) → Recognition(1) → Recall(2) → Context(3) → Mastered(4)     │
 │   Modes: multiple_choice | typed_recall | context                           │
-│   Distractors: Ollama gemma4:e4b generates 5 plausible wrong answers       │
+│   Distractors: Ollama gemma4:e2b generates 5 plausible wrong answers       │
 └─────────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -767,6 +767,6 @@ AssetKind          { Cover=0, InlineImage=1 }
 21. **Reading goals** - Daily minutes or books/year with streak tracking (min minutes threshold)
 22. **Achievements** - 20 codes across milestone/streak/time/special; AchievementChecker runs after sessions
 23. **Vocabulary SRS** - 5-stage spaced repetition (New→Recognition→Recall→Context→Mastered)
-25. **LLM distractors** - Ollama gemma4:e4b generates MC wrong answers at word save time; stored as JSON
+25. **LLM distractors** - Ollama gemma4:e2b generates MC wrong answers at word save time; stored as JSON
 26. **Fire-and-forget distractors** - IServiceScopeFactory creates scoped DbContext for background generation
 27. **Vocabulary word uniqueness** - unique(user_id, site_id, word, language) prevents duplicates

--- a/docs/04-dev/llm-provider-swap.md
+++ b/docs/04-dev/llm-provider-swap.md
@@ -1,6 +1,6 @@
 # LLM Provider Swap Guide
 
-Default: self-hosted **Ollama** (`gemma4:e4b`) in Docker. This doc shows how to swap it for a managed LLM API (OpenAI, Anthropic, Groq, etc.) if self-hosting is undesirable.
+Default: self-hosted **Ollama** (`gemma4:e2b`) in Docker. This doc shows how to swap it for a managed LLM API (OpenAI, Anthropic, Groq, etc.) if self-hosting is undesirable.
 
 ## What the LLM does
 
@@ -78,7 +78,7 @@ var response = await client.PostAsJsonAsync($"{_options.BaseUrl}/v1/messages", r
 Remove:
 ```
 Ollama__BaseUrl=http://ollama:11434
-Ollama__Model=gemma4:e4b
+Ollama__Model=gemma4:e2b
 ```
 
 Add (example for OpenAI):

--- a/docs/05-features/vocabulary-srs.md
+++ b/docs/05-features/vocabulary-srs.md
@@ -40,7 +40,7 @@ When building MC prompt: definition → translation → blank sentence (if LLM d
 
 MC quiz quality depends on plausible wrong answers. Random words = too easy.
 
-**Solution**: Local Ollama LLM (`gemma4:e4b`) generates 5 semantically similar distractors per word.
+**Solution**: Local Ollama LLM (`gemma4:e2b`) generates 5 semantically similar distractors per word.
 
 ### Flow
 1. User saves word in reader → API saves to DB immediately (fast response)
@@ -64,11 +64,11 @@ ollama:
         memory: 4G
 ```
 
-Config: `Ollama:BaseUrl`, `Ollama:Model` (gemma4:e4b), `Ollama:TimeoutSeconds` (10)
+Config: `Ollama:BaseUrl`, `Ollama:Model` (gemma4:e2b), `Ollama:TimeoutSeconds` (10)
 
 ### Model Pull
 ```bash
-docker compose exec ollama ollama pull gemma4:e4b
+docker compose exec ollama ollama pull gemma4:e2b
 ```
 
 ## API Endpoints

--- a/docs/ux-roadmap/17-ai-auto-tags.md
+++ b/docs/ux-roadmap/17-ai-auto-tags.md
@@ -46,7 +46,7 @@ After ingestion completes, Ollama proposes 3–5 tags for the book based on titl
   
   Tags should be in {userNativeLanguage}.
   ```
-- **Model:** reuse existing `Ollama:Model` config (`gemma4:e4b` per CLAUDE.md). No new model.
+- **Model:** reuse existing `Ollama:Model` config (`gemma4:e2b` per CLAUDE.md). No new model.
 - **Timeout:** 30s (matches existing). On timeout/error, log and skip — never block ingestion.
 - **Validation:** parsed tags must be 1–30 chars, lowercase, alphanumeric+hyphen. Drop invalid silently.
 - **De-duplicate** suggestions against user's existing tags (via `useUserTags()` data).

--- a/tests/TextStack.AiEvals/LlmServiceChatClientTests.cs
+++ b/tests/TextStack.AiEvals/LlmServiceChatClientTests.cs
@@ -28,7 +28,7 @@ public class LlmServiceChatClientTests
     }
 
     private static LlmResponse Canned(string text = "hello") =>
-        new(text, [], new LlmUsage(11, 22, 0m), "gemma4:e4b", Guid.NewGuid());
+        new(text, [], new LlmUsage(11, 22, 0m), "gemma4:e2b", Guid.NewGuid());
 
     [Fact]
     public async Task GetResponseAsync_collapses_system_and_maps_messages()
@@ -61,7 +61,7 @@ public class LlmServiceChatClientTests
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("the answer", resp.Text);
-        Assert.Equal("gemma4:e4b", resp.ModelId);
+        Assert.Equal("gemma4:e2b", resp.ModelId);
         Assert.Equal(11, resp.Usage?.InputTokenCount);
         Assert.Equal(22, resp.Usage?.OutputTokenCount);
     }


### PR DESCRIPTION
The README named `gpt-5-mini` for explanations/translation, but the **actual configured model is `gpt-4.1-nano`** (`appsettings.json` `OpenAI:Model`, `.env.example` `OPENAI_MODEL=gpt-4.1-nano` — which notes gpt-5-mini is reasoning-tier and not needed for the short hot-path tasks). Synced all 3 README mentions to match prod. The dated loadtest report is left as-is (historical artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)