### PR TITLE
feat(ai): table-driven routing + one-click promote/rollback (Phase 12, AI-077 slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Phase 12 — table-driven routing + one-click promote/rollback (AI-077, slice 3) (2026-06-18)
+
+The `models` registry is now a **routing input**, not just an audit log — and an admin can swap which model serves a feature in one click, no redeploy.
+- **Table-driven primary routing**: `ModelGateway.Route` resolves a feature's primary **provider key** from the registry (`status=Primary`) before the config route. New `IModelRouteProvider` (Core; impl `RegistryModelRouteProvider` in Application) serves a cached immutable `feature→provider_key` snapshot (TTL `Ai:Routes:CacheSeconds`, default 30s; built in a fresh scope under a double-checked lock; `Invalidate()` drops it). **The gateway can never fail a live call because of the registry** — null/throwing provider, empty registry, or a row whose ProviderKey has no keyed `ILlmService` all fall back: registry → config `Ai:Routes:{tag}` → `Ai:DefaultProvider` → `openai` (nullable keyed resolve + log, never throw). The snapshot build is duplicate-key resilient (oldest wins) even if the one-Primary invariant were ever violated.
+- **Promote / rollback** (first mutating Phase-12 endpoints): `POST /admin/ai-quality/models/{id}/promote` (Shadow→Primary, demotes the incumbent to Shadow so it keeps shadowing) and `POST /admin/ai-quality/models/{feature}/rollback` (replays the inverse of the latest promotion). Each is transactional with an append-only **`model_promotions`** audit trail (who/when via `GetAdminUserId()`), invalidates the route cache **only after commit**, and is **strictly Shadow→Primary** (Retired rejected → 400). A DB **partial unique index** `(feature_tag) WHERE status='Primary'` enforces exactly one Primary per feature — concurrent promotes surface as **409**, never two primaries.
+- **Candidates**: a shadow run now auto-upserts a promotable `Shadow` `ModelRegistration` for its (feature, provider, model) (guarded on the fire-and-forget path), so enabling a shadow route makes a promote target appear. After a promote, `MaybeShadow` **skips self-shadowing** (resolved shadow key == primary key).
+- **Admin UI**: the Models tab is now actionable — Promote on Shadow rows, Rollback on Primary rows (shown only when a Shadow candidate exists), each behind a confirm dialog (these change prod routing live); server error text (409 race / 400 reasons) surfaced without closing the dialog; refetch reflects the new split immediately.
+
+Shadow remains config-driven (`Ai:Shadow:Routes`) this slice — registry Shadow rows are a candidate/audit list, not a shadow-routing input (registry-driven shadow + cost-cap = later slices). Migration `AddModelPromotionAndPrimaryUniqueIndex`. Architect → backend + frontend (parallel) → adversarial QA (verdict SHIP; 2 P1 fixes: snapshot duplicate-resilience + concurrent-promote 409 coverage). 724 unit tests green; admin tsc + build clean; solution clean.
+
 ### Phase 12 — admin Shadow + Models tabs (AI-076, slice 2) (2026-06-18)
 
 Makes the slice-1 shadow data visible. Two **read-only** tabs on the admin AI-quality page (`/ai-quality`):

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -616,6 +616,14 @@ export interface ModelRegistration {
 export interface ModelsRegistry {
   models: ModelRegistration[]
 }
+export interface ModelPromotionResult {
+  featureTag: string
+  newPrimary: ModelRegistration
+  demotedToShadow: ModelRegistration | null
+  action: 'Promote' | 'Rollback'
+  adminUserId: string | null
+  createdAt: string
+}
 
 async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
@@ -1280,6 +1288,18 @@ export const adminApi = {
 
   getModels: async (): Promise<ModelsRegistry> => {
     return fetchJson<ModelsRegistry>('/admin/ai-quality/models')
+  },
+
+  promoteModel: async (id: string): Promise<ModelPromotionResult> => {
+    return fetchJson<ModelPromotionResult>(`/admin/ai-quality/models/${id}/promote`, {
+      method: 'POST',
+    })
+  },
+
+  rollbackModel: async (feature: string): Promise<ModelPromotionResult> => {
+    return fetchJson<ModelPromotionResult>(`/admin/ai-quality/models/${encodeURIComponent(feature)}/rollback`, {
+      method: 'POST',
+    })
   },
 
   // Podcasts

--- a/apps/admin/src/pages/AiQualityPage.tsx
+++ b/apps/admin/src/pages/AiQualityPage.tsx
@@ -15,6 +15,7 @@ import {
   ShadowPair,
   ShadowSample,
   ModelRegistration,
+  ModelPromotionResult,
 } from '../api/client'
 
 type Tab = 'summary' | 'traces' | 'transcripts' | 'evals' | 'shadow' | 'models'
@@ -1126,12 +1127,21 @@ function modelStatusColor(status: string): string {
   return '#6b7280' // Retired
 }
 
+// A pending confirm action: which row + what kind of mutation.
+type ModelAction =
+  | { kind: 'promote'; row: ModelRegistration }
+  | { kind: 'rollback'; row: ModelRegistration }
+
 function ModelsTab() {
   const [models, setModels] = useState<ModelRegistration[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [confirm, setConfirm] = useState<ModelAction | null>(null)
+  const [dialogError, setDialogError] = useState<string | null>(null)
+  const [pending, setPending] = useState(false)
 
-  useEffect(() => {
+  const load = () =>
     adminApi
       .getModels()
       .then((d) => {
@@ -1139,16 +1149,48 @@ function ModelsTab() {
         setError(null)
       })
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load'))
-      .finally(() => setLoading(false))
+
+  useEffect(() => {
+    load().finally(() => setLoading(false))
   }, [])
+
+  // Features that currently have at least one Shadow row — rollback needs a prior promotion.
+  const featuresWithShadow = new Set(models.filter((m) => m.status === 'Shadow').map((m) => m.featureTag))
+
+  const runAction = async () => {
+    if (!confirm) return
+    setPending(true)
+    setDialogError(null)
+    try {
+      let res: ModelPromotionResult
+      if (confirm.kind === 'promote') {
+        res = await adminApi.promoteModel(confirm.row.id)
+      } else {
+        res = await adminApi.rollbackModel(confirm.row.featureTag)
+      }
+      await load()
+      setConfirm(null)
+      setSuccess(
+        `${res.action === 'Rollback' ? 'Rolled back' : 'Promoted'} ${res.featureTag} → primary ${res.newPrimary.modelId}` +
+          (res.demotedToShadow ? ` (${res.demotedToShadow.modelId} now shadow)` : ''),
+      )
+    } catch (e) {
+      // Surface the server message (409 race / 400 reasons) in the dialog; keep it open.
+      setDialogError(e instanceof Error ? e.message : 'Action failed')
+    } finally {
+      setPending(false)
+    }
+  }
 
   return (
     <>
       <p className="dashboard-page__subtitle" style={{ margin: '0 0 12px' }}>
-        Registered models per feature and their routing status. Read-only.
+        Registered models per feature and their routing status. Promote a shadow to primary or roll a feature back to its
+        previous primary.
       </p>
 
       {error && <Banner text={error} />}
+      {success && <SuccessBanner text={success} onClose={() => setSuccess(null)} />}
 
       {loading ? (
         <p className="dashboard-page__subtitle">Loading…</p>
@@ -1163,6 +1205,7 @@ function ModelsTab() {
               <th style={th}>Model</th>
               <th style={th}>Status</th>
               <th style={th}>Created</th>
+              <th style={th}>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -1173,12 +1216,94 @@ function ModelsTab() {
                 <td style={td}>{m.modelId}</td>
                 <td style={{ ...td, fontWeight: 600, color: modelStatusColor(m.status) }}>{m.status}</td>
                 <td style={td}>{timeAgo(m.createdAt)}</td>
+                <td style={td}>
+                  {m.status === 'Shadow' && (
+                    <button
+                      onClick={() => {
+                        setDialogError(null)
+                        setConfirm({ kind: 'promote', row: m })
+                      }}
+                      disabled={pending}
+                      style={rangeBtn(false)}
+                    >
+                      Promote
+                    </button>
+                  )}
+                  {m.status === 'Primary' && featuresWithShadow.has(m.featureTag) && (
+                    <button
+                      onClick={() => {
+                        setDialogError(null)
+                        setConfirm({ kind: 'rollback', row: m })
+                      }}
+                      disabled={pending}
+                      style={rangeBtn(false)}
+                    >
+                      Rollback
+                    </button>
+                  )}
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       )}
+
+      {confirm && (
+        <ModelConfirmDialog
+          action={confirm}
+          pending={pending}
+          error={dialogError}
+          onConfirm={runAction}
+          onClose={() => {
+            if (!pending) setConfirm(null)
+          }}
+        />
+      )}
     </>
+  )
+}
+
+function ModelConfirmDialog({
+  action,
+  pending,
+  error,
+  onConfirm,
+  onClose,
+}: {
+  action: ModelAction
+  pending: boolean
+  error: string | null
+  onConfirm: () => void
+  onClose: () => void
+}) {
+  const { row } = action
+  const title = action.kind === 'promote' ? 'Promote to primary' : 'Roll back primary'
+  const message =
+    action.kind === 'promote'
+      ? `Promote ${row.modelId} to primary for ${row.featureTag}? The current primary will keep running as shadow.`
+      : `Roll back ${row.featureTag} to its previous primary?`
+  return (
+    <div onClick={onClose} style={overlay}>
+      <div onClick={(e) => e.stopPropagation()} style={{ ...modal, maxWidth: 460 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+          <h2 style={{ margin: 0, fontSize: 18 }}>{title}</h2>
+          <button onClick={onClose} disabled={pending} style={{ ...rangeBtn(false), border: 'none' }}>
+            ✕
+          </button>
+        </div>
+        <p style={{ fontSize: 14, color: '#374151', margin: '0 0 4px' }}>{message}</p>
+        <p style={{ fontSize: 12, color: '#9ca3af', margin: '0 0 8px' }}>This changes production routing immediately.</p>
+        {error && <Banner text={error} />}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>
+          <button onClick={onClose} disabled={pending} style={rangeBtn(false)}>
+            Cancel
+          </button>
+          <button onClick={onConfirm} disabled={pending} style={rangeBtn(true)}>
+            {pending ? 'Working…' : action.kind === 'promote' ? 'Promote' : 'Roll back'}
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -1216,6 +1341,22 @@ function Pager({
 
 function Banner({ text }: { text: string }) {
   return <div style={{ background: '#fef2f2', color: '#b91c1c', padding: 12, borderRadius: 8, margin: '12px 0' }}>{text}</div>
+}
+
+function SuccessBanner({ text, onClose }: { text: string; onClose: () => void }) {
+  return (
+    <div
+      style={{
+        background: '#ecfdf5', color: '#065f46', padding: 12, borderRadius: 8, margin: '12px 0',
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12,
+      }}
+    >
+      <span>{text}</span>
+      <button onClick={onClose} style={{ border: 'none', background: 'none', color: '#065f46', cursor: 'pointer', fontSize: 14 }}>
+        ✕
+      </button>
+    </div>
+  )
 }
 
 function formatBreakdown(json: string | null): string {

--- a/backend/src/Ai/TextStack.Ai.Core/IModelRouteProvider.cs
+++ b/backend/src/Ai/TextStack.Ai.Core/IModelRouteProvider.cs
@@ -1,0 +1,20 @@
+namespace TextStack.Ai.Core;
+
+/// <summary>
+/// Resolves the PRIMARY provider key for a feature tag from the <c>models</c> registry
+/// (the table-driven source of truth, set by admin promote/rollback). The
+/// ModelGateway consults this BEFORE its config fallback, so a promotion takes effect
+/// without a redeploy. Hot path: the implementation MUST cache and MUST NEVER throw —
+/// any failure (no DB, empty registry, race) returns <c>null</c> so the gateway falls
+/// straight through to its config route. Implemented in Application (EF kept out of Llm).
+/// </summary>
+public interface IModelRouteProvider
+{
+    /// <summary>Primary provider key for the feature, or null when none is registered
+    /// or on ANY failure (never throws). Cached for a short TTL.</summary>
+    string? PrimaryProviderKey(string featureTag);
+
+    /// <summary>Drop the cached snapshot so the next read rebuilds from the registry
+    /// (called after a promote/rollback writes a new Primary).</summary>
+    void Invalidate();
+}

--- a/backend/src/Ai/TextStack.Ai.Core/IShadowRunWriter.cs
+++ b/backend/src/Ai/TextStack.Ai.Core/IShadowRunWriter.cs
@@ -32,4 +32,7 @@ public record ShadowRun(
     Guid? ShadowTraceId,
     string PromptHash,
     Guid? UserId,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    // Resolved shadow PROVIDER key (e.g. "openai-explain"), threaded from the gateway so
+    // the writer can upsert a candidate Shadow ModelRegistration (promotable later).
+    string ShadowProviderKey = "");

--- a/backend/src/Ai/TextStack.Ai.Llm/ModelGateway.cs
+++ b/backend/src/Ai/TextStack.Ai.Llm/ModelGateway.cs
@@ -29,6 +29,7 @@ public sealed class ModelGateway(
     IConfiguration config,
     IServiceScopeFactory scopeFactory,
     ShadowOptions shadowOptions,
+    IModelRouteProvider routeProvider,
     ILogger<ModelGateway> logger) : ILlmService
 {
     public async Task<LlmResponse> CompleteAsync(LlmRequest request, CancellationToken ct)
@@ -79,15 +80,58 @@ public sealed class ModelGateway(
 
     private ILlmService Route(string? featureTag)
     {
-        string? key = null;
-        if (!string.IsNullOrWhiteSpace(featureTag))
+        // Precedence: registry Primary (table-driven, set by admin promote/rollback) →
+        // config Ai:Routes:{feature} → Ai:DefaultProvider → "openai". The route provider
+        // is hot-path safe (cached, never throws → null on any failure), so a missing DB
+        // or empty registry transparently falls through to the config route below.
+        var registryKey = RegistryKey(featureTag);
+        var configKey = !string.IsNullOrWhiteSpace(featureTag)
+            ? config[$"Ai:Routes:{featureTag}"]
+            : null;
+        var key = registryKey ?? configKey ?? config["Ai:DefaultProvider"] ?? "openai";
+
+        // A registry row may name a provider key with no keyed registration (e.g. a key
+        // renamed in config but still recorded in `models`). That must NEVER throw — fall
+        // back to the config route + log, mirroring an unknown-key first-deploy guard.
+        var svc = serviceProvider.GetKeyedService<ILlmService>(key);
+        if (svc is null)
         {
-            key = config[$"Ai:Routes:{featureTag}"];
-            if (key is null)
-                logger.LogDebug("No Ai:Routes entry for feature '{Feature}'; using default provider", featureTag);
+            logger.LogWarning(
+                "Unknown provider key '{Key}' for feature '{Feature}'; falling back to config route", key, featureTag);
+            key = configKey ?? config["Ai:DefaultProvider"] ?? "openai";
+            svc = serviceProvider.GetRequiredKeyedService<ILlmService>(key);
         }
-        key ??= config["Ai:DefaultProvider"] ?? "openai";
-        return serviceProvider.GetRequiredKeyedService<ILlmService>(key);
+        return svc;
+    }
+
+    /// <summary>Resolved PRIMARY provider key for a feature (registry → config → default),
+    /// mirroring <see cref="Route"/>'s precedence WITHOUT touching DI. Used to skip a
+    /// shadow that now points at the same provider as the primary.</summary>
+    private string ResolvedPrimaryKey(string? featureTag)
+    {
+        var registryKey = RegistryKey(featureTag);
+        var configKey = !string.IsNullOrWhiteSpace(featureTag)
+            ? config[$"Ai:Routes:{featureTag}"]
+            : null;
+        return registryKey ?? configKey ?? config["Ai:DefaultProvider"] ?? "openai";
+    }
+
+    /// <summary>Registry Primary key for a feature, defensively. The provider contract is
+    /// never-throws, but we ALSO guard here so a misbehaving provider can never break a real
+    /// LLM call — it just falls through to the config route.</summary>
+    private string? RegistryKey(string? featureTag)
+    {
+        if (string.IsNullOrWhiteSpace(featureTag))
+            return null;
+        try
+        {
+            return routeProvider.PrimaryProviderKey(featureTag);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Registry route lookup threw for feature '{Feature}'; using config route", featureTag);
+            return null;
+        }
     }
 
     /// <summary>
@@ -101,6 +145,18 @@ public sealed class ModelGateway(
         var shadowKey = shadowOptions.ShadowKeyFor(request.FeatureTag);
         if (shadowKey is null)
             return;
+
+        // Post-promotion guard: if the shadow route now points at the SAME provider the
+        // primary already resolves to (e.g. the shadow candidate got promoted), shadowing
+        // would compare a model to itself + burn paid calls for nothing. Skip it.
+        if (string.Equals(shadowKey, ResolvedPrimaryKey(request.FeatureTag), StringComparison.Ordinal))
+        {
+            logger.LogDebug(
+                "Shadow key '{Key}' equals the primary for feature '{Feature}'; skipping self-shadow",
+                shadowKey, request.FeatureTag);
+            return;
+        }
+
         if (!ShouldSample(shadowOptions.RateFor(request.FeatureTag)))
             return;
 
@@ -125,7 +181,7 @@ public sealed class ModelGateway(
                 // the gateway threads one (mirrors how LlmTrace.UserId is currently null).
                 var run = BuildShadowRun(
                     feature, primary, primaryLatencyMs, shadowResponse, sw.ElapsedMilliseconds,
-                    ComputePromptHash(request), userId: null);
+                    ComputePromptHash(request), userId: null, shadowProviderKey: shadowKey);
 
                 var writer = scope.ServiceProvider.GetRequiredService<IShadowRunWriter>();
                 await writer.WriteAsync(run, CancellationToken.None);
@@ -155,7 +211,8 @@ public sealed class ModelGateway(
     /// </summary>
     public static Core.ShadowRun BuildShadowRun(
         string featureTag, LlmResponse primary, long primaryMs,
-        LlmResponse shadow, long shadowMs, string promptHash, Guid? userId) =>
+        LlmResponse shadow, long shadowMs, string promptHash, Guid? userId,
+        string shadowProviderKey = "") =>
         new(
             Id: Guid.NewGuid(),
             FeatureTag: featureTag,
@@ -175,7 +232,8 @@ public sealed class ModelGateway(
             ShadowTraceId: shadow.TraceId,
             PromptHash: promptHash,
             UserId: userId,
-            CreatedAt: DateTimeOffset.UtcNow);
+            CreatedAt: DateTimeOffset.UtcNow,
+            ShadowProviderKey: shadowProviderKey);
 
     /// <summary>Same prompt-hash scheme as the TracingDecorator (system prompt + messages JSON).</summary>
     public static string ComputePromptHash(LlmRequest request)

--- a/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminAiQualityEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.Middleware;
 using Application.Common.Interfaces;
 using Contracts.Admin;
 using Infrastructure.Persistence;
@@ -37,6 +38,8 @@ public static class AdminAiQualityEndpoints
         group.MapGet("/shadow/summary", GetShadowSummary);
         group.MapGet("/shadow/samples", GetShadowSamples);
         group.MapGet("/models", GetModels);
+        group.MapPost("/models/{id:guid}/promote", PromoteModel);
+        group.MapPost("/models/{feature}/rollback", RollbackModel);
     }
 
     // Phase 7 DoD gate (AI-046): A/B the single-call baseline vs the full FieldCrew on the same brief+source over
@@ -660,6 +663,47 @@ public static class AdminAiQualityEndpoints
 
         return Results.Ok(new ModelsRegistryDto(models));
     }
+
+    // Phase 12 (RLOps): make a Shadow registration the new Primary for its feature, demoting
+    // the current Primary to Shadow + writing an audit row, in one transaction. Service throws
+    // DomainException (→400 for not-found/Retired/already-Primary) or ConflictException (→409 for
+    // a concurrent promote), both mapped by the ExceptionMiddleware. AdminUserId is audited.
+    private static async Task<IResult> PromoteModel(
+        Guid id,
+        HttpContext httpContext,
+        Application.Ai.ModelPromotionService service,
+        CancellationToken ct)
+    {
+        var adminId = httpContext.GetAdminUserId();
+        var result = await service.PromoteAsync(id, adminId, ct);
+        return Results.Ok(ToDto(result));
+    }
+
+    // Phase 12 (RLOps): revert the most recent promotion for a feature (the demoted model becomes
+    // Primary again). 409 (ConflictException) if there's no prior promotion to roll back.
+    private static async Task<IResult> RollbackModel(
+        string feature,
+        HttpContext httpContext,
+        Application.Ai.ModelPromotionService service,
+        CancellationToken ct)
+    {
+        var adminId = httpContext.GetAdminUserId();
+        var result = await service.RollbackAsync(feature, adminId, ct);
+        return Results.Ok(ToDto(result));
+    }
+
+    private static ModelPromotionResultDto ToDto(Application.Ai.ModelPromotionResult r) =>
+        new(
+            r.FeatureTag,
+            new ModelRegistrationDto(
+                r.NewPrimary.Id, r.NewPrimary.FeatureTag, r.NewPrimary.ProviderKey,
+                r.NewPrimary.ModelId, r.NewPrimary.Status.ToString(), r.NewPrimary.CreatedAt),
+            r.DemotedToShadow is null ? null : new ModelRegistrationDto(
+                r.DemotedToShadow.Id, r.DemotedToShadow.FeatureTag, r.DemotedToShadow.ProviderKey,
+                r.DemotedToShadow.ModelId, r.DemotedToShadow.Status.ToString(), r.DemotedToShadow.CreatedAt),
+            r.Action.ToString(),
+            r.AdminUserId,
+            r.CreatedAt);
 
     /// <summary>Raw-SQL row for the shadow-pair aggregate (public + mutable for EF SqlQuery
     /// materialization, like FeatureRow). Avg columns are nullable — an all-null group yields NULL.</summary>

--- a/backend/src/Application/Ai/DbShadowRunWriter.cs
+++ b/backend/src/Application/Ai/DbShadowRunWriter.cs
@@ -1,5 +1,8 @@
 using Application.Common.Interfaces;
 using Domain.Entities;
+using Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Ai;
 
@@ -10,7 +13,9 @@ namespace Application.Ai;
 /// namespace clash (Application.* vs TextStack.*) and the type-name clash with the EF
 /// entity <see cref="ShadowRun"/>.
 /// </summary>
-public sealed class DbShadowRunWriter(IAppDbContext db) : global::TextStack.Ai.Core.IShadowRunWriter
+public sealed class DbShadowRunWriter(
+    IAppDbContext db,
+    ILogger<DbShadowRunWriter> logger) : global::TextStack.Ai.Core.IShadowRunWriter
 {
     public async Task WriteAsync(global::TextStack.Ai.Core.ShadowRun run, CancellationToken ct)
     {
@@ -37,5 +42,41 @@ public sealed class DbShadowRunWriter(IAppDbContext db) : global::TextStack.Ai.C
             CreatedAt = run.CreatedAt,
         });
         await db.SaveChangesAsync(ct);
+
+        // Candidate registration: ensure a Shadow ModelRegistration exists for this
+        // (feature, shadow provider, shadow model) so an admin has a row to promote. Keyed
+        // on the existing (feature_tag, provider_key, model_id) unique index. Best-effort —
+        // this runs on the gateway's fire-and-forget shadow path, so a failure here must
+        // NOT bubble out of the writer (the shadow_run itself is already persisted).
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(run.ShadowProviderKey)
+                && !string.IsNullOrWhiteSpace(run.ShadowModelId))
+            {
+                var exists = await db.Models.AnyAsync(
+                    m => m.FeatureTag == run.FeatureTag
+                        && m.ProviderKey == run.ShadowProviderKey
+                        && m.ModelId == run.ShadowModelId,
+                    ct);
+                if (!exists)
+                {
+                    db.Models.Add(new ModelRegistration
+                    {
+                        Id = Guid.NewGuid(),
+                        FeatureTag = run.FeatureTag,
+                        ProviderKey = run.ShadowProviderKey,
+                        ModelId = run.ShadowModelId,
+                        Status = ModelStatus.Shadow,
+                        CreatedAt = DateTimeOffset.UtcNow,
+                    });
+                    await db.SaveChangesAsync(ct);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // A concurrent shadow write may lose the unique-index race; swallow + log.
+            logger.LogDebug(ex, "Shadow candidate upsert skipped for feature '{Feature}'", run.FeatureTag);
+        }
     }
 }

--- a/backend/src/Application/Ai/ModelPromotionService.cs
+++ b/backend/src/Application/Ai/ModelPromotionService.cs
@@ -1,0 +1,149 @@
+using Application.Common.Interfaces;
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Exceptions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Ai;
+
+/// <summary>
+/// One-click promote / rollback of the PRIMARY model for a feature (Phase 12 RLOps).
+/// Mutates the <c>models</c> registry — the source of truth the gateway routes by via
+/// <see cref="global::TextStack.Ai.Core.IModelRouteProvider"/> — and writes an
+/// append-only <see cref="ModelPromotion"/> audit row, all in one transaction. After a
+/// successful commit it <see cref="global::TextStack.Ai.Core.IModelRouteProvider.Invalidate">invalidates</see>
+/// the route cache so traffic flips on the next call.
+///
+/// Invariants: exactly one Primary per feature (a partial unique index enforces it; a
+/// concurrent promote surfaces as a <see cref="ConflictException"/>); transitions are
+/// strictly Shadow→Primary (a Retired model is never promotable); rollback replays the
+/// inverse of the latest promotion for the feature, at any age.
+/// </summary>
+public sealed class ModelPromotionService(
+    IAppDbContext db,
+    global::TextStack.Ai.Core.IModelRouteProvider routeProvider)
+{
+    /// <summary>Make the given Shadow registration the Primary for its feature, demoting
+    /// the current Primary (if any) to Shadow. Rejects not-found / Retired / already-Primary
+    /// (<see cref="DomainException"/> → 400) and a concurrent promote (<see cref="ConflictException"/> → 409).</summary>
+    public async Task<ModelPromotionResult> PromoteAsync(Guid modelRegistrationId, Guid? adminUserId, CancellationToken ct)
+    {
+        await using var tx = await db.BeginTransactionAsync(ct);
+
+        var target = await db.Models.FirstOrDefaultAsync(m => m.Id == modelRegistrationId, ct)
+            ?? throw new DomainException("MODEL_NOT_FOUND", $"Model registration '{modelRegistrationId}' not found");
+
+        if (target.Status == ModelStatus.Retired)
+            throw new DomainException("MODEL_RETIRED", "A retired model cannot be promoted");
+        if (target.Status == ModelStatus.Primary)
+            throw new DomainException("ALREADY_PRIMARY", $"Model is already the primary for feature '{target.FeatureTag}'");
+
+        // Current Primary of the SAME feature (the outgoing one). May be none.
+        var outgoing = await db.Models.FirstOrDefaultAsync(
+            m => m.FeatureTag == target.FeatureTag && m.Status == ModelStatus.Primary, ct);
+
+        if (outgoing is not null)
+            outgoing.Status = ModelStatus.Shadow;
+        target.Status = ModelStatus.Primary;
+
+        db.ModelPromotions.Add(new ModelPromotion
+        {
+            Id = Guid.NewGuid(),
+            FeatureTag = target.FeatureTag,
+            FromModelRegistrationId = outgoing?.Id,
+            FromProviderKey = outgoing?.ProviderKey,
+            FromModelId = outgoing?.ModelId,
+            ToModelRegistrationId = target.Id,
+            ToProviderKey = target.ProviderKey,
+            ToModelId = target.ModelId,
+            Action = PromotionAction.Promote,
+            AdminUserId = adminUserId,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+
+        await SaveAndCommitAsync(tx, ct);
+        routeProvider.Invalidate();
+
+        return new ModelPromotionResult(target.FeatureTag, target, outgoing, PromotionAction.Promote, adminUserId);
+    }
+
+    /// <summary>Revert the most recent promotion for a feature: make the previously
+    /// demoted Shadow (the latest row's <c>From</c>) Primary again and demote the current
+    /// Primary to Shadow. Rejects when there's no prior promotion or it had no outgoing
+    /// model to restore (<see cref="ConflictException"/> → 409). Never rejects by age.</summary>
+    public async Task<ModelPromotionResult> RollbackAsync(string featureTag, Guid? adminUserId, CancellationToken ct)
+    {
+        await using var tx = await db.BeginTransactionAsync(ct);
+
+        var latest = await db.ModelPromotions
+            .Where(p => p.FeatureTag == featureTag)
+            .OrderByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (latest is null)
+            throw new ConflictException($"No prior promotion to roll back for feature '{featureTag}'");
+        if (latest.FromModelRegistrationId is null)
+            throw new ConflictException($"The latest promotion for feature '{featureTag}' had no prior primary to restore");
+
+        // The model to restore (the one demoted by `latest`).
+        var restore = await db.Models.FirstOrDefaultAsync(m => m.Id == latest.FromModelRegistrationId.Value, ct)
+            ?? throw new ConflictException("The model to roll back to no longer exists");
+        if (restore.Status == ModelStatus.Retired)
+            throw new ConflictException("The model to roll back to is retired");
+
+        var current = await db.Models.FirstOrDefaultAsync(
+            m => m.FeatureTag == featureTag && m.Status == ModelStatus.Primary, ct);
+
+        if (current is not null)
+            current.Status = ModelStatus.Shadow;
+        restore.Status = ModelStatus.Primary;
+
+        db.ModelPromotions.Add(new ModelPromotion
+        {
+            Id = Guid.NewGuid(),
+            FeatureTag = featureTag,
+            FromModelRegistrationId = current?.Id,
+            FromProviderKey = current?.ProviderKey,
+            FromModelId = current?.ModelId,
+            ToModelRegistrationId = restore.Id,
+            ToProviderKey = restore.ProviderKey,
+            ToModelId = restore.ModelId,
+            Action = PromotionAction.Rollback,
+            AdminUserId = adminUserId,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+
+        await SaveAndCommitAsync(tx, ct);
+        routeProvider.Invalidate();
+
+        return new ModelPromotionResult(featureTag, restore, current, PromotionAction.Rollback, adminUserId);
+    }
+
+    // SaveChanges can violate the partial unique index (feature_tag) WHERE status='Primary'
+    // under a concurrent promote → surface as a conflict for the endpoint to map to 409.
+    private async Task SaveAndCommitAsync(
+        Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction tx, CancellationToken ct)
+    {
+        try
+        {
+            await db.SaveChangesAsync(ct);
+            await tx.CommitAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            throw new ConflictException("Concurrent primary change detected; please retry");
+        }
+    }
+}
+
+/// <summary>Outcome of a promote/rollback: the new Primary, the model demoted to Shadow
+/// (null if there was none), and the audited action + admin.</summary>
+public sealed record ModelPromotionResult(
+    string FeatureTag,
+    ModelRegistration NewPrimary,
+    ModelRegistration? DemotedToShadow,
+    PromotionAction Action,
+    Guid? AdminUserId)
+{
+    public DateTimeOffset CreatedAt { get; } = DateTimeOffset.UtcNow;
+}

--- a/backend/src/Application/Ai/RegistryModelRouteProvider.cs
+++ b/backend/src/Application/Ai/RegistryModelRouteProvider.cs
@@ -1,0 +1,94 @@
+using Application.Common.Interfaces;
+using Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Ai;
+
+/// <summary>
+/// Table-driven primary routing (Phase 12 RLOps): resolves the PRIMARY provider key for
+/// a feature from the <c>models</c> registry, the source of truth that admin
+/// promote/rollback mutates. Holds ONE immutable snapshot (feature_tag → provider_key)
+/// in <see cref="IMemoryCache"/> under a short absolute TTL (<c>Ai:Routes:CacheSeconds</c>,
+/// default 30s); a promote/rollback calls <see cref="Invalidate"/> for an instant flip.
+///
+/// Singleton. Hot path: <see cref="PrimaryProviderKey"/> NEVER throws — any failure
+/// (no DB, empty table, transient error) logs Debug + returns null so the gateway falls
+/// through to its config route. The snapshot is built inside a fresh DI scope (the
+/// singleton can't hold a scoped DbContext), guarded by a lock so a cache miss under load
+/// does at most a brief double-build rather than a thundering herd of DB queries.
+/// </summary>
+public sealed class RegistryModelRouteProvider(
+    IServiceScopeFactory scopeFactory,
+    IMemoryCache cache,
+    IConfiguration config,
+    ILogger<RegistryModelRouteProvider> logger) : global::TextStack.Ai.Core.IModelRouteProvider
+{
+    private const string CacheKey = "ai:routes:primary";
+    private readonly Lock _gate = new();
+
+    public string? PrimaryProviderKey(string featureTag)
+    {
+        if (string.IsNullOrWhiteSpace(featureTag))
+            return null;
+
+        try
+        {
+            var snapshot = GetOrBuildSnapshot();
+            return snapshot.TryGetValue(featureTag, out var key) ? key : null;
+        }
+        catch (Exception ex)
+        {
+            // Hot path: never throw. The gateway falls through to its config route.
+            logger.LogDebug(ex, "Primary route lookup failed for feature '{Feature}'; falling through", featureTag);
+            return null;
+        }
+    }
+
+    public void Invalidate() => cache.Remove(CacheKey);
+
+    private IReadOnlyDictionary<string, string> GetOrBuildSnapshot()
+    {
+        if (cache.TryGetValue(CacheKey, out IReadOnlyDictionary<string, string>? cached) && cached is not null)
+            return cached;
+
+        // Serialize the (re)build so concurrent misses don't all hit the DB. Double-check
+        // inside the lock in case another thread just populated it.
+        lock (_gate)
+        {
+            if (cache.TryGetValue(CacheKey, out cached) && cached is not null)
+                return cached;
+
+            var snapshot = BuildSnapshot();
+            var ttl = TimeSpan.FromSeconds(config.GetValue("Ai:Routes:CacheSeconds", 30));
+            cache.Set(CacheKey, snapshot, new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = ttl });
+            return snapshot;
+        }
+    }
+
+    private IReadOnlyDictionary<string, string> BuildSnapshot()
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<IAppDbContext>();
+
+        // One Primary per feature SHOULD be enforced by a partial unique index. But this is
+        // the LLM hot path: if that index ever fails to enforce (mis-filtered migration, a
+        // manual DB edit, a not-yet-applied migration), two Primary rows for one feature must
+        // NOT crash every call via a duplicate-key ToDictionary. Group defensively and take
+        // the first deterministically (oldest by CreatedAt) so routing stays deterministic.
+        var primaries = db.Models
+            .AsNoTracking()
+            .Where(m => m.Status == ModelStatus.Primary)
+            .OrderBy(m => m.CreatedAt)
+            .Select(m => new { m.FeatureTag, m.ProviderKey })
+            .ToList();
+
+        var snapshot = new Dictionary<string, string>(primaries.Count);
+        foreach (var p in primaries)
+            snapshot.TryAdd(p.FeatureTag, p.ProviderKey); // first (oldest) wins; dupes ignored
+        return snapshot;
+    }
+}

--- a/backend/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/backend/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -61,6 +61,7 @@ public interface IAppDbContext
     DbSet<LlmTrace> LlmTraces { get; }
     DbSet<ShadowRun> ShadowRuns { get; }
     DbSet<ModelRegistration> Models { get; }
+    DbSet<ModelPromotion> ModelPromotions { get; }
     DbSet<EvalRun> EvalRuns { get; }
     DbSet<AgentRun> AgentRuns { get; }
     DbSet<PodcastGenerationJob> PodcastGenerationJobs { get; }

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -117,14 +117,23 @@ public static class DependencyInjection
                     sp.GetRequiredService<ILogger<global::TextStack.Ai.Llm.TracingDecorator>>()));
         }
 
+        // Table-driven primary routing (Phase 12 RLOps): the gateway consults this BEFORE
+        // its config route, so an admin promote/rollback flips traffic without a redeploy.
+        // Singleton (caches one snapshot of the `models` registry); hot-path safe + never throws.
+        services.AddSingleton<global::TextStack.Ai.Core.IModelRouteProvider, Ai.RegistryModelRouteProvider>();
+
+        // One-click promote / rollback of the primary model for a feature.
+        services.AddScoped<Ai.ModelPromotionService>();
+
         // Default Core.ILlmService = the gateway (routes FeatureTag → decorated provider;
-        // optional fire-and-forget shadow routing per Ai:Shadow).
+        // registry-first primary routing + optional fire-and-forget shadow routing per Ai:Shadow).
         services.AddSingleton<global::TextStack.Ai.Core.ILlmService>(sp =>
             new global::TextStack.Ai.Llm.ModelGateway(
                 sp,
                 sp.GetRequiredService<IConfiguration>(),
                 sp.GetRequiredService<IServiceScopeFactory>(),
                 sp.GetRequiredService<global::TextStack.Ai.Llm.ShadowOptions>(),
+                sp.GetRequiredService<global::TextStack.Ai.Core.IModelRouteProvider>(),
                 sp.GetRequiredService<ILogger<global::TextStack.Ai.Llm.ModelGateway>>()));
 
         // Embeddings (Phase 4 RAG). Single OpenAI provider; resolved lazily so a keyless

--- a/backend/src/Contracts/Admin/AiQualityDtos.cs
+++ b/backend/src/Contracts/Admin/AiQualityDtos.cs
@@ -179,3 +179,13 @@ public record ModelRegistrationDto(
 
 /// <summary>The models registry payload (whole table; tiny).</summary>
 public record ModelsRegistryDto(IReadOnlyList<ModelRegistrationDto> Models);
+
+/// <summary>Result of a promote/rollback: the new Primary, the model demoted to Shadow
+/// (null if there was none), the audited action ("Promote"/"Rollback") + admin + time.</summary>
+public record ModelPromotionResultDto(
+    string FeatureTag,
+    ModelRegistrationDto NewPrimary,
+    ModelRegistrationDto? DemotedToShadow,
+    string Action,
+    Guid? AdminUserId,
+    DateTimeOffset CreatedAt);

--- a/backend/src/Domain/Entities/ModelPromotion.cs
+++ b/backend/src/Domain/Entities/ModelPromotion.cs
@@ -1,0 +1,38 @@
+using Domain.Enums;
+
+namespace Domain.Entities;
+
+/// <summary>
+/// Append-only audit of a primary-routing change for one feature (table
+/// <c>model_promotions</c>, Phase 12 RLOps). Each row records the swap an admin made:
+/// the outgoing Primary (<c>From*</c>, null on the very first promotion for a feature)
+/// and the incoming one (<c>To*</c>), with provider/model denormalized so the history
+/// reads even after the <c>models</c> rows change. Rollback reads the latest row for a
+/// feature and re-applies the inverse swap, writing a new row with
+/// <see cref="PromotionAction.Rollback"/>. Never updated or deleted — it's the audit
+/// trail the rollback path replays. Plain POCO; EF mapping lives in AppDbContext.Ai.cs.
+/// </summary>
+public class ModelPromotion
+{
+    public Guid Id { get; set; }
+    public required string FeatureTag { get; set; }
+
+    /// <summary>The outgoing Primary that was demoted to Shadow; null on the first
+    /// promotion for a feature (no prior Primary registration).</summary>
+    public Guid? FromModelRegistrationId { get; set; }
+
+    /// <summary>The incoming model that became Primary.</summary>
+    public required Guid ToModelRegistrationId { get; set; }
+
+    public string? FromProviderKey { get; set; }
+    public string? FromModelId { get; set; }
+    public required string ToProviderKey { get; set; }
+    public required string ToModelId { get; set; }
+
+    public PromotionAction Action { get; set; }
+
+    /// <summary>The admin who triggered the change (null when unattributed).</summary>
+    public Guid? AdminUserId { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/backend/src/Domain/Enums/PromotionAction.cs
+++ b/backend/src/Domain/Enums/PromotionAction.cs
@@ -1,0 +1,13 @@
+namespace Domain.Enums;
+
+/// <summary>
+/// Why a <see cref="Domain.Entities.ModelPromotion"/> row was written. <c>Promote</c> =
+/// an admin made a Shadow model the new Primary; <c>Rollback</c> = reverting the most
+/// recent promotion for a feature (the demoted Shadow becomes Primary again). Stored as
+/// a string column (HasConversion&lt;string&gt;) so the values read in SQL.
+/// </summary>
+public enum PromotionAction
+{
+    Promote = 0,
+    Rollback = 1
+}

--- a/backend/src/Infrastructure/Migrations/20260618145458_AddModelPromotionAndPrimaryUniqueIndex.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260618145458_AddModelPromotionAndPrimaryUniqueIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618145458_AddModelPromotionAndPrimaryUniqueIndex")]
+    partial class AddModelPromotionAndPrimaryUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260618145458_AddModelPromotionAndPrimaryUniqueIndex.cs
+++ b/backend/src/Infrastructure/Migrations/20260618145458_AddModelPromotionAndPrimaryUniqueIndex.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddModelPromotionAndPrimaryUniqueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "model_promotions",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    feature_tag = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    from_model_registration_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    to_model_registration_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    from_provider_key = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    from_model_id = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    to_provider_key = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    to_model_id = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    action = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    admin_user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_model_promotions", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_models_feature_tag",
+                table: "models",
+                column: "feature_tag",
+                unique: true,
+                filter: "status = 'Primary'");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_model_promotions_feature_tag_created_at",
+                table: "model_promotions",
+                columns: new[] { "feature_tag", "created_at" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "model_promotions");
+
+            migrationBuilder.DropIndex(
+                name: "ix_models_feature_tag",
+                table: "models");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Ai.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Ai.cs
@@ -70,6 +70,28 @@ public partial class AppDbContext
             e.Property(x => x.ModelId).HasMaxLength(128);
             e.Property(x => x.FeatureTag).HasMaxLength(64);
             e.Property(x => x.Status).HasConversion<string>().HasMaxLength(20);
+
+            // Table-driven routing invariant (Phase 12 RLOps): AT MOST ONE Primary per
+            // feature. A partial unique index enforces it at the DB level, so a concurrent
+            // promote violates it (caught in ModelPromotionService → 409) rather than
+            // racing two Primaries. Filter uses the STORED enum string ('Primary') on the
+            // snake_case column.
+            e.HasIndex(x => x.FeatureTag)
+                .IsUnique()
+                .HasFilter("status = 'Primary'");
+        });
+
+        modelBuilder.Entity<ModelPromotion>(e =>
+        {
+            // Hot query: latest promotion for a feature (rollback) — feature + time.
+            e.HasIndex(x => new { x.FeatureTag, x.CreatedAt });
+
+            e.Property(x => x.FeatureTag).HasMaxLength(64);
+            e.Property(x => x.FromProviderKey).HasMaxLength(64);
+            e.Property(x => x.FromModelId).HasMaxLength(128);
+            e.Property(x => x.ToProviderKey).HasMaxLength(64);
+            e.Property(x => x.ToModelId).HasMaxLength(128);
+            e.Property(x => x.Action).HasConversion<string>().HasMaxLength(20);
         });
 
         modelBuilder.Entity<EvalRun>(e =>

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -82,6 +82,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
     public DbSet<LlmTrace> LlmTraces => Set<LlmTrace>();
     public DbSet<ShadowRun> ShadowRuns => Set<ShadowRun>();
     public DbSet<ModelRegistration> Models => Set<ModelRegistration>();
+    public DbSet<ModelPromotion> ModelPromotions => Set<ModelPromotion>();
     public DbSet<EvalRun> EvalRuns => Set<EvalRun>();
     public DbSet<AgentRun> AgentRuns => Set<AgentRun>();
     public DbSet<PodcastGenerationJob> PodcastGenerationJobs => Set<PodcastGenerationJob>();

--- a/tests/TextStack.AiEvals/CapturingDb.cs
+++ b/tests/TextStack.AiEvals/CapturingDb.cs
@@ -98,5 +98,6 @@ internal sealed class CapturingDb : IAppDbContext
     public DbSet<AgentRun> AgentRuns => throw new NotSupportedException();
     public DbSet<ShadowRun> ShadowRuns => throw new NotSupportedException();
     public DbSet<ModelRegistration> Models => throw new NotSupportedException();
+    public DbSet<ModelPromotion> ModelPromotions => throw new NotSupportedException();
     public DbSet<PodcastGenerationJob> PodcastGenerationJobs => throw new NotSupportedException();
 }

--- a/tests/TextStack.IntegrationTests/AdminModelPromotionEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/AdminModelPromotionEndpointTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using System.Text.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the table-driven promote/rollback endpoints (Phase 12 RLOps slice 3),
+/// against the live API on the admin host. Mirrors AdminShadowEndpointTests: auth + validation
+/// paths assert without depending on seeded mutable state, and a full promote→reflected-in-/models
+/// →rollback round-trip runs when the fixture user is admin. Skips (not fails) when auth/endpoint
+/// is unavailable. To run: `docker compose up` (API on :8080) with ENABLE_TEST_AUTH=true; runs in CI.
+/// </summary>
+public class AdminModelPromotionEndpointTests : IClassFixture<AuthenticatedApiFixture>
+{
+    private readonly AuthenticatedApiFixture _fixture;
+
+    public AdminModelPromotionEndpointTests(AuthenticatedApiFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Promote_NoAuth_Unauthorized()
+    {
+        var request = new HttpRequestMessage(
+            HttpMethod.Post, $"/admin/ai-quality/models/{Guid.NewGuid()}/promote");
+        request.Headers.Host = AuthenticatedApiFixture.AdminHost;
+
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(response.StatusCode is HttpStatusCode.NotFound, "endpoint not deployed");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Rollback_NoAuth_Unauthorized()
+    {
+        var request = new HttpRequestMessage(
+            HttpMethod.Post, "/admin/ai-quality/models/explain/rollback");
+        request.Headers.Host = AuthenticatedApiFixture.AdminHost;
+
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(response.StatusCode is HttpStatusCode.NotFound, "endpoint not deployed");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Promote_NonexistentModel_BadRequest()
+    {
+        Assert.SkipUnless(_fixture.IsAuthenticated, "auth unavailable");
+
+        var request = _fixture.CreateAdminRequest(
+            HttpMethod.Post, $"/admin/ai-quality/models/{Guid.NewGuid()}/promote");
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint not deployed");
+        Assert.SkipWhen(
+            response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden,
+            "test user is not admin");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Promote_AlreadyPrimaryRow_BadRequest()
+    {
+        Assert.SkipUnless(_fixture.IsAuthenticated, "auth unavailable");
+
+        // Find a currently-Primary registration from the seeded registry; promoting it again
+        // must be rejected (already-Primary → 400). Read-only; leaves the registry untouched.
+        var models = await GetModels();
+        Assert.SkipWhen(models is null, "endpoint not deployed / not admin");
+        var primary = models!.Value.EnumerateArray()
+            .FirstOrDefault(m => m.GetProperty("status").GetString() == "Primary");
+        Assert.SkipWhen(primary.ValueKind == JsonValueKind.Undefined, "no seeded Primary row");
+
+        var id = primary.GetProperty("id").GetString();
+        var request = _fixture.CreateAdminRequest(
+            HttpMethod.Post, $"/admin/ai-quality/models/{id}/promote");
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Rollback_NoPriorPromotion_Conflict()
+    {
+        Assert.SkipUnless(_fixture.IsAuthenticated, "auth unavailable");
+
+        // A feature that has never been promoted has nothing to roll back → 409.
+        var request = _fixture.CreateAdminRequest(
+            HttpMethod.Post, $"/admin/ai-quality/models/__never_promoted__{Guid.NewGuid():N}/rollback");
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint not deployed");
+        Assert.SkipWhen(
+            response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden,
+            "test user is not admin");
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    private async Task<JsonElement?> GetModels()
+    {
+        var request = _fixture.CreateAdminRequest(HttpMethod.Get, "/admin/ai-quality/models");
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        if (IntegrationSkip.Unavailable(response)
+            || response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
+            || response.StatusCode != HttpStatusCode.OK)
+            return null;
+
+        var doc = JsonDocument.Parse(
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        return doc.RootElement.GetProperty("models").Clone();
+    }
+}

--- a/tests/TextStack.UnitTests/ModelGatewayShadowTests.cs
+++ b/tests/TextStack.UnitTests/ModelGatewayShadowTests.cs
@@ -223,6 +223,50 @@ public class ModelGatewayShadowTests
         Assert.NotEqual(cts.Token, capturing.SeenToken);
     }
 
+    // ---- shadow self-skip: shadow key == resolved primary key → no shadow ----
+
+    [Fact]
+    public async Task MaybeShadow_ShadowKeyEqualsPrimaryKey_SkipsShadow()
+    {
+        // Registry promotes explain's primary to "openai-explain" — the SAME provider the
+        // shadow route points at. Shadowing would compare a model to itself; the gateway skips.
+        var writer = new FakeShadowRunWriter();
+        var rawShadow = new RecordingLlm(Resp("shadow"));
+        var primary = new RecordingLlm(Resp("primary"));
+
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ai:DefaultProvider"] = "openai",
+                ["Ai:Routes:explain"] = "openai",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        // Registry routes explain → "openai-explain", so the primary resolves that keyed svc.
+        services.AddKeyedSingleton<ILlmService>("openai-explain", primary);
+        services.AddKeyedSingleton<ILlmService>("openai-explain-raw", rawShadow);
+        services.AddScoped<IShadowRunWriter>(_ => writer);
+        var inner = services.BuildServiceProvider();
+        var spy = new KeyRecordingProvider(inner, RequestedKeys);
+
+        var opts = new ShadowOptions(
+            DefaultSampleRate: 1.0,
+            Routes: new Dictionary<string, string> { ["explain"] = "openai-explain" },
+            PerFeatureRates: null,
+            TimeoutSeconds: 15);
+        var routes = new StubRouteProvider(new() { ["explain"] = "openai-explain" });
+
+        var gateway = new ModelGateway(spy, cfg, spy.ScopeFactory, opts, routes, NullLogger<ModelGateway>.Instance);
+
+        var result = await gateway.CompleteAsync(Req(), CancellationToken.None);
+        Assert.Equal("primary", result.Text);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+        Assert.False(writer.Written.Task.IsCompleted); // self-shadow skipped → no row
+        Assert.Equal(0, rawShadow.CallCount);
+    }
+
     // ---- StreamAsync edge: empty stream still fires exactly one shadow on clean end ----
 
     [Fact]
@@ -301,7 +345,8 @@ public class ModelGatewayShadowTests
 
     private ModelGateway Build(
         ILlmService primary, ILlmService shadow, FakeShadowRunWriter writer,
-        double sampleRate = 1.0, int timeoutSeconds = 15, ShadowOptions? shadowOpts = null)
+        double sampleRate = 1.0, int timeoutSeconds = 15, ShadowOptions? shadowOpts = null,
+        IModelRouteProvider? routeProvider = null)
     {
         var cfg = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -328,7 +373,17 @@ public class ModelGatewayShadowTests
             PerFeatureRates: null,
             TimeoutSeconds: timeoutSeconds);
 
-        return new ModelGateway(spy, cfg, spy.ScopeFactory, opts, NullLogger<ModelGateway>.Instance);
+        var routes = routeProvider ?? new StubRouteProvider();
+        return new ModelGateway(spy, cfg, spy.ScopeFactory, opts, routes, NullLogger<ModelGateway>.Instance);
+    }
+
+    /// <summary>Registry route provider returning a fixed map (empty = no registry hit).</summary>
+    private sealed class StubRouteProvider(Dictionary<string, string>? routes = null) : IModelRouteProvider
+    {
+        private readonly Dictionary<string, string> _routes = routes ?? new();
+        public string? PrimaryProviderKey(string featureTag) =>
+            _routes.TryGetValue(featureTag, out var k) ? k : null;
+        public void Invalidate() { }
     }
 
     // ---- fakes ----

--- a/tests/TextStack.UnitTests/ModelGatewayTests.cs
+++ b/tests/TextStack.UnitTests/ModelGatewayTests.cs
@@ -31,8 +31,19 @@ public class ModelGatewayTests
 
         // No shadow routes → primary-only routing (these tests cover primary routing).
         var shadow = new ShadowOptions(0.0, new Dictionary<string, string>(), null, 15);
+        // No registry routes → falls through to the config route (these tests cover config routing).
+        var routes = new StubRouteProvider();
         return new ModelGateway(
-            sp, cfg, sp.GetRequiredService<IServiceScopeFactory>(), shadow, NullLogger<ModelGateway>.Instance);
+            sp, cfg, sp.GetRequiredService<IServiceScopeFactory>(), shadow, routes, NullLogger<ModelGateway>.Instance);
+    }
+
+    /// <summary>Registry route provider returning a fixed map (empty = no registry hit).</summary>
+    private sealed class StubRouteProvider(Dictionary<string, string>? routes = null) : IModelRouteProvider
+    {
+        private readonly Dictionary<string, string> _routes = routes ?? new();
+        public string? PrimaryProviderKey(string featureTag) =>
+            _routes.TryGetValue(featureTag, out var k) ? k : null;
+        public void Invalidate() { }
     }
 
     [Theory]
@@ -49,6 +60,104 @@ public class ModelGatewayTests
         var response = await gateway.CompleteAsync(request, CancellationToken.None);
 
         Assert.Equal(expectedProvider, response.ModelId);
+    }
+
+    // ── Table-driven primary routing precedence (Phase 12 RLOps) ──────────────────
+
+    // Build a gateway with an explicit route provider + the standard openai/ollama stubs.
+    private static ModelGateway BuildGateway(IModelRouteProvider routes)
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ai:DefaultProvider"] = "openai",
+                ["Ai:Routes:explain"] = "openai",       // config route
+                ["Ai:Routes:distractor"] = "ollama",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ILlmService>("openai", new KeyEchoLlm("openai"));
+        services.AddKeyedSingleton<ILlmService>("ollama", new KeyEchoLlm("ollama"));
+        var sp = services.BuildServiceProvider();
+
+        var shadow = new ShadowOptions(0.0, new Dictionary<string, string>(), null, 15);
+        return new ModelGateway(
+            sp, cfg, sp.GetRequiredService<IServiceScopeFactory>(), shadow, routes, NullLogger<ModelGateway>.Instance);
+    }
+
+    [Fact]
+    public async Task Route_RegistryHit_BeatsConfigRoute()
+    {
+        // Config says explain→openai, registry overrides to ollama → registry wins.
+        var routes = new StubRouteProvider(new() { ["explain"] = "ollama" });
+        var gateway = BuildGateway(routes);
+
+        var resp = await gateway.CompleteAsync(
+            new LlmRequest("s", Array.Empty<LlmMessage>(), 10, FeatureTag: "explain"), CancellationToken.None);
+
+        Assert.Equal("ollama", resp.ModelId);
+    }
+
+    [Fact]
+    public async Task Route_NoRegistry_FallsBackToConfigRoute()
+    {
+        var routes = new StubRouteProvider(); // empty → no registry hit
+        var gateway = BuildGateway(routes);
+
+        var resp = await gateway.CompleteAsync(
+            new LlmRequest("s", Array.Empty<LlmMessage>(), 10, FeatureTag: "explain"), CancellationToken.None);
+
+        Assert.Equal("openai", resp.ModelId); // config route
+    }
+
+    [Fact]
+    public async Task Route_NoRegistryNoConfig_FallsBackToDefaultProvider()
+    {
+        var routes = new StubRouteProvider();
+        var gateway = BuildGateway(routes);
+
+        var resp = await gateway.CompleteAsync(
+            new LlmRequest("s", Array.Empty<LlmMessage>(), 10, FeatureTag: "no-route-feature"), CancellationToken.None);
+
+        Assert.Equal("openai", resp.ModelId); // DefaultProvider
+    }
+
+    [Fact]
+    public async Task Route_RegistryUnknownProviderKey_FallsBackToConfig_NoThrow()
+    {
+        // Registry names a provider key with no keyed registration → must NOT throw; the
+        // gateway falls back to the config route (explain→openai).
+        var routes = new StubRouteProvider(new() { ["explain"] = "ghost-provider" });
+        var gateway = BuildGateway(routes);
+
+        var resp = await gateway.CompleteAsync(
+            new LlmRequest("s", Array.Empty<LlmMessage>(), 10, FeatureTag: "explain"), CancellationToken.None);
+
+        Assert.Equal("openai", resp.ModelId);
+    }
+
+    [Fact]
+    public async Task Route_RouteProviderThrows_GatewayStillResolvesViaConfig()
+    {
+        // The provider contract is never-throws, but the gateway ALSO guards the lookup so a
+        // misbehaving provider can't break a real call — it falls through to the config route.
+        var routes = new ThrowingRouteProvider();
+        var gateway = BuildGateway(routes);
+
+        var resp = await gateway.CompleteAsync(
+            new LlmRequest("s", Array.Empty<LlmMessage>(), 10, FeatureTag: "explain"), CancellationToken.None);
+
+        Assert.Equal("openai", resp.ModelId); // config route, no throw
+    }
+
+    /// <summary>A deliberately-broken provider (violates the never-throw contract) — used to
+    /// document that a thrown lookup propagates rather than being silently swallowed by the
+    /// gateway (the contract puts the never-throw guarantee in the IMPL, not the gateway).</summary>
+    private sealed class ThrowingRouteProvider : IModelRouteProvider
+    {
+        public string? PrimaryProviderKey(string featureTag) => throw new InvalidOperationException("boom");
+        public void Invalidate() { }
     }
 
     private sealed class KeyEchoLlm(string key) : ILlmService

--- a/tests/TextStack.UnitTests/ModelPromotionServiceTests.cs
+++ b/tests/TextStack.UnitTests/ModelPromotionServiceTests.cs
@@ -1,0 +1,310 @@
+using Application.Ai;
+using Application.Common.Interfaces;
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Moq;
+using TextStack.Ai.Core;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// Promote/rollback transitions over a Moq <see cref="IAppDbContext"/> whose Models +
+/// ModelPromotions sets are backed by plain List&lt;T&gt; (async LINQ via TestAsyncQueryable —
+/// the production AppDbContext can't load on EF InMemory). Asserts the registry swap, the
+/// one-Primary invariant, the audit row, rejections, and a symmetric rollback. The route
+/// provider is a spy so we can assert Invalidate() fires after a commit.
+/// </summary>
+public class ModelPromotionServiceTests
+{
+    private sealed class Harness
+    {
+        public List<ModelRegistration> Models { get; } = [];
+        public List<ModelPromotion> Promotions { get; } = [];
+        public int SaveCalls { get; private set; }
+        public int CommitCalls { get; private set; }
+        public int RollbackCalls { get; private set; }
+        public SpyRouteProvider Routes { get; } = new();
+        public ModelPromotionService Service { get; }
+
+        /// <summary>When set, SaveChangesAsync throws this on the Nth call (1-based) to
+        /// simulate the partial-unique-index violation a concurrent promote triggers.</summary>
+        public Exception? ThrowOnSaveCall { get; set; }
+        public int ThrowOnSaveCallNumber { get; set; } = 1;
+
+        public Harness()
+        {
+            var db = new Mock<IAppDbContext>();
+            db.Setup(x => x.Models).Returns(() => FakeSet(Models).Object);
+            db.Setup(x => x.ModelPromotions).Returns(() => FakeSet(Promotions).Object);
+            db.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    SaveCalls++;
+                    if (ThrowOnSaveCall is not null && SaveCalls == ThrowOnSaveCallNumber)
+                        throw ThrowOnSaveCall;
+                    return 0;
+                });
+
+            var tx = new Mock<IDbContextTransaction>();
+            tx.Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+                .Returns(() => { CommitCalls++; return Task.CompletedTask; });
+            tx.Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
+                .Returns(() => { RollbackCalls++; return Task.CompletedTask; });
+            db.Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(tx.Object);
+
+            Service = new ModelPromotionService(db.Object, Routes);
+        }
+
+        public ModelRegistration AddModel(string feature, string provider, string model, ModelStatus status)
+        {
+            var m = new ModelRegistration
+            {
+                Id = Guid.NewGuid(),
+                FeatureTag = feature,
+                ProviderKey = provider,
+                ModelId = model,
+                Status = status,
+                CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+            };
+            Models.Add(m);
+            return m;
+        }
+    }
+
+    private sealed class SpyRouteProvider : IModelRouteProvider
+    {
+        public int InvalidateCount { get; private set; }
+        public string? PrimaryProviderKey(string featureTag) => null;
+        public void Invalidate() => InvalidateCount++;
+    }
+
+    private static Mock<DbSet<T>> FakeSet<T>(List<T> data) where T : class
+    {
+        var q = new TestAsyncEnumerable<T>(data);
+        var set = new Mock<DbSet<T>>();
+        var iq = set.As<IQueryable<T>>();
+        iq.Setup(m => m.Provider).Returns(((IQueryable<T>)q).Provider);
+        iq.Setup(m => m.Expression).Returns(((IQueryable<T>)q).Expression);
+        iq.Setup(m => m.ElementType).Returns(((IQueryable<T>)q).ElementType);
+        iq.Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
+        set.As<IAsyncEnumerable<T>>()
+            .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+            .Returns(() => new TestAsyncEnumerator<T>(data.GetEnumerator()));
+        set.Setup(m => m.Add(It.IsAny<T>())).Callback<T>(e => data.Add(e));
+        return set;
+    }
+
+    // ── Promote ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PromoteAsync_ShadowToPrimary_FlipsBoth_AndWritesAudit()
+    {
+        var h = new Harness();
+        var outgoing = h.AddModel("explain", "openai", "gpt-4.1-nano", ModelStatus.Primary);
+        var target = h.AddModel("explain", "openai-explain", "gpt-4.1-mini", ModelStatus.Shadow);
+        var admin = Guid.NewGuid();
+
+        var result = await h.Service.PromoteAsync(target.Id, admin, CancellationToken.None);
+
+        Assert.Equal(ModelStatus.Primary, target.Status);     // target promoted
+        Assert.Equal(ModelStatus.Shadow, outgoing.Status);    // outgoing demoted
+        Assert.Equal(target.Id, result.NewPrimary.Id);
+        Assert.Equal(outgoing.Id, result.DemotedToShadow!.Id);
+        Assert.Equal(PromotionAction.Promote, result.Action);
+
+        // Exactly one feature has a Primary (invariant).
+        Assert.Single(h.Models.Where(m => m is { FeatureTag: "explain", Status: ModelStatus.Primary }));
+
+        // Audit row with denormalized keys + admin.
+        var audit = Assert.Single(h.Promotions);
+        Assert.Equal(PromotionAction.Promote, audit.Action);
+        Assert.Equal(outgoing.Id, audit.FromModelRegistrationId);
+        Assert.Equal("openai", audit.FromProviderKey);
+        Assert.Equal(target.Id, audit.ToModelRegistrationId);
+        Assert.Equal("openai-explain", audit.ToProviderKey);
+        Assert.Equal(admin, audit.AdminUserId);
+
+        Assert.Equal(1, h.Routes.InvalidateCount); // cache flipped after commit
+    }
+
+    [Fact]
+    public async Task PromoteAsync_NoExistingPrimary_FirstPromotion_FromIsNull()
+    {
+        var h = new Harness();
+        var target = h.AddModel("podcast.script", "ollama", "gemma4:e2b", ModelStatus.Shadow);
+
+        var result = await h.Service.PromoteAsync(target.Id, null, CancellationToken.None);
+
+        Assert.Equal(ModelStatus.Primary, target.Status);
+        Assert.Null(result.DemotedToShadow);
+        var audit = Assert.Single(h.Promotions);
+        Assert.Null(audit.FromModelRegistrationId);
+    }
+
+    [Fact]
+    public async Task PromoteAsync_NotFound_Throws()
+    {
+        var h = new Harness();
+        await Assert.ThrowsAsync<DomainException>(() =>
+            h.Service.PromoteAsync(Guid.NewGuid(), null, CancellationToken.None));
+        Assert.Equal(0, h.Routes.InvalidateCount);
+    }
+
+    [Fact]
+    public async Task PromoteAsync_Retired_Throws()
+    {
+        var h = new Harness();
+        var retired = h.AddModel("explain", "openai", "old", ModelStatus.Retired);
+        await Assert.ThrowsAsync<DomainException>(() =>
+            h.Service.PromoteAsync(retired.Id, null, CancellationToken.None));
+        Assert.Equal(ModelStatus.Retired, retired.Status); // untouched
+    }
+
+    [Fact]
+    public async Task PromoteAsync_AlreadyPrimary_Throws()
+    {
+        var h = new Harness();
+        var primary = h.AddModel("explain", "openai", "gpt", ModelStatus.Primary);
+        await Assert.ThrowsAsync<DomainException>(() =>
+            h.Service.PromoteAsync(primary.Id, null, CancellationToken.None));
+    }
+
+    // ── Rollback ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RollbackAsync_RestoresPriorPrimary_Symmetrically()
+    {
+        var h = new Harness();
+        var a = h.AddModel("explain", "openai", "nano", ModelStatus.Primary);   // original primary
+        var b = h.AddModel("explain", "openai-explain", "mini", ModelStatus.Shadow);
+
+        // Promote b (a → Shadow, b → Primary).
+        await h.Service.PromoteAsync(b.Id, null, CancellationToken.None);
+        Assert.Equal(ModelStatus.Primary, b.Status);
+        Assert.Equal(ModelStatus.Shadow, a.Status);
+
+        // Rollback: a → Primary again, b → Shadow.
+        var result = await h.Service.RollbackAsync("explain", null, CancellationToken.None);
+
+        Assert.Equal(ModelStatus.Primary, a.Status);
+        Assert.Equal(ModelStatus.Shadow, b.Status);
+        Assert.Equal(a.Id, result.NewPrimary.Id);
+        Assert.Equal(b.Id, result.DemotedToShadow!.Id);
+        Assert.Equal(PromotionAction.Rollback, result.Action);
+
+        // Invariant holds + a Rollback audit row was appended.
+        Assert.Single(h.Models.Where(m => m is { FeatureTag: "explain", Status: ModelStatus.Primary }));
+        Assert.Equal(2, h.Promotions.Count);
+        Assert.Equal(PromotionAction.Rollback, h.Promotions[^1].Action);
+        Assert.Equal(2, h.Routes.InvalidateCount); // promote + rollback
+    }
+
+    [Fact]
+    public async Task RollbackAsync_NoPriorPromotion_Conflicts()
+    {
+        var h = new Harness();
+        h.AddModel("explain", "openai", "nano", ModelStatus.Primary);
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            h.Service.RollbackAsync("explain", null, CancellationToken.None));
+    }
+
+    // ── Concurrency / atomicity (the partial-unique-index invariant) ────────────────
+
+    [Fact]
+    public async Task PromoteAsync_ConcurrentPromote_IndexViolation_SurfacesConflict_NoInvalidate()
+    {
+        // Two admins promote different shadows for the same feature at once: the loser's
+        // SaveChanges violates the (feature_tag) WHERE status='Primary' partial unique index.
+        // EF surfaces DbUpdateException → the service MUST map it to ConflictException (→409),
+        // NOT a 500, and MUST NOT invalidate the route cache (the swap never committed).
+        var h = new Harness
+        {
+            ThrowOnSaveCall = new DbUpdateException("23505: duplicate key value violates unique constraint"),
+        };
+        h.AddModel("explain", "openai", "nano", ModelStatus.Primary);
+        var target = h.AddModel("explain", "openai-explain", "mini", ModelStatus.Shadow);
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            h.Service.PromoteAsync(target.Id, null, CancellationToken.None));
+
+        Assert.Equal(0, h.CommitCalls);          // never committed
+        Assert.Equal(0, h.Routes.InvalidateCount); // cache NOT flipped on a failed swap
+    }
+
+    [Fact]
+    public async Task RollbackAsync_ConcurrentChange_IndexViolation_SurfacesConflict_NoInvalidate()
+    {
+        var h = new Harness
+        {
+            ThrowOnSaveCall = new DbUpdateException("23505"),
+            ThrowOnSaveCallNumber = 99, // don't throw during the setup promote
+        };
+        var a = h.AddModel("explain", "openai", "nano", ModelStatus.Primary);
+        var b = h.AddModel("explain", "openai-explain", "mini", ModelStatus.Shadow);
+        await h.Service.PromoteAsync(b.Id, null, CancellationToken.None); // 1st save ok
+        var invalidatesAfterPromote = h.Routes.InvalidateCount;
+
+        // Next save (the rollback) throws the index violation.
+        h.ThrowOnSaveCallNumber = h.SaveCalls + 1;
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            h.Service.RollbackAsync("explain", null, CancellationToken.None));
+
+        Assert.Equal(invalidatesAfterPromote, h.Routes.InvalidateCount); // rollback did NOT invalidate
+    }
+
+    [Fact]
+    public async Task RollbackAsync_RestoreTargetGone_Conflicts_Not500()
+    {
+        // The prior primary row was deleted/retired-away since the promotion: rollback must
+        // surface a clean ConflictException (→409), never a NullReference/500.
+        var h = new Harness();
+        var a = h.AddModel("explain", "openai", "nano", ModelStatus.Primary);
+        var b = h.AddModel("explain", "openai-explain", "mini", ModelStatus.Shadow);
+        await h.Service.PromoteAsync(b.Id, null, CancellationToken.None);
+
+        h.Models.Remove(a); // the model we'd roll back TO no longer exists
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            h.Service.RollbackAsync("explain", null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RollbackAsync_RestoreTargetRetired_Conflicts()
+    {
+        var h = new Harness();
+        var a = h.AddModel("explain", "openai", "nano", ModelStatus.Primary);
+        var b = h.AddModel("explain", "openai-explain", "mini", ModelStatus.Shadow);
+        await h.Service.PromoteAsync(b.Id, null, CancellationToken.None);
+
+        a.Status = ModelStatus.Retired; // prior primary was retired since the promotion
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            h.Service.RollbackAsync("explain", null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PromoteAsync_PicksLatestPromotionForRollback_NotAnOlderFeaturesRow()
+    {
+        // Rollback must read the latest promotion FOR THIS feature only — an interleaved
+        // promotion of a DIFFERENT feature must not be mistaken for the one to revert.
+        var h = new Harness();
+        var ex1 = h.AddModel("explain", "openai", "nano", ModelStatus.Primary);
+        var ex2 = h.AddModel("explain", "openai-explain", "mini", ModelStatus.Shadow);
+        var tr1 = h.AddModel("translate", "openai", "nano", ModelStatus.Primary);
+        var tr2 = h.AddModel("translate", "ollama", "gemma", ModelStatus.Shadow);
+
+        await h.Service.PromoteAsync(ex2.Id, null, CancellationToken.None); // explain: ex1→shadow, ex2→primary
+        await h.Service.PromoteAsync(tr2.Id, null, CancellationToken.None); // translate (newer audit row)
+
+        var result = await h.Service.RollbackAsync("explain", null, CancellationToken.None);
+
+        Assert.Equal(ex1.Id, result.NewPrimary.Id);     // restored explain's prior primary
+        Assert.Equal(ModelStatus.Primary, ex1.Status);
+        Assert.Equal(ModelStatus.Shadow, ex2.Status);
+        Assert.Equal(ModelStatus.Primary, tr2.Status);  // translate untouched
+    }
+}

--- a/tests/TextStack.UnitTests/RegistryModelRouteProviderTests.cs
+++ b/tests/TextStack.UnitTests/RegistryModelRouteProviderTests.cs
@@ -1,0 +1,166 @@
+using Application.Ai;
+using Application.Common.Interfaces;
+using Domain.Entities;
+using Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// RegistryModelRouteProvider: builds ONE snapshot (feature → primary provider_key) of the
+/// Models registry inside a fresh scope, caches it under a short TTL, serves repeat reads
+/// from cache (one scope build), and rebuilds after Invalidate. Models set is a List behind a
+/// Moq DbSet (async LINQ via TestAsyncQueryable); the scope factory counts builds.
+/// </summary>
+public class RegistryModelRouteProviderTests
+{
+    private sealed class Harness
+    {
+        public List<ModelRegistration> Models { get; } = [];
+        public int ScopeBuilds { get; private set; }
+        public RegistryModelRouteProvider Provider { get; }
+
+        public Harness()
+        {
+            var db = new Mock<IAppDbContext>();
+            db.Setup(x => x.Models).Returns(() => FakeSet(Models).Object);
+
+            var scope = new Mock<IServiceScope>();
+            var sp = new Mock<IServiceProvider>();
+            sp.Setup(x => x.GetService(typeof(IAppDbContext))).Returns(() => db.Object);
+            scope.Setup(x => x.ServiceProvider).Returns(sp.Object);
+
+            var factory = new Mock<IServiceScopeFactory>();
+            factory.Setup(x => x.CreateScope()).Returns(() => { ScopeBuilds++; return scope.Object; });
+
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var config = new ConfigurationBuilder().Build(); // default TTL 30s
+            Provider = new RegistryModelRouteProvider(
+                factory.Object, cache, config, NullLogger<RegistryModelRouteProvider>.Instance);
+        }
+
+        public void AddPrimary(string feature, string provider) =>
+            Models.Add(new ModelRegistration
+            {
+                Id = Guid.NewGuid(),
+                FeatureTag = feature,
+                ProviderKey = provider,
+                ModelId = "m",
+                Status = ModelStatus.Primary,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+    }
+
+    private static Mock<DbSet<T>> FakeSet<T>(List<T> data) where T : class
+    {
+        var q = new TestAsyncEnumerable<T>(data);
+        var set = new Mock<DbSet<T>>();
+        var iq = set.As<IQueryable<T>>();
+        iq.Setup(m => m.Provider).Returns(((IQueryable<T>)q).Provider);
+        iq.Setup(m => m.Expression).Returns(((IQueryable<T>)q).Expression);
+        iq.Setup(m => m.ElementType).Returns(((IQueryable<T>)q).ElementType);
+        iq.Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
+        set.As<IAsyncEnumerable<T>>()
+            .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+            .Returns(() => new TestAsyncEnumerator<T>(data.GetEnumerator()));
+        return set;
+    }
+
+    [Fact]
+    public void PrimaryProviderKey_BuildsSnapshot_ReturnsPrimaryKey()
+    {
+        var h = new Harness();
+        h.AddPrimary("explain", "openai-explain");
+        h.AddPrimary("translate", "openai");
+
+        Assert.Equal("openai-explain", h.Provider.PrimaryProviderKey("explain"));
+        Assert.Equal("openai", h.Provider.PrimaryProviderKey("translate"));
+        Assert.Null(h.Provider.PrimaryProviderKey("no-such-feature"));
+    }
+
+    [Fact]
+    public void PrimaryProviderKey_OnlyPrimaryRows_AreSnapshotted()
+    {
+        var h = new Harness();
+        h.AddPrimary("explain", "openai-explain");
+        h.Models.Add(new ModelRegistration
+        {
+            Id = Guid.NewGuid(), FeatureTag = "explain", ProviderKey = "ollama",
+            ModelId = "m", Status = ModelStatus.Shadow, CreatedAt = DateTimeOffset.UtcNow,
+        });
+
+        Assert.Equal("openai-explain", h.Provider.PrimaryProviderKey("explain")); // shadow ignored
+    }
+
+    [Fact]
+    public void PrimaryProviderKey_WithinTtl_ServedFromCache_OneBuild()
+    {
+        var h = new Harness();
+        h.AddPrimary("explain", "openai-explain");
+
+        for (var i = 0; i < 5; i++)
+            Assert.Equal("openai-explain", h.Provider.PrimaryProviderKey("explain"));
+
+        Assert.Equal(1, h.ScopeBuilds); // built once, then cached
+    }
+
+    [Fact]
+    public void Invalidate_ForcesRebuild_AndPicksUpNewPrimary()
+    {
+        var h = new Harness();
+        h.AddPrimary("explain", "openai");
+        Assert.Equal("openai", h.Provider.PrimaryProviderKey("explain"));
+        Assert.Equal(1, h.ScopeBuilds);
+
+        // Simulate a promotion: swap the registry's Primary.
+        h.Models.Clear();
+        h.AddPrimary("explain", "openai-explain");
+
+        // Still cached → stale until invalidated.
+        Assert.Equal("openai", h.Provider.PrimaryProviderKey("explain"));
+        Assert.Equal(1, h.ScopeBuilds);
+
+        h.Provider.Invalidate();
+        Assert.Equal("openai-explain", h.Provider.PrimaryProviderKey("explain"));
+        Assert.Equal(2, h.ScopeBuilds); // rebuilt after invalidate
+    }
+
+    [Fact]
+    public void PrimaryProviderKey_TwoPrimariesSameFeature_DoesNotThrow_DeterministicWinner()
+    {
+        // Defends the LLM hot path: if the partial unique index ever fails to enforce
+        // one-Primary-per-feature (bad migration filter, manual DB edit), the snapshot build
+        // must NOT crash via a duplicate-key ToDictionary — every call for that feature would
+        // 500. It must return a deterministic winner (oldest CreatedAt) and keep serving.
+        var h = new Harness();
+        h.Models.Add(new ModelRegistration
+        {
+            Id = Guid.NewGuid(), FeatureTag = "explain", ProviderKey = "openai-explain",
+            ModelId = "m", Status = ModelStatus.Primary,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-2), // older → wins
+        });
+        h.Models.Add(new ModelRegistration
+        {
+            Id = Guid.NewGuid(), FeatureTag = "explain", ProviderKey = "ollama",
+            ModelId = "m", Status = ModelStatus.Primary,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+        });
+
+        var key = h.Provider.PrimaryProviderKey("explain"); // must not throw
+        Assert.Equal("openai-explain", key); // oldest deterministically wins
+    }
+
+    [Fact]
+    public void PrimaryProviderKey_NullOrBlankFeature_ReturnsNull_NoBuild()
+    {
+        var h = new Harness();
+        Assert.Null(h.Provider.PrimaryProviderKey(""));
+        Assert.Null(h.Provider.PrimaryProviderKey("   "));
+        Assert.Equal(0, h.ScopeBuilds);
+    }
+}


### PR DESCRIPTION
## Phase 12 (RLOps) — slice 3: promotion in one click

The `models` registry becomes a **routing input** (not just audit), and an admin can swap which model serves a feature **in one click, no redeploy**. Delivers the DoD "promotion shadow→primary is one click; rollback is one click."

### Table-driven primary routing
`ModelGateway.Route` resolves a feature's primary **provider key** from the registry (`status=Primary`) before the config route. `IModelRouteProvider` (Core) → `RegistryModelRouteProvider` serves a **cached** immutable `feature→provider_key` snapshot (TTL `Ai:Routes:CacheSeconds`, default 30s; fresh scope, double-checked lock; `Invalidate()` drops it).

**The gateway can never fail a live call because of the registry** — null/throwing provider, empty registry, or a row whose ProviderKey has no keyed `ILlmService` ALL fall back: registry → config `Ai:Routes:{tag}` → `Ai:DefaultProvider` → `openai`. Snapshot build is duplicate-key resilient (oldest wins) even if the one-Primary invariant were ever violated. First deploy = identical behavior (seeded keys == config).

### Promote / rollback (first mutating Phase-12 endpoints)
- `POST /admin/ai-quality/models/{id}/promote` — Shadow→Primary, demotes incumbent to Shadow (keeps shadowing).
- `POST /admin/ai-quality/models/{feature}/rollback` — replays inverse of the latest promotion.
- Transactional + append-only **`model_promotions`** audit (who/when); cache invalidated **only after commit**; **strictly Shadow→Primary** (Retired → 400).
- **Partial unique index** `(feature_tag) WHERE status='Primary'` ⇒ exactly one Primary; concurrent promote → **409**, never two primaries.

### Candidates + self-shadow
A shadow run auto-upserts a promotable `Shadow` candidate (guarded, fire-and-forget) — enabling a shadow route makes a promote target appear. After a promote, `MaybeShadow` **skips self-shadowing**.

### Admin UI
Models tab is now actionable — Promote (Shadow rows) / Rollback (Primary rows, shown only when a Shadow candidate exists), each behind a confirm dialog (changes prod routing live); 409/400 server text surfaced; instant refetch.

### Scope
Shadow stays **config-driven** this slice — registry Shadow rows are candidate/audit, not a shadow-routing input (registry-driven shadow + cost-cap = later slices).

### Verification
Migration `AddModelPromotionAndPrimaryUniqueIndex`. architect → backend + frontend (parallel, locked contract) → **adversarial QA (verdict SHIP)**; 2 P1 fixes applied (snapshot duplicate-resilience; concurrent-promote 409 now covered — the scariest path, partial-index filter literal verified correct). **724 unit tests** green; admin tsc + build clean; full solution clean. Browser-check deferred to owner (admin JWT + needs a shadow candidate to promote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)