### PR TITLE
fix(ext): split API base (/api) from site origin — fixes Connect

### DIFF
--- a/extension/config.js
+++ b/extension/config.js
@@ -1,19 +1,29 @@
-// config.js — API origin resolution for the "Send to TextStack" extension.
+// config.js — origin resolution for the "Send to TextStack" extension.
 //
-// Production default is https://textstack.app. The owner can override it for
-// local dev via chrome.storage.local.apiOrigin (set in the options page), e.g.
-// http://localhost:8080 — which ALSO requires temporarily adding
-// "http://localhost:8080/*" to host_permissions in manifest.json (see README).
+// PROD has TWO bases that differ by path:
+//   • Site origin (SPA):  https://textstack.app          — /connect-extension, /en/library, reader links
+//   • API base:           https://textstack.app/api      — /auth/*, /me/* (nginx proxies /api → backend)
+// So the extension must NOT collapse them into one origin (the API lives under /api).
+//
+// Overrides (options page, for local dev):
+//   • siteOrigin  e.g. http://localhost:5173  (web dev server)
+//   • apiBase     e.g. http://localhost:8080  (backend at root — no /api in dev)
+// If apiBase is unset it defaults to `${siteOrigin}/api` (the prod shape).
 
-export const DEFAULT_API_ORIGIN = "https://textstack.app";
-
-// Branded web connect page the device flow opens in a tab (reads ?code= and runs
-// the same device-approve flow as /device, with extension-flavored copy).
+export const DEFAULT_SITE_ORIGIN = "https://textstack.app";
 export const CONNECT_PATH = "/connect-extension";
 
