### PR TITLE
feat(ext): clip-only — remove document upload from the extension

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,7 +1,7 @@
 # TextStack — Save to read later — Chrome extension (MV3)
 
-Clip the article you're reading, or send a document (PDF/EPUB), to your own
-private TextStack **Read-later** library. Vanilla JS, MV3, no bundler, no npm.
+Clip the web article you're reading to your own private TextStack
+**Read-later** library. Vanilla JS, MV3, no bundler, no npm.
 
 ## What it does
 
@@ -9,8 +9,6 @@ private TextStack **Read-later** library. Vanilla JS, MV3, no bundler, no npm.
   `POST /me/books/clip`.
 - **Selection** → clip only the highlighted text.
 - **Preview & edit** → review/edit the cleaned title/author before sending.
-- **Documents** (`.pdf` / `.epub`) → fetched and `POST /me/books/upload`
-  (multipart).
 - **Right-click menus**: "Clip page to TextStack", "Clip selection to TextStack".
 - **Connect** uses the OAuth 2.0 Device Authorization flow (RFC 8628) — the same
   device flow as the MCP CLI. No new backend.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,23 +1,17 @@
 // background.js — MV3 service worker (type: module). The orchestration hub:
 //   • registers context menus
 //   • drives the device-flow poll on chrome.alarms ticks
-//   • routes messages from the popup (extract, clip, upload, connect, status)
+//   • routes messages from the popup (extract, clip, connect, status)
 //   • performs the on-demand content-script injection + extraction
 //
 // All network/auth lives here and in lib/*. The SW can be evicted between events,
 // so it holds no long-lived in-memory state (flow state is in chrome.storage.local).
 
 import { POLL_ALARM, pollOnce, startDeviceFlow, isConnected, disconnect, getTokens } from "./lib/auth.js";
-import { clip, upload, listReadLater, deleteClip, me, NotConnectedError } from "./lib/api.js";
+import { clip, listReadLater, deleteClip, me, NotConnectedError } from "./lib/api.js";
 
 const MENU_PAGE = "textstack-clip-page";
 const MENU_SELECTION = "textstack-clip-selection";
