### PR TITLE
feat: Send to TextStack — Phase 1 (clip backend + Read later shelf)

### DIFF
--- a/apps/web/src/api/userBooks.ts
+++ b/apps/web/src/api/userBooks.ts
@@ -21,6 +21,12 @@ export interface UserBook {
   progressChapterSlug: string | null
   tags?: string[]
   suggestedTags?: string[]
+  // "Send to TextStack" web clips (Read later shelf). Present on every list row;
+  // sourceUrl/readAt are null for non-clips and for unread clips respectively.
+  sourceUrl?: string | null
+  isClip?: boolean
+  isRead?: boolean
+  readAt?: string | null
 }
 
 export interface UserChapterSummary {
@@ -125,8 +131,24 @@ export async function uploadUserBook(
   })
 }
 
-export async function getUserBooks(): Promise<UserBook[]> {
-  return authFetch<UserBook[]>('/me/books')
+export interface GetUserBooksOptions {
+  /** 'readlater' → only web clips (Read later shelf). Omit → Books tab (excludes clips). */
+  shelf?: 'readlater'
+  /** 'unread' → only unread books (applied within the chosen shelf). */
+  status?: 'unread'
+}
+
+export async function getUserBooks(opts?: GetUserBooksOptions): Promise<UserBook[]> {
+  const params = new URLSearchParams()
+  if (opts?.shelf) params.set('shelf', opts.shelf)
+  if (opts?.status) params.set('status', opts.status)
+  const qs = params.toString()
+  return authFetch<UserBook[]>(qs ? `/me/books?${qs}` : '/me/books')
+}
+
+/** Mark a clip read (isRead=true, readAt=now). Owner-scoped; 404 if not yours. */
+export async function markUserBookRead(id: string): Promise<void> {
+  await authFetch<void>(`/me/books/${id}/read`, { method: 'PUT' })
 }
 
 export async function getUserBook(id: string): Promise<UserBookDetail> {

--- a/apps/web/src/components/library/ReadLaterShelf.test.ts
+++ b/apps/web/src/components/library/ReadLaterShelf.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { cardState, sourceDomain, estReadMinutes, isHttpUrl } from './ReadLaterShelf'
+import type { UserBook } from '../../api/userBooks'
+
+function book(overrides: Partial<UserBook> = {}): UserBook {
+  return {
+    id: 'b1',
+    title: 'T',
+    slug: 's',
+    language: 'en',
+    author: null,
+    description: null,
+    coverPath: null,
+    genre: null,
+    status: 'Ready',
+    errorMessage: null,
+    chapterCount: 1,
+    totalWordCount: 0,
+    createdAt: '2026-06-01T00:00:00Z',
+    completedAt: null,
+    progressPercent: null,
+    progressUpdatedAt: null,
+    progressChapterSlug: null,
+    sourceUrl: null,
+    isClip: true,
+    isRead: false,
+    readAt: null,
+    ...overrides,
+  }
+}
+
+describe('cardState', () => {
+  it('Processing wins over everything', () => {
+    expect(cardState(book({ status: 'Processing', isRead: true, progressPercent: 0.5 })))
+      .toEqual({ kind: 'processing' })
+  })
+
+  it('Failed status', () => {
+    expect(cardState(book({ status: 'Failed' }))).toEqual({ kind: 'failed' })
+  })
+
+  it('Read when isRead true', () => {
+    expect(cardState(book({ isRead: true, progressPercent: 0.4 }))).toEqual({ kind: 'read' })
+  })
+
+  it('inProgress with rounded percent', () => {
+    expect(cardState(book({ progressPercent: 0.604 }))).toEqual({ kind: 'inProgress', percent: 60 })
+  })
+
+  it('New when unread and no progress', () => {
+    expect(cardState(book({ progressPercent: 0 }))).toEqual({ kind: 'new' })
+    expect(cardState(book({ progressPercent: null }))).toEqual({ kind: 'new' })
+  })
+})
+
+describe('sourceDomain', () => {
+  it('strips www', () => {
+    expect(sourceDomain('https://www.anthropic.com/x')).toBe('anthropic.com')
+  })
+  it('keeps subdomains', () => {
+    expect(sourceDomain('https://blog.example.com/p')).toBe('blog.example.com')
+  })
+  it('null on missing/garbage', () => {
+    expect(sourceDomain(null)).toBeNull()
+    expect(sourceDomain('not a url')).toBeNull()
+  })
+})
+
+describe('estReadMinutes', () => {
+  it('~200 wpm, floored at 1', () => {
+    expect(estReadMinutes(2400)).toBe(12)
+    expect(estReadMinutes(0)).toBe(1)
+    expect(estReadMinutes(null)).toBe(1)
+  })
+})
+
+describe('isHttpUrl', () => {
+  it('accepts http(s) only', () => {
+    expect(isHttpUrl('https://x.com')).toBe(true)
+    expect(isHttpUrl('http://x.com')).toBe(true)
+    expect(isHttpUrl('javascript:alert(1)')).toBe(false)
+    expect(isHttpUrl(null)).toBe(false)
+  })
+})

--- a/apps/web/src/components/library/ReadLaterShelf.tsx
+++ b/apps/web/src/components/library/ReadLaterShelf.tsx
@@ -1,0 +1,277 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { UserBook } from '../../api/userBooks'
+import { deleteUserBook, markUserBookRead, getUserBookCoverUrl } from '../../api/userBooks'
+import { emitDataChanges } from '../../lib/dataEvents'
+
+// ── Pure helpers (unit-tested) ───────────────────────────────────────────────
+
+export type CardState =
+  | { kind: 'processing' }
+  | { kind: 'failed' }
+  | { kind: 'read' }
+  | { kind: 'inProgress'; percent: number } // 0..100
+  | { kind: 'new' }
+
+/**
+ * Badge/state for a Read later card. Order matters: Processing/Failed win over
+ * read state; then Read; then an in-progress % bar; else New (unread).
+ */
+export function cardState(book: UserBook): CardState {
+  if (book.status === 'Processing') return { kind: 'processing' }
+  if (book.status === 'Failed') return { kind: 'failed' }
+  if (book.isRead) return { kind: 'read' }
+  const percent = book.progressPercent ?? 0
+  if (percent > 0) return { kind: 'inProgress', percent: Math.round(percent * 100) }
+  return { kind: 'new' }
+}
+
+/** Hostname of a clip's source URL, sans leading www. Null on missing/parse error. */
+export function sourceDomain(sourceUrl: string | null | undefined): string | null {
+  if (!sourceUrl) return null
+  try {
+    return new URL(sourceUrl).hostname.replace(/^www\./, '')
+  } catch {
+    return null
+  }
+}
+
+/** Estimated read time in minutes at ~200 wpm, floored at 1. */
+export function estReadMinutes(totalWordCount: number | null | undefined): number {
+  return Math.max(1, Math.round((totalWordCount ?? 0) / 200))
+}
+
+/** http(s) guard for rendering an external <a> (backend validates; defence-in-depth). */
+export function isHttpUrl(url: string | null | undefined): url is string {
+  if (!url) return false
+  try {
+    const p = new URL(url).protocol
+    return p === 'http:' || p === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function relativeTime(dateStr: string, t: (key: string) => string): string {
+  const diffMs = Date.now() - new Date(dateStr).getTime()
+  const mins = Math.floor(diffMs / 60000)
+  const hours = Math.floor(mins / 60)
+  const days = Math.floor(hours / 24)
+  if (mins < 1) return t('library.timeJustNow')
+  if (mins < 60) return `${mins} ${t('library.timeMinAgo')}`
+  if (hours < 24) return `${hours} ${t('library.timeHoursAgo')}`
+  if (days === 1) return t('library.timeYesterday')
+  if (days < 7) return `${days} ${t('library.timeDaysAgo')}`
+  return new Date(dateStr).toLocaleDateString()
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface Props {
+  books: UserBook[]
+  language: string
+  loading: boolean
+  unreadOnly: boolean
+  onToggleUnread: () => void
+  onChange: () => void
+  t: (key: string) => string
+}
+
+export function ReadLaterShelf({
+  books, language, loading, unreadOnly, onToggleUnread, onChange, t,
+}: Props) {
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  const handleMarkRead = async (id: string) => {
+    setBusyId(id)
+    try {
+      await markUserBookRead(id)
+      emitDataChanges(['user-books', 'shelves'])
+      onChange()
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const handleDelete = async (book: UserBook) => {
+    if (!window.confirm(`${t('library.readLater.deleteConfirm')}\n\n${book.title}`)) return
+    setBusyId(book.id)
+    try {
+      await deleteUserBook(book.id)
+      emitDataChanges(['user-books', 'shelves'])
+      onChange()
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <div className="read-later">
+      <div className="read-later__toolbar">
+        <button
+          type="button"
+          className={`read-later__filter${unreadOnly ? ' read-later__filter--active' : ''}`}
+          onClick={onToggleUnread}
+          aria-pressed={unreadOnly}
+        >
+          <span className="material-icons-outlined">filter_list</span>
+          {t('library.readLater.unread')}
+        </button>
+      </div>
+
+      {loading && books.length === 0 ? (
+        <div className="library-page__loading">{t('library.loading')}</div>
+      ) : books.length === 0 ? (
+        <div className="read-later__empty">
+          <div className="empty-state__icon">🔖</div>
+          <p className="empty-state__title">{t('library.readLater.empty')}</p>
+        </div>
+      ) : (
+        <div className="read-later__list">
+          {books.map((book) => (
+            <ReadLaterCard
+              key={book.id}
+              book={book}
+              language={language}
+              busy={busyId === book.id}
+              onMarkRead={() => handleMarkRead(book.id)}
+              onDelete={() => handleDelete(book)}
+              t={t}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface CardProps {
+  book: UserBook
+  language: string
+  busy: boolean
+  onMarkRead: () => void
+  onDelete: () => void
+  t: (key: string) => string
+}
+
+function ReadLaterCard({ book, language, busy, onMarkRead, onDelete, t }: CardProps) {
+  const state = cardState(book)
+  const isReady = book.status === 'Ready'
+  const domain = sourceDomain(book.sourceUrl)
+  const coverUrl = getUserBookCoverUrl(book.coverPath)
+  const destination = isReady
+    ? (book.progressChapterSlug
+        ? `/${language}/library/my/${book.id}/read/${book.progressChapterSlug}`
+        : `/${language}/library/my/${book.id}`)
+    : '#'
+  const metaParts: string[] = []
+  if (domain) metaParts.push(domain)
+  metaParts.push(`${estReadMinutes(book.totalWordCount)} ${t('library.readLater.min')}`)
+  metaParts.push(relativeTime(book.createdAt, t))
+
+  const Thumb = (
+    <div className={`read-later__thumb${state.kind === 'processing' ? ' read-later__thumb--processing' : ''}`}>
+      {coverUrl ? (
+        <img
+          src={coverUrl}
+          alt=""
+          onError={(e) => {
+            e.currentTarget.style.display = 'none'
+            e.currentTarget.nextElementSibling?.classList.remove('hidden')
+          }}
+        />
+      ) : null}
+      <span className={`material-icons-outlined read-later__thumb-icon ${coverUrl ? 'hidden' : ''}`}>
+        {state.kind === 'processing' ? 'sync' : 'description'}
+      </span>
+    </div>
+  )
+
+  return (
+    <article className={`read-later__item${isReady ? '' : ' read-later__item--disabled'}`} data-book-id={book.id}>
+      {isReady ? (
+        <Link to={destination} className="read-later__thumb-link" aria-label={book.title}>{Thumb}</Link>
+      ) : Thumb}
+
+      <div className="read-later__body">
+        {/* SECURITY: title is untrusted (clipped from arbitrary pages) — render
+            as React text only, never dangerouslySetInnerHTML. */}
+        {isReady ? (
+          <Link to={destination} className="read-later__title" title={book.title}>{book.title}</Link>
+        ) : (
+          <span className="read-later__title">{book.title}</span>
+        )}
+
+        {state.kind === 'processing' ? (
+          <p className="read-later__meta">{t('library.readLater.processing')}</p>
+        ) : (
+          <p className="read-later__meta">
+            {isHttpUrl(book.sourceUrl) && (
+              <a
+                href={book.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="read-later__source-link"
+                title={t('library.readLater.openOriginal')}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="material-icons-outlined">open_in_new</span>
+              </a>
+            )}
+            {/* domain is derived from untrusted sourceUrl — text only. */}
+            <span>{metaParts.join(' · ')}</span>
+          </p>
+        )}
+
+        {state.kind === 'inProgress' && (
+          <div className="read-later__bar">
+            <div className="read-later__bar-fill" style={{ width: `${state.percent}%` }} />
+          </div>
+        )}
+      </div>
+
+      <div className="read-later__right">
+        {state.kind === 'processing' && (
+          <span className="read-later__badge read-later__badge--processing">{t('library.badge.processing')}</span>
+        )}
+        {state.kind === 'failed' && (
+          <span className="read-later__badge read-later__badge--failed">{t('library.failed')}</span>
+        )}
+        {state.kind === 'read' && (
+          <span className="read-later__badge read-later__badge--read">{t('library.badge.finished')}</span>
+        )}
+        {state.kind === 'inProgress' && (
+          <span className="read-later__pct">{state.percent}%</span>
+        )}
+        {state.kind === 'new' && (
+          <span className="read-later__badge read-later__badge--new">{t('library.badge.new')}</span>
+        )}
+
+        <div className="read-later__actions">
+          {isReady && !book.isRead && (
+            <button
+              type="button"
+              className="read-later__action"
+              onClick={onMarkRead}
+              disabled={busy}
+              title={t('library.readLater.markRead')}
+              aria-label={t('library.readLater.markRead')}
+            >
+              <span className="material-icons-outlined">check_circle</span>
+            </button>
+          )}
+          <button
+            type="button"
+            className="read-later__action read-later__action--danger"
+            onClick={onDelete}
+            disabled={busy}
+            title={t('library.readLater.delete')}
+            aria-label={t('library.readLater.delete')}
+          >
+            <span className="material-icons-outlined">delete_outline</span>
+          </button>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/apps/web/src/components/reader/ReaderTopBar.tsx
+++ b/apps/web/src/components/reader/ReaderTopBar.tsx
@@ -8,6 +8,8 @@ interface Props {
   progress: number
   isBookmarked: boolean
   backUrl: string
+  sourceUrl?: string | null // Send to TextStack clips — link to the original article
+  sourceDomain?: string | null // hostname of sourceUrl (sans www), shown as the link label
   useLocalizedLink?: boolean // true for public books (uses LocalizedLink), false for user books (uses Link)
   showAsk?: boolean // catalog editions only — user uploads aren't chunked for RAG
   onAskClick?: () => void
@@ -24,6 +26,8 @@ export function ReaderTopBar({
   progress,
   isBookmarked,
   backUrl,
+  sourceUrl,
+  sourceDomain,
   useLocalizedLink = true,
   showAsk = false,
   onAskClick,
@@ -50,7 +54,25 @@ export function ReaderTopBar({
         </BackLink>
         <div className="reader-top-bar__title">
           <span className="reader-top-bar__book-title">{title}</span>
-          <span className="reader-top-bar__chapter-title">{chapterTitle}</span>
+          {sourceUrl && sourceDomain ? (
+            // Send to TextStack clip: link to the original article. sourceDomain is
+            // derived from an untrusted clipped URL — render as text only.
+            <a
+              href={sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="reader-top-bar__source"
+              title={sourceUrl}
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <path d="M15 3h6v6M10 14L21 3" />
+              </svg>
+              {sourceDomain}
+            </a>
+          ) : (
+            <span className="reader-top-bar__chapter-title">{chapterTitle}</span>
+          )}
         </div>
       </div>
 

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -485,6 +485,18 @@
       "scrollLeft": "Scroll left",
       "scrollRight": "Scroll right"
     },
+    "readLater": {
+      "tab": "Read later",
+      "tabBooks": "Books",
+      "unread": "Unread",
+      "min": "min",
+      "processing": "Processing…",
+      "markRead": "Mark as read",
+      "delete": "Delete",
+      "deleteConfirm": "Delete this clip?",
+      "openOriginal": "Open original article",
+      "empty": "Nothing saved yet — install the Send to TextStack extension to clip articles."
+    },
     "sidebar": {
       "all": "All books",
       "uploads": "My uploads",

--- a/apps/web/src/pages/LibraryPage.tsx
+++ b/apps/web/src/pages/LibraryPage.tsx
@@ -37,6 +37,7 @@ import {
   bulkDeleteUserBooks, bulkFinishUserBooks, bulkTagUserBooks, bulkAddToCollection,
   searchUserLibrary, type UserBookSearchHit,
 } from '../api/userBooks'
+import { ReadLaterShelf } from '../components/library/ReadLaterShelf'
 import { stringToColor } from '../utils/colors'
 import { getAllProgress, ReadingProgressDto, markAsRead, markAsUnread } from '../api/auth'
 import { emitDataChanges, useDataChange } from '../lib/dataEvents'
@@ -57,6 +58,11 @@ export function LibraryPage() {
   const highlightedBookId = useHighlightedBook()
   const [userBooks, setUserBooks] = useState<UserBook[]>([])
   const [userBooksLoading, setUserBooksLoading] = useState(false)
+  // "Read later" shelf (Send to TextStack clips) — separate from the Books tab.
+  const [shelf, setShelf] = useState<'books' | 'readlater'>('books')
+  const [readLaterBooks, setReadLaterBooks] = useState<UserBook[]>([])
+  const [readLaterLoading, setReadLaterLoading] = useState(false)
+  const [readLaterUnread, setReadLaterUnread] = useState(false)
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     return (localStorage.getItem('library-view') as ViewMode) || 'list'
   })
@@ -154,10 +160,33 @@ export function LibraryPage() {
     fetchUserBooks()
   }, [fetchUserBooks])
 
+  // Read later shelf — separate fetch (clips only; backend excludes them from
+  // the default /me/books list). Refetches when the Unread filter toggles.
+  const fetchReadLater = useCallback(async () => {
+    if (!isAuthenticated) return
+    setReadLaterLoading(true)
+    try {
+      const books = await getUserBooks({
+        shelf: 'readlater',
+        status: readLaterUnread ? 'unread' : undefined,
+      })
+      setReadLaterBooks(books)
+    } catch {
+      // Ignore errors
+    } finally {
+      setReadLaterLoading(false)
+    }
+  }, [isAuthenticated, readLaterUnread])
+
+  useEffect(() => {
+    if (shelf === 'readlater') fetchReadLater()
+  }, [shelf, fetchReadLater])
+
   // Cross-component refresh: any add/delete/update in user-books anywhere in
   // the app (upload modal, action menu, bulk bar, detail page, etc) refetches
   // here. See lib/dataEvents.ts for the bus.
   useDataChange('user-books', fetchUserBooks)
+  useDataChange('user-books', fetchReadLater)
 
 
   // Auto-refresh processing books
@@ -168,6 +197,15 @@ export function LibraryPage() {
     const interval = setInterval(fetchUserBooks, 5000)
     return () => clearInterval(interval)
   }, [userBooks, fetchUserBooks])
+
+  // Reuse the 5s Processing poll for the Read later shelf (freshly clipped
+  // articles ingest async).
+  useEffect(() => {
+    if (shelf !== 'readlater') return
+    if (!readLaterBooks.some(b => b.status === 'Processing')) return
+    const interval = setInterval(fetchReadLater, 5000)
+    return () => clearInterval(interval)
+  }, [shelf, readLaterBooks, fetchReadLater])
 
   // Mark book as read
   const handleMarkRead = useCallback(async (editionId: string, slug: string, bookLanguage: string) => {
@@ -444,7 +482,39 @@ export function LibraryPage() {
 
         <CollectionChips activeId={activeCollectionId} onSelect={onCollectionChange} />
 
-        {(() => {
+        {/* Shelf tabs: Books (existing library) vs Read later (Send to TextStack clips) */}
+        <div className="library-shelf-tabs" role="tablist" aria-label={t('library.title')}>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={shelf === 'books'}
+            className={`library-shelf-tab${shelf === 'books' ? ' library-shelf-tab--active' : ''}`}
+            onClick={() => setShelf('books')}
+          >
+            {t('library.readLater.tabBooks')}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={shelf === 'readlater'}
+            className={`library-shelf-tab${shelf === 'readlater' ? ' library-shelf-tab--active' : ''}`}
+            onClick={() => setShelf('readlater')}
+          >
+            {t('library.readLater.tab')}
+          </button>
+        </div>
+
+        {shelf === 'readlater' ? (
+          <ReadLaterShelf
+            books={readLaterBooks}
+            language={language}
+            loading={readLaterLoading}
+            unreadOnly={readLaterUnread}
+            onToggleUnread={() => setReadLaterUnread(v => !v)}
+            onChange={fetchReadLater}
+            t={t}
+          />
+        ) : (() => {
           const totalRaw = (showSavedBlock ? items.length : 0) + (showUploadsBlock ? userBooks.length : 0)
           const totalVisible = renderList.length
           const isLoadingAny = (showSavedBlock && loading) || (showUploadsBlock && userBooksLoading && userBooks.length === 0)
@@ -787,7 +857,7 @@ export function LibraryPage() {
       </main>
 
       {/* FAB */}
-      {showUploadsBlock && !selection.active && (
+      {shelf === 'books' && showUploadsBlock && !selection.active && (
         <button
           className="library-fab"
           onClick={() => window.dispatchEvent(new Event('textstack:open-upload'))}

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -35,6 +35,8 @@ import { ReaderStatsWidget } from '../components/reader/ReaderStatsWidget'
 import { useGuestLimits } from '../context/GuestLimitsContext'
 import { WordHint } from '../components/reader/WordHint'
 import { SaveProgressPrompt } from '../components/reader/SaveProgressPrompt'
+import { getUserBooks } from '../api/userBooks'
+import { sourceDomain } from '../components/library/ReadLaterShelf'
 import '../styles/micro-practice.css'
 
 export type { ReaderMode } from '../hooks/useReaderChapter'
@@ -66,6 +68,22 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
     userChapterSlug,
     isAuthenticated,
   })
+
+  // Source URL for "Send to TextStack" clips. The userbook detail DTO doesn't
+  // carry it, so resolve from the Read later list (clips only) once per book.
+  const [clipSourceUrl, setClipSourceUrl] = useState<string | null>(null)
+  useEffect(() => {
+    if (mode !== 'userbook' || !isAuthenticated || !id) { setClipSourceUrl(null); return }
+    let cancelled = false
+    getUserBooks({ shelf: 'readlater' })
+      .then(books => {
+        if (cancelled) return
+        const match = books.find(b => b.id === id)
+        setClipSourceUrl(match?.sourceUrl ?? null)
+      })
+      .catch(() => { if (!cancelled) setClipSourceUrl(null) })
+    return () => { cancelled = true }
+  }, [mode, isAuthenticated, id])
 
   const [tocOpen, setTocOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -488,6 +506,8 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
         progress={overallProgress}
         isBookmarked={isBookmarked(activeChapterIdentifier)}
         backUrl={backUrl}
+        sourceUrl={mode === 'userbook' ? clipSourceUrl : null}
+        sourceDomain={mode === 'userbook' ? sourceDomain(clipSourceUrl) : null}
         useLocalizedLink={mode === 'public'}
         showAsk={!!askEditionId}
         onAskClick={() => setAskOpen(true)}

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -8074,3 +8074,197 @@ html.dark .collection-chip--active {
   background: var(--color-bg-secondary, #f1ece2);
   color: var(--color-text-secondary, #6b7280);
 }
+
+/* ── Shelf tabs (Books / Read later) ───────────────────────────────────── */
+.library-shelf-tabs {
+  display: flex;
+  gap: 20px;
+  border-bottom: 1px solid var(--color-border, rgba(0, 0, 0, 0.12));
+  margin: 8px 0 16px;
+}
+
+.library-shelf-tab {
+  background: none;
+  border: none;
+  padding: 8px 2px;
+  font: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  color: var(--color-text-secondary, #6b7280);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.library-shelf-tab--active {
+  color: var(--color-text, #1f1f1d);
+  font-weight: 600;
+  border-bottom-color: var(--color-accent, #8b5a2b);
+}
+
+/* ── Read later shelf ──────────────────────────────────────────────────── */
+.read-later__toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
+.read-later__filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+  padding: 6px 12px;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.read-later__filter .material-icons-outlined { font-size: 18px; }
+
+.read-later__filter--active {
+  color: var(--color-text, #1f1f1d);
+  border-color: var(--color-accent, #8b5a2b);
+  background: var(--color-bg-secondary, #f5f0e8);
+}
+
+.read-later__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.read-later__item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+  background: var(--color-surface, #fff);
+}
+
+.read-later__item--disabled { opacity: 0.7; }
+
+.read-later__thumb-link { display: flex; flex-shrink: 0; }
+
+.read-later__thumb {
+  width: 40px;
+  height: 52px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: var(--color-bg-secondary, #f5f0e8);
+}
+
+.read-later__thumb img { width: 100%; height: 100%; object-fit: cover; }
+.read-later__thumb-icon { color: var(--color-text-secondary, #6b7280); font-size: 20px; }
+.read-later__thumb-icon.hidden { display: none; }
+
+.read-later__body { flex: 1; min-width: 0; }
+
+.read-later__title {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text, #1f1f1d);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+a.read-later__title:hover { text-decoration: underline; }
+
+.read-later__meta {
+  margin: 3px 0 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.read-later__source-link {
+  display: inline-flex;
+  color: inherit;
+}
+
+.read-later__source-link .material-icons-outlined { font-size: 14px; }
+.read-later__source-link:hover { color: var(--color-accent, #8b5a2b); }
+
+.read-later__bar {
+  height: 4px;
+  border-radius: 2px;
+  margin-top: 5px;
+  background: var(--color-bg-secondary, #f5f0e8);
+  overflow: hidden;
+}
+
+.read-later__bar-fill { height: 100%; background: var(--color-accent, #8b5a2b); }
+
+.read-later__right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.read-later__pct { font-size: 12px; color: var(--color-text-secondary, #6b7280); }
+
+.read-later__badge {
+  font-size: 11px;
+  padding: 3px 9px;
+  border-radius: 8px;
+  white-space: nowrap;
+}
+
+.read-later__badge--new {
+  background: var(--info-bg, #e6f1fb);
+  color: var(--info-text, #185fa5);
+}
+
+.read-later__badge--read {
+  background: var(--color-bg-secondary, #f5f0e8);
+  color: var(--success, #0f6e56);
+}
+
+.read-later__badge--processing {
+  background: var(--warning-bg, #faeeda);
+  color: var(--warning-text, #854f0b);
+}
+
+.read-later__badge--failed {
+  background: var(--warning-bg, #f8d7da);
+  color: var(--danger, #a32d2d);
+}
+
+.read-later__actions { display: flex; gap: 4px; }
+
+.read-later__action {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  display: flex;
+  color: var(--color-text-secondary, #6b7280);
+  border-radius: 6px;
+}
+
+.read-later__action:hover { background: var(--color-bg-secondary, #f5f0e8); color: var(--color-text, #1f1f1d); }
+.read-later__action:disabled { opacity: 0.5; cursor: default; }
+.read-later__action--danger:hover { color: var(--danger, #a32d2d); }
+.read-later__action .material-icons-outlined { font-size: 20px; }
+
+.read-later__empty { text-align: center; padding: 48px 20px; }
+.read-later__empty .empty-state__icon { font-size: 40px; margin-bottom: 8px; }
+.read-later__empty .empty-state__title {
+  color: var(--color-text-secondary, #6b7280);
+  max-width: 340px;
+  margin: 0 auto;
+}

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -174,6 +174,23 @@ body:has(.reader-page) .site-header {
   text-overflow: ellipsis;
 }
 
+.reader-top-bar__source {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--reader-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.reader-top-bar__source:hover {
+  color: var(--reader-text);
+  text-decoration: underline;
+}
+
 .reader-top-bar__right {
   display: flex;
   align-items: center;

--- a/backend/src/Api/Endpoints/UserBooksEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserBooksEndpoints.cs
@@ -17,9 +17,15 @@ public static class UserBooksEndpoints
 
         group.MapPost("/upload", UploadBook)
             .WithName("UploadUserBook")
+            .RequireRateLimiting("user-upload")
             .DisableAntiforgery();
 
+        group.MapPost("/clip", ClipArticle)
+            .WithName("ClipArticle")
+            .RequireRateLimiting("clip");
+
         group.MapGet("", GetBooks).WithName("GetUserBooks");
+        group.MapPut("/{id:guid}/read", MarkRead).WithName("MarkUserBookRead");
         group.MapGet("/quota", GetStorageQuota).WithName("GetStorageQuota");
         group.MapGet("/{id:guid}", GetBook).WithName("GetUserBook");
         group.MapGet("/{id:guid}/chapters/{slug}", GetChapterBySlug).WithName("GetUserBookChapter");
@@ -234,7 +240,56 @@ public static class UserBooksEndpoints
         return Results.Ok(response);
     }
 
+    private const int MaxClipHtmlBytes = 2 * 1024 * 1024; // ~2 MB
+
+    private static async Task<IResult> ClipArticle(
+        HttpContext httpContext,
+        AuthService authService,
+        UserBookService userBookService,
+        [FromBody] ClipRequest request,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        if (request is null || string.IsNullOrWhiteSpace(request.Title))
+            return Results.BadRequest(new { error = "Title is required" });
+
+        if (string.IsNullOrWhiteSpace(request.Html))
+            return Results.BadRequest(new { error = "Html is required" });
+
+        if (System.Text.Encoding.UTF8.GetByteCount(request.Html) > MaxClipHtmlBytes)
+            return Results.BadRequest(new { error = "Article is too large (max 2 MB)" });
+
+        if (!string.IsNullOrWhiteSpace(request.SourceUrl) &&
+            !(Uri.TryCreate(request.SourceUrl, UriKind.Absolute, out var uri) &&
+              (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)))
+            return Results.BadRequest(new { error = "SourceUrl must be an http(s) URL" });
+
+        var (response, error) = await userBookService.ClipAsync(userId.Value, request, ct);
+        if (error is not null)
+            return Results.BadRequest(new { error });
+
+        return Results.Ok(response);
+    }
+
     private static async Task<IResult> GetBooks(
+        HttpContext httpContext,
+        AuthService authService,
+        UserBookService userBookService,
+        [FromQuery] string? shelf,
+        [FromQuery] string? status,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var books = await userBookService.GetBooksAsync(userId.Value, ct, shelf, status);
+        return Results.Ok(books);
+    }
+
+    private static async Task<IResult> MarkRead(
+        Guid id,
         HttpContext httpContext,
         AuthService authService,
         UserBookService userBookService,
@@ -243,8 +298,11 @@ public static class UserBooksEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var books = await userBookService.GetBooksAsync(userId.Value, ct);
-        return Results.Ok(books);
+        var (success, error) = await userBookService.SetReadAsync(userId.Value, id, true, ct);
+        if (!success)
+            return Results.NotFound(new { error });
+
+        return Results.NoContent();
     }
 
     private static async Task<IResult> GetStorageQuota(

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -294,6 +294,31 @@ builder.Services.AddRateLimiter(options =>
             QueueLimit = 0,
         });
     });
+    // "Send to TextStack" web clip receiver — per-IP cap. Each clip queues an
+    // ingestion job + stores HTML, so this blocks scripted bulk-clipping while
+    // staying generous for a human saving a handful of articles in a session.
+    options.AddPolicy("clip", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromMinutes(1),
+            PermitLimit = 20,
+            QueueLimit = 0,
+        });
+    });
+    // User book upload — per-IP cap, mirrors the clip zone. Uploads are heavier
+    // (file ingestion) so the same conservative bucket applies.
+    options.AddPolicy("user-upload", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromMinutes(1),
+            PermitLimit = 20,
+            QueueLimit = 0,
+        });
+    });
     // TTS synthesis — per-IP cap. Generous enough for bursty vocab-review /
     // reader-tap usage (~2/s average, tolerates ~20-req bursts via window
     // timing), but blocks scripted abuse hammering the upstream Bing WS.

--- a/backend/src/Application/UserBooks/UserBookService.cs
+++ b/backend/src/Application/UserBooks/UserBookService.cs
@@ -14,15 +14,69 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
     public async Task<(UploadUserBookResponse? Response, string? Error)> UploadAsync(
         Guid userId, Stream fileStream, string fileName, string? title, string? language, CancellationToken ct)
     {
-        // Get user and check quota
+        // Detect format
+        var format = DetectFormat(fileName);
+        if (format == BookFormat.Other)
+            return (null, "Unsupported file format. Only EPUB, PDF, and FB2 are supported.");
+
+        using var ms = new MemoryStream();
+        await fileStream.CopyToAsync(ms, ct);
+
+        return await CreateBookAsync(
+            userId,
+            content: ms,
+            originalFileName: fileName,
+            storedFileName: $"original{Path.GetExtension(fileName)}",
+            format: format,
+            title: title ?? Path.GetFileNameWithoutExtension(fileName),
+            author: null,
+            language: language ?? "en",
+            sourceUrl: null,
+            isClip: false,
+            ct);
+    }
+
+    /// <summary>
+    /// "Send to TextStack" receiver: persists already-clean article HTML as a private clip
+    /// (UserBook with <c>IsClip=true</c>, <see cref="BookFormat.Html"/>) reusing the same
+    /// upload plumbing. NEVER creates Work/Edition/Chapter rows or touches the SSG path.
+    /// </summary>
+    public async Task<(UploadUserBookResponse? Response, string? Error)> ClipAsync(
+        Guid userId, ClipRequest req, CancellationToken ct)
+    {
+        using var ms = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(req.Html));
+
+        return await CreateBookAsync(
+            userId,
+            content: ms,
+            // Worker uses OriginalFileName as the extraction request FileName, so it must
+            // carry .html for the registry to resolve HtmlTextExtractor.
+            originalFileName: "original.html",
+            storedFileName: "original.html",
+            format: BookFormat.Html,
+            title: req.Title,
+            author: req.Author,
+            language: req.Language ?? "en",
+            sourceUrl: req.SourceUrl,
+            isClip: true,
+            ct);
+    }
+
+    /// <summary>
+    /// Shared body for <see cref="UploadAsync"/> and <see cref="ClipAsync"/>: quota check,
+    /// slug gen + collision, create UserBook + UserBookFile + UserIngestionJob, storage save,
+    /// SHA256, quota update. <paramref name="content"/> position is reset internally.
+    /// </summary>
+    private async Task<(UploadUserBookResponse? Response, string? Error)> CreateBookAsync(
+        Guid userId, MemoryStream content, string originalFileName, string storedFileName,
+        BookFormat format, string title, string? author, string language, string? sourceUrl,
+        bool isClip, CancellationToken ct)
+    {
         var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId, ct);
         if (user is null)
             return (null, "User not found");
 
-        // Get file size (need to read to memory for size check and hashing)
-        using var ms = new MemoryStream();
-        await fileStream.CopyToAsync(ms, ct);
-        var fileSize = ms.Length;
+        var fileSize = content.Length;
 
         var storageLimit = user.IsGuest ? User.GuestStorageLimitBytes : User.StorageLimitBytes;
         if (user.StorageUsedBytes + fileSize > storageLimit)
@@ -35,20 +89,12 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
                 return (null, "Guest accounts can upload 1 book. Sign up for more.");
         }
 
-        // Detect format
-        var format = DetectFormat(fileName);
-        if (format == BookFormat.Other)
-            return (null, "Unsupported file format. Only EPUB, PDF, and FB2 are supported.");
+        content.Position = 0;
+        var sha256 = await ComputeSha256Async(content, ct);
 
-        // Calculate SHA256
-        ms.Position = 0;
-        var sha256 = await ComputeSha256Async(ms, ct);
-
-        // Create UserBook
         var userBookId = Guid.NewGuid();
-        var slug = SlugGenerator.GenerateSlug(title ?? Path.GetFileNameWithoutExtension(fileName));
+        var slug = SlugGenerator.GenerateSlug(title);
 
-        // Ensure unique slug for user
         var existingSlug = await db.UserBooks
             .Where(b => b.UserId == userId && b.Slug == slug)
             .Select(b => b.Slug)
@@ -60,23 +106,25 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
         {
             Id = userBookId,
             UserId = userId,
-            Title = title ?? Path.GetFileNameWithoutExtension(fileName),
+            Title = title,
             Slug = slug,
-            Language = language ?? "en",
+            Language = language,
+            Author = author,
             Status = UserBookStatus.Processing,
+            SourceUrl = sourceUrl,
+            IsClip = isClip,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow
         };
 
-        // Save file
-        ms.Position = 0;
-        var storagePath = await storage.SaveUserFileAsync(userId, userBookId, $"original{Path.GetExtension(fileName)}", ms, ct);
+        content.Position = 0;
+        var storagePath = await storage.SaveUserFileAsync(userId, userBookId, storedFileName, content, ct);
 
         var userBookFile = new UserBookFile
         {
             Id = Guid.NewGuid(),
             UserBookId = userBookId,
-            OriginalFileName = fileName,
+            OriginalFileName = originalFileName,
             StoragePath = storagePath,
             Format = format,
             Sha256 = sha256,
@@ -93,7 +141,6 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
             CreatedAt = DateTimeOffset.UtcNow
         };
 
-        // Update storage usage
         user.StorageUsedBytes += fileSize;
 
         db.UserBooks.Add(userBook);
@@ -104,10 +151,24 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
         return (new UploadUserBookResponse(userBookId, job.Id, UserBookStatus.Processing.ToString()), null);
     }
 
-    public async Task<IReadOnlyList<UserBookListDto>> GetBooksAsync(Guid userId, CancellationToken ct)
+    /// <summary>
+    /// Lists the user's books. <paramref name="shelf"/>="readlater" returns only clips
+    /// (the Read later shelf); absent/other returns only non-clips (the Books tab) so clips
+    /// never pollute the normal library. <paramref name="status"/>="unread" filters IsRead==false.
+    /// </summary>
+    public async Task<IReadOnlyList<UserBookListDto>> GetBooksAsync(
+        Guid userId, CancellationToken ct, string? shelf = null, string? status = null)
     {
-        var books = await db.UserBooks
+        var readLater = string.Equals(shelf, "readlater", StringComparison.OrdinalIgnoreCase);
+
+        var query = db.UserBooks
             .Where(b => b.UserId == userId && b.TakedownAt == null)
+            .Where(b => b.IsClip == readLater);
+
+        if (string.Equals(status, "unread", StringComparison.OrdinalIgnoreCase))
+            query = query.Where(b => !b.IsRead);
+
+        var books = await query
             .OrderByDescending(b => b.CreatedAt)
             .Select(b => new
             {
@@ -129,7 +190,11 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
                 b.ProgressUpdatedAt,
                 b.ProgressChapterSlug,
                 b.Tags,
-                b.SuggestedTags
+                b.SuggestedTags,
+                b.SourceUrl,
+                b.IsClip,
+                b.IsRead,
+                b.ReadAt
             })
             .ToListAsync(ct);
 
@@ -152,8 +217,28 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
             b.ProgressUpdatedAt,
             b.ProgressChapterSlug,
             b.Tags ?? [],
-            b.SuggestedTags ?? []
+            b.SuggestedTags ?? [],
+            b.SourceUrl,
+            b.IsClip,
+            b.IsRead,
+            b.ReadAt
         )).ToList();
+    }
+
+    /// <summary>Manually flip a book's read state (Read later shelf). Owner-scoped.</summary>
+    public async Task<(bool Success, string? Error)> SetReadAsync(
+        Guid userId, Guid bookId, bool isRead, CancellationToken ct)
+    {
+        var book = await db.UserBooks.FirstOrDefaultAsync(
+            b => b.UserId == userId && b.Id == bookId && b.TakedownAt == null, ct);
+        if (book is null)
+            return (false, "Book not found");
+
+        book.IsRead = isRead;
+        book.ReadAt = isRead ? DateTimeOffset.UtcNow : null;
+        book.UpdatedAt = DateTimeOffset.UtcNow;
+        await db.SaveChangesAsync(ct);
+        return (true, null);
     }
 
     public async Task<UserBookDetailDto?> GetBookAsync(Guid userId, Guid bookId, CancellationToken ct)
@@ -420,8 +505,16 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
         book.ProgressPercent = request.Percent;
         book.ProgressUpdatedAt = request.UpdatedAt ?? DateTimeOffset.UtcNow;
 
-        if (book.CompletedAt is null && request.Percent is >= 0.99)
-            book.CompletedAt = DateTimeOffset.UtcNow;
+        if (request.Percent is >= 0.99)
+        {
+            book.CompletedAt ??= DateTimeOffset.UtcNow;
+            // Auto-mark clips read once finished so they leave the Unread shelf.
+            if (!book.IsRead)
+            {
+                book.IsRead = true;
+                book.ReadAt = DateTimeOffset.UtcNow;
+            }
+        }
 
         await db.SaveChangesAsync(ct);
         return (true, null);

--- a/backend/src/Application/UserBooks/UserBookService.cs
+++ b/backend/src/Application/UserBooks/UserBookService.cs
@@ -100,7 +100,10 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage)
             .Select(b => b.Slug)
             .FirstOrDefaultAsync(ct);
         if (existingSlug is not null)
-            slug = $"{slug}-{DateTime.UtcNow:yyyyMMddHHmmss}";
+            // Suffix with the (globally unique) book id, NOT a second-resolution
+            // timestamp: two same-title saves within the same second would otherwise
+            // collide on the (UserId, Slug) unique index and 500 on SaveChangesAsync.
+            slug = $"{slug}-{userBookId.ToString("N")[..8]}";
 
         var userBook = new UserBook
         {

--- a/backend/src/Contracts/UserBooks/UserBookDtos.cs
+++ b/backend/src/Contracts/UserBooks/UserBookDtos.cs
@@ -19,7 +19,11 @@ public record UserBookListDto(
     DateTimeOffset? ProgressUpdatedAt,
     string? ProgressChapterSlug,
     string[] Tags,
-    string[] SuggestedTags
+    string[] SuggestedTags,
+    string? SourceUrl,
+    bool IsClip,
+    bool IsRead,
+    DateTimeOffset? ReadAt
 );
 
 public record AcceptSuggestedTagsRequest(string[] Accepted);
@@ -68,6 +72,12 @@ public record UserChapterNavDto(int ChapterNumber, string? Slug, string Title);
 public record TocEntryDto(string Title, int? ChapterNumber, IReadOnlyList<TocEntryDto>? Children);
 
 public record UploadUserBookResponse(Guid UserBookId, Guid JobId, string Status);
+
+/// <summary>
+/// "Send to TextStack" web clip — the extension sends already-clean (Readability) article HTML.
+/// The server never fetches a URL. Lands on the private Read later shelf.
+/// </summary>
+public record ClipRequest(string Title, string? Author, string? SourceUrl, string Html, string? Language);
 
 public record StorageQuotaDto(long UsedBytes, long LimitBytes, double UsedPercent);
 

--- a/backend/src/Domain/Entities/UserBook.cs
+++ b/backend/src/Domain/Entities/UserBook.cs
@@ -32,6 +32,12 @@ public class UserBook
     public DateTimeOffset? TakedownAt { get; set; }
     public string? TakedownReason { get; set; }
 
+    // "Send to TextStack" web clip (private only — never enters the public Work/Edition/SSG path).
+    public string? SourceUrl { get; set; }   // original article URL
+    public bool IsClip { get; set; }         // true => Read later shelf
+    public bool IsRead { get; set; }         // manual or auto-set when progress completes
+    public DateTimeOffset? ReadAt { get; set; }
+
     // Editable metadata (slice 11)
     // 'auto' = LLM/import-derived, 'manual' = user-edited (protect from auto-overwrite)
     public string SeoSource { get; set; } = "auto";

--- a/backend/src/Domain/Enums/BookFormat.cs
+++ b/backend/src/Domain/Enums/BookFormat.cs
@@ -5,5 +5,6 @@ public enum BookFormat
     Epub = 0,
     Pdf = 1,
     Fb2 = 2,
+    Html = 3,
     Other = 99
 }

--- a/backend/src/Extraction/TextStack.Extraction/Enums/SourceFormat.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Enums/SourceFormat.cs
@@ -5,5 +5,6 @@ public enum SourceFormat
     Unknown = 0,
     Epub = 1,
     Pdf = 2,
-    Fb2 = 3
+    Fb2 = 3,
+    Html = 4
 }

--- a/backend/src/Extraction/TextStack.Extraction/Extractors/HtmlTextExtractor.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Extractors/HtmlTextExtractor.cs
@@ -1,0 +1,198 @@
+using System.Text;
+using HtmlAgilityPack;
+using TextStack.Extraction.Contracts;
+using TextStack.Extraction.Enums;
+using TextStack.Extraction.Toc;
+using TextStack.Extraction.Utilities;
+
+namespace TextStack.Extraction.Extractors;
+
+/// <summary>
+/// Extracts a single clean web article ("Send to TextStack" clip) into reader chapters.
+/// Input is already-clean HTML (Readability runs in the browser extension); this just
+/// sanitizes via <see cref="HtmlCleaner"/>, splits on h1/h2 when multi-section, and pulls
+/// title/author/description metadata. Never enters the public Work/Edition/SSG path.
+/// </summary>
+public sealed class HtmlTextExtractor : ITextExtractor
+{
+    public SourceFormat SupportedFormat => SourceFormat.Html;
+
+    public Task<ExtractionResult> ExtractAsync(ExtractionRequest request, CancellationToken ct = default)
+    {
+        var warnings = new List<ExtractionWarning>();
+
+        string rawHtml;
+        try
+        {
+            using var reader = new StreamReader(request.Content, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            rawHtml = reader.ReadToEnd();
+        }
+        catch (Exception ex)
+        {
+            warnings.Add(new ExtractionWarning(ExtractionWarningCode.ParseError, $"Failed to read HTML: {ex.Message}"));
+            return Task.FromResult(Empty(warnings));
+        }
+
+        if (string.IsNullOrWhiteSpace(rawHtml))
+        {
+            warnings.Add(new ExtractionWarning(ExtractionWarningCode.EmptyContent, "HTML clip was empty"));
+            return Task.FromResult(Empty(warnings));
+        }
+
+        try
+        {
+            var (title, authors, description) = ExtractMetadata(rawHtml);
+
+            var sections = SplitByHeadings(rawHtml);
+
+            var units = new List<ContentUnit>();
+            var tocChapters = new List<(int ChapterNumber, string Html)>();
+            var order = 0;
+
+            foreach (var (sectionTitle, sectionHtml) in sections)
+            {
+                if (ct.IsCancellationRequested) break;
+
+                var (cleanHtml, plainText) = HtmlCleaner.Clean(sectionHtml);
+                if (string.IsNullOrWhiteSpace(plainText)) continue;
+
+                var chapterNumber = order + 1;
+                cleanHtml = TocGenerator.InjectAnchorIds(cleanHtml, chapterNumber);
+                tocChapters.Add((chapterNumber, cleanHtml));
+
+                units.Add(new ContentUnit(
+                    Type: ContentUnitType.Chapter,
+                    Title: sectionTitle ?? title ?? $"Section {chapterNumber}",
+                    Html: cleanHtml,
+                    PlainText: plainText,
+                    OrderIndex: order++,
+                    WordCount: HtmlCleaner.CountWords(plainText)));
+            }
+
+            if (units.Count == 0)
+            {
+                warnings.Add(new ExtractionWarning(ExtractionWarningCode.EmptyContent, "No readable text in HTML clip"));
+                return Task.FromResult(Empty(warnings));
+            }
+
+            // Fallback book title: supplied <title>/<h1> via ExtractTitle, else first unit's title.
+            title ??= HtmlCleaner.ExtractTitle(rawHtml) ?? units[0].Title;
+
+            var toc = TocGenerator.GenerateToc(tocChapters);
+            var metadata = new ExtractionMetadata(title, authors, null, description);
+            var diagnostics = new ExtractionDiagnostics(TextSource.NativeText, null, warnings);
+
+            return Task.FromResult(new ExtractionResult(SourceFormat.Html, metadata, units, [], diagnostics, toc));
+        }
+        catch (Exception ex)
+        {
+            warnings.Add(new ExtractionWarning(ExtractionWarningCode.ParseError, $"Failed to parse HTML clip: {ex.Message}"));
+            return Task.FromResult(Empty(warnings));
+        }
+    }
+
+    private static ExtractionResult Empty(IReadOnlyList<ExtractionWarning> warnings) => new(
+        SourceFormat.Html,
+        new ExtractionMetadata(null, null, null, null),
+        [],
+        [],
+        new ExtractionDiagnostics(TextSource.None, null, warnings));
+
+    /// <summary>
+    /// Pulls book-level metadata from the RAW html (before HtmlCleaner strips &lt;head&gt;).
+    /// title: first visible &lt;h1&gt; → &lt;title&gt;; author: &lt;meta name="author"&gt; → byline;
+    /// description: &lt;meta name="description"&gt;.
+    /// </summary>
+    private static (string? Title, string? Authors, string? Description) ExtractMetadata(string html)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+        var root = doc.DocumentNode;
+
+        var title = Clean(root.SelectSingleNode("//h1")?.InnerText)
+                    ?? Clean(root.SelectSingleNode("//title")?.InnerText);
+
+        var author = MetaContent(root, "author")
+                     ?? Clean(root.SelectSingleNode("//*[contains(@class,'byline')]")?.InnerText);
+        // "By Jane Doe" → "Jane Doe"
+        if (author is not null && author.StartsWith("By ", StringComparison.OrdinalIgnoreCase))
+            author = author[3..].Trim();
+
+        var description = MetaContent(root, "description");
+
+        return (title, NullIfEmpty(author), description);
+    }
+
+    private static string? MetaContent(HtmlNode root, string name)
+    {
+        var node = root.SelectSingleNode($"//meta[translate(@name,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='{name}']");
+        return NullIfEmpty(Clean(node?.GetAttributeValue("content", string.Empty)));
+    }
+
+    private static string? Clean(string? text)
+        => string.IsNullOrWhiteSpace(text) ? null : HtmlEntity.DeEntitize(text).Trim();
+
+    private static string? NullIfEmpty(string? text)
+        => string.IsNullOrWhiteSpace(text) ? null : text;
+
+    /// <summary>
+    /// Splits article body into sections at each &lt;h1&gt;/&lt;h2&gt;. Single-section articles
+    /// (the common case) return one unit. Content before the first heading is prepended to
+    /// the first section so nothing is dropped.
+    /// </summary>
+    private static List<(string? Title, string Html)> SplitByHeadings(string html)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        // Drop non-content nodes up front so they never land in a section.
+        doc.DocumentNode.SelectNodes("//script|//style|//head|//noscript")?.ToList()
+            .ForEach(n => n.Remove());
+
+        var body = doc.DocumentNode.SelectSingleNode("//body") ?? doc.DocumentNode;
+
+        // Flatten to top-level content nodes. If the article is wrapped in a single
+        // <article>/<main>/<div>, descend into it so headings become siblings.
+        var container = body;
+        var elementChildren = container.ChildNodes.Where(n => n.NodeType == HtmlNodeType.Element).ToList();
+        while (elementChildren.Count == 1 &&
+               (elementChildren[0].Name is "article" or "main" or "div" or "section"))
+        {
+            container = elementChildren[0];
+            elementChildren = container.ChildNodes.Where(n => n.NodeType == HtmlNodeType.Element).ToList();
+        }
+
+        var nodes = container.ChildNodes.ToList();
+        var sections = new List<(string? Title, StringBuilder Html)>();
+        StringBuilder? current = null;
+
+        foreach (var node in nodes)
+        {
+            var isHeading = node.NodeType == HtmlNodeType.Element &&
+                            (node.Name == "h1" || node.Name == "h2");
+
+            if (isHeading)
+            {
+                var sectionTitle = Clean(node.InnerText);
+                current = new StringBuilder();
+                sections.Add((sectionTitle, current));
+                current.Append(node.OuterHtml);
+                continue;
+            }
+
+            if (current is null)
+            {
+                // Preamble before the first heading — open an untitled section.
+                current = new StringBuilder();
+                sections.Add((null, current));
+            }
+
+            current.Append(node.OuterHtml);
+        }
+
+        if (sections.Count == 0)
+            return [(null, container.InnerHtml)];
+
+        return sections.Select(s => (s.Title, s.Html.ToString())).ToList();
+    }
+}

--- a/backend/src/Extraction/TextStack.Extraction/Registry/ExtractorRegistry.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Registry/ExtractorRegistry.cs
@@ -10,7 +10,8 @@ public sealed class ExtractorRegistry : IExtractorRegistry
     {
         [".epub"] = SourceFormat.Epub,
         [".pdf"] = SourceFormat.Pdf,
-        [".fb2"] = SourceFormat.Fb2
+        [".fb2"] = SourceFormat.Fb2,
+        [".html"] = SourceFormat.Html
     };
 
     private readonly Dictionary<SourceFormat, ITextExtractor> _extractors;

--- a/backend/src/Extraction/TextStack.Extraction/Utilities/HtmlCleaner.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Utilities/HtmlCleaner.cs
@@ -12,7 +12,16 @@ namespace TextStack.Extraction.Utilities;
 /// </summary>
 public partial class HtmlCleaner
 {
-    private static readonly string[] DangerousAttributes = ["onclick", "onload", "onerror", "onmouseover", "onfocus", "onblur"];
+    // Tags that can execute script or hijack the page even after script/style are dropped.
+    // Removed entirely (with their subtree) before attribute scrubbing. <base> rebases every
+    // relative URL; <form>/<iframe>/<object>/<embed> are active vectors; <link>/<meta> can
+    // load/redirect. Kept conservative so trusted-book prose (p/a/img/svg/figure/etc.) survives.
+    private static readonly string[] DangerousTags =
+        ["iframe", "object", "embed", "base", "form", "link", "meta", "noscript", "frame", "frameset", "applet"];
+
+    // URL-bearing attributes scrubbed with the same scheme allowlist as href.
+    private static readonly string[] UrlAttributes =
+        ["href", "src", "srcset", "data", "action", "formaction", "poster", "background", "xlink:href"];
 
     private readonly IProcessingPipeline _pipeline;
     private readonly TextProcessingOptions _options;
@@ -43,6 +52,8 @@ public partial class HtmlCleaner
 
         doc.DocumentNode.SelectNodes("//script|//style|//head")?.ToList()
             .ForEach(n => n.Remove());
+
+        RemoveDangerousTags(doc.DocumentNode);
 
         var body = doc.DocumentNode.SelectSingleNode("//body");
         var content = body ?? doc.DocumentNode;
@@ -136,40 +147,89 @@ public partial class HtmlCleaner
     [GeneratedRegex(@"<(script|title)(\s[^>]*)?\s*/>", RegexOptions.IgnoreCase)]
     private static partial Regex SelfClosingNonVoidRegex();
 
+    private static void RemoveDangerousTags(HtmlNode root)
+    {
+        // Build an XPath union of //iframe|//object|... — case-insensitive because HAP
+        // lower-cases element names on parse.
+        var xpath = string.Join("|", DangerousTags.Select(t => $"//{t}"));
+        root.SelectNodes(xpath)?.ToList().ForEach(n => n.Remove());
+    }
+
     private static void RemoveDangerousAttributes(HtmlNode node)
     {
         foreach (var descendant in node.DescendantsAndSelf())
         {
-            foreach (var attr in DangerousAttributes)
+            // Strip EVERY event handler (on*), not a fixed denylist — onerror/ontoggle/
+            // onmouseenter/onanimationstart/etc. all execute script. Snapshot first:
+            // we mutate the collection inside the loop.
+            foreach (var attr in descendant.Attributes.ToList())
             {
-                descendant.Attributes.Remove(attr);
+                if (attr.Name.StartsWith("on", StringComparison.OrdinalIgnoreCase))
+                    descendant.Attributes.Remove(attr);
             }
 
-            var href = descendant.GetAttributeValue("href", "");
-            if (!string.IsNullOrEmpty(href))
+            // Scrub every URL-bearing attribute with one scheme allowlist.
+            foreach (var attrName in UrlAttributes)
             {
-                if (href.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase))
-                {
-                    descendant.SetAttributeValue("href", "#");
-                }
-                else if (!href.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
-                         !href.StartsWith("https://", StringComparison.OrdinalIgnoreCase) &&
-                         !href.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (href.StartsWith('#'))
-                    {
-                        // Keep anchor-only links
-                    }
-                    else if (href.Contains('#'))
-                    {
-                        descendant.SetAttributeValue("href", "#" + href.Split('#')[1]);
-                    }
-                    else
-                    {
-                        descendant.SetAttributeValue("href", "#");
-                    }
-                }
+                var value = descendant.GetAttributeValue(attrName, "");
+                if (string.IsNullOrEmpty(value))
+                    continue;
+
+                var sanitized = SanitizeUrl(attrName, value);
+                if (sanitized is null)
+                    descendant.Attributes.Remove(attrName);
+                else if (!ReferenceEquals(sanitized, value))
+                    descendant.SetAttributeValue(attrName, sanitized);
             }
         }
+    }
+
+    // Schemes that can execute or smuggle script. Anything matching is rejected; everything
+    // else (http(s), mailto, RELATIVE paths like "OEBPS/img.jpg", protocol-relative, anchors,
+    // and data:image/* used for inline covers) is allowed so trusted-book rendering is intact.
+    private static readonly string[] DangerousSchemes =
+        ["javascript:", "vbscript:", "file:", "blob:", "data:text/html"];
+
+    /// <summary>
+    /// Returns the value unchanged if safe, a neutered "#" for unsafe href-like links,
+    /// or null to signal the attribute should be removed entirely (src/srcset/etc.).
+    /// Only URLs whose scheme is in <see cref="DangerousSchemes"/> are treated as unsafe.
+    /// Bare <c>data:</c> (without an image/* media type) is also rejected.
+    /// </summary>
+    private static string? SanitizeUrl(string attrName, string value)
+    {
+        // Browsers ignore leading/embedded control chars & whitespace when resolving the
+        // scheme (e.g. "java\tscript:" → "javascript:"). Decode entities and strip those
+        // chars up to the first ':' before matching so obfuscated payloads don't slip past.
+        var decoded = HtmlEntity.DeEntitize(value) ?? value;
+        var collapsed = new string(decoded.Where(c => c is not ('\t' or '\n' or '\r' or '\f' or '\0' or ' ')).ToArray());
+        // srcset is a comma list of "url descriptor" pairs; check the first url.
+        var firstUrl = attrName == "srcset"
+            ? collapsed.Split(',')[0].Split(' ')[0]
+            : collapsed;
+
+        var isNavigational = attrName is "href" or "xlink:href";
+        // data:image/* is safe as an <img src> (browsers never run script there) but a NAVIGATIONAL
+        // data: link (href) opens in a document context where SVG/HTML scripts can run — reject those.
+        var dataImageOk = firstUrl.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase)
+                          && !isNavigational
+                          && !firstUrl.StartsWith("data:image/svg", StringComparison.OrdinalIgnoreCase);
+
+        var unsafeScheme = DangerousSchemes.Any(s =>
+                               firstUrl.StartsWith(s, StringComparison.OrdinalIgnoreCase))
+                           || (firstUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase) && !dataImageOk);
+
+        if (!unsafeScheme)
+            return value; // safe — keep as-is (relative paths preserved for image rewrite)
+
+        // href can be downgraded to a harmless anchor; everything else gets dropped.
+        if (attrName is "href" or "xlink:href")
+        {
+            if (value.Contains('#'))
+                return "#" + value.Split('#')[1];
+            return "#";
+        }
+
+        return null; // remove src/srcset/data/action/formaction/poster/background
     }
 }

--- a/backend/src/Infrastructure/Migrations/20260618195832_AddClipAndReadState.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260618195832_AddClipAndReadState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618195832_AddClipAndReadState")]
+    partial class AddClipAndReadState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260618195832_AddClipAndReadState.cs
+++ b/backend/src/Infrastructure/Migrations/20260618195832_AddClipAndReadState.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClipAndReadState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_clip",
+                table: "user_books",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_read",
+                table: "user_books",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "read_at",
+                table: "user_books",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "source_url",
+                table: "user_books",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_books_user_id_is_clip",
+                table: "user_books",
+                columns: new[] { "user_id", "is_clip" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_user_books_user_id_is_clip",
+                table: "user_books");
+
+            migrationBuilder.DropColumn(
+                name: "is_clip",
+                table: "user_books");
+
+            migrationBuilder.DropColumn(
+                name: "is_read",
+                table: "user_books");
+
+            migrationBuilder.DropColumn(
+                name: "read_at",
+                table: "user_books");
+
+            migrationBuilder.DropColumn(
+                name: "source_url",
+                table: "user_books");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.UserBooks.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.UserBooks.cs
@@ -31,6 +31,11 @@ public partial class AppDbContext
             e.Property(x => x.Tags).HasColumnType("text[]").HasDefaultValueSql("ARRAY[]::text[]");
             e.HasIndex(x => x.Tags).HasMethod("gin");
             e.Property(x => x.SuggestedTags).HasColumnType("text[]").HasDefaultValueSql("ARRAY[]::text[]");
+            // "Send to TextStack" clip fields. IsClip/IsRead NOT NULL default false.
+            e.Property(x => x.SourceUrl).HasMaxLength(2048);
+            e.Property(x => x.IsClip).HasDefaultValue(false);
+            e.Property(x => x.IsRead).HasDefaultValue(false);
+            e.HasIndex(x => new { x.UserId, x.IsClip });
             e.HasOne(x => x.User).WithMany(x => x.UserBooks).HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
         });
 

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -52,6 +52,7 @@ else
 builder.Services.AddSingleton<ITextExtractor, EpubTextExtractor>();
 builder.Services.AddSingleton<ITextExtractor, PdfTextExtractor>();
 builder.Services.AddSingleton<ITextExtractor, Fb2TextExtractor>();
+builder.Services.AddSingleton<ITextExtractor, HtmlTextExtractor>();
 builder.Services.AddSingleton<IExtractorRegistry, ExtractorRegistry>();
 
 // Image optimization

--- a/tests/TextStack.Extraction.Tests/Fixtures/article.html
+++ b/tests/TextStack.Extraction.Tests/Fixtures/article.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>The Title Tag Article</title>
+  <meta name="author" content="Jane Doe">
+  <meta name="description" content="A short summary of the clipped article.">
+  <script>window.tracker = function(){ doEvil(); };</script>
+</head>
+<body>
+  <article>
+    <h1>How Reading Builds Fluency</h1>
+    <p class="byline">By Jane Doe</p>
+    <p>Long-form reading is the core engine of language learning. It exposes
+       the learner to real vocabulary in real context, again and again.</p>
+    <p>Micro-exercises cannot replace the depth of a full book. <a href="javascript:steal()">click me</a></p>
+    <img src="https://example.com/hero.jpg" alt="A reader at a desk">
+
+    <h2>Why Context Matters</h2>
+    <p onclick="alert('xss')">Words learned in isolation fade fast. Words met inside
+       a sentence stick, because the brain has a hook to hang them on.</p>
+    <p>This is why TextStack enhances reading instead of interrupting it.</p>
+  </article>
+</body>
+</html>

--- a/tests/TextStack.Extraction.Tests/HtmlExtractorTests.cs
+++ b/tests/TextStack.Extraction.Tests/HtmlExtractorTests.cs
@@ -1,0 +1,161 @@
+using System.Text;
+using TextStack.Extraction.Contracts;
+using TextStack.Extraction.Enums;
+using TextStack.Extraction.Extractors;
+
+namespace TextStack.Extraction.Tests;
+
+public class HtmlExtractorTests
+{
+    private static string FixturePath => Path.Combine(
+        AppContext.BaseDirectory, "Fixtures", "article.html");
+
+    private static ExtractionRequest RequestFromString(string html, string fileName = "original.html")
+        => new() { Content = new MemoryStream(Encoding.UTF8.GetBytes(html)), FileName = fileName };
+
+    private static async Task<ExtractionRequest> RequestFromFixtureAsync()
+    {
+        var bytes = await File.ReadAllBytesAsync(FixturePath, TestContext.Current.CancellationToken);
+        return new ExtractionRequest { Content = new MemoryStream(bytes), FileName = "original.html" };
+    }
+
+    [Fact]
+    public async Task ExtractAsync_CleanArticle_ReturnsUnitsWithContentAndHtmlFormat()
+    {
+        var extractor = new HtmlTextExtractor();
+        var request = await RequestFromFixtureAsync();
+
+        var result = await extractor.ExtractAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(SourceFormat.Html, result.SourceFormat);
+        Assert.Equal(TextSource.NativeText, result.Diagnostics.TextSource);
+        Assert.NotEmpty(result.Units);
+        var unit = result.Units[0];
+        Assert.False(string.IsNullOrWhiteSpace(unit.PlainText));
+        Assert.True(result.Units.Sum(u => u.WordCount ?? 0) > 0);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MultiSection_SplitsIntoMultipleUnits()
+    {
+        var extractor = new HtmlTextExtractor();
+        var request = await RequestFromFixtureAsync();
+
+        var result = await extractor.ExtractAsync(request, TestContext.Current.CancellationToken);
+
+        // Fixture has an <h1> section and an <h2> section.
+        Assert.True(result.Units.Count >= 2, $"expected >=2 units, got {result.Units.Count}");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_SingleSection_ReturnsOneUnit()
+    {
+        var extractor = new HtmlTextExtractor();
+        const string html = "<h1>Just One</h1><p>Only a single section of prose here, no other headings.</p>";
+        var request = RequestFromString(html);
+
+        var result = await extractor.ExtractAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Single(result.Units);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_Metadata_ExtractsTitleAuthorDescription()
+    {
+        var extractor = new HtmlTextExtractor();
+        var request = await RequestFromFixtureAsync();
+
+        var result = await extractor.ExtractAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal("How Reading Builds Fluency", result.Metadata.Title);
+        Assert.Equal("Jane Doe", result.Metadata.Authors);
+        Assert.Equal("A short summary of the clipped article.", result.Metadata.Description);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MaliciousHtml_StripsScriptAndHandlers()
+    {
+        var extractor = new HtmlTextExtractor();
+        var request = await RequestFromFixtureAsync();
+
+        var result = await extractor.ExtractAsync(request, TestContext.Current.CancellationToken);
+
+        var allHtml = string.Concat(result.Units.Select(u => u.Html));
+        Assert.DoesNotContain("<script", allHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onclick", allHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("javascript:", allHtml, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Attacker-controlled clip HTML: each payload below survived the original
+    // event-handler denylist + href-only scheme check. The stored chapter Html is
+    // rendered verbatim by the web reader, so any survivor is a stored-XSS.
+    [Theory]
+    [InlineData("<p>x</p><iframe src=\"javascript:evil()\"></iframe>", "<iframe")]
+    [InlineData("<p>x</p><object data=\"javascript:alert(1)\"></object>", "<object")]
+    [InlineData("<p>x</p><embed src=\"javascript:alert(1)\">", "<embed")]
+    [InlineData("<base href=\"javascript:alert(1)\"><p>x</p>", "<base")]
+    [InlineData("<form action=\"javascript:alert(1)\"><button>x</button></form>", "action")]
+    [InlineData("<p>x</p><img src=y onerror=alert(1)>", "onerror")]
+    [InlineData("<p ontoggle=alert(1)>x</p>", "ontoggle")]
+    [InlineData("<details ontoggle=alert(1) open>x</details>", "ontoggle")]
+    [InlineData("<p onmouseenter=alert(1)>x</p>", "onmouseenter")]
+    [InlineData("<input autofocus onfocus=alert(1)>x", "onfocus")]
+    [InlineData("<button formaction=\"javascript:alert(1)\">x</button>", "formaction")]
+    [InlineData("<img srcset=\"javascript:alert(1)\">x", "javascript:")]
+    [InlineData("<svg><script>alert(1)</script></svg><p>x</p>", "<script")]
+    [InlineData("<a href=\"java\tscript:alert(1)\">x</a>", "javascript:")]
+    [InlineData("<a href=\"data:text/html,<script>alert(1)</script>\">x</a>", "data:text/html")]
+    public async Task ExtractAsync_XssVector_DoesNotSurviveIntoChapterHtml(string payload, string forbidden)
+    {
+        var extractor = new HtmlTextExtractor();
+        // Wrap with prose so a readable unit is always produced.
+        var html = $"<h1>Article</h1><p>Some readable prose here for the unit.</p>{payload}";
+        var request = RequestFromString(html);
+
+        var result = await extractor.ExtractAsync(request, TestContext.Current.CancellationToken);
+
+        var allHtml = string.Concat(result.Units.Select(u => u.Html));
+        Assert.DoesNotContain(forbidden, allHtml, StringComparison.OrdinalIgnoreCase);
+        // No event-handler attribute of any name should survive.
+        Assert.DoesNotContain("onerror", allHtml, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_RelativeImageSrc_IsPreservedForRewrite()
+    {
+        // The worker rewrites relative img src -> /api asset URLs AFTER cleaning, so the
+        // sanitizer must NOT drop relative (scheme-less) src or book images break.
+        var extractor = new HtmlTextExtractor();
+        const string html = "<h1>Pics</h1><p>prose</p><img src=\"OEBPS/images/photo.jpg\" alt=\"x\">";
+        var request = RequestFromString(html);
+
+        var result = await extractor.ExtractAsync(request, TestContext.Current.CancellationToken);
+
+        var allHtml = string.Concat(result.Units.Select(u => u.Html));
+        Assert.Contains("OEBPS/images/photo.jpg", allHtml, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_InvalidStream_NeverThrows()
+    {
+        var extractor = new HtmlTextExtractor();
+        using var stream = new MemoryStream([0xFF, 0xFE, 0x00, 0x01]);
+        var request = new ExtractionRequest { Content = stream, FileName = "original.html" };
+
+        var exception = await Record.ExceptionAsync(() => extractor.ExtractAsync(request, TestContext.Current.CancellationToken));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptyInput_ReturnsNoUnitsWithoutThrowing()
+    {
+        var extractor = new HtmlTextExtractor();
+        var request = RequestFromString("");
+
+        var result = await extractor.ExtractAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(SourceFormat.Html, result.SourceFormat);
+        Assert.Empty(result.Units);
+    }
+}

--- a/tests/TextStack.IntegrationTests/UserBookEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/UserBookEndpointTests.cs
@@ -105,6 +105,218 @@ public class UserBookEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtur
 
     #endregion
 
+    #region Clip (Send to TextStack)
+
+    private static readonly object SampleClip = new
+    {
+        title = "Integration Test Clip",
+        author = "Test Author",
+        sourceUrl = "https://example.com/article",
+        html = "<h1>Integration Test Clip</h1><p>Real fluency comes from real books, read deeply.</p>",
+        language = "en"
+    };
+
+    [Fact]
+    public async Task ClipArticle_WithoutAuth_Returns401()
+    {
+        var request = _anon.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        request.Content = JsonContent.Create(SampleClip);
+        var response = await _anon.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ClipArticle_Authenticated_Returns200WithProcessingStatus()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        var request = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        request.Content = JsonContent.Create(SampleClip);
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<ClipResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(body);
+        Assert.NotEqual(Guid.Empty, body!.UserBookId);
+        Assert.NotEqual(Guid.Empty, body.JobId);
+        Assert.Equal("Processing", body.Status);
+    }
+
+    [Fact]
+    public async Task ClipArticle_EmptyHtml_Returns400()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        var request = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        request.Content = JsonContent.Create(new { title = "T", html = "", language = "en" });
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ClipArticle_MissingTitle_Returns400()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        var request = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        request.Content = JsonContent.Create(new { title = "", html = "<p>body</p>", language = "en" });
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ClipArticle_OversizedHtml_Returns400()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        var bigHtml = "<p>" + new string('a', 3 * 1024 * 1024) + "</p>"; // > 2 MB
+        var request = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        request.Content = JsonContent.Create(new { title = "Big", html = bigHtml, language = "en" });
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ClipArticle_InvalidSourceUrl_Returns400()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        var request = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        request.Content = JsonContent.Create(new
+        {
+            title = "T",
+            sourceUrl = "javascript:alert(1)",
+            html = "<p>body</p>",
+            language = "en"
+        });
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("vbscript:msgbox(1)")]
+    [InlineData("JAVASCRIPT:alert(1)")]
+    public async Task ClipArticle_DangerousSourceUrlScheme_Returns400(string sourceUrl)
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        var request = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        request.Content = JsonContent.Create(new
+        {
+            title = "T",
+            sourceUrl,
+            html = "<p>body</p>",
+            language = "en"
+        });
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MarkRead_NonExistentOrForeignBook_Returns404NotSilentSuccess()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        // A random id stands in for "a book the caller does not own": the owner-scoped
+        // query must miss it and return 404 rather than NoContent.
+        var mark = _auth.CreateRequest(HttpMethod.Put, $"/me/books/{Guid.NewGuid()}/read");
+        var resp = await _auth.Client.SendAsync(mark, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetUserBooks_ReadLaterShelf_ReturnsOnlyClips()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        // Seed a clip so the shelf is non-empty.
+        var seed = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        seed.Content = JsonContent.Create(SampleClip);
+        var seedResp = await _auth.Client.SendAsync(seed, TestContext.Current.CancellationToken);
+        Assert.SkipWhen(seedResp.StatusCode != HttpStatusCode.OK, "clip seed unavailable");
+
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/books?shelf=readlater");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var books = await response.Content.ReadFromJsonAsync<UserBookListItem[]>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(books);
+        Assert.All(books!, b => Assert.True(b.IsClip));
+    }
+
+    [Fact]
+    public async Task MarkRead_Authenticated_FlipsState()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        var seed = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        seed.Content = JsonContent.Create(SampleClip);
+        var seedResp = await _auth.Client.SendAsync(seed, TestContext.Current.CancellationToken);
+        Assert.SkipWhen(seedResp.StatusCode != HttpStatusCode.OK, "clip seed unavailable");
+        var clip = await seedResp.Content.ReadFromJsonAsync<ClipResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var mark = _auth.CreateRequest(HttpMethod.Put, $"/me/books/{clip!.UserBookId}/read");
+        var markResp = await _auth.Client.SendAsync(mark, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NoContent, markResp.StatusCode);
+
+        var listReq = _auth.CreateRequest(HttpMethod.Get, "/me/books?shelf=readlater");
+        var listResp = await _auth.Client.SendAsync(listReq, TestContext.Current.CancellationToken);
+        var books = await listResp.Content.ReadFromJsonAsync<UserBookListItem[]>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        var seeded = Assert.Single(books!, b => b.Id == clip.UserBookId.ToString());
+        Assert.True(seeded.IsRead);
+    }
+
+    [Fact]
+    public async Task GetUserBooks_UnreadFilter_ExcludesReadClips()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        var seed = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        seed.Content = JsonContent.Create(SampleClip);
+        var seedResp = await _auth.Client.SendAsync(seed, TestContext.Current.CancellationToken);
+        Assert.SkipWhen(seedResp.StatusCode != HttpStatusCode.OK, "clip seed unavailable");
+        var clip = await seedResp.Content.ReadFromJsonAsync<ClipResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var mark = _auth.CreateRequest(HttpMethod.Put, $"/me/books/{clip!.UserBookId}/read");
+        await _auth.Client.SendAsync(mark, TestContext.Current.CancellationToken);
+
+        var req = _auth.CreateRequest(HttpMethod.Get, "/me/books?shelf=readlater&status=unread");
+        var resp = await _auth.Client.SendAsync(req, TestContext.Current.CancellationToken);
+        var books = await resp.Content.ReadFromJsonAsync<UserBookListItem[]>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(books);
+        Assert.DoesNotContain(books!, b => b.Id == clip.UserBookId.ToString());
+    }
+
+    [Fact]
+    public async Task GetUserBooks_DefaultBooksTab_ExcludesClips()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test auth unavailable");
+
+        var seed = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        seed.Content = JsonContent.Create(SampleClip);
+        var seedResp = await _auth.Client.SendAsync(seed, TestContext.Current.CancellationToken);
+        Assert.SkipWhen(seedResp.StatusCode != HttpStatusCode.OK, "clip seed unavailable");
+
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/books");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        var books = await response.Content.ReadFromJsonAsync<UserBookListItem[]>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(books);
+        Assert.All(books!, b => Assert.False(b.IsClip));
+    }
+
+    private record ClipResponse(Guid UserBookId, Guid JobId, string Status);
+
+    #endregion
+
     private record UserBookListItem(
         string Id,
         string Title,
@@ -118,7 +330,13 @@ public class UserBookEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtur
         string? ErrorMessage,
         int ChapterCount,
         int? TotalWordCount,
-        string? CreatedAt
+        string? CreatedAt,
+        string[]? Tags,
+        string[]? SuggestedTags,
+        string? SourceUrl,
+        bool IsClip,
+        bool IsRead,
+        string? ReadAt
     );
 
     private record StorageQuotaResponse(long UsedBytes, long LimitBytes, double UsedPercent);

--- a/tests/TextStack.UnitTests/UserBookClipServiceTests.cs
+++ b/tests/TextStack.UnitTests/UserBookClipServiceTests.cs
@@ -1,0 +1,212 @@
+using Application.Common.Interfaces;
+using Application.UserBooks;
+using Contracts.UserBooks;
+using Domain.Entities;
+using Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace TextStack.UnitTests;
+
+// ClipAsync over a Moq IAppDbContext whose sets are backed by List<T> (async LINQ via
+// TestAsyncQueryable). The production AppDbContext can't load on EF InMemory (NpgsqlTsVector
+// on Chapter), so we fake just the sets ClipAsync touches. The key assertion is the spec
+// §1.7 invariant: a clip is a PRIVATE UserBook and MUST NEVER create Work/Edition/Chapter rows.
+public class UserBookClipServiceTests
+{
+    private sealed class Harness
+    {
+        public List<User> Users { get; } = [];
+        public List<UserBook> UserBooks { get; } = [];
+        public List<UserBookFile> UserBookFiles { get; } = [];
+        public List<UserIngestionJob> Jobs { get; } = [];
+        public List<Work> Works { get; } = [];
+        public List<Edition> Editions { get; } = [];
+        public List<Chapter> Chapters { get; } = [];
+        public Mock<IFileStorageService> Storage { get; } = new();
+        public UserBookService Service { get; }
+
+        public Harness()
+        {
+            Storage
+                .Setup(s => s.SaveUserFileAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid uid, Guid bid, string name, Stream _, CancellationToken _) => $"users/{uid}/books/{bid}/{name}");
+
+            var db = new Mock<IAppDbContext>();
+            db.Setup(x => x.Users).Returns(() => FakeSet(Users).Object);
+            db.Setup(x => x.UserBooks).Returns(() => FakeSet(UserBooks).Object);
+            db.Setup(x => x.UserBookFiles).Returns(() => FakeSet(UserBookFiles).Object);
+            db.Setup(x => x.UserIngestionJobs).Returns(() => FakeSet(Jobs).Object);
+            db.Setup(x => x.Works).Returns(() => FakeSet(Works).Object);
+            db.Setup(x => x.Editions).Returns(() => FakeSet(Editions).Object);
+            db.Setup(x => x.Chapters).Returns(() => FakeSet(Chapters).Object);
+            db.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+
+            Service = new UserBookService(db.Object, Storage.Object);
+        }
+
+        public User SeedUser()
+        {
+            var u = new User { Id = Guid.NewGuid(), Email = "clip@test.dev", IsGuest = false, StorageUsedBytes = 0 };
+            Users.Add(u);
+            return u;
+        }
+    }
+
+    private static Mock<DbSet<T>> FakeSet<T>(List<T> data) where T : class
+    {
+        var q = new TestAsyncEnumerable<T>(data);
+        var set = new Mock<DbSet<T>>();
+        var iq = set.As<IQueryable<T>>();
+        iq.Setup(m => m.Provider).Returns(((IQueryable<T>)q).Provider);
+        iq.Setup(m => m.Expression).Returns(((IQueryable<T>)q).Expression);
+        iq.Setup(m => m.ElementType).Returns(((IQueryable<T>)q).ElementType);
+        iq.Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
+        set.As<IAsyncEnumerable<T>>()
+            .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+            .Returns(() => new TestAsyncEnumerator<T>(data.GetEnumerator()));
+        set.Setup(m => m.Add(It.IsAny<T>())).Callback<T>(e => data.Add(e));
+        return set;
+    }
+
+    private static ClipRequest SampleClip() => new(
+        Title: "How Reading Builds Fluency",
+        Author: "Jane Doe",
+        SourceUrl: "https://example.com/article",
+        Html: "<h1>How Reading Builds Fluency</h1><p>Real fluency comes from real books.</p>",
+        Language: "en");
+
+    [Fact]
+    public async Task ClipAsync_ValidRequest_CreatesPrivateUserBookClip()
+    {
+        var h = new Harness();
+        var user = h.SeedUser();
+
+        var (response, error) = await h.Service.ClipAsync(user.Id, SampleClip(), CancellationToken.None);
+
+        Assert.Null(error);
+        Assert.NotNull(response);
+        Assert.Equal("Processing", response!.Status);
+
+        var book = Assert.Single(h.UserBooks);
+        Assert.True(book.IsClip);
+        Assert.Equal("https://example.com/article", book.SourceUrl);
+        Assert.Equal("Jane Doe", book.Author);
+        Assert.Equal("en", book.Language);
+
+        var file = Assert.Single(h.UserBookFiles);
+        Assert.Equal(BookFormat.Html, file.Format);
+        // OriginalFileName must carry .html so the worker registry resolves HtmlTextExtractor.
+        Assert.EndsWith(".html", file.OriginalFileName);
+
+        Assert.Single(h.Jobs);
+    }
+
+    [Fact]
+    public async Task ClipAsync_AnyClip_CreatesNoWorkOrEdition()
+    {
+        var h = new Harness();
+        var user = h.SeedUser();
+
+        await h.Service.ClipAsync(user.Id, SampleClip(), CancellationToken.None);
+
+        // The locked constraint: clips are private UserBooks only — never the public path.
+        Assert.Empty(h.Works);
+        Assert.Empty(h.Editions);
+        Assert.Empty(h.Chapters);
+    }
+
+    [Fact]
+    public async Task ClipAsync_MissingUser_ReturnsError()
+    {
+        var h = new Harness();
+
+        var (response, error) = await h.Service.ClipAsync(Guid.NewGuid(), SampleClip(), CancellationToken.None);
+
+        Assert.Null(response);
+        Assert.Equal("User not found", error);
+    }
+
+    [Fact]
+    public async Task ClipAsync_StorageLimitExceeded_ReturnsError()
+    {
+        var h = new Harness();
+        var user = h.SeedUser();
+        user.StorageUsedBytes = User.StorageLimitBytes; // already full
+
+        var (response, error) = await h.Service.ClipAsync(user.Id, SampleClip(), CancellationToken.None);
+
+        Assert.Null(response);
+        Assert.NotNull(error);
+        Assert.Contains("Storage limit", error);
+    }
+
+    [Fact]
+    public async Task ClipAsync_CountsAgainstStorageQuota()
+    {
+        var h = new Harness();
+        var user = h.SeedUser();
+
+        await h.Service.ClipAsync(user.Id, SampleClip(), CancellationToken.None);
+
+        // A clip is a stored file; its bytes must be added to the user's quota.
+        Assert.True(user.StorageUsedBytes > 0, "clip did not consume storage quota");
+        var file = Assert.Single(h.UserBookFiles);
+        Assert.Equal(user.StorageUsedBytes, file.FileSize);
+    }
+
+    // The UserBook.Title shows in the shelf + reader header. The backend stores it as TEXT
+    // verbatim (it is NOT HTML), so the frontend is responsible for escaping it on render.
+    // This test pins the contract: a script-y title is persisted raw, never executed/parsed here.
+    [Fact]
+    public async Task ClipAsync_HtmlTitle_StoredVerbatimAsText()
+    {
+        var h = new Harness();
+        var user = h.SeedUser();
+        var clip = new ClipRequest(
+            Title: "<img src=x onerror=alert(1)>",
+            Author: null,
+            SourceUrl: "https://example.com/a",
+            Html: "<h1>Body</h1><p>prose</p>",
+            Language: "en");
+
+        await h.Service.ClipAsync(user.Id, clip, CancellationToken.None);
+
+        var book = Assert.Single(h.UserBooks);
+        Assert.Equal("<img src=x onerror=alert(1)>", book.Title);
+        Assert.True(book.IsClip);
+    }
+
+    [Fact]
+    public async Task SetReadAsync_ForeignBook_ReturnsErrorNotSilentSuccess()
+    {
+        var h = new Harness();
+        var owner = h.SeedUser();
+        var other = h.SeedUser();
+        await h.Service.ClipAsync(owner.Id, SampleClip(), CancellationToken.None);
+        var book = h.UserBooks[0];
+
+        // A different user must not be able to flip read-state on someone else's clip.
+        var (success, error) = await h.Service.SetReadAsync(other.Id, book.Id, true, CancellationToken.None);
+
+        Assert.False(success);
+        Assert.Equal("Book not found", error);
+        Assert.False(book.IsRead);
+    }
+
+    [Fact]
+    public async Task SetReadAsync_OwnBook_FlipsState()
+    {
+        var h = new Harness();
+        var owner = h.SeedUser();
+        await h.Service.ClipAsync(owner.Id, SampleClip(), CancellationToken.None);
+        var book = h.UserBooks[0];
+
+        var (success, error) = await h.Service.SetReadAsync(owner.Id, book.Id, true, CancellationToken.None);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.True(book.IsRead);
+        Assert.NotNull(book.ReadAt);
+    }
+}


### PR DESCRIPTION
## Send to TextStack — Phase 1 (backend receiver + Read later data + shelf)

Implements Phase 1 of `SPEC-send-to-textstack.md` (steps 1–5). **No capture UI / no extension** — that's Phase 2. Ships the endpoint the extension will call + the Read-later data model and shelf.

### Locked invariant
Clips are **private `UserBook` only** — they NEVER create `Work`/`Edition`/`Chapter` rows or touch the SSG/public path. Asserted by `ClipAsync_AnyClip_CreatesNoWorkOrEdition`. Existing upload/ingestion plumbing is **reused** (shared `CreateBookAsync`), not forked.

### What landed (commit per step)
1. **Enums + Read-later columns + migration** — `BookFormat.Html=3`, `SourceFormat.Html=4`, registry `.html→Html`; `UserBook += SourceUrl/IsClip/IsRead/ReadAt` (migration `AddClipAndReadState`, columns only).
2. **`HtmlTextExtractor`** (TDD) — reuses `HtmlCleaner`, splits body on `h1`/`h2` → Units, extracts title/author/description, never throws. **Security: rewrote `HtmlCleaner` sanitizer** from a 6-name event denylist to allowlist-by-scheme (removes `iframe`/`object`/`embed`/`base`/`form`/…, strips ALL `on*` handlers, scrubs every URL attr against http(s)/relative) — closes stored-XSS in rendered chapter HTML; **also hardens the existing trusted-book path** (263 prior extraction tests still green).
3. **`ClipAsync` + `POST /me/books/clip`** — Bearer auth, quota, ≤2MB (byte cap), http(s) `SourceUrl`, Title required; new per-IP rate-limit zones `clip` + `user-upload`. `GET /me/books?shelf=readlater&status=unread` split (default Books tab excludes clips); `PUT /me/books/{id}/read` (owner-scoped) + auto-mark-read at ≥99% progress.
4. **Worker** — zero structural change; `original.html` resolves `HtmlTextExtractor` end-to-end.
5. **Read later shelf (web)** — tab alongside Books, Unread filter, cards (source domain · est. read time · relative time, New/%-progress/Read/Processing badge, source link, mark-read, delete), reused 5s processing-poll; reader header shows a source link for clips. Untrusted title/domain rendered **as text only**; external links `rel="noopener noreferrer"`.

### Verification
architect-grounded → backend → **adversarial QA (verdict SHIP; P1 stored-XSS found + fixed)** → frontend. Solution build clean; **279 extraction + 816 unit** green; web tsc + build + 534 Vitest green; `dotnet format` clean. Integration tests written (clip flow, quota, oversized/empty/bad-URL, shelf filters, mark-read, no-Work/Edition) — run in CI (skip without a live server).

### Deferred (owner / Phase 2)
- Browser-check the shelf + reader source link (needs a real clip + auth).
- `UserBookDetailDto` lacks `SourceUrl` → the reader resolves it via an extra `?shelf=readlater` lookup; add the field to the detail DTO later to drop it.
- P3: no `MaxSections` cap on a heading-spam article (bounded by the 2MB cap today).
- **Phase 2** (extension, `/connect-extension`, capture flows) — NOT started, per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)