-/** Resolve the active API origin (storage override → prod default). No trailing slash. */
-export async function getApiOrigin() {
-  const { apiOrigin } = await chrome.storage.local.get("apiOrigin");
-  const origin = (apiOrigin && String(apiOrigin).trim()) || DEFAULT_API_ORIGIN;
-  return origin.replace(/\/+$/, "");
+const stripTrailingSlash = (s) => String(s).trim().replace(/\/+$/, "");
+
+/** Web/SPA origin (connect page, library + reader links). No trailing slash. */
+export async function getSiteOrigin() {
+  const { siteOrigin } = await chrome.storage.local.get("siteOrigin");
+  return stripTrailingSlash((siteOrigin && String(siteOrigin).trim()) || DEFAULT_SITE_ORIGIN);
+}
+
+/** API base for /auth/* and /me/* calls. Defaults to `${siteOrigin}/api` (prod). */
+export async function getApiBase() {
+  const { apiBase } = await chrome.storage.local.get("apiBase");
+  if (apiBase && String(apiBase).trim()) return stripTrailingSlash(apiBase);
+  return (await getSiteOrigin()) + "/api";
 }

--- a/extension/lib/api.js
+++ b/extension/lib/api.js
@@ -4,7 +4,7 @@
 // Bearer, no CORS-with-credentials). On 401 it refreshes the token once via
 // lib/auth.getToken() and retries the request.
 
-import { getApiOrigin } from "../config.js";
+import { getApiBase } from "../config.js";
 import { getToken } from "./auth.js";
 
 class NotConnectedError extends Error {
@@ -20,7 +20,7 @@ async function request(path, { method = "GET", body, isForm = false, retry = tru
   const token = await getToken();
   if (!token) throw new NotConnectedError();
 
-  const origin = await getApiOrigin();
+  const apiBase = await getApiBase();
   const headers = { Authorization: `Bearer ${token}` };
   let payload = body;
   if (body != null && !isForm) {
@@ -28,7 +28,7 @@ async function request(path, { method = "GET", body, isForm = false, retry = tru
     payload = JSON.stringify(body);
   }
 
-  const res = await fetch(`${origin}${path}`, {
+  const res = await fetch(`${apiBase}${path}`, {
     method,
     headers,
     credentials: "omit",

--- a/extension/lib/auth.js
+++ b/extension/lib/auth.js
@@ -14,7 +14,7 @@
 // The service worker can be evicted between alarm ticks, so ALL flow state lives
 // in chrome.storage.local (key: "deviceFlow"), not in module memory.
 
-import { getApiOrigin, CONNECT_PATH } from "../config.js";
+import { getApiBase, getSiteOrigin, CONNECT_PATH } from "../config.js";
 
 const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 const TOKENS_KEY = "tokens"; // { access_token, refresh_token }
@@ -77,8 +77,8 @@ export async function getToken() {
 /** POST /auth/refresh-mobile { refreshToken } → new tokens, or null on failure. */
 async function tryRefresh(refreshToken) {
   try {
-    const origin = await getApiOrigin();
-    const res = await fetch(`${origin}/auth/refresh-mobile`, {
+    const apiBase = await getApiBase();
+    const res = await fetch(`${apiBase}/auth/refresh-mobile`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "omit",
@@ -109,8 +109,8 @@ export async function startDeviceFlow() {
     return { user_code: existing.user_code, verification_uri: existing.verification_uri };
   }
 
-  const origin = await getApiOrigin();
-  const res = await fetch(`${origin}/auth/device/code`, {
+  const apiBase = await getApiBase();
+  const res = await fetch(`${apiBase}/auth/device/code`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "omit",
@@ -125,17 +125,18 @@ export async function startDeviceFlow() {
 
   const intervalSec = code.interval > 0 ? code.interval : 5;
   const expiresInSec = code.expires_in > 0 ? code.expires_in : 600;
-  // Prefer our branded extension connect page (reads ?code= and runs the same
-  // device-approve flow as /device). Fall back to the server's
-  // verification_uri_complete only if we somehow lack the user_code.
+  // The connect page is a WEB route (no /api), so build it from the site origin.
+  // Prefer our branded /connect-extension page (reads ?code= and runs the same
+  // device-approve flow as /device); fall back only if we lack the user_code.
+  const siteOrigin = await getSiteOrigin();
   const connectUrl = code.user_code
-    ? `${origin}${CONNECT_PATH}?code=${encodeURIComponent(code.user_code)}`
-    : code.verification_uri_complete || `${origin}${CONNECT_PATH}`;
+    ? `${siteOrigin}${CONNECT_PATH}?code=${encodeURIComponent(code.user_code)}`
+    : code.verification_uri_complete || `${siteOrigin}${CONNECT_PATH}`;
 
   const flow = {
     device_code: code.device_code,
     user_code: code.user_code,
-    verification_uri: code.verification_uri || `${origin}${CONNECT_PATH}`,
+    verification_uri: code.verification_uri || `${siteOrigin}${CONNECT_PATH}`,
     connect_url: connectUrl,
     interval_sec: intervalSec,
     deadline_ms: Date.now() + expiresInSec * 1000,
@@ -208,8 +209,8 @@ export async function pollOnce() {
 
 /** POST /auth/device/token → outcome { kind, tokens? }. */
 async function pollToken(deviceCode) {
-  const origin = await getApiOrigin();
-  const res = await fetch(`${origin}/auth/device/token`, {
+  const apiBase = await getApiBase();
+  const res = await fetch(`${apiBase}/auth/device/token`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "omit",

--- a/extension/options.html
+++ b/extension/options.html
@@ -29,12 +29,17 @@
     </div>
 
     <div class="card">
-      <label for="origin">API origin (developer override)</label>
-      <input id="origin" type="text" placeholder="https://textstack.app" />
+      <label for="site">Site origin (developer override)</label>
+      <input id="site" type="text" placeholder="https://textstack.app" />
+      <p class="muted">Web app (connect page + library/reader links). Leave blank for production.</p>
+
+      <label for="apibase" style="margin-top:12px;">API base (developer override)</label>
+      <input id="apibase" type="text" placeholder="https://textstack.app/api" />
       <p class="muted">
-        Leave blank for production. For local dev set e.g. <code>http://localhost:8080</code> —
-        you must ALSO add <code>http://localhost:8080/*</code> to <code>host_permissions</code>
-        in <code>manifest.json</code> and reload the unpacked extension. See the README.
+        Leave blank to use <code>&lt;site origin&gt;/api</code> (production). For a local backend set
+        e.g. <code>http://localhost:8080</code> (dev serves the API at root, no <code>/api</code>) —
+        you must ALSO add that host to <code>host_permissions</code> in <code>manifest.json</code>
+        and reload the unpacked extension. See the README.
       </p>
       <button id="btn-save">Save</button>
       <div class="msg" id="save-msg"></div>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,6 +1,6 @@
 // options.js — connection status, Disconnect, and the dev API-origin override.
 
-import { DEFAULT_API_ORIGIN } from "./config.js";
+import { DEFAULT_SITE_ORIGIN } from "./config.js";
 
 const $ = (id) => document.getElementById(id);
 
@@ -45,16 +45,18 @@ $("btn-disconnect").addEventListener("click", async () => {
 });
 
 $("btn-save").addEventListener("click", async () => {
-  const val = $("origin").value.trim().replace(/\/+$/, "");
-  await chrome.storage.local.set({ apiOrigin: val || "" });
-  $("save-msg").textContent = val
-    ? `Saved. Using ${val} — ensure host_permissions includes it.`
-    : `Saved. Using production default (${DEFAULT_API_ORIGIN}).`;
+  const site = $("site").value.trim().replace(/\/+$/, "");
+  const apiBase = $("apibase").value.trim().replace(/\/+$/, "");
+  await chrome.storage.local.set({ siteOrigin: site || "", apiBase: apiBase || "" });
+  $("save-msg").textContent = site || apiBase
+    ? `Saved. Site=${site || DEFAULT_SITE_ORIGIN}, API=${apiBase || (site || DEFAULT_SITE_ORIGIN) + "/api"} — ensure host_permissions includes the API host.`
+    : `Saved. Using production defaults (${DEFAULT_SITE_ORIGIN} + /api).`;
 });
 
 async function loadOrigin() {
-  const { apiOrigin } = await chrome.storage.local.get("apiOrigin");
-  $("origin").value = apiOrigin || "";
+  const { siteOrigin, apiBase } = await chrome.storage.local.get(["siteOrigin", "apiBase"]);
+  $("site").value = siteOrigin || "";
+  $("apibase").value = apiBase || "";
 }
 
 loadOrigin();

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,7 +1,7 @@
 // popup.js — UI controller. Talks ONLY to background.js via chrome.runtime
 // messages (the SW owns all auth/network). No tokens ever touch the popup.
 
-import { getApiOrigin } from "./config.js";
+import { getSiteOrigin } from "./config.js";
 
 const $ = (id) => document.getElementById(id);
 
@@ -225,11 +225,11 @@ function handleErr(e) {
 
 async function openReader(id) {
   if (!id) return openLibrary();
-  const origin = await getApiOrigin();
+  const origin = await getSiteOrigin();
   chrome.tabs.create({ url: `${origin}/en/library/my/${id}` });
 }
 async function openLibrary() {
-  const origin = await getApiOrigin();
+  const origin = await getSiteOrigin();
   chrome.tabs.create({ url: `${origin}/en/library` });
 }
 


### PR DESCRIPTION
Prod serves the API under /api (nginx) but the SPA is at root; the extension conflated them, so the device-flow Connect hit `textstack.app/auth/device/code` (SPA, not API) → 'Could not reach TextStack'. Split `getApiBase()` (/auth/*, /me/*) from `getSiteOrigin()` (connect page, reader/library links). `node --check` green. Extension-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)