-
-const DOC_EXTENSIONS = /\.(pdf|epub)(\?|#|$)/i;
-const DOC_CONTENT_TYPES = [
-  "application/pdf",
-  "application/epub+zip",
-];
 
 // ── lifecycle ────────────────────────────────────────────────────────────────
 
@@ -64,10 +58,6 @@ async function handleMessage(msg) {
     case "disconnect":
       await disconnect();
       return { connected: false };
-    case "detectPageType": {
-      const tab = await activeTab();
-      return { kind: await detectPageType(tab), url: tab?.url, title: tab?.title };
-    }
     case "hasSelection": {
       const tab = await activeTab();
       return { hasSelection: await hasSelection(tab) };
@@ -82,12 +72,6 @@ async function handleMessage(msg) {
       const tab = await activeTab();
       return clipActiveTab(tab, msg.mode || "page");
     }
-    case "sendDocument": {
-      const tab = await activeTab();
-      return sendDocument(tab);
-    }
-    case "uploadFile":
-      return uploadPickedFile(msg.file);
     case "recent":
       return listReadLater();
     case "delete": {
@@ -116,22 +100,6 @@ async function getStatus() {
     }
   }
   return { connected, email };
-}
-
-// ── page-type detection ──────────────────────────────────────────────────────
-
-async function detectPageType(tab) {
-  const url = tab?.url || "";
-  if (DOC_EXTENSIONS.test(url)) return "document";
-  if (!/^https?:/i.test(url)) return "article"; // can't HEAD non-http; assume article
-  try {
-    const res = await fetch(url, { method: "HEAD", credentials: "omit" });
-    const ct = (res.headers.get("content-type") || "").toLowerCase();
-    if (DOC_CONTENT_TYPES.some((t) => ct.includes(t))) return "document";
-  } catch {
-    /* HEAD blocked (CORS/etc) → treat as article */
-  }
-  return "article";
 }
 
 // ── selection probe (for greying "Send selection" like Kindle) ───────────────
@@ -185,43 +153,11 @@ async function clipActiveTab(tab, mode) {
   return result;
 }
 
-/** Fetch the document bytes and upload as multipart file. */
-async function sendDocument(tab) {
-  if (!tab?.url) throw new Error("No active tab.");
-  const res = await fetch(tab.url, { credentials: "omit" });
-  if (!res.ok) throw new Error(`Could not fetch document (${res.status}).`);
-  const blob = await res.blob();
-  const filename = filenameFromUrl(tab.url);
-  const result = await upload(blob, filename);
-  notify("Document sent to TextStack");
-  return result;
-}
-
-/** Upload a file the user picked in the popup. `file` = { name, type, bytes:ArrayBuffer }. */
-async function uploadPickedFile(file) {
-  if (!file || !file.bytes) throw new Error("No file selected.");
-  const blob = new Blob([file.bytes], { type: file.type || "application/octet-stream" });
-  const result = await upload(blob, file.name || "document");
-  notify("Document sent to TextStack");
-  return result;
-}
-
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 async function activeTab() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   return tab;
-}
-
-function filenameFromUrl(url) {
-  try {
-    const path = new URL(url).pathname;
-    const base = decodeURIComponent(path.split("/").pop() || "");
-    if (base && /\.(pdf|epub)$/i.test(base)) return base;
-    return base || "document";
-  } catch {
-    return "document";
-  }
 }
 
 function notify(message) {

--- a/extension/lib/api.js
+++ b/extension/lib/api.js
@@ -75,13 +75,6 @@ export function clip({ title, author, sourceUrl, html, language }) {
   });
 }
 
