### PR TITLE
fix(worker): register IMemoryCache — worker crash-loop (PROD-DOWN, all ingestion stuck)

### DIFF
--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -117,6 +117,12 @@ public static class DependencyInjection
                     sp.GetRequiredService<ILogger<global::TextStack.Ai.Llm.TracingDecorator>>()));
         }
 
+        // RegistryModelRouteProvider (below) + RollingSpendTracker depend on IMemoryCache.
+        // The API host calls AddMemoryCache(), but the Worker host does NOT — so without this
+        // the Worker crash-loops on startup ("Unable to resolve IMemoryCache") and processes
+        // ZERO ingestion jobs (uploads + clips stuck Queued forever). Idempotent (TryAdd).
+        services.AddMemoryCache();
+
         // Table-driven primary routing (Phase 12 RLOps): the gateway consults this BEFORE
         // its config route, so an admin promote/rollback flips traffic without a redeploy.
         // Singleton (caches one snapshot of the `models` registry); hot-path safe + never throws.


### PR DESCRIPTION
**Prod-down.** The Worker container was crash-looping (`Restarting (139)`): `Unable to resolve service for type IMemoryCache while attempting to activate RegistryModelRouteProvider`. Phase 12 slice 3's `RegistryModelRouteProvider` (+ `RollingSpendTracker`) need `IMemoryCache`; the API host registers it but the **Worker host doesn't**, so the worker never started → **zero ingestion jobs processed** → every user upload + every clip stuck 'Processing…' forever (confirmed via SSH: the clip job sits Queued, attempt_count=0). Fix: move `AddMemoryCache()` into the shared `AddApplication()` DI (idempotent). Worker builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)