### PR TITLE
test(ai): de-flake spend-alert concurrent test (unblocks deploy)

### DIFF
--- a/tests/TextStack.UnitTests/RollingSpendTrackerTests.cs
+++ b/tests/TextStack.UnitTests/RollingSpendTrackerTests.cs
@@ -151,9 +151,10 @@ public class RollingSpendTrackerTests
         var t = Build(out _, out var email, budgets: Budget("explain", 10m, BudgetMode.Fallback), clock: new FakeClock(Day1));
         Parallel.For(0, 200, _ => t.Record("explain", 0.1m)); // sums to $20, well over 80%
 
-        Thread.Sleep(100);
-        email.Verify(e => e.SendAdminAlertAsync(
-            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        // The alert email is fire-and-forget — poll (don't Thread.Sleep a fixed 100ms,
+        // which flakes on a slow CI runner before the dispatched Task runs).
+        Eventually(() => email.Verify(e => e.SendAdminAlertAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once));
     }
 
     [Fact]


### PR DESCRIPTION
The post-merge `main` CI (which gates deploy) failed on a flaky
`RollingSpendTrackerTests.Alert_ConcurrentCrossing_ExactlyOneEmail` — it used `Thread.Sleep(100)` + a synchronous Moq `Verify(Times.Once)` against a **fire-and-forget** alert email, so on a slow CI runner the dispatched Task hadn't run yet → 0 calls → fail → **deploy skipped**.

Fix: use the existing `Eventually()` poll (up to 2s), matching the sibling alert tests. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)