### PR TITLE
fix(rag): Ask counts the chapter you're reading + ext rename

### DIFF
--- a/apps/web/src/api/ask.ts
+++ b/apps/web/src/api/ask.ts
@@ -12,11 +12,12 @@ export function ask(
   question: string,
   k?: number,
   signal?: AbortSignal,
+  currentChapterId?: string,
 ): Promise<AskResponse> {
   return authFetch<AskResponse>(`/books/${editionId}/ask`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ question, k }),
+    body: JSON.stringify({ question, k, ...(currentChapterId ? { currentChapterId } : {}) }),
     signal,
   })
 }

--- a/apps/web/src/components/reader/AskPanel.tsx
+++ b/apps/web/src/components/reader/AskPanel.tsx
@@ -7,16 +7,18 @@ import type { AskCitation } from '../../api/ask'
 interface Props {
   open: boolean
   editionId: string
+  /** GUID of the chapter the user is actively reading — gates the RAG spoiler check. */
+  currentChapterId?: string
   isAuthenticated: boolean
   onSignIn: () => void
   onNavigateToCitation: (citation: AskCitation) => void
   onClose: () => void
 }
 
-export function AskPanel({ open, editionId, isAuthenticated, onSignIn, onNavigateToCitation, onClose }: Props) {
+export function AskPanel({ open, editionId, currentChapterId, isAuthenticated, onSignIn, onNavigateToCitation, onClose }: Props) {
   const { t } = useTranslation()
   const containerRef = useFocusTrap(open)
-  const { history, isLoading, error, ask } = useAsk(editionId)
+  const { history, isLoading, error, ask } = useAsk(editionId, currentChapterId)
   const [input, setInput] = useState('')
   const historyRef = useRef<HTMLDivElement>(null)
 

--- a/apps/web/src/hooks/useAsk.test.ts
+++ b/apps/web/src/hooks/useAsk.test.ts
@@ -46,6 +46,16 @@ describe('useAsk', () => {
     expect(result.current.history[0].insufficient).toBe(true)
   })
 
+  it('forwards currentChapterId to the api when provided', async () => {
+    mockAsk.mockResolvedValueOnce({ answer: 'ok', citations: [], lastReadOrd: 0, insufficient: false })
+    const { result } = renderHook(() => useAsk('ed-1', 'chap-guid-4'))
+
+    await act(() => result.current.ask('why?'))
+
+    await waitFor(() => expect(mockAsk).toHaveBeenCalled())
+    expect(mockAsk).toHaveBeenCalledWith('ed-1', 'why?', undefined, expect.anything(), 'chap-guid-4')
+  })
+
   it('no-ops without an editionId', async () => {
     const { result } = renderHook(() => useAsk(undefined))
     await act(() => result.current.ask('why?'))

--- a/apps/web/src/hooks/useAsk.ts
+++ b/apps/web/src/hooks/useAsk.ts
@@ -13,7 +13,7 @@ export interface AskTurn {
  * Session "Ask this book" state (AI-026a): an in-memory Q&A history (not persisted), plus loading
  * and error. `ask` appends a turn; in-flight requests are aborted on a new question / unmount.
  */
-export function useAsk(editionId: string | undefined) {
+export function useAsk(editionId: string | undefined, currentChapterId?: string) {
   const [history, setHistory] = useState<AskTurn[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -33,7 +33,7 @@ export function useAsk(editionId: string | undefined) {
       setError(null)
 
       try {
-        const res = await askApi(editionId, q, undefined, ctrl.signal)
+        const res = await askApi(editionId, q, undefined, ctrl.signal, currentChapterId)
         setHistory(prev => [
           ...prev,
           { question: q, answer: res.answer, citations: res.citations, insufficient: res.insufficient },
@@ -46,7 +46,7 @@ export function useAsk(editionId: string | undefined) {
         if (abortRef.current === ctrl) setIsLoading(false)
       }
     },
-    [editionId, isLoading],
+    [editionId, isLoading, currentChapterId],
   )
 
   return { history, isLoading, error, ask }

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -606,6 +606,7 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
         <AskPanel
           open={askOpen}
           editionId={askEditionId}
+          currentChapterId={activeChapter?.id}
           isAuthenticated={isAuthenticated}
           onSignIn={openAuthModal}
           onNavigateToCitation={handleNavigateToCitation}

--- a/backend/src/Api/Endpoints/AdminRagEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminRagEndpoints.cs
@@ -127,7 +127,7 @@ public static class AdminRagEndpoints
 
         var siteId = httpContext.GetSiteId();
         var limit = Math.Clamp(k ?? IRagService.DefaultK, 1, MaxK);
-        var ctx = await ctxService.BuildAsync(userId, siteId, editionId, q, limit, ct);
+        var ctx = await ctxService.BuildAsync(userId, siteId, editionId, q, limit, currentChapterId: null, ct);
 
         return Results.Ok(new RagContextDto(
             ctx.LastReadOrd,

--- a/backend/src/Api/Endpoints/AskEndpoints.cs
+++ b/backend/src/Api/Endpoints/AskEndpoints.cs
@@ -61,7 +61,8 @@ public static class AskEndpoints
         try
         {
             var k = request.K is > 0 ? request.K.Value : IRagService.DefaultK;
-            var answer = await ask.AskAsync(userId.Value, siteId, editionId, request.Question, k, ct);
+            var answer = await ask.AskAsync(
+                userId.Value, siteId, editionId, request.Question, k, request.CurrentChapterId, ct);
 
             var citations = answer.Citations.Select(c => new AskCitation(
                 c.Marker, c.Chunk.ChunkId, c.Chunk.ChapterId, c.Chunk.ChapterOrd,

--- a/backend/src/Application/Rag/RagAskService.cs
+++ b/backend/src/Application/Rag/RagAskService.cs
@@ -23,8 +23,14 @@ public record AskAnswer(
 /// </summary>
 public interface IRagAskService
 {
-    /// <summary>Spoiler-safe ask for a real reader: gates context by their reading progress.</summary>
-    Task<AskAnswer> AskAsync(Guid userId, Guid siteId, Guid editionId, string question, int k, CancellationToken ct);
+    /// <summary>
+    /// Spoiler-safe ask for a real reader: gates context by their reading progress. Pass
+    /// <paramref name="currentChapterId"/> (the chapter open in the reader) so it counts as read even
+    /// before the debounced progress-save persists — resolved server-side, ignored if not this edition.
+    /// </summary>
+    Task<AskAnswer> AskAsync(
+        Guid userId, Guid siteId, Guid editionId, string question, int k,
+        Guid? currentChapterId, CancellationToken ct);
 
     /// <summary>
     /// Generate a grounded, cited answer from an already-retrieved chunk set — bypasses user-progress
@@ -49,9 +55,10 @@ public sealed class RagAskService(RagContextService context, ILlmService llm) : 
         "You haven't read enough of this book yet for me to answer from it. Keep reading and ask again.";
 
     public async Task<AskAnswer> AskAsync(
-        Guid userId, Guid siteId, Guid editionId, string question, int k, CancellationToken ct)
+        Guid userId, Guid siteId, Guid editionId, string question, int k,
+        Guid? currentChapterId, CancellationToken ct)
     {
-        var ctx = await context.BuildAsync(userId, siteId, editionId, question, k, ct);
+        var ctx = await context.BuildAsync(userId, siteId, editionId, question, k, currentChapterId, ct);
         var noteTexts = ctx.Notes.Select(n => n.Text).ToList();
         return await AskFromChunksAsync(question, ctx.Chunks, noteTexts, ctx.LastReadOrd, ct);
     }

--- a/backend/src/Application/Rag/RagContextService.cs
+++ b/backend/src/Application/Rag/RagContextService.cs
@@ -31,18 +31,52 @@ public sealed class RagContextService(IAppDbContext db, IRagService rag)
 
     /// <summary>
     /// Builds the spoiler-safe context. When the user has no progress (lastRead = 0) both lists
-    /// are empty — nothing is retrievable until they've read.
+    /// are empty — nothing is retrievable until they've read. Pass <paramref name="currentChapterId"/>
+    /// (the chapter open in the reader) to count it as read even before the debounced progress-save
+    /// persists; it's resolved to an ordinal server-side and ignored unless it belongs to this edition.
     /// </summary>
     public async Task<RagContext> BuildAsync(
-        Guid userId, Guid siteId, Guid editionId, string query, int k, CancellationToken ct)
+        Guid userId, Guid siteId, Guid editionId, string query, int k,
+        Guid? currentChapterId, CancellationToken ct)
     {
-        var lastRead = await ResolveLastReadOrdAsync(userId, siteId, editionId, ct);
+        var persistedLastRead = await ResolveLastReadOrdAsync(userId, siteId, editionId, ct);
+        var currentOrd = await ResolveCurrentChapterOrdAsync(editionId, currentChapterId, ct);
+
+        // The spoiler gate is an anti-accidental-spoiler UX guard, not a security boundary — the book
+        // is public/free and the reader can navigate ahead anyway. Counting the chapter they're
+        // actively viewing is correct and unblocks "ask about what I'm reading" without waiting on the
+        // 2s progress-sync debounce. We resolve the ordinal server-side (above) so a client can't
+        // claim a fake high ord; an id from another edition resolves to 0 and is ignored.
+        var lastRead = EffectiveLastReadOrd(persistedLastRead, currentOrd);
         if (lastRead <= 0)
             return new RagContext([], [], 0);
 
         var chunks = await rag.RetrieveAsync(editionId, query, k, maxChapterOrd: lastRead, ct);
         var notes = await GetPrivateNotesAsync(userId, siteId, editionId, lastRead, ct);
         return new RagContext(chunks, notes, lastRead);
+    }
+
+    /// <summary>
+    /// The gate ordinal: the larger of the persisted high-water mark and the currently-open chapter's
+    /// ordinal (0 when that chapter isn't part of this edition). Pure so it's directly unit-testable.
+    /// </summary>
+    public static int EffectiveLastReadOrd(int persistedLastRead, int currentOrd)
+        => Math.Max(persistedLastRead, currentOrd);
+
+    /// <summary>
+    /// Resolves the open chapter's ordinal authoritatively from the DB, but only if it belongs to this
+    /// edition (so a client can't pass a fake/foreign id to peek ahead). 0 when null or not matched.
+    /// </summary>
+    public async Task<int> ResolveCurrentChapterOrdAsync(
+        Guid editionId, Guid? currentChapterId, CancellationToken ct)
+    {
+        if (currentChapterId is not { } id)
+            return 0;
+
+        return await db.Chapters
+            .Where(c => c.Id == id && c.EditionId == editionId)
+            .Select(c => c.ChapterNumber)
+            .FirstOrDefaultAsync(ct);
     }
 
     /// <summary>

--- a/backend/src/Contracts/Books/AskDtos.cs
+++ b/backend/src/Contracts/Books/AskDtos.cs
@@ -1,7 +1,12 @@
 namespace Contracts.Books;
 
-/// <summary>"Ask this book" request (AI-025). <see cref="K"/> overrides the default retrieval count.</summary>
-public record AskRequest(string Question, int? K = null);
+/// <summary>
+/// "Ask this book" request (AI-025). <see cref="K"/> overrides the default retrieval count.
+/// <see cref="CurrentChapterId"/> is the chapter the reader has open right now; the spoiler gate
+/// counts it as read (max with persisted progress) so "ask about what I'm reading" works before the
+/// debounced progress-save fires. Resolved server-side and ignored if it isn't part of this edition.
+/// </summary>
+public record AskRequest(string Question, int? K = null, Guid? CurrentChapterId = null);
 
 /// <summary>
 /// A cited source for an answer. <see cref="Marker"/> is the <c>[n]</c> number in the answer text;

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,4 +1,4 @@
-# Send to TextStack — Chrome extension (MV3)
+# TextStack — Save to read later — Chrome extension (MV3)
 
 Clip the article you're reading, or send a document (PDF/EPUB/FB2), to your own
 private TextStack **Read-later** library. Vanilla JS, MV3, no bundler, no npm.

--- a/extension/config.js
+++ b/extension/config.js
@@ -1,4 +1,4 @@
-// config.js — origin resolution for the "Send to TextStack" extension.
+// config.js — origin resolution for the "TextStack — Save to read later" extension.
 //
 // PROD has TWO bases that differ by path:
 //   • Site origin (SPA):  https://textstack.app          — /connect-extension, /en/library, reader links

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Send to TextStack",
+  "name": "TextStack — Save to read later",
   "version": "0.1.0",
-  "description": "Clip articles and send documents (EPUB/PDF/FB2) to your private TextStack Read-later library.",
+  "description": "Save articles and documents (EPUB/PDF/FB2) to your private TextStack library to read later — with TTS, highlights, and vocabulary.",
   "permissions": [
     "activeTab",
     "scripting",

--- a/extension/options.html
+++ b/extension/options.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Send to TextStack — Settings</title>
+    <title>TextStack — Save to read later — Settings</title>
     <style>
       body { font: 14px/1.5 system-ui, sans-serif; max-width: 560px; margin: 40px auto; padding: 0 20px; color: #111827; }
       h1 { font-size: 18px; }
@@ -19,7 +19,7 @@
     </style>
   </head>
   <body>
-    <h1>Send to TextStack</h1>
+    <h1>TextStack — Save to read later</h1>
 
     <div class="card">
       <p>Connection: <span id="status" class="status">Checking…</span></p>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Send to TextStack</title>
+    <title>TextStack — Save to read later</title>
     <style>
       :root {
         --bg: #ffffff;
@@ -98,7 +98,7 @@
   <body>
     <header>
       <img src="icons/icon-32.png" alt="" />
-      <b>Send to TextStack</b>
+      <b>TextStack</b>
       <span class="email" id="email"></span>
     </header>
 

--- a/extension/privacy.html
+++ b/extension/privacy.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Send to TextStack — Privacy Policy</title>
+    <title>TextStack — Save to read later — Privacy Policy</title>
     <style>
       body { font: 15px/1.6 system-ui, sans-serif; max-width: 640px; margin: 40px auto; padding: 0 20px; color: #111827; }
       h1 { font-size: 20px; }
@@ -11,12 +11,12 @@
     </style>
   </head>
   <body>
-    <h1>Send to TextStack — Privacy Policy</h1>
+    <h1>TextStack — Save to read later — Privacy Policy</h1>
     <p><em>Last updated: 2026.</em></p>
 
     <h2>What this extension does</h2>
     <p>
-      "Send to TextStack" lets you clip the article you are reading, or send a
+      "TextStack — Save to read later" lets you clip the article you are reading, or send a
       document (PDF/EPUB/FB2) you have open, to your own private TextStack
       Read-later library.
     </p>

--- a/tests/TextStack.AiEvals/RagEvalRunnerTests.cs
+++ b/tests/TextStack.AiEvals/RagEvalRunnerTests.cs
@@ -56,7 +56,7 @@ public class RagEvalRunnerTests
     /// <summary>Echoes back a one-citation answer pointing at the first supplied chunk.</summary>
     private sealed class FakeAsk : IRagAskService
     {
-        public Task<AskAnswer> AskAsync(Guid u, Guid s, Guid e, string q, int k, CancellationToken ct) =>
+        public Task<AskAnswer> AskAsync(Guid u, Guid s, Guid e, string q, int k, Guid? currentChapterId, CancellationToken ct) =>
             throw new NotSupportedException();
 
         public Task<AskAnswer> AskFromChunksAsync(

--- a/tests/TextStack.UnitTests/RagContextServiceTests.cs
+++ b/tests/TextStack.UnitTests/RagContextServiceTests.cs
@@ -19,4 +19,23 @@ public class RagContextServiceTests
     [InlineData("   ")]
     public void HighlightToText_BlankNote_ReturnsSelectionOnly(string note)
         => Assert.Equal("passage", RagContextService.HighlightToText("passage", note));
+
+    // Gate ordinal = max(persisted high-water mark, currently-open chapter ord). currentOrd is 0 when
+    // the open chapter isn't part of this edition (resolved server-side), so it can't push the gate up.
+
+    [Fact]
+    public void EffectiveLastReadOrd_NoPersistedProgressOpenChapter4_Uses4()
+        => Assert.Equal(4, RagContextService.EffectiveLastReadOrd(persistedLastRead: 0, currentOrd: 4));
+
+    [Fact]
+    public void EffectiveLastReadOrd_ForeignOrBogusChapter_Ignored_StaysAtPersisted()
+        => Assert.Equal(0, RagContextService.EffectiveLastReadOrd(persistedLastRead: 0, currentOrd: 0));
+
+    [Fact]
+    public void EffectiveLastReadOrd_PersistedAheadOfOpenChapter_KeepsPersisted()
+        => Assert.Equal(6, RagContextService.EffectiveLastReadOrd(persistedLastRead: 6, currentOrd: 2));
+
+    [Fact]
+    public void EffectiveLastReadOrd_OpenChapterAheadOfPersisted_UsesCurrent()
+        => Assert.Equal(5, RagContextService.EffectiveLastReadOrd(persistedLastRead: 3, currentOrd: 5));
 }


### PR DESCRIPTION
Ask this book returned 'you haven't read enough' even when clearly on chapter 4 — the spoiler gate read only persisted `ReadingProgress.MaxChapterNumber` (0 until the 2s debounced save fires). Client now sends `currentChapterId`; gate uses `max(persistedLastRead, currentChapterOrd)` (current ord resolved server-side, ignored if not in the edition → no peek-ahead). Spoiler-safe; unblocks asking about what you're reading. Also bundles the extension rename to 'TextStack — Save to read later'. 8 unit + 537 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)