### PR TITLE
fix(reader): persist progress on chapter open + RAG ord-0 gate

### DIFF
--- a/apps/mobile/src/components/reader/useEditionReaderSource.ts
+++ b/apps/mobile/src/components/reader/useEditionReaderSource.ts
@@ -86,7 +86,7 @@ export function useEditionReaderSource({
       chapterId: snap.chapterId,
       chapterSlug: snap.chapterSlug,
       progress: snap.chapterPercent,
-    }).catch(() => {})
+    }).catch((e) => { console.warn('[progress] save failed', e) })
   }, [isAuthenticated])
 
   const loadPosition = useCallback(async (slug: string): Promise<SavedPosition> => {

--- a/apps/mobile/src/hooks/useReaderPersistence.ts
+++ b/apps/mobile/src/hooks/useReaderPersistence.ts
@@ -96,8 +96,22 @@ export function useReaderPersistence({
     tryRestore()
   }, [tryRestore, injectJs, progressRef])
 
+  // Pending-save buffer: chapterId resolves AFTER the chapter fetch lands, so a
+  // save requested during rapid chapter tap-through (e.g. emit-on-load firing
+  // before the destination chapter's id is known) would early-return and the
+  // destination chapter's first progress would be lost. Instead we stash a flag
+  // and replay the save once chapterId resolves (effect below). We don't snapshot
+  // the payload values — saveProgress already reads the live refs at flush time,
+  // which carry the latest scroll/percent for the destination chapter.
+  const pendingSaveRef = useRef(false)
+
   const saveProgress = useCallback(() => {
-    if (!bookKey || !chapterId || !chapterSlug) return
+    if (!bookKey || !chapterSlug) return
+    if (!chapterId) {
+      // Defer: remember that a save is owed; the chapterId effect flushes it.
+      pendingSaveRef.current = true
+      return
+    }
     const slug = currentChapterSlugRef.current || chapterSlug
     persist({
       chapterId,
@@ -108,6 +122,15 @@ export function useReaderPersistence({
       updatedAt: Date.now(),
     })
   }, [bookKey, chapterId, chapterSlug, persist, currentChapterSlugRef, progressRef, scrollOffsetRef, bookProgressRef])
+
+  // Flush a deferred save once chapterId resolves. Keyed on chapterId so it runs
+  // exactly when the destination chapter's id lands.
+  useEffect(() => {
+    if (chapterId && pendingSaveRef.current) {
+      pendingSaveRef.current = false
+      saveProgress()
+    }
+  }, [chapterId, saveProgress])
 
   // 2s-debounced save fired on every WebView progress bump. Short enough that
   // a force-kill mid-chapter loses < ~2s of scroll, long enough that fast
@@ -129,6 +152,7 @@ export function useReaderPersistence({
     positionLoadedRef.current = false
     savedOffsetRef.current = null
     savedPercentRef.current = null
+    pendingSaveRef.current = false
     if (!bookKey || !chapterSlug) return
     let cancelled = false
     loadPosition(chapterSlug)

--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -322,6 +322,29 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
         type: 'loaded',
         scrollHeight: document.documentElement.scrollHeight
       }));
+      // Emit-on-load: the scroll-gated reportProgress only fires once the
+      // reader actually moves, so a chapter the user navigates INTO records
+      // nothing (and ReadingProgress.MaxChapterNumber stays unset) until they
+      // scroll. Post one initial progress so ReaderShell runs its full
+      // book-progress + debounced-persistence path for the DESTINATION chapter
+      // immediately. Guard: only on the FIRST load (no infinite-scroll appends
+      // yet — chapterSlugs holds at most the initial chapter), so appends never
+      // re-fire this or reset getCurrentChapterSlug to the top chapter.
+      if (chapterSlugs.length <= 1) {
+        var initSlug = getCurrentChapterSlug();
+        if (initSlug) {
+          var initScrollTop = window.scrollY;
+          var initDocHeight = document.documentElement.scrollHeight - window.innerHeight;
+          var initProgress = initDocHeight > 0 ? Math.min(initScrollTop / initDocHeight, 1) : 0;
+          lastProgress = initProgress;
+          window.ReactNativeWebView.postMessage(JSON.stringify({
+            type: 'progress',
+            progress: initProgress,
+            chapterSlug: initSlug,
+            scrollY: Math.round(initScrollTop)
+          }));
+        }
+      }
       setTimeout(checkInfiniteScroll, 100);
     });
 

--- a/apps/web/src/components/reader/ReaderNav.tsx
+++ b/apps/web/src/components/reader/ReaderNav.tsx
@@ -4,6 +4,7 @@
 
 interface Props {
   chapterTitle: string
+  /** 1-based positional index of the active chapter (NOT catalog chapterNumber, which is 0-based). */
   chapterNumber: number | null
   totalChapters: number | null
   /** Percent 0..1 of current chapter read (intra-chapter). */

--- a/apps/web/src/components/reader/__tests__/ReaderNav.test.tsx
+++ b/apps/web/src/components/reader/__tests__/ReaderNav.test.tsx
@@ -20,6 +20,20 @@ describe('ReaderNav', () => {
     expect(getByText('1 / 10')).toBeTruthy()
   })
 
+  it('shows 1 / N for the first chapter (positional index+1, not 0-based catalog number)', () => {
+    const { getByText } = render(
+      <ReaderNav
+        chapterTitle="First"
+        chapterNumber={1}
+        totalChapters={29}
+        chapterProgress={0}
+        onPrev={null}
+        onNext={() => {}}
+      />,
+    )
+    expect(getByText('1 / 29')).toBeTruthy()
+  })
+
   it('omits counter when totalChapters is null', () => {
     const { container } = render(
       <ReaderNav

--- a/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
@@ -264,7 +264,7 @@ describe('useReaderScrollSync — save on chapter open', () => {
     // Re-armed: a third write for ch1 (id + slug correct). Offset value isn't asserted here — it's
     // exercised by the dedicated clobber test above; this case only proves the once-guard re-arms.
     expect(updateProgress).toHaveBeenCalledTimes(3)
-    const last = updateProgress.mock.calls.at(-1)!
+    const last = updateProgress.mock.calls[updateProgress.mock.calls.length - 1]
     expect(last[3]).toBe('ch1-id')
     expect(last[4]).toBe('ch1')
   })

--- a/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
@@ -14,6 +14,14 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  // Tests that simulate a real scrollTo mutate the shared scrollingElement.scrollTop — reset it so
+  // it can't leak a non-zero offset into the next test.
+  const el = (document.scrollingElement || document.documentElement) as HTMLElement
+  try {
+    Object.defineProperty(el, 'scrollTop', { value: 0, writable: true, configurable: true })
+  } catch {
+    // ignore if not redefinable
+  }
 })
 
 const noopProgress = {
@@ -125,5 +133,139 @@ describe('useReaderScrollSync — scroll restore', () => {
       effectiveProgress: { locator: 'scroll:ch1:8000' },
     })
     expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'instant' })
+  })
+})
+
+describe('useReaderScrollSync — save on chapter open', () => {
+  it('fires exactly one public save when a chapter opens (after restore)', () => {
+    const updateProgress = vi.fn()
+    const props: Props = {
+      ...baseProps,
+      publicProgress: { updateProgress, flushSave: vi.fn() },
+    }
+    renderHook(() => useReaderScrollSync(props))
+
+    expect(updateProgress).toHaveBeenCalledTimes(1)
+    // (progress, page, scrollLocator, chapterId, chapterSlug)
+    expect(updateProgress).toHaveBeenCalledWith(0, undefined, 'scroll:ch1:0', 'ch1-id', 'ch1')
+  })
+
+  it('fires one userbook save when a chapter opens', () => {
+    const saveProgress = vi.fn()
+    const props: Props = {
+      ...baseProps,
+      mode: 'userbook',
+      publicBookChapters: undefined,
+      userProgress: { saveProgress, flushSave: vi.fn() },
+    }
+    renderHook(() => useReaderScrollSync(props))
+
+    expect(saveProgress).toHaveBeenCalledTimes(1)
+    expect(saveProgress).toHaveBeenCalledWith('ch1', 0, 0, 'scroll:ch1:0')
+  })
+
+  it('saves once per chapter on navigation (ch1 → ch2)', () => {
+    const updateProgress = vi.fn()
+    const props: Props = {
+      ...baseProps,
+      publicBookChapters: [
+        { id: 'ch1-id', slug: 'ch1' },
+        { id: 'ch2-id', slug: 'ch2' },
+      ] as any,
+      publicProgress: { updateProgress, flushSave: vi.fn() },
+    }
+    const { rerender } = renderHook((p: Props) => useReaderScrollSync(p), {
+      initialProps: props,
+    })
+    expect(updateProgress).toHaveBeenCalledTimes(1)
+    expect(updateProgress).toHaveBeenLastCalledWith(0, undefined, 'scroll:ch1:0', 'ch1-id', 'ch1')
+
+    rerender({ ...props, chapterIdentifier: 'ch2' })
+    expect(updateProgress).toHaveBeenCalledTimes(2)
+    expect(updateProgress).toHaveBeenLastCalledWith(0, undefined, 'scroll:ch2:0', 'ch2-id', 'ch2')
+  })
+
+  it('does not save before chapter is loaded', () => {
+    const updateProgress = vi.fn()
+    renderHook(() =>
+      useReaderScrollSync({
+        ...baseProps,
+        chapterLoaded: false,
+        publicProgress: { updateProgress, flushSave: vi.fn() },
+      }),
+    )
+    expect(updateProgress).not.toHaveBeenCalled()
+  })
+
+  // CLOBBER GUARD: the save-on-open must read scrollTop AFTER window.scrollTo restored it,
+  // never a transient 0. If it captured 0 here, the next load would restore to the top and the
+  // reader would silently lose their place. We make scrollTo actually move scrollingElement.scrollTop
+  // (jsdom's default scrollTo is a no-op) so the save reflects the RESTORED offset.
+  it('save-on-open captures the RESTORED offset, not a transient 0', () => {
+    const scrollEl = (document.scrollingElement || document.documentElement) as HTMLElement
+    Object.defineProperty(scrollEl, 'scrollTop', { value: 0, writable: true, configurable: true })
+    window.scrollTo = vi.fn((arg: any) => {
+      // Mirror real browser behaviour: scrollTo updates scrollTop synchronously.
+      ;(scrollEl as any).scrollTop = typeof arg === 'object' ? arg.top : arg
+    }) as unknown as typeof window.scrollTo
+
+    const updateProgress = vi.fn()
+    renderHook(() =>
+      useReaderScrollSync({
+        ...baseProps,
+        effectiveProgress: { locator: 'scroll:ch1:5000' },
+        publicProgress: { updateProgress, flushSave: vi.fn() },
+      }),
+    )
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 5000, behavior: 'instant' })
+    // The leak/clobber assertion: the open-save must record the RESTORED offset 5000, and must NEVER
+    // record a transient 0 for ch1 (a 0 here would persist top-of-chapter and lose the reader's place).
+    const locators = updateProgress.mock.calls.map(c => c[2] as string)
+    expect(locators).toContain('scroll:ch1:5000')
+    expect(locators).not.toContain('scroll:ch1:0')
+  })
+
+  // Re-render that does NOT change the chapter (e.g. overallProgress ticks) must not re-fire the
+  // open-save: exactly-once per opened chapter, else every render double-writes.
+  it('does not re-fire save-on-open on a same-chapter re-render', () => {
+    const updateProgress = vi.fn()
+    const props: Props = {
+      ...baseProps,
+      publicProgress: { updateProgress, flushSave: vi.fn() },
+    }
+    const { rerender } = renderHook((p: Props) => useReaderScrollSync(p), { initialProps: props })
+    expect(updateProgress).toHaveBeenCalledTimes(1)
+
+    // Same chapter, only overallProgress moved — open-save must stay armed-off.
+    rerender({ ...props, overallProgress: 0.42 })
+    expect(updateProgress).toHaveBeenCalledTimes(1)
+  })
+
+  // Re-arm guard: navigating away and BACK to the same chapter must save again (the once-guard is
+  // reset on chapter change), not stay permanently suppressed.
+  it('re-arms save-on-open when returning to a previously-opened chapter', () => {
+    const updateProgress = vi.fn()
+    const props: Props = {
+      ...baseProps,
+      publicBookChapters: [
+        { id: 'ch1-id', slug: 'ch1' },
+        { id: 'ch2-id', slug: 'ch2' },
+      ] as any,
+      publicProgress: { updateProgress, flushSave: vi.fn() },
+    }
+    const { rerender } = renderHook((p: Props) => useReaderScrollSync(p), { initialProps: props })
+    expect(updateProgress).toHaveBeenCalledTimes(1)
+
+    rerender({ ...props, chapterIdentifier: 'ch2' })
+    expect(updateProgress).toHaveBeenCalledTimes(2)
+
+    rerender({ ...props, chapterIdentifier: 'ch1' })
+    // Re-armed: a third write for ch1 (id + slug correct). Offset value isn't asserted here — it's
+    // exercised by the dedicated clobber test above; this case only proves the once-guard re-arms.
+    expect(updateProgress).toHaveBeenCalledTimes(3)
+    const last = updateProgress.mock.calls.at(-1)!
+    expect(last[3]).toBe('ch1-id')
+    expect(last[4]).toBe('ch1')
   })
 })