-/** POST /me/books/upload — multipart `file` (Blob) → { userBookId, jobId, status }. */
-export function upload(blob, filename) {
-  const form = new FormData();
-  form.append("file", blob, filename);
-  return request("/me/books/upload", { method: "POST", body: form, isForm: true });
-}
-
 /** GET /me/books?shelf=readlater → recent clips (UserBookListDto[]). */
 export function listReadLater() {
   return request("/me/books?shelf=readlater");

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "TextStack — Save to read later",
   "version": "0.1.0",
-  "description": "Save articles and documents (EPUB/PDF) to your private TextStack library to read later — with TTS, highlights, and vocabulary.",
+  "description": "Clip web articles to your private TextStack library to read later — with TTS, highlights, and vocabulary.",
   "permissions": [
     "activeTab",
     "scripting",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -135,9 +135,6 @@
         fill: none;
       }
       .action-row .label { flex: 1; }
-      .action-row .hint { color: var(--text-secondary); font-size: 11px; }
-
-      .sep { height: 1px; background: var(--border); margin: 6px 4px; }
 
       /* ── disconnected ── */
       .intro { color: var(--text-secondary); font-size: 12px; margin: 4px 4px 12px; }
@@ -255,7 +252,7 @@
 
       <!-- ── disconnected ── -->
       <section id="view-disconnected" class="hidden">
-        <p class="intro">Connect this extension to your TextStack account to clip pages and send documents.</p>
+        <p class="intro">Connect this extension to your TextStack account to clip web articles to read later.</p>
         <button class="btn-primary" id="btn-connect">Connect to TextStack</button>
         <p class="hint-text" id="connect-hint"></p>
       </section>
@@ -277,21 +274,6 @@
             <svg class="ico" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7V5a1 1 0 0 1 1-1h2M17 4h2a1 1 0 0 1 1 1v2M20 17v2a1 1 0 0 1-1 1h-2M7 20H5a1 1 0 0 1-1-1v-2"/><path d="M8 12h8"/></svg>
             <span class="label">Send selection</span>
           </button>
-
-          <div class="sep"></div>
-
-          <!-- shown only when the current tab itself is a document -->
-          <button class="action-row hidden" id="btn-send-doc">
-            <svg class="ico" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>
-            <span class="label">Send this document</span>
-          </button>
-
-          <button class="action-row" id="btn-pick-file">
-            <svg class="ico" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
-            <span class="label">Send a document…</span>
-            <span class="hint">PDF · EPUB</span>
-          </button>
-          <input type="file" id="file-input" accept=".pdf,.epub" class="hidden" />
         </div>
       </section>
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -64,9 +64,6 @@ async function init() {
     }
     $("email").textContent = status.email || "";
 
-    const page = await send("detectPageType");
-    // The current tab is itself a document → offer a direct "Send this document".
-    $("btn-send-doc").classList.toggle("hidden", page.kind !== "document");
     // Greyed "Send selection" until we know there's a live selection (like Kindle).
     await refreshSelectionState();
 
@@ -223,42 +220,6 @@ $("btn-pv-send").addEventListener("click", async () => {
     onSuccess();
   } catch (e) {
     handleErr(e);
-  } finally {
-    spinner(false);
-  }
-});
-
-// Send THIS tab's document (only visible when the tab is a PDF/EPUB).
-$("btn-send-doc").addEventListener("click", async () => {
-  clearToast();
-  spinner(true);
-  try {
-    lastResult = await send("sendDocument");
-    onSuccess();
-  } catch (e) {
-    handleErr(e);
-  } finally {
-    spinner(false);
-  }
-});
-
-// Send a document from disk via the file picker.
-$("btn-pick-file").addEventListener("click", () => $("file-input").click());
-
-$("file-input").addEventListener("change", async (e) => {
-  const file = e.target.files && e.target.files[0];
-  e.target.value = ""; // allow re-picking the same file
-  if (!file) return;
-  clearToast();
-  spinner(true);
-  try {
-    const bytes = await file.arrayBuffer();
-    lastResult = await send("uploadFile", {
-      file: { name: file.name, type: file.type, bytes },
-    });
-    onSuccess();
-  } catch (err) {
-    handleErr(err);
   } finally {
     spinner(false);
   }

--- a/extension/privacy.html
+++ b/extension/privacy.html
@@ -16,16 +16,15 @@
 
     <h2>What this extension does</h2>
     <p>
-      "TextStack — Save to read later" lets you clip the article you are reading, or send a
-      document (PDF/EPUB) you have open, to your own private TextStack
-      Read-later library.
+      "TextStack — Save to read later" lets you clip the web article you are
+      reading to your own private TextStack Read-later library.
     </p>
 
     <h2>What data is sent, and when</h2>
     <ul>
       <li>
         We send page content to TextStack <strong>only when you explicitly act</strong> —
-        clicking "Clip this page", "Clip selection", "Send clip", "Send document",
+        clicking "Clip this page", "Send selection", "Send clip",
         or the corresponding right-click menu items. Nothing is sent in the
         background or while you merely browse.
       </li>
@@ -33,9 +32,6 @@
         For an article clip we send the cleaned article HTML (extracted locally by
         Mozilla Readability), its title, detected author, the source page URL, and
         the detected language.
-      </li>
-      <li>
-        For a document we send the document file you have open.
       </li>
     </ul>
 


### PR DESCRIPTION
The extension is a **web-article clipper**; uploading whole books (PDF/EPUB) belongs to the web app's Upload flow, not the clipper. Mixing it broke the model and the tab-byte-fetch path was flaky (fetched the PDF.js viewer wrapper, not the file → 'Processing Failed: could not read'). Removes Send-this-document / Send-a-document, the file input, doc page-type detection + content-type arrays, uploadFile/sendDocument handlers, and the unused `upload()` api. Popup is now **Clip / Preview & edit / Selection + recent clips**. Description + privacy + README updated to article-clipper only. `node --check` green on all 8 JS; manifest valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)