--- a/apps/web/src/hooks/useReaderChapter.ts
+++ b/apps/web/src/hooks/useReaderChapter.ts
@@ -90,9 +90,21 @@ export function useReaderChapter({
           if (cachedEditionId) {
             const cached = await getCachedChapter(cachedEditionId, chapterSlug!)
             if (cached && !cancelled) {
+              // CachedChapter doesn't persist chapterNumber; resolve the real one
+              // from the (separately fetched) book so it isn't a misleading 0.
+              let bk: BookDetail | null = null
+              try {
+                bk = await api.getBook(bookSlug!)
+              } catch {
+                // Book fetch failed but chapter from cache - ok
+              }
+              if (cancelled) return
+              const realChapterNumber =
+                bk?.chapters.find(c => c.slug === cached.chapterSlug)?.chapterNumber ?? 0
+
               const rawChapter: Chapter = {
                 id: cached.key,
-                chapterNumber: 0,
+                chapterNumber: realChapterNumber,
                 slug: cached.chapterSlug,
                 title: cached.title,
                 html: cached.html,
@@ -111,23 +123,18 @@ export function useReaderChapter({
                 prev: rawChapter.prev ? { identifier: rawChapter.prev.slug, title: rawChapter.prev.title } : null,
                 next: rawChapter.next ? { identifier: rawChapter.next.slug, title: rawChapter.next.title } : null,
               })
-              try {
-                const bk = await api.getBook(bookSlug!)
-                if (!cancelled) {
-                  setPublicBook(bk)
-                  setBook({
-                    id: bk.id,
-                    title: bk.title,
-                    chapters: bk.chapters.map(c => ({
-                      id: c.id,
-                      identifier: c.slug,
-                      title: c.title,
-                      chapterNumber: c.chapterNumber,
-                    })),
-                  })
-                }
-              } catch {
-                // Book fetch failed but chapter from cache - ok
+              if (bk) {
+                setPublicBook(bk)
+                setBook({
+                  id: bk.id,
+                  title: bk.title,
+                  chapters: bk.chapters.map(c => ({
+                    id: c.id,
+                    identifier: c.slug,
+                    title: c.title,
+                    chapterNumber: c.chapterNumber,
+                  })),
+                })
               }
               fetchedKeyRef.current = fetchKey
               setLoading(false)

--- a/apps/web/src/hooks/useReaderScrollSync.ts
+++ b/apps/web/src/hooks/useReaderScrollSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { BookDetail } from '../types/api'
 import type { ReaderMode } from './useReaderChapter'
 
@@ -52,10 +52,17 @@ export function useReaderScrollSync({
   const lastSaveRef = useRef<{ identifier: string; offset: number; timestamp: number } | null>(null)
   const saveTimerRef = useRef<number | null>(null)
   const pendingSaveRef = useRef<{ identifier: string; offset: number; progress: number } | null>(null)
+  // State-backed mirror of scrollRestoredRef so the save-on-open effect can
+  // re-run AFTER restore completes (a ref flip won't trigger a re-render).
+  // Keyed by the chapter identifier that was restored.
+  const [restoredFor, setRestoredFor] = useState<string | null>(null)
+  // Guard: emit exactly one save-on-open per opened chapter.
+  const savedOnOpenForRef = useRef<string | null>(null)
 
   // Reset restore guard on chapter change.
   useEffect(() => {
     scrollRestoredRef.current = false
+    setRestoredFor(null)
   }, [chapterIdentifier])
 
   // Restore scroll: locator must match current chapter. Otherwise scroll to
@@ -78,8 +85,43 @@ export function useReaderScrollSync({
     requestAnimationFrame(() => {
       window.scrollTo({ top: targetOffset, behavior: 'instant' })
       scrollRestoredRef.current = true
+      setRestoredFor(chapterIdentifier ?? null)
     })
   }, [chapterLoaded, effectiveLoading, effectiveProgress, chapterIdentifier])
+
+  // Save-on-chapter-open: the debounced scroll save is gated by user scrolling,
+  // so chapter→chapter navigation (route param change; ReaderPage stays mounted)
+  // recorded NOTHING for the new chapter — MaxChapterNumber stayed unset and the
+  // book indicator showed "0 / N". Fire exactly ONE save when a chapter opens,
+  // sequenced AFTER restore so the offset reflects the restored scroll, not a
+  // transient 0. Uses the current chapter's id + book-level overallProgress.
+  useEffect(() => {
+    if (!chapterLoaded || !chapterIdentifier) return
+    // Wait until restore has run for THIS chapter (offset is settled).
+    if (restoredFor !== chapterIdentifier) return
+    if (savedOnOpenForRef.current === chapterIdentifier) return
+    savedOnOpenForRef.current = chapterIdentifier
+
+    const offset = (document.scrollingElement || document.documentElement).scrollTop
+    const scrollLocator = `scroll:${chapterIdentifier}:${Math.round(offset)}`
+
+    // Prime the dedupe/skip refs so the next scroll-debounced save doesn't
+    // immediately re-fire an identical write for the same chapter.
+    lastSaveRef.current = { identifier: chapterIdentifier, offset, timestamp: Date.now() }
+    pendingSaveRef.current = { identifier: chapterIdentifier, offset, progress: overallProgress }
+
+    if (mode === 'public' && publicBookChapters) {
+      const bookChapter = publicBookChapters.find(c => c.slug === chapterIdentifier)
+      if (bookChapter) {
+        publicProgress.updateProgress(overallProgress, undefined, scrollLocator, bookChapter.id, chapterIdentifier)
+      }
+    } else if (mode === 'userbook') {
+      userProgress.saveProgress(chapterIdentifier, 0, overallProgress, scrollLocator)
+    }
+    // overallProgress intentionally excluded: we snapshot it on open only. The
+    // scroll-debounced effect owns continuous updates as the user reads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chapterIdentifier, chapterLoaded, mode, restoredFor, publicBookChapters, publicProgress, userProgress])
 
   // Flush pending save now: write locally + ask the underlying hook to ship
   // synchronously (keepalive fetch) so we don't lose the write on tab death.

--- a/apps/web/src/hooks/useReadingProgress.ts
+++ b/apps/web/src/hooks/useReadingProgress.ts
@@ -95,8 +95,10 @@ export function useReadingProgress(
           lastAckedKeyRef.current = `${payload.locator}:${payload.percent.toFixed(4)}`
           if (pendingSyncRef.current === payload) pendingSyncRef.current = null
         })
-        .catch(() => {
+        .catch((err) => {
           // Leave lastAckedKeyRef as-is so subsequent updateProgress retries.
+          // Log only — never interrupt reading with a toast/UI.
+          console.warn('[progress] save failed', err)
         })
     }, 2000)
   }, [bookSlug, chapterSlug, isAuthenticated, editionId, chapterId, resolvedChapterSlug])
@@ -128,7 +130,9 @@ export function useReadingProgress(
       .then(() => {
         lastAckedKeyRef.current = `${payload.locator}:${payload.percent.toFixed(4)}`
       })
-      .catch(() => {})
+      .catch((err) => {
+        console.warn('[progress] flush save failed', err)
+      })
 
     pendingSyncRef.current = null
   }, [isAuthenticated])

--- a/apps/web/src/hooks/useUserBookProgress.ts
+++ b/apps/web/src/hooks/useUserBookProgress.ts
@@ -114,8 +114,9 @@ export function useUserBookProgress(bookId: string) {
           lastAckedKeyRef.current = `${toSync.chapterSlug}:${toSync.locator ?? ''}`
           if (pendingSyncRef.current === toSync) pendingSyncRef.current = null
         })
-        .catch(() => {
-          // Leave ref so next save retries.
+        .catch((err) => {
+          // Leave ref so next save retries. Log only — never interrupt reading.
+          console.warn('[progress] userbook save failed', err)
         })
     }, DEBOUNCE_MS)
   }, [bookId])
@@ -150,7 +151,9 @@ export function useUserBookProgress(bookId: string) {
       .then(() => {
         lastAckedKeyRef.current = `${toSync.chapterSlug}:${toSync.locator ?? ''}`
       })
-      .catch(() => {})
+      .catch((err) => {
+        console.warn('[progress] userbook flush save failed', err)
+      })
 
     pendingSyncRef.current = null
   }, [bookId])

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -382,6 +382,13 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
     setSearchOpen(true)
   }, [chapterHtml, search])
 
+  // Ship the LEAVING chapter's latest scroll synchronously before a same-component
+  // route change (the unmount flush doesn't fire when ReaderPage stays mounted).
+  const flushProgress = useCallback(() => {
+    if (mode === 'public') publicProgress.flushSave()
+    else userProgress.flushSave()
+  }, [mode, publicProgress, userProgress])
+
   // Chapter URL helper
   const getChapterUrl = useCallback((identifier: string) => {
     if (mode === 'public') {
@@ -548,11 +555,14 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
             />
             <ReaderNav
               chapterTitle={chapter.title}
-              chapterNumber={chapter.chapterNumber}
+              // Positional 1-based index — catalog chapterNumber is 0-based
+              // (0..N-1) but user-books are 1-based, so it's unreliable for
+              // display. Mirror ReaderFooterNav's currentChapterIndex + 1.
+              chapterNumber={currentChapterIndex >= 0 ? currentChapterIndex + 1 : null}
               totalChapters={totalChapters || null}
               chapterProgress={overlayScrollProgress}
-              onPrev={chapter.prev ? () => navigate(getChapterUrl(chapter.prev!.identifier)) : null}
-              onNext={chapter.next ? () => navigate(getChapterUrl(chapter.next!.identifier)) : null}
+              onPrev={chapter.prev ? () => { flushProgress(); navigate(getChapterUrl(chapter.prev!.identifier)) } : null}
+              onNext={chapter.next ? () => { flushProgress(); navigate(getChapterUrl(chapter.next!.identifier)) } : null}
             />
           </div>
           {searchOpen && (

--- a/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
+++ b/backend/src/Ai/TextStack.Ai.Rag/RagService.cs
@@ -36,9 +36,12 @@ public sealed class RagService : IRagService
     {
         if (string.IsNullOrWhiteSpace(query))
             return [];
-        // Gate ≤ 0 means "no chapters read" → guaranteed empty; skip the embedding API call.
-        if (maxChapterOrd is <= 0)
-            return [];
+        // No gate-value short-circuit: `null` means "no gate" (ungated full-book retrieval — the tool
+        // path for anonymous users), and a non-null ordinal — INCLUDING 0 — is a real spoiler ceiling
+        // that flows to the SQL gate (`chapter_ord <= @maxChapterOrd`, correct for 0 since catalog
+        // chapters are 0-based). The previous `<= 0` short-circuit wrongly treated ord-0 (a read first
+        // chapter) as "nothing read". The authenticated RAG path null-guards "no progress" upstream in
+        // RagContextService, so retrieve is never asked to surface a whole book for a non-reader there.
         if (k <= 0)
             k = IRagService.DefaultK;
 

--- a/backend/src/Api/Endpoints/UserDataEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserDataEndpoints.cs
@@ -148,8 +148,12 @@ public static class UserDataEndpoints
             existing.ChapterId = request.ChapterId;
             existing.Locator = request.Locator;
             existing.Percent = request.Percent;
-            // High-water mark for the RAG spoiler gate — monotonic, never decreases.
-            existing.MaxChapterNumber = Math.Max(existing.MaxChapterNumber ?? 0, chapter.ChapterNumber);
+            // High-water mark for the RAG spoiler gate — monotonic, never decreases. NULL means
+            // "never recorded" (distinct from ordinal 0, a real 0-based first chapter), so the first
+            // write seeds it rather than max-ing against an implied 0.
+            existing.MaxChapterNumber = existing.MaxChapterNumber.HasValue
+                ? Math.Max(existing.MaxChapterNumber.Value, chapter.ChapterNumber)
+                : chapter.ChapterNumber;
             existing.UpdatedAt = DateTimeOffset.UtcNow;
         }
         else

--- a/backend/src/Application/Rag/RagContextService.cs
+++ b/backend/src/Application/Rag/RagContextService.cs
@@ -30,10 +30,12 @@ public sealed class RagContextService(IAppDbContext db, IRagService rag)
     public const int PrivateNoteCap = 30;
 
     /// <summary>
-    /// Builds the spoiler-safe context. When the user has no progress (lastRead = 0) both lists
-    /// are empty — nothing is retrievable until they've read. Pass <paramref name="currentChapterId"/>
-    /// (the chapter open in the reader) to count it as read even before the debounced progress-save
-    /// persists; it's resolved to an ordinal server-side and ignored unless it belongs to this edition.
+    /// Builds the spoiler-safe context. When the user has no progress at all (effective ord is null)
+    /// both lists are empty — nothing is retrievable until they've read. An ordinal of <c>0</c> is a
+    /// real read chapter (catalog chapters are 0-based), so it does NOT mean "nothing read". Pass
+    /// <paramref name="currentChapterId"/> (the chapter open in the reader) to count it as read even
+    /// before the debounced progress-save persists; it's resolved to an ordinal server-side and ignored
+    /// unless it belongs to this edition.
     /// </summary>
     public async Task<RagContext> BuildAsync(
         Guid userId, Guid siteId, Guid editionId, string query, int k,
@@ -46,45 +48,56 @@ public sealed class RagContextService(IAppDbContext db, IRagService rag)
         // is public/free and the reader can navigate ahead anyway. Counting the chapter they're
         // actively viewing is correct and unblocks "ask about what I'm reading" without waiting on the
         // 2s progress-sync debounce. We resolve the ordinal server-side (above) so a client can't
-        // claim a fake high ord; an id from another edition resolves to 0 and is ignored.
+        // claim a fake high ord; an id from another edition resolves to null and is ignored.
         var lastRead = EffectiveLastReadOrd(persistedLastRead, currentOrd);
-        if (lastRead <= 0)
+        // null = no progress at all → empty. 0 = read the first (0-based) chapter → retrieve normally.
+        if (lastRead is null)
             return new RagContext([], [], 0);
 
         var chunks = await rag.RetrieveAsync(editionId, query, k, maxChapterOrd: lastRead, ct);
-        var notes = await GetPrivateNotesAsync(userId, siteId, editionId, lastRead, ct);
-        return new RagContext(chunks, notes, lastRead);
+        var notes = await GetPrivateNotesAsync(userId, siteId, editionId, lastRead.Value, ct);
+        return new RagContext(chunks, notes, lastRead.Value);
     }
 
     /// <summary>
     /// The gate ordinal: the larger of the persisted high-water mark and the currently-open chapter's
-    /// ordinal (0 when that chapter isn't part of this edition). Pure so it's directly unit-testable.
+    /// ordinal. Each input is null when absent (no progress row / chapter not in this edition); the
+    /// result is null only when BOTH are null. A present <c>0</c> is a real read chapter (catalog
+    /// chapters are 0-based) and wins over null. Pure so it's directly unit-testable.
     /// </summary>
-    public static int EffectiveLastReadOrd(int persistedLastRead, int currentOrd)
-        => Math.Max(persistedLastRead, currentOrd);
+    public static int? EffectiveLastReadOrd(int? persistedLastRead, int? currentOrd)
+        => (persistedLastRead, currentOrd) switch
+        {
+            (null, null) => null,
+            (null, var c) => c,
+            (var p, null) => p,
+            (var p, var c) => Math.Max(p.Value, c.Value),
+        };
 
     /// <summary>
     /// Resolves the open chapter's ordinal authoritatively from the DB, but only if it belongs to this
-    /// edition (so a client can't pass a fake/foreign id to peek ahead). 0 when null or not matched.
+    /// edition (so a client can't pass a fake/foreign id to peek ahead). null when no id is supplied or
+    /// it isn't part of this edition; an ordinal of 0 is a legitimate (0-based) first chapter.
     /// </summary>
-    public async Task<int> ResolveCurrentChapterOrdAsync(
+    public async Task<int?> ResolveCurrentChapterOrdAsync(
         Guid editionId, Guid? currentChapterId, CancellationToken ct)
     {
         if (currentChapterId is not { } id)
-            return 0;
+            return null;
 
         return await db.Chapters
             .Where(c => c.Id == id && c.EditionId == editionId)
-            .Select(c => c.ChapterNumber)
+            .Select(c => (int?)c.ChapterNumber)
             .FirstOrDefaultAsync(ct);
     }
 
     /// <summary>
     /// The furthest chapter ordinal the user has reached in this edition (high-water mark), so
-    /// flipping back doesn't hide already-read chapters; falls back to the current chapter when the
-    /// mark is null (legacy rows). 0 when there's no progress at all.
+    /// flipping back doesn't hide already-read chapters; falls back to the current chapter's ordinal
+    /// when the mark is null (legacy rows). null when there's no progress row at all — distinct from a
+    /// resolved ordinal of 0 (the read first, 0-based chapter).
     /// </summary>
-    public async Task<int> ResolveLastReadOrdAsync(
+    public async Task<int?> ResolveLastReadOrdAsync(
         Guid userId, Guid siteId, Guid editionId, CancellationToken ct)
     {
         var row = await db.ReadingProgresses
@@ -93,14 +106,15 @@ public sealed class RagContextService(IAppDbContext db, IRagService rag)
                 (p, c) => new { p.MaxChapterNumber, c.ChapterNumber })
             .FirstOrDefaultAsync(ct);
 
-        return row is null ? 0 : row.MaxChapterNumber ?? row.ChapterNumber;
+        return row is null ? null : row.MaxChapterNumber ?? row.ChapterNumber;
     }
 
     /// <summary>Highlights + notes from chapters with ChapterNumber ≤ maxOrd (read chapters).</summary>
     public async Task<IReadOnlyList<PrivateNote>> GetPrivateNotesAsync(
         Guid userId, Guid siteId, Guid editionId, int maxOrd, CancellationToken ct)
     {
-        if (maxOrd <= 0)
+        // 0 is a valid read (0-based first) chapter; only a negative ord means "none".
+        if (maxOrd < 0)
             return [];
 
         // Materialize raw fields first — HighlightToText is a C# method EF can't translate.

--- a/tests/TextStack.UnitTests/RagContextServiceTests.cs
+++ b/tests/TextStack.UnitTests/RagContextServiceTests.cs
@@ -1,9 +1,163 @@
+using Application.Common.Interfaces;
 using Application.Rag;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using TextStack.Ai.Rag;
 
 namespace TextStack.UnitTests;
 
 public class RagContextServiceTests
 {
+    // ---- BuildAsync spoiler-gate contract (the leak-critical path) -------------------------------
+    // These lock down the single most dangerous regression: that the AUTHENTICATED ask path must
+    // NEVER hand a `null` gate to IRagService.RetrieveAsync (null = ungated full-book). No progress
+    // must short-circuit to an empty context WITHOUT calling retrieve; ord 0 must call retrieve with
+    // maxChapterOrd: 0 (a real read first chapter), not null.
+
+    private static readonly Guid User = Guid.NewGuid();
+    private static readonly Guid Site = Guid.NewGuid();
+    private static readonly Guid Edition = Guid.NewGuid();
+
+    private sealed class RagSpy : IRagService
+    {
+        public int Calls { get; private set; }
+        public int? LastGate { get; private set; }
+        public bool GateWasNullOnAnyCall { get; private set; }
+
+        public Task<IReadOnlyList<RetrievedChunk>> RetrieveAsync(
+            Guid editionId, string query, int k, int? maxChapterOrd, CancellationToken ct)
+        {
+            Calls++;
+            LastGate = maxChapterOrd;
+            if (maxChapterOrd is null) GateWasNullOnAnyCall = true;
+            return Task.FromResult<IReadOnlyList<RetrievedChunk>>([]);
+        }
+    }
+
+    private static Mock<DbSet<T>> FakeSet<T>(List<T> data) where T : class
+    {
+        var q = new TestAsyncEnumerable<T>(data);
+        var set = new Mock<DbSet<T>>();
+        var iq = set.As<IQueryable<T>>();
+        iq.Setup(m => m.Provider).Returns(((IQueryable<T>)q).Provider);
+        iq.Setup(m => m.Expression).Returns(((IQueryable<T>)q).Expression);
+        iq.Setup(m => m.ElementType).Returns(((IQueryable<T>)q).ElementType);
+        iq.Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
+        set.As<IAsyncEnumerable<T>>()
+            .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+            .Returns(() => new TestAsyncEnumerator<T>(data.GetEnumerator()));
+        return set;
+    }
+
+    private static Chapter Chap(Guid id, Guid editionId, int ord) =>
+        new() { Id = id, EditionId = editionId, ChapterNumber = ord, Title = "t", Html = "<p/>", PlainText = "t" };
+
+    private static ReadingProgress Progress(Guid chapterId, int maxOrd) =>
+        new()
+        {
+            UserId = User,
+            SiteId = Site,
+            EditionId = Edition,
+            ChapterId = chapterId,
+            MaxChapterNumber = maxOrd,
+            Locator = string.Empty,
+        };
+
+    private static RagContextService BuildService(
+        RagSpy rag,
+        List<ReadingProgress> progress,
+        List<Chapter> chapters,
+        List<Highlight>? highlights = null,
+        List<Note>? notes = null)
+    {
+        var db = new Mock<IAppDbContext>();
+        db.Setup(x => x.ReadingProgresses).Returns(() => FakeSet(progress).Object);
+        db.Setup(x => x.Chapters).Returns(() => FakeSet(chapters).Object);
+        db.Setup(x => x.Highlights).Returns(() => FakeSet(highlights ?? []).Object);
+        db.Setup(x => x.Notes).Returns(() => FakeSet(notes ?? []).Object);
+        return new RagContextService(db.Object, rag);
+    }
+
+    [Fact]
+    public async Task BuildAsync_NoProgress_ReturnsEmpty_NeverCallsRetrieve()
+    {
+        var rag = new RagSpy();
+        var svc = BuildService(rag, progress: [], chapters: []);
+
+        var ctx = await svc.BuildAsync(
+            User, Site, Edition, "what happens?", 8, currentChapterId: null, TestContext.Current.CancellationToken);
+
+        Assert.Empty(ctx.Chunks);
+        Assert.Empty(ctx.Notes);
+        // The leak guard: retrieve must NOT run on the no-progress path. If it did with a null gate,
+        // the SQL would surface the WHOLE book to a non-reader.
+        Assert.Equal(0, rag.Calls);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ProgressAtOrdZero_CallsRetrieveWithGateZero_NotNull()
+    {
+        var chapterId = Guid.NewGuid();
+        var rag = new RagSpy();
+        var svc = BuildService(
+            rag,
+            progress: [Progress(chapterId, maxOrd: 0)],
+            chapters: [Chap(chapterId, Edition, ord: 0)]);
+
+        await svc.BuildAsync(
+            User, Site, Edition, "what happens?", 8, currentChapterId: null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, rag.Calls);
+        Assert.False(rag.GateWasNullOnAnyCall);
+        Assert.Equal(0, rag.LastGate);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ForeignCurrentChapterId_Ignored_GateStaysAtPersisted()
+    {
+        var readChapter = Guid.NewGuid();
+        var foreignChapter = Guid.NewGuid();
+        var rag = new RagSpy();
+        var svc = BuildService(
+            rag,
+            progress: [Progress(readChapter, maxOrd: 2)],
+            // The "foreign" chapter has a high ord but belongs to a DIFFERENT edition.
+            chapters:
+            [
+                Chap(readChapter, Edition, ord: 2),
+                Chap(foreignChapter, Guid.NewGuid(), ord: 99),
+            ]);
+
+        await svc.BuildAsync(
+            User, Site, Edition, "spoil me", 8, currentChapterId: foreignChapter, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, rag.Calls);
+        // Peek-ahead defense: a chapter id from another edition must resolve to null and NOT push the gate.
+        Assert.Equal(2, rag.LastGate);
+    }
+
+    [Fact]
+    public async Task BuildAsync_CurrentChapterAheadOfPersisted_GateRisesToCurrent()
+    {
+        var readChapter = Guid.NewGuid();
+        var openChapter = Guid.NewGuid();
+        var rag = new RagSpy();
+        var svc = BuildService(
+            rag,
+            progress: [Progress(readChapter, maxOrd: 1)],
+            chapters:
+            [
+                Chap(readChapter, Edition, ord: 1),
+                Chap(openChapter, Edition, ord: 3),
+            ]);
+
+        await svc.BuildAsync(
+            User, Site, Edition, "current chapter", 8, currentChapterId: openChapter, TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, rag.LastGate);
+    }
+
     [Fact]
     public void HighlightToText_NoNote_ReturnsSelectionOnly()
         => Assert.Equal("the selected passage", RagContextService.HighlightToText("the selected passage", null));
@@ -20,20 +174,34 @@ public class RagContextServiceTests
     public void HighlightToText_BlankNote_ReturnsSelectionOnly(string note)
         => Assert.Equal("passage", RagContextService.HighlightToText("passage", note));
 
-    // Gate ordinal = max(persisted high-water mark, currently-open chapter ord). currentOrd is 0 when
-    // the open chapter isn't part of this edition (resolved server-side), so it can't push the gate up.
+    // Gate ordinal = max(persisted high-water mark, currently-open chapter ord), each null when absent.
+    // null = "no progress at all" (gate empty/insufficient); a present 0 is a real read first (0-based)
+    // chapter and must NOT be treated as "nothing read". currentOrd is null when the open chapter isn't
+    // part of this edition (resolved server-side), so it can't push the gate up.
 
     [Fact]
     public void EffectiveLastReadOrd_NoPersistedProgressOpenChapter4_Uses4()
-        => Assert.Equal(4, RagContextService.EffectiveLastReadOrd(persistedLastRead: 0, currentOrd: 4));
+        => Assert.Equal(4, RagContextService.EffectiveLastReadOrd(persistedLastRead: null, currentOrd: 4));
 
     [Fact]
-    public void EffectiveLastReadOrd_ForeignOrBogusChapter_Ignored_StaysAtPersisted()
-        => Assert.Equal(0, RagContextService.EffectiveLastReadOrd(persistedLastRead: 0, currentOrd: 0));
+    public void EffectiveLastReadOrd_NoPersistedOpenChapter0_Uses0_NotTreatedAsEmpty()
+        => Assert.Equal(0, RagContextService.EffectiveLastReadOrd(persistedLastRead: null, currentOrd: 0));
+
+    [Fact]
+    public void EffectiveLastReadOrd_NothingRead_ReturnsNull()
+        => Assert.Null(RagContextService.EffectiveLastReadOrd(persistedLastRead: null, currentOrd: null));
+
+    [Fact]
+    public void EffectiveLastReadOrd_ForeignOrBogusChapter_Ignored_KeepsPersisted()
+        => Assert.Equal(6, RagContextService.EffectiveLastReadOrd(persistedLastRead: 6, currentOrd: null));
 
     [Fact]
     public void EffectiveLastReadOrd_PersistedAheadOfOpenChapter_KeepsPersisted()
         => Assert.Equal(6, RagContextService.EffectiveLastReadOrd(persistedLastRead: 6, currentOrd: 2));
+
+    [Fact]
+    public void EffectiveLastReadOrd_PersistedZeroOpenChapter3_Uses3()
+        => Assert.Equal(3, RagContextService.EffectiveLastReadOrd(persistedLastRead: 0, currentOrd: 3));
 
     [Fact]
     public void EffectiveLastReadOrd_OpenChapterAheadOfPersisted_UsesCurrent()


### PR DESCRIPTION
Reading progress only persisted on scroll+debounce → navigating chapters recorded nothing → '0/29' indicator, stuck `MaxChapterNumber`, and Ask 'haven't read enough' mid-book.

- **web**: save-on-chapter-open (sequenced after scroll-restore, exactly-once), flush-on-Next/Prev, positional indicator (index+1, fixes '0/29'), offline-cache real chapterNumber, surface save failures (log, no toast).
- **mobile**: emit one progress on WebView load (guarded vs infinite-scroll), pending-save buffer so the destination chapter isn't lost when chapterId is briefly null, log failures.
- **backend (RAG)**: catalog ChapterNumber is 0-based; the gate treated 0 as 'nothing read'. Last-read ordinal is now nullable end-to-end (null=no progress→closed; 0=read 0-based first chapter→open at ord 0). No data migration.

architect → web+mobile+backend → adversarial QA (SHIP; no spoiler leak, no clobbered restore, no double-write). 545 web + 15 RAG + 4 eval tests; mobile tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)