### PR TITLE
feat(rag): Ask this book — on-demand per-book indexing P1 (catalog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Ask this book — on-demand indexing, Phase 1 (catalog) (2026-06-19)
+
+"Ask this book" returned a misleading "you haven't read enough" for **every** catalog book — because none were RAG-indexed (the 614 editions were imported before RAG; `chapter_chunk` was empty). Books are now indexed **on demand, per book**: a reader clicks **"Prepare this book for questions"** → `POST /books/{editionId}/index` **atomically claims** the edition (`UPDATE … WHERE rag_status IN (NotIndexed, Failed)` — DB-level dedup, concurrent triggers index once, a Ready book is a no-op so OpenAI is never re-billed), chunks it (`BookChunkingService`, extracted from ingestion + reused), and the existing `ChapterEmbeddingWorker` fills embeddings and flips `rag_status → Ready` once `embedded == chunk`. `GET /books/{editionId}/index` polls progress; the reader shows Prepare → "Preparing… N/M" → Ask. **No bulk indexing** — only books someone actually asks, one-time embed per book, rate-limited (`rag.index`, 20/hr/IP). The misleading message now only appears for a genuinely-indexed book hitting the spoiler gate; un-indexed books show the Prepare CTA. New `editions.rag_status/rag_chunk_count/rag_embedded_count/rag_indexed_at/rag_error` (migration `AddEditionRagIndexState`, with a backfill that marks already-chunked editions Ready at $0). architect → backend + frontend → adversarial QA (P1 double-chunk/re-embed-on-legacy + unmount-poll fixed). 845 unit + 555 web tests green. (Phase 2 = user-uploaded books; Phase 3 = observability.)
+
 ### Dropped FB2 (FictionBook) support (2026-06-19)
 
 FB2 was a niche format that never fit the dev-first, English-technical reading audience — pulling it shrinks the extraction surface and the upload contract. Removed across the stack: backend extraction (`Fb2TextExtractor` deleted), the upload/ingestion accept-list (API + Worker), the web + admin upload UIs, the mobile uploader, and the browser extension's "send document" path. **Supported upload formats are now EPUB + PDF only**; `.fb2` uploads are rejected at the boundary.

--- a/apps/web/src/api/ask.ts
+++ b/apps/web/src/api/ask.ts
@@ -1,7 +1,25 @@
 import { authFetch } from './client'
 import type { AskResponse } from '@textstack/shared'
+import type { RagIndexState } from '../types/api'
 
 export type { AskResponse, AskCitation } from '@textstack/shared'
+export type { RagIndexState, RagIndexStatus } from '../types/api'
+
+/**
+ * On-demand RAG index (AI-027 P1). Reads the current index state for a catalog edition.
+ * Cookie auth via {@link authFetch}; throws `ApiError` on failure.
+ */
+export function getIndexStatus(editionId: string, signal?: AbortSignal): Promise<RagIndexState> {
+  return authFetch<RagIndexState>(`/books/${editionId}/index`, { method: 'GET', signal })
+}
+
+/**
+ * Triggers (or re-triggers) indexing for a catalog edition. Returns the (possibly still `Indexing`)
+ * state; the caller polls {@link getIndexStatus} until it reaches `Ready`/`Failed`.
+ */
+export function prepareIndex(editionId: string, signal?: AbortSignal): Promise<RagIndexState> {
+  return authFetch<RagIndexState>(`/books/${editionId}/index`, { method: 'POST', signal })
+}
 
 /**
  * "Ask this book" (AI-025). Authenticated POST — spoiler-safe answer + citations for a catalog

--- a/apps/web/src/components/reader/AskPanel.tsx
+++ b/apps/web/src/components/reader/AskPanel.tsx
@@ -2,7 +2,9 @@ import { useEffect, useRef, useState } from 'react'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
 import { useTranslation } from '../../hooks/useTranslation'
 import { useAsk } from '../../hooks/useAsk'
+import { useRagIndex } from '../../hooks/useRagIndex'
 import type { AskCitation } from '../../api/ask'
+import type { RagIndexStatus } from '../../types/api'
 
 interface Props {
   open: boolean
@@ -10,15 +12,36 @@ interface Props {
   /** GUID of the chapter the user is actively reading — gates the RAG spoiler check. */
   currentChapterId?: string
   isAuthenticated: boolean
+  /** Seed RAG index state from `publicBook` so the panel renders correctly with no extra fetch. */
+  initialRagStatus?: RagIndexStatus
+  initialChunkCount?: number
+  initialEmbeddedCount?: number
   onSignIn: () => void
   onNavigateToCitation: (citation: AskCitation) => void
   onClose: () => void
 }
 
-export function AskPanel({ open, editionId, currentChapterId, isAuthenticated, onSignIn, onNavigateToCitation, onClose }: Props) {
+export function AskPanel({
+  open,
+  editionId,
+  currentChapterId,
+  isAuthenticated,
+  initialRagStatus,
+  initialChunkCount,
+  initialEmbeddedCount,
+  onSignIn,
+  onNavigateToCitation,
+  onClose,
+}: Props) {
   const { t } = useTranslation()
   const containerRef = useFocusTrap(open)
   const { history, isLoading, error, ask } = useAsk(editionId, currentChapterId)
+  const { status, chunkCount, embeddedCount, preparing, prepare } = useRagIndex(
+    editionId,
+    initialRagStatus,
+    initialChunkCount,
+    initialEmbeddedCount,
+  )
   const [input, setInput] = useState('')
   const historyRef = useRef<HTMLDivElement>(null)
 
@@ -83,7 +106,40 @@ export function AskPanel({ open, editionId, currentChapterId, isAuthenticated, o
           {error && error !== 'auth' && <p className="ask-panel__error">{error}</p>}
         </div>
 
-        {isAuthenticated ? (
+        {!isAuthenticated ? (
+          <div className="ask-panel__composer ask-panel__composer--signin">
+            <p>{t('reader.ask.signIn')}</p>
+            <button className="ask-panel__send" onClick={onSignIn}>
+              {t('reader.ask.signInCta')}
+            </button>
+          </div>
+        ) : status === 'Indexing' ? (
+          <div className="ask-panel__composer ask-panel__composer--prepare">
+            <p className="ask-panel__preparing">
+              {t('reader.ask.preparing', { done: embeddedCount, total: chunkCount })}
+            </p>
+            <div className="ask-panel__progress" role="progressbar" aria-valuemin={0} aria-valuemax={chunkCount || 1} aria-valuenow={embeddedCount}>
+              <span
+                className="ask-panel__progress-bar"
+                style={{ width: `${chunkCount > 0 ? Math.round((embeddedCount / chunkCount) * 100) : 0}%` }}
+              />
+            </div>
+          </div>
+        ) : status === 'Failed' ? (
+          <div className="ask-panel__composer ask-panel__composer--prepare">
+            <p className="ask-panel__error">{t('reader.ask.indexFailed')}</p>
+            <button className="ask-panel__send" onClick={prepare} disabled={preparing}>
+              {t('reader.ask.indexRetry')}
+            </button>
+          </div>
+        ) : status !== 'Ready' ? (
+          <div className="ask-panel__composer ask-panel__composer--prepare">
+            <p className="ask-panel__prepare-copy">{t('reader.ask.prepareCopy')}</p>
+            <button className="ask-panel__send" onClick={prepare} disabled={preparing}>
+              {t('reader.ask.prepareCta')}
+            </button>
+          </div>
+        ) : (
           <div className="ask-panel__composer">
             {error === 'auth' && <p className="ask-panel__error">{t('reader.ask.signIn')}</p>}
             <textarea
@@ -101,13 +157,6 @@ export function AskPanel({ open, editionId, currentChapterId, isAuthenticated, o
             />
             <button className="ask-panel__send" onClick={submit} disabled={isLoading || !input.trim()}>
               {t('reader.ask.send')}
-            </button>
-          </div>
-        ) : (
-          <div className="ask-panel__composer ask-panel__composer--signin">
-            <p>{t('reader.ask.signIn')}</p>
-            <button className="ask-panel__send" onClick={onSignIn}>
-              {t('reader.ask.signInCta')}
             </button>
           </div>
         )}

--- a/apps/web/src/components/reader/__tests__/AskPanel.test.tsx
+++ b/apps/web/src/components/reader/__tests__/AskPanel.test.tsx
@@ -11,6 +11,11 @@ const { askState } = vi.hoisted(() => ({
 }))
 vi.mock('../../../hooks/useAsk', () => ({ useAsk: () => askState }))
 
+const { ragState } = vi.hoisted(() => ({
+  ragState: { status: 'Ready', chunkCount: 0, embeddedCount: 0, preparing: false, prepare: vi.fn() },
+}))
+vi.mock('../../../hooks/useRagIndex', () => ({ useRagIndex: () => ragState }))
+
 import { AskPanel } from '../AskPanel'
 
 const baseProps = {
@@ -24,6 +29,10 @@ const baseProps = {
 afterEach(() => {
   cleanup()
   askState.history = []
+  ragState.status = 'Ready'
+  ragState.chunkCount = 0
+  ragState.embeddedCount = 0
+  ragState.prepare = vi.fn()
 })
 
 describe('AskPanel', () => {
@@ -37,6 +46,34 @@ describe('AskPanel', () => {
   it('shows the composer when authenticated', () => {
     render(<AskPanel {...baseProps} isAuthenticated={true} />)
     expect(screen.getByPlaceholderText('reader.ask.placeholder')).toBeTruthy()
+  })
+
+  it('shows the prepare CTA when not indexed (not the read-enough message)', () => {
+    ragState.status = 'NotIndexed'
+    const prepare = vi.fn()
+    ragState.prepare = prepare
+    render(<AskPanel {...baseProps} isAuthenticated={true} />)
+    expect(screen.queryByPlaceholderText('reader.ask.placeholder')).toBeNull()
+    fireEvent.click(screen.getByText('reader.ask.prepareCta'))
+    expect(prepare).toHaveBeenCalled()
+  })
+
+  it('shows progress while indexing with composer hidden', () => {
+    ragState.status = 'Indexing'
+    ragState.chunkCount = 4
+    ragState.embeddedCount = 2
+    render(<AskPanel {...baseProps} isAuthenticated={true} />)
+    expect(screen.getByRole('progressbar')).toBeTruthy()
+    expect(screen.queryByPlaceholderText('reader.ask.placeholder')).toBeNull()
+  })
+
+  it('shows retry on failure', () => {
+    ragState.status = 'Failed'
+    const prepare = vi.fn()
+    ragState.prepare = prepare
+    render(<AskPanel {...baseProps} isAuthenticated={true} />)
+    fireEvent.click(screen.getByText('reader.ask.indexRetry'))
+    expect(prepare).toHaveBeenCalled()
   })
 
   it('renders a citation chip and navigates on click', () => {

--- a/apps/web/src/hooks/useRagIndex.test.ts
+++ b/apps/web/src/hooks/useRagIndex.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+vi.mock('../api/ask', () => ({ getIndexStatus: vi.fn(), prepareIndex: vi.fn() }))
+import { getIndexStatus, prepareIndex } from '../api/ask'
+import { useRagIndex } from './useRagIndex'
+
+const mockGet = getIndexStatus as unknown as ReturnType<typeof vi.fn>
+const mockPrepare = prepareIndex as unknown as ReturnType<typeof vi.fn>
+
+describe('useRagIndex', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPrepare.mockReset()
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('seeds from initial status without fetching', () => {
+    const { result } = renderHook(() => useRagIndex('ed-1', 'Ready', 10, 10))
+    expect(result.current.status).toBe('Ready')
+    expect(result.current.chunkCount).toBe(10)
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('defaults to NotIndexed when unseeded', () => {
+    const { result } = renderHook(() => useRagIndex('ed-1'))
+    expect(result.current.status).toBe('NotIndexed')
+  })
+
+  it('NotIndexed → prepare → Indexing → poll → Ready', async () => {
+    mockPrepare.mockResolvedValueOnce({ status: 'Indexing', chunkCount: 4, embeddedCount: 0 })
+    mockGet
+      .mockResolvedValueOnce({ status: 'Indexing', chunkCount: 4, embeddedCount: 2 })
+      .mockResolvedValueOnce({ status: 'Ready', chunkCount: 4, embeddedCount: 4 })
+
+    const { result } = renderHook(() => useRagIndex('ed-1', 'NotIndexed'))
+
+    await act(async () => {
+      result.current.prepare()
+    })
+    expect(result.current.status).toBe('Indexing')
+    expect(result.current.chunkCount).toBe(4)
+
+    // First poll tick → still Indexing, embedded advances.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    expect(result.current.status).toBe('Indexing')
+    expect(result.current.embeddedCount).toBe(2)
+
+    // Second poll tick → Ready, polling stops.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    expect(result.current.status).toBe('Ready')
+    expect(result.current.embeddedCount).toBe(4)
+
+    // No further polls after Ready.
+    const callsAfterReady = mockGet.mock.calls.length
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000)
+    })
+    expect(mockGet.mock.calls.length).toBe(callsAfterReady)
+  })
+
+  it('prepare returning Ready immediately does not poll', async () => {
+    mockPrepare.mockResolvedValueOnce({ status: 'Ready', chunkCount: 8, embeddedCount: 8 })
+    const { result } = renderHook(() => useRagIndex('ed-1', 'NotIndexed'))
+
+    await act(async () => {
+      result.current.prepare()
+    })
+    expect(result.current.status).toBe('Ready')
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('sets Failed when prepare throws', async () => {
+    mockPrepare.mockRejectedValueOnce(new Error('boom'))
+    const { result } = renderHook(() => useRagIndex('ed-1', 'NotIndexed'))
+
+    await act(async () => {
+      await result.current.prepare()
+    })
+    expect(result.current.status).toBe('Failed')
+    expect(result.current.preparing).toBe(false)
+  })
+
+  it('polls when seeded already Indexing', async () => {
+    mockGet.mockResolvedValueOnce({ status: 'Ready', chunkCount: 3, embeddedCount: 3 })
+    const { result } = renderHook(() => useRagIndex('ed-1', 'Indexing', 3, 1))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    expect(result.current.status).toBe('Ready')
+  })
+
+  it('stops polling after unmount (no further getIndexStatus calls)', async () => {
+    mockGet.mockResolvedValue({ status: 'Indexing', chunkCount: 4, embeddedCount: 1 })
+    const { unmount } = renderHook(() => useRagIndex('ed-1', 'Indexing', 4, 1))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    const callsBeforeUnmount = mockGet.mock.calls.length
+    unmount()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9000)
+    })
+    expect(mockGet.mock.calls.length).toBe(callsBeforeUnmount)
+  })
+
+  it('does not throw on a poll that resolves after unmount', async () => {
+    // Poll request is in flight when the component unmounts; its setState must be guarded.
+    let resolvePoll: (v: unknown) => void = () => {}
+    mockGet.mockImplementationOnce(
+      () => new Promise(res => { resolvePoll = res }),
+    )
+    const { unmount } = renderHook(() => useRagIndex('ed-1', 'Indexing', 4, 1))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000) // fires poll → pending promise
+    })
+    unmount()
+    await act(async () => {
+      resolvePoll({ status: 'Ready', chunkCount: 4, embeddedCount: 4 })
+      await Promise.resolve()
+    })
+    // No assertion error / unhandled rejection = pass; the guard skips setState post-unmount.
+    expect(true).toBe(true)
+  })
+})

--- a/apps/web/src/hooks/useRagIndex.ts
+++ b/apps/web/src/hooks/useRagIndex.ts
@@ -1,0 +1,103 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { getIndexStatus, prepareIndex } from '../api/ask'
+import type { RagIndexStatus } from '../types/api'
+
+const POLL_INTERVAL_MS = 3000
+
+export interface RagIndexHook {
+  status: RagIndexStatus
+  chunkCount: number
+  embeddedCount: number
+  /** True while a `prepare()` POST is in flight (before the first poll resolves). */
+  preparing: boolean
+  /** Triggers indexing, then polls until Ready/Failed. */
+  prepare: () => void
+}
+
+/**
+ * On-demand per-book RAG index state (AI-027 P1). Seeds from the catalog book's `ragStatus` /
+ * counts so the panel renders correctly on load with no extra fetch. `prepare()` POSTs to start
+ * indexing, then polls `getIndexStatus` every ~3s while `status === 'Indexing'`, stopping at
+ * Ready/Failed. The poll interval is cleaned up on unmount and whenever indexing finishes.
+ */
+export function useRagIndex(
+  editionId: string | undefined,
+  initialStatus?: RagIndexStatus,
+  initialChunkCount?: number,
+  initialEmbeddedCount?: number,
+): RagIndexHook {
+  const [status, setStatus] = useState<RagIndexStatus>(initialStatus ?? 'NotIndexed')
+  const [chunkCount, setChunkCount] = useState(initialChunkCount ?? 0)
+  const [embeddedCount, setEmbeddedCount] = useState(initialEmbeddedCount ?? 0)
+  const [preparing, setPreparing] = useState(false)
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const mountedRef = useRef(true)
+
+  const stopPolling = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      stopPolling()
+      abortRef.current?.abort()
+    }
+  }, [stopPolling])
+
+  const poll = useCallback(async () => {
+    if (!editionId) return
+    try {
+      const res = await getIndexStatus(editionId)
+      // The interval is cleared on unmount, but an already-in-flight poll can still resolve after
+      // unmount — guard the setState to avoid an update on an unmounted component.
+      if (!mountedRef.current) return
+      setStatus(res.status)
+      setChunkCount(res.chunkCount)
+      setEmbeddedCount(res.embeddedCount)
+      if (res.status !== 'Indexing') stopPolling()
+    } catch {
+      // Transient poll failure — keep polling; a persistent failure surfaces via the next tick.
+    }
+  }, [editionId, stopPolling])
+
+  const startPolling = useCallback(() => {
+    stopPolling()
+    timerRef.current = setInterval(poll, POLL_INTERVAL_MS)
+  }, [poll, stopPolling])
+
+  const prepare = useCallback(async () => {
+    if (!editionId || preparing) return
+    abortRef.current?.abort()
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+    setPreparing(true)
+    try {
+      const res = await prepareIndex(editionId, ctrl.signal)
+      if (!mountedRef.current) return
+      setStatus(res.status)
+      setChunkCount(res.chunkCount)
+      setEmbeddedCount(res.embeddedCount)
+      if (res.status === 'Indexing') startPolling()
+    } catch {
+      if (mountedRef.current) setStatus('Failed')
+    } finally {
+      if (mountedRef.current && abortRef.current === ctrl) setPreparing(false)
+    }
+  }, [editionId, preparing, startPolling])
+
+  // If we mount already mid-index (seeded), pick up polling.
+  useEffect(() => {
+    if (status === 'Indexing' && !timerRef.current) startPolling()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { status, chunkCount, embeddedCount, preparing, prepare }
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -195,7 +195,12 @@
       "empty": "Ask a question about the book — answers come only from chapters you've read.",
       "signIn": "Sign in to ask questions about this book.",
       "signInCta": "Sign in",
-      "citation": "ch.{{ch}}"
+      "citation": "ch.{{ch}}",
+      "prepareCopy": "One-time setup so you can ask about this book.",
+      "prepareCta": "Prepare this book for questions",
+      "preparing": "Preparing this book… {{done}}/{{total}}",
+      "indexFailed": "Preparation failed.",
+      "indexRetry": "Retry"
     },
     "studyBuddy": {
       "title": "Help me understand this",

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -618,6 +618,9 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
           editionId={askEditionId}
           currentChapterId={activeChapter?.id}
           isAuthenticated={isAuthenticated}
+          initialRagStatus={publicBook?.ragStatus}
+          initialChunkCount={publicBook?.ragChunkCount}
+          initialEmbeddedCount={publicBook?.ragEmbeddedCount}
           onSignIn={openAuthModal}
           onNavigateToCitation={handleNavigateToCitation}
           onClose={() => setAskOpen(false)}

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -2306,6 +2306,34 @@ html[data-theme="dark"] .vocab-translation-overlay__item {
   cursor: default;
 }
 
+/* On-demand RAG index prepare/progress states (AI-027 P1). */
+.ask-panel__composer--prepare {
+  align-items: flex-start;
+}
+.ask-panel__prepare-copy,
+.ask-panel__preparing {
+  margin: 0;
+  font-size: 14px;
+  color: var(--reader-text);
+}
+.ask-panel__composer--prepare .ask-panel__send {
+  align-self: stretch;
+  text-align: center;
+}
+.ask-panel__progress {
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--reader-border);
+  overflow: hidden;
+}
+.ask-panel__progress-bar {
+  display: block;
+  height: 100%;
+  background: #2563eb;
+  transition: width 0.3s ease;
+}
+
 /* Cited-passage flash (AI-026b) — CSS Custom Highlight API, fades via the timer in citationScroll. */
 ::highlight(rag-citation) {
   background-color: rgba(37, 99, 235, 0.25);

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -93,6 +93,20 @@ export interface BookDetail {
   authors: BookAuthor[]
   genres: BookGenre[]
   moreByAuthor: RelatedBook[]
+  // On-demand RAG index for "Ask this book" (AI-027 P1). Absent on older payloads → treat as NotIndexed.
+  ragStatus?: RagIndexStatus
+  ragChunkCount?: number
+  ragEmbeddedCount?: number
+}
+
+/** Per-book RAG index lifecycle (camelCase JSON from the backend). */
+export type RagIndexStatus = 'NotIndexed' | 'Indexing' | 'Ready' | 'Failed'
+
+/** Response of GET/POST `/books/{editionId}/index`. */
+export interface RagIndexState {
+  status: RagIndexStatus
+  chunkCount: number
+  embeddedCount: number
 }
 
 export interface SearchEdition {

--- a/backend/src/Api/Endpoints/BookIndexEndpoints.cs
+++ b/backend/src/Api/Endpoints/BookIndexEndpoints.cs
@@ -1,0 +1,140 @@
+using Api.Extensions;
+using Api.Sites;
+using Application.Auth;
+using Application.Rag;
+using Contracts.Books;
+using Domain.Enums;
+using Infrastructure.Persistence;
+using Infrastructure.Rag;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Endpoints;
+
+/// <summary>
+/// On-demand per-book RAG indexing (Phase 1 "Ask this book"). Catalog editions imported before RAG
+/// have zero <c>chapter_chunk</c> rows, so Ask returns "not enough read" for everyone. These endpoints
+/// let an authenticated user trigger indexing for a book and poll its state:
+/// <list type="bullet">
+///   <item><c>POST /books/{editionId}/index</c> — atomically claim (NotIndexed/Failed → Indexing),
+///   chunk the edition, return 202; idempotent no-op (200) if already Indexing/Ready.</item>
+///   <item><c>GET  /books/{editionId}/index</c> — current { status, chunkCount, embeddedCount } for polling.</item>
+/// </list>
+/// The embedding worker fills the vectors and flips Indexing → Ready. User books are Phase 2.
+/// </summary>
+public static class BookIndexEndpoints
+{
+    public static void MapBookIndexEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/books").WithTags("RAG");
+
+        group.MapPost("/{editionId:guid}/index", TriggerIndex)
+            .RequireRateLimiting("rag.index");
+
+        group.MapGet("/{editionId:guid}/index", GetIndexStatus);
+    }
+
+    private static async Task<IResult> TriggerIndex(
+        Guid editionId,
+        HttpContext httpContext,
+        AuthService authService,
+        AppDbContext db,
+        BookChunkingService chunking,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var siteId = httpContext.GetSiteId();
+
+        // Validate the edition exists + belongs to this site (mirror AskEndpoints). Read the prior
+        // status to drive the (pure, tested) claim decision; the actual transition is still atomic.
+        var prior = await db.Editions
+            .Where(e => e.Id == editionId && e.SiteId == siteId)
+            .Select(e => (RagIndexStatus?)e.RagStatus)
+            .FirstOrDefaultAsync(ct);
+        if (prior is null) return Results.NotFound("Edition not found");
+
+        // Atomic claim / dedup (guard mirrors RagIndexLogic.CanClaim): only NotIndexed(0) or
+        // Failed(3) editions transition to Indexing(1). A concurrent/repeat trigger affects 0 rows.
+        var claimed = await db.Database.ExecuteSqlInterpolatedAsync($"""
+            UPDATE editions
+            SET rag_status = 1, rag_error = NULL
+            WHERE id = {editionId} AND rag_status IN (0, 3);
+            """, ct);
+
+        if (claimed == 0)
+        {
+            // Already Indexing or Ready — return current state, no-op (200).
+            var current = await ReadStatusAsync(db, editionId, ct);
+            return current is null ? Results.NotFound("Edition not found") : Results.Ok(current);
+        }
+
+        // Clear any pre-existing chunks before re-chunking. This covers:
+        //   * Failed re-claims (stale partial chunks), and
+        //   * NotIndexed claims of legacy editions that ALREADY have chapter_chunk rows from the
+        //     pre-Phase-1 ingestion chunker (AI-019) but were defaulted to NotIndexed/count=0 by the
+        //     AddEditionRagIndexState migration. Without this, ChunkEditionAsync would AddRange a
+        //     second full set → duplicate chunks, double OpenAI embed spend, and a chunk_count that
+        //     never equals embedded_count (Ready never flips → stuck "Indexing" forever).
+        // On a truly-empty NotIndexed claim the DELETE is a harmless no-op.
+        if (RagIndexLogic.ShouldClearChunksBeforeChunking(prior.Value))
+        {
+            await db.Database.ExecuteSqlInterpolatedAsync(
+                $"DELETE FROM chapter_chunk WHERE edition_id = {editionId};", ct);
+        }
+
+        var chunkCount = await chunking.ChunkEditionAsync(db, editionId, ct);
+
+        var edition = await db.Editions.FirstAsync(e => e.Id == editionId, ct);
+        if (chunkCount == 0)
+        {
+            edition.RagStatus = RagIndexStatus.Failed;
+            edition.RagChunkCount = 0;
+            edition.RagEmbeddedCount = 0;
+            edition.RagError = "No chapters to index";
+            edition.RagIndexedAt = null;
+            await db.SaveChangesAsync(ct);
+            return Results.Ok(new BookIndexStatusDto("Failed", 0, 0));
+        }
+
+        edition.RagStatus = RagIndexStatus.Indexing;
+        edition.RagChunkCount = chunkCount;
+        edition.RagEmbeddedCount = 0;
+        edition.RagError = null;
+        edition.RagIndexedAt = null;
+        await db.SaveChangesAsync(ct);
+
+        return Results.Json(new BookIndexStatusDto("Indexing", chunkCount, 0), statusCode: StatusCodes.Status202Accepted);
+    }
+
+    private static async Task<IResult> GetIndexStatus(
+        Guid editionId,
+        HttpContext httpContext,
+        AuthService authService,
+        AppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var siteId = httpContext.GetSiteId();
+        var exists = await db.Editions.AnyAsync(e => e.Id == editionId && e.SiteId == siteId, ct);
+        if (!exists) return Results.NotFound("Edition not found");
+
+        var status = await ReadStatusAsync(db, editionId, ct);
+        return status is null ? Results.NotFound("Edition not found") : Results.Ok(status);
+    }
+
+    private static async Task<BookIndexStatusDto?> ReadStatusAsync(
+        AppDbContext db, Guid editionId, CancellationToken ct)
+    {
+        var row = await db.Editions
+            .Where(e => e.Id == editionId)
+            .Select(e => new { e.RagStatus, e.RagChunkCount, e.RagEmbeddedCount })
+            .FirstOrDefaultAsync(ct);
+
+        return row is null
+            ? null
+            : new BookIndexStatusDto(row.RagStatus.ToString(), row.RagChunkCount, row.RagEmbeddedCount);
+    }
+}

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -144,6 +144,9 @@ else
 // RAG vector retrieval (Phase 4). Raw Npgsql like the search provider; query embedded via
 // IEmbeddingService (registered in AddApplication). Used by the admin debug endpoint (AI-022).
 builder.Services.AddRagRetrieval(_ => () => new NpgsqlConnection(connectionString));
+// On-demand "Ask this book" index trigger (Phase 1): the chunker + shared chunking service.
+builder.Services.AddAiRag();
+builder.Services.AddScoped<Infrastructure.Rag.BookChunkingService>();
 // Spoiler-safe context builder (AI-024): resolves lastRead + gates chunks + private corpus.
 builder.Services.AddScoped<Application.Rag.RagContextService>();
 // "Ask this book" orchestration (AI-025): context + LLM gateway → grounded answer with citations.
@@ -400,6 +403,18 @@ builder.Services.AddRateLimiter(options =>
             QueueLimit = 0,
         });
     });
+    // On-demand "Ask this book" index trigger (Phase 1): per-IP cap so a user can't mass-index
+    // the whole catalog. ~20/hour — generous for legit "index this book then poll" flows.
+    options.AddPolicy("rag.index", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromHours(1),
+            PermitLimit = 20,
+            QueueLimit = 0,
+        });
+    });
     // Study Buddy agent (AI-037): each run is several LLM calls, so a tighter per-IP limit.
     options.AddPolicy("studybuddy", httpContext =>
     {
@@ -639,6 +654,7 @@ app.MapAdminBookQualityEndpoints();
 app.MapAdminAiQualityEndpoints();
 app.MapAdminRagEndpoints();
 app.MapAskEndpoints();
+app.MapBookIndexEndpoints();
 app.MapStudyBuddyEndpoints();
 app.MapVocabularyEndpoints();
 app.MapTtsEndpoints();

--- a/backend/src/Application/Books/BookService.cs
+++ b/backend/src/Application/Books/BookService.cs
@@ -90,6 +90,9 @@ public class BookService(IAppDbContext db)
                 e.SeoThemesJson,
                 e.SeoFaqsJson,
                 e.TocJson,
+                e.RagStatus,
+                e.RagChunkCount,
+                e.RagEmbeddedCount,
                 Work = new WorkDto(e.Work.Id, e.Work.Slug),
                 Chapters = e.Chapters
                     .OrderBy(c => c.ChapterNumber)
@@ -172,7 +175,10 @@ public class BookService(IAppDbContext db)
             result.Authors,
             result.Genres,
             moreByAuthor,
-            toc
+            toc,
+            result.RagStatus.ToString(),
+            result.RagChunkCount,
+            result.RagEmbeddedCount
         );
     }
 

--- a/backend/src/Application/Rag/RagIndexLogic.cs
+++ b/backend/src/Application/Rag/RagIndexLogic.cs
@@ -1,0 +1,44 @@
+using Domain.Enums;
+
+namespace Application.Rag;
+
+/// <summary>
+/// Pure decision logic for on-demand "Ask this book" indexing (Phase 1). Kept framework-free and
+/// side-effect-free so the load-bearing state transitions are unit-testable without a DB. The
+/// endpoint + embedding worker run the equivalent guarded SQL; these predicates mirror those guards
+/// so a regression is caught in a fast test rather than only against pgvector.
+/// </summary>
+public static class RagIndexLogic
+{
+    /// <summary>
+    /// A trigger may CLAIM an edition for indexing only from <see cref="RagIndexStatus.NotIndexed"/>
+    /// or <see cref="RagIndexStatus.Failed"/>. Already-Indexing/Ready editions are a no-op (return
+    /// current status). This mirrors the atomic <c>WHERE rag_status IN (0, 3)</c> claim in SQL.
+    /// </summary>
+    public static bool CanClaim(RagIndexStatus status)
+        => status is RagIndexStatus.NotIndexed or RagIndexStatus.Failed;
+
+    /// <summary>
+    /// Before (re-)chunking a claimed edition we must delete any pre-existing <c>chapter_chunk</c>
+    /// rows, otherwise <c>ChunkEditionAsync</c> AddRange's a second full set → duplicate chunks,
+    /// double embed spend, and a chunk_count that never matches embedded_count (Ready never flips).
+    /// This is true for BOTH claimable priors:
+    /// <list type="bullet">
+    ///   <item><see cref="RagIndexStatus.Failed"/> — clears stale partial chunks from the prior run.</item>
+    ///   <item><see cref="RagIndexStatus.NotIndexed"/> — legacy editions ingested under AI-019 already
+    ///   carry chunks but were defaulted to NotIndexed by the migration; a truly-fresh edition has
+    ///   none so the DELETE is a harmless no-op.</item>
+    /// </list>
+    /// Only the two claimable states are ever reached here (Indexing/Ready no-op before this point).
+    /// </summary>
+    public static bool ShouldClearChunksBeforeChunking(RagIndexStatus priorStatus)
+        => priorStatus is RagIndexStatus.NotIndexed or RagIndexStatus.Failed;
+
+    /// <summary>
+    /// An edition is fully embedded (→ flip to <see cref="RagIndexStatus.Ready"/>) exactly when its
+    /// embedded-chunk count equals its total chunk count AND it has at least one chunk. The
+    /// <c>chunkCount &gt; 0</c> guard prevents a chunk-less edition (0 == 0) from flipping Ready.
+    /// </summary>
+    public static bool IsReady(int embeddedCount, int chunkCount)
+        => chunkCount > 0 && embeddedCount == chunkCount;
+}

--- a/backend/src/Contracts/Books/BookDetailDto.cs
+++ b/backend/src/Contracts/Books/BookDetailDto.cs
@@ -22,8 +22,15 @@ public record BookDetailDto(
     IReadOnlyList<BookAuthorDto> Authors,
     IReadOnlyList<BookGenreDto> Genres,
     IReadOnlyList<RelatedBookDto> MoreByAuthor,
-    IReadOnlyList<TocEntryDto>? Toc = null
+    IReadOnlyList<TocEntryDto>? Toc = null,
+    // On-demand RAG index state (Phase 1 "Ask this book"). Lets the reader know index state on load.
+    string RagStatus = "NotIndexed",
+    int RagChunkCount = 0,
+    int RagEmbeddedCount = 0
 );
+
+/// <summary>On-demand "Ask this book" index state, returned by the index trigger + status endpoints.</summary>
+public record BookIndexStatusDto(string Status, int ChunkCount, int EmbeddedCount);
 
 public record BookGenreDto(Guid Id, string Slug, string Name);
 

--- a/backend/src/Domain/Entities/Edition.cs
+++ b/backend/src/Domain/Entities/Edition.cs
@@ -45,6 +45,14 @@ public class Edition
     /// </summary>
     public float[]? Embedding { get; set; }
 
+    // On-demand RAG index state (Phase 1 "Ask this book"). Catalog editions imported before RAG
+    // start NotIndexed (0 chunks); a user trigger claims → chunks → embedding worker flips to Ready.
+    public RagIndexStatus RagStatus { get; set; } = RagIndexStatus.NotIndexed;
+    public int RagChunkCount { get; set; }
+    public int RagEmbeddedCount { get; set; }
+    public DateTimeOffset? RagIndexedAt { get; set; }
+    public string? RagError { get; set; }
+
     public Work Work { get; set; } = null!;
     public Site Site { get; set; } = null!;
     public Edition? SourceEdition { get; set; }

--- a/backend/src/Domain/Enums/RagIndexStatus.cs
+++ b/backend/src/Domain/Enums/RagIndexStatus.cs
@@ -1,0 +1,15 @@
+namespace Domain.Enums;
+
+/// <summary>
+/// Per-edition on-demand RAG index state (Phase 1 "Ask this book"). Catalog editions imported
+/// before RAG start <see cref="NotIndexed"/>; a user trigger claims the edition (<see cref="Indexing"/>),
+/// chunks are created, then the embedding worker flips it to <see cref="Ready"/> once every chunk is
+/// embedded. <see cref="Failed"/> is re-claimable (clears stale partial chunks).
+/// </summary>
+public enum RagIndexStatus
+{
+    NotIndexed = 0,
+    Indexing = 1,
+    Ready = 2,
+    Failed = 3
+}

--- a/backend/src/Infrastructure/Migrations/20260619045430_AddEditionRagIndexState.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260619045430_AddEditionRagIndexState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619045430_AddEditionRagIndexState")]
+    partial class AddEditionRagIndexState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260619045430_AddEditionRagIndexState.cs
+++ b/backend/src/Infrastructure/Migrations/20260619045430_AddEditionRagIndexState.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEditionRagIndexState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "rag_chunk_count",
+                table: "editions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "rag_embedded_count",
+                table: "editions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "rag_error",
+                table: "editions",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "rag_indexed_at",
+                table: "editions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "rag_status",
+                table: "editions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            // Backfill from chunks that already exist (AI-019 ingestion chunker ran before this
+            // feature). Without this, editions that are already chunked/embedded default to
+            // NotIndexed/0 — and the on-demand trigger would re-chunk them into DUPLICATE rows and
+            // re-embed every chunk (wasted OpenAI $), and never flip Ready. Set counts from the
+            // chunk table and status: Ready when every chunk is embedded, else Indexing (the
+            // embedding worker drains the remainder). Editions with no chunks stay NotIndexed/0.
+            migrationBuilder.Sql("""
+                UPDATE editions e
+                SET rag_chunk_count = c.total,
+                    rag_embedded_count = c.embedded,
+                    rag_status = CASE WHEN c.embedded = c.total THEN 2 ELSE 1 END,
+                    rag_indexed_at = CASE WHEN c.embedded = c.total THEN now() ELSE NULL END
+                FROM (
+                    SELECT edition_id,
+                           count(*) AS total,
+                           count(*) FILTER (WHERE embedding IS NOT NULL) AS embedded
+                    FROM chapter_chunk
+                    GROUP BY edition_id
+                ) c
+                WHERE e.id = c.edition_id;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "rag_chunk_count",
+                table: "editions");
+
+            migrationBuilder.DropColumn(
+                name: "rag_embedded_count",
+                table: "editions");
+
+            migrationBuilder.DropColumn(
+                name: "rag_error",
+                table: "editions");
+
+            migrationBuilder.DropColumn(
+                name: "rag_indexed_at",
+                table: "editions");
+
+            migrationBuilder.DropColumn(
+                name: "rag_status",
+                table: "editions");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Catalog.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Catalog.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistence;
@@ -54,6 +55,11 @@ public partial class AppDbContext
             e.HasIndex(x => new { x.SiteId, x.Language, x.Slug }).IsUnique();
             e.Property(x => x.Language).HasMaxLength(8);
             e.Property(x => x.TocJson).HasColumnType("jsonb");
+
+            // On-demand RAG index state (Phase 1). RagStatus persisted as int (enum).
+            e.Property(x => x.RagStatus).HasConversion<int>().HasDefaultValue(RagIndexStatus.NotIndexed);
+            e.Property(x => x.RagChunkCount).HasDefaultValue(0);
+            e.Property(x => x.RagEmbeddedCount).HasDefaultValue(0);
 
             // AI-054: mean-pool edition embedding. Same float[] <-> pgvector vector(1536)
             // conversion as ChapterChunk.Embedding (see AppDbContext.Rag.cs). Nullable —

--- a/backend/src/Infrastructure/Rag/BookChunkingService.cs
+++ b/backend/src/Infrastructure/Rag/BookChunkingService.cs
@@ -1,0 +1,90 @@
+using Domain.Entities;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TextStack.Ai.Rag;
+
+namespace Infrastructure.Rag;
+
+/// <summary>
+/// Splits an edition's chapters into RAG chunks (<see cref="ChapterChunk"/> rows with a null
+/// embedding, filled later by the embedding worker). Extracted from the ingestion path so the
+/// on-demand "Ask this book" index trigger (Phase 1) and ingestion share one chunking codepath.
+/// Lives in Infrastructure because it touches the <c>chapter_chunk</c> DbSet directly.
+/// </summary>
+public sealed class BookChunkingService(IChunker chunker, ILogger<BookChunkingService> logger)
+{
+    /// <summary>
+    /// Creates <see cref="ChapterChunk"/> rows for every chapter of <paramref name="editionId"/>
+    /// using the shared <see cref="IChunker"/>, persists them (null embedding), and returns the
+    /// total chunk count. Best-effort: logs and returns 0 on failure rather than throwing, so an
+    /// ingestion job is never failed by a chunking hiccup. Callers that need to react to "no
+    /// chunks" (the on-demand trigger) check the returned count.
+    /// </summary>
+    public async Task<int> ChunkEditionAsync(AppDbContext db, Guid editionId, CancellationToken ct)
+    {
+        try
+        {
+            var chapters = await db.Chapters
+                .Where(c => c.EditionId == editionId)
+                .OrderBy(c => c.ChapterNumber)
+                .Select(c => new { c.Id, c.ChapterNumber, c.PlainText })
+                .ToListAsync(ct);
+
+            var rows = BuildRows(
+                chunker, editionId,
+                chapters.Select(c => (c.Id, c.ChapterNumber, (string?)c.PlainText)));
+
+            if (rows.Count > 0)
+            {
+                db.ChapterChunks.AddRange(rows);
+                await db.SaveChangesAsync(ct);
+                logger.LogInformation(
+                    "Created {Count} RAG chunks for edition {EditionId}", rows.Count, editionId);
+            }
+
+            return rows.Count;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "RAG chunking failed for edition {EditionId}; chunks can be regenerated on reprocess", editionId);
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Pure mapping: chapters → ordered <see cref="ChapterChunk"/> rows (null embedding) via
+    /// <paramref name="chunker"/>. Extracted so the row shape (denormalized ChapterOrd, offsets,
+    /// per-chapter Ord) is unit-testable without a DB. <c>ChapterOrd</c> is copied from the
+    /// chapter number so the spoiler gate can filter in SQL without a chapters join.
+    /// </summary>
+    public static List<ChapterChunk> BuildRows(
+        IChunker chunker,
+        Guid editionId,
+        IEnumerable<(Guid Id, int ChapterNumber, string? PlainText)> chapters)
+    {
+        var rows = new List<ChapterChunk>();
+        foreach (var chapter in chapters)
+        {
+            foreach (var chunk in chunker.Chunk(chapter.PlainText ?? string.Empty))
+            {
+                rows.Add(new ChapterChunk
+                {
+                    Id = Guid.NewGuid(),
+                    EditionId = editionId,
+                    ChapterId = chapter.Id,
+                    ChapterOrd = chapter.ChapterNumber,
+                    Ord = chunk.Ord,
+                    Text = chunk.Text,
+                    TokenCount = chunk.TokenCount,
+                    CharStart = chunk.CharStart,
+                    CharEnd = chunk.CharEnd,
+                    Embedding = null
+                });
+            }
+        }
+
+        return rows;
+    }
+}

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -73,6 +73,8 @@ builder.Services.AddSingleton<ITtsService, EdgeTtsService>();
 builder.Services.AddSingleton<IAudioAssembler, AudioAssembler>();
 // Phase 4 RAG: sentence-aware chunker emits chapter_chunk rows during ingestion.
 builder.Services.AddAiRag();
+// Shared chunking service (ingestion + on-demand "Ask this book" index trigger).
+builder.Services.AddSingleton<Infrastructure.Rag.BookChunkingService>();
 builder.Services.AddSingleton<IngestionWorkerService>();
 builder.Services.AddSingleton<UserIngestionService>();
 builder.Services.AddHostedService<IngestionWorker>();

--- a/backend/src/Worker/Services/ChapterEmbeddingWorker.cs
+++ b/backend/src/Worker/Services/ChapterEmbeddingWorker.cs
@@ -104,14 +104,61 @@ public sealed class ChapterEmbeddingWorker : BackgroundService
 
         await db.SaveChangesAsync(ct);
 
+        var touchedEditions = batch.Select(c => c.EditionId).Distinct().ToList();
+
+        // Phase 1 "Ask this book": refresh each touched edition's rag_embedded_count and flip
+        // rag_status → Ready (with rag_indexed_at) once every chunk is embedded. Cheap single
+        // UPDATE per edition. Runs before the mean-pool recompute so status surfaces ASAP.
+        await UpdateRagProgressAsync(db, touchedEditions, ct);
+
         // AI-054: now that this batch's vectors are persisted, recompute the mean-pool
         // edition embedding for each touched edition that is now FULLY embedded. The
         // fully-embedded guard avoids writing a partial mean on every batch (and avoids
         // per-chunk recompute); editions still draining are caught when their last batch
         // lands (or by the backfill CLI). Best-effort — match the worker's resilience.
-        await RecomputeFullyEmbeddedEditionsAsync(db, batch.Select(c => c.EditionId), ct);
+        await RecomputeFullyEmbeddedEditionsAsync(db, touchedEditions, ct);
 
         return batch.Count;
+    }
+
+    /// <summary>
+    /// For each touched edition, set <c>rag_embedded_count</c> to its current count of embedded
+    /// chunks; and when that equals <c>rag_chunk_count</c> (and &gt; 0) flip <c>rag_status</c> to
+    /// Ready(2) with <c>rag_indexed_at = now()</c>. One UPDATE per edition. Best-effort: a hiccup
+    /// is logged and never stalls the embedding backlog — the next batch (or a final drain) retries.
+    /// </summary>
+    private async Task UpdateRagProgressAsync(
+        AppDbContext db, IReadOnlyList<Guid> editionIds, CancellationToken ct)
+    {
+        foreach (var editionId in editionIds)
+        {
+            try
+            {
+                await db.Database.ExecuteSqlInterpolatedAsync($"""
+                    UPDATE editions e
+                    SET rag_embedded_count = sub.embedded,
+                        rag_status = CASE
+                            WHEN sub.embedded = e.rag_chunk_count AND e.rag_chunk_count > 0 THEN 2
+                            ELSE e.rag_status
+                        END,
+                        rag_indexed_at = CASE
+                            WHEN sub.embedded = e.rag_chunk_count AND e.rag_chunk_count > 0 THEN now()
+                            ELSE e.rag_indexed_at
+                        END
+                    FROM (
+                        SELECT count(*) FILTER (WHERE embedding IS NOT NULL) AS embedded
+                        FROM chapter_chunk
+                        WHERE edition_id = {editionId}
+                    ) sub
+                    WHERE e.id = {editionId};
+                    """, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to update RAG progress for edition {EditionId}; will retry next batch.", editionId);
+            }
+        }
     }
 
     /// <summary>

--- a/backend/src/Worker/Services/IngestionService.cs
+++ b/backend/src/Worker/Services/IngestionService.cs
@@ -4,13 +4,13 @@ using Application.Common.Interfaces;
 using Domain.Entities;
 using Domain.Enums;
 using Infrastructure.Persistence;
+using Infrastructure.Rag;
 using Infrastructure.Telemetry;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TextStack.Extraction.Contracts;
 using TextStack.Extraction.Enums;
 using TextStack.Extraction.Lint;
-using TextStack.Ai.Rag;
 using TextStack.Extraction.Registry;
 using TextStack.Search.Abstractions;
 using TextStack.Search.Contracts;
@@ -26,7 +26,7 @@ public class IngestionWorkerService
     private readonly IExtractorRegistry _extractorRegistry;
     private readonly ISearchIndexer _searchIndexer;
     private readonly IImageOptimizer _imageOptimizer;
-    private readonly IChunker _chunker;
+    private readonly BookChunkingService _chunking;
     private readonly ILogger<IngestionWorkerService> _logger;
     private readonly ILogger<AppIngestion.IngestionService> _ingestionLogger;
 
@@ -36,7 +36,7 @@ public class IngestionWorkerService
         IExtractorRegistry extractorRegistry,
         ISearchIndexer searchIndexer,
         IImageOptimizer imageOptimizer,
-        IChunker chunker,
+        BookChunkingService chunking,
         ILogger<IngestionWorkerService> logger,
         ILogger<AppIngestion.IngestionService> ingestionLogger)
     {
@@ -45,7 +45,7 @@ public class IngestionWorkerService
         _extractorRegistry = extractorRegistry;
         _searchIndexer = searchIndexer;
         _imageOptimizer = imageOptimizer;
-        _chunker = chunker;
+        _chunking = chunking;
         _logger = logger;
         _ingestionLogger = ingestionLogger;
     }
@@ -298,8 +298,26 @@ public class IngestionWorkerService
             // required for reading, so a failure here must not fail the ingestion job.
             using (var chunkActivity = IngestionActivitySource.Source.StartActivity("rag.chunk"))
             {
-                var chunkCount = await ChunkChaptersAsync(db, job.EditionId, ct);
+                var chunkCount = await _chunking.ChunkEditionAsync(db, job.EditionId, ct);
                 chunkActivity?.SetTag("chunks_created", chunkCount);
+
+                // Surface freshly-ingested books through the same Indexing→Ready lifecycle as
+                // on-demand triggers: mark Indexing + chunk count now; the embedding worker
+                // flips to Ready once every chunk is embedded. Best-effort — chunkCount 0 means
+                // nothing to index, leave the edition NotIndexed.
+                if (chunkCount > 0)
+                {
+                    var edition = await db.Editions.FirstOrDefaultAsync(e => e.Id == job.EditionId, ct);
+                    if (edition is not null)
+                    {
+                        edition.RagStatus = RagIndexStatus.Indexing;
+                        edition.RagChunkCount = chunkCount;
+                        edition.RagEmbeddedCount = 0;
+                        edition.RagError = null;
+                        edition.RagIndexedAt = null;
+                        await db.SaveChangesAsync(ct);
+                    }
+                }
             }
 
             // Run linter and save results
@@ -447,61 +465,6 @@ public class IngestionWorkerService
         {
             await _searchIndexer.IndexBatchAsync(documents, ct);
             _logger.LogInformation("Indexed {Count} chapters for edition {EditionId}", documents.Count, editionId);
-        }
-    }
-
-    /// <summary>
-    /// Splits each just-saved chapter's plain text into RAG chunks (Phase 4) and persists
-    /// <see cref="ChapterChunk"/> rows with a null embedding (filled later by AI-020/021).
-    /// Old chunks were cascade-deleted when chapters were replaced. Best-effort: logs and
-    /// returns 0 on failure rather than failing the ingestion job.
-    /// </summary>
-    private async Task<int> ChunkChaptersAsync(AppDbContext db, Guid editionId, CancellationToken ct)
-    {
-        try
-        {
-            var chapters = await db.Chapters
-                .Where(c => c.EditionId == editionId)
-                .OrderBy(c => c.ChapterNumber)
-                .Select(c => new { c.Id, c.ChapterNumber, c.PlainText })
-                .ToListAsync(ct);
-
-            var rows = new List<ChapterChunk>();
-            foreach (var chapter in chapters)
-            {
-                foreach (var chunk in _chunker.Chunk(chapter.PlainText ?? string.Empty))
-                {
-                    rows.Add(new ChapterChunk
-                    {
-                        Id = Guid.NewGuid(),
-                        EditionId = editionId,
-                        ChapterId = chapter.Id,
-                        ChapterOrd = chapter.ChapterNumber,
-                        Ord = chunk.Ord,
-                        Text = chunk.Text,
-                        TokenCount = chunk.TokenCount,
-                        CharStart = chunk.CharStart,
-                        CharEnd = chunk.CharEnd,
-                        Embedding = null
-                    });
-                }
-            }
-
-            if (rows.Count > 0)
-            {
-                db.ChapterChunks.AddRange(rows);
-                await db.SaveChangesAsync(ct);
-                _logger.LogInformation(
-                    "Created {Count} RAG chunks for edition {EditionId}", rows.Count, editionId);
-            }
-
-            return rows.Count;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "RAG chunking failed for edition {EditionId}; chunks can be regenerated on reprocess", editionId);
-            return 0;
         }
     }
 

--- a/tests/TextStack.IntegrationTests/BookIndexEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/BookIndexEndpointTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Integration tests for on-demand "Ask this book" indexing (Phase 1), against the live API.
+/// The no-auth path runs without a key; the trigger/status paths need a user session + a real
+/// catalog edition, so they skip when not reachable.
+/// </summary>
+public class BookIndexEndpointTests : IClassFixture<LiveApiFixture>, IClassFixture<AuthenticatedApiFixture>
+{
+    private static readonly Guid SomeEdition = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    private readonly LiveApiFixture _anon;
+    private readonly AuthenticatedApiFixture _auth;
+
+    public BookIndexEndpointTests(LiveApiFixture anon, AuthenticatedApiFixture auth)
+    {
+        _anon = anon;
+        _auth = auth;
+    }
+
+    private sealed record IndexStatus(string Status, int ChunkCount, int EmbeddedCount);
+    private sealed record BookListItem(Guid Id);
+    private sealed record BookList(int Total, List<BookListItem> Items);
+
+    [Fact]
+    public async Task PostIndex_NoAuth_Unauthorized()
+    {
+        // Unauthenticated request → 401 before any DB/chunk work (no key needed).
+        var request = _anon.CreateRequest(HttpMethod.Post, $"/books/{SomeEdition}/index");
+        var response = await _anon.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(response.StatusCode is HttpStatusCode.NotFound, "endpoint not deployed");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetIndex_NoAuth_Unauthorized()
+    {
+        var request = _anon.CreateRequest(HttpMethod.Get, $"/books/{SomeEdition}/index");
+        var response = await _anon.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(response.StatusCode is HttpStatusCode.NotFound, "endpoint not deployed");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostIndex_AuthedKnownEdition_Returns202Or200WithStatus()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "auth unavailable");
+        var editionId = await DiscoverEditionIdAsync();
+        Assert.SkipWhen(editionId is null, "no catalog edition available");
+
+        var request = _auth.CreateRequest(HttpMethod.Post, $"/books/{editionId}/index");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        // 202 on a fresh claim, 200 on a no-op (already Indexing/Ready). Either is a success.
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Accepted or HttpStatusCode.OK,
+            $"expected 202 or 200, got {(int)response.StatusCode}");
+
+        var status = await response.Content.ReadFromJsonAsync<IndexStatus>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(status);
+        Assert.Contains(status!.Status, new[] { "NotIndexed", "Indexing", "Ready", "Failed" });
+        Assert.True(status.ChunkCount >= 0);
+        Assert.True(status.EmbeddedCount >= 0);
+    }
+
+    [Fact]
+    public async Task GetIndex_AuthedKnownEdition_ReturnsStatusShape()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "auth unavailable");
+        var editionId = await DiscoverEditionIdAsync();
+        Assert.SkipWhen(editionId is null, "no catalog edition available");
+
+        var request = _auth.CreateRequest(HttpMethod.Get, $"/books/{editionId}/index");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var status = await response.Content.ReadFromJsonAsync<IndexStatus>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(status);
+        Assert.Contains(status!.Status, new[] { "NotIndexed", "Indexing", "Ready", "Failed" });
+        Assert.True(status.ChunkCount >= 0);
+        Assert.True(status.EmbeddedCount >= 0);
+    }
+
+    [Fact]
+    public async Task GetIndex_UnknownEdition_Returns404()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "auth unavailable");
+
+        var request = _auth.CreateRequest(HttpMethod.Get, $"/books/{SomeEdition}/index");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // 500 → host erroring; skip rather than fail. 404 is the contract for an unknown edition.
+        Assert.SkipWhen(response.StatusCode == HttpStatusCode.InternalServerError, "host erroring");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    /// <summary>Resolves a real catalog edition id from <c>GET /books</c>; null when the catalog is empty.</summary>
+    private async Task<Guid?> DiscoverEditionIdAsync()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/books?limit=1");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        var list = await response.Content.ReadFromJsonAsync<BookList>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        return list?.Items.Count > 0 ? list.Items[0].Id : null;
+    }
+}

--- a/tests/TextStack.UnitTests/BookChunkingServiceTests.cs
+++ b/tests/TextStack.UnitTests/BookChunkingServiceTests.cs
@@ -1,0 +1,88 @@
+using Domain.Entities;
+using Infrastructure.Rag;
+using TextStack.Ai.Rag;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// Phase 1 on-demand indexing: the pure chapters → <see cref="ChapterChunk"/> row mapping shared by
+/// ingestion and the "Ask this book" trigger. DB persistence is exercised by integration tests; here
+/// we lock the row shape (null embedding, denormalized ChapterOrd, offsets that slice back) against
+/// the real <see cref="Chunker"/>.
+/// </summary>
+public class BookChunkingServiceTests
+{
+    private const string ChapterOne =
+        "Alpha beta gamma delta. Epsilon zeta eta theta. Iota kappa lambda mu. " +
+        "Nu xi omicron pi. Rho sigma tau upsilon.";
+
+    [Fact]
+    public void BuildRows_KnownChapters_ChunkCountMatchesChunker()
+    {
+        var editionId = Guid.NewGuid();
+        var chapterId = Guid.NewGuid();
+        var chunker = new Chunker(maxTokens: 12, overlapTokens: 4);
+
+        var expected = chunker.Chunk(ChapterOne).Count;
+        var rows = BookChunkingService.BuildRows(
+            chunker, editionId, [(chapterId, 0, ChapterOne)]);
+
+        Assert.True(expected >= 2, "fixture must split into multiple chunks");
+        Assert.Equal(expected, rows.Count);
+    }
+
+    [Fact]
+    public void BuildRows_RowsCarryEditionChapterAndNullEmbedding()
+    {
+        var editionId = Guid.NewGuid();
+        var chapterId = Guid.NewGuid();
+
+        var rows = BookChunkingService.BuildRows(
+            new Chunker(), editionId, [(chapterId, 3, "One short sentence here.")]);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(editionId, row.EditionId);
+        Assert.Equal(chapterId, row.ChapterId);
+        Assert.Equal(3, row.ChapterOrd);          // denormalized from chapter number
+        Assert.Equal(0, row.Ord);
+        Assert.Null(row.Embedding);               // filled later by the embedding worker
+        Assert.True(row.TokenCount > 0);
+    }
+
+    [Fact]
+    public void BuildRows_OffsetsSliceBackToChunkText()
+    {
+        var rows = BookChunkingService.BuildRows(
+            new Chunker(maxTokens: 12, overlapTokens: 4),
+            Guid.NewGuid(), [(Guid.NewGuid(), 0, ChapterOne)]);
+
+        foreach (var r in rows)
+            Assert.Equal(r.Text, ChapterOne.Substring(r.CharStart, r.CharEnd - r.CharStart));
+    }
+
+    [Fact]
+    public void BuildRows_MultipleChapters_OrdResetsPerChapter()
+    {
+        var rows = BookChunkingService.BuildRows(
+            new Chunker(maxTokens: 12, overlapTokens: 4),
+            Guid.NewGuid(),
+            [(Guid.NewGuid(), 0, ChapterOne), (Guid.NewGuid(), 1, ChapterOne)]);
+
+        var byChapter = rows.GroupBy(r => r.ChapterId);
+        foreach (var chapter in byChapter)
+        {
+            var ords = chapter.Select(r => r.Ord).ToList();
+            for (var i = 0; i < ords.Count; i++)
+                Assert.Equal(i, ords[i]); // 0-based, contiguous, per chapter
+        }
+    }
+
+    [Fact]
+    public void BuildRows_EmptyChapterText_ProducesNoRows()
+    {
+        var rows = BookChunkingService.BuildRows(
+            new Chunker(), Guid.NewGuid(), [(Guid.NewGuid(), 0, "   ")]);
+
+        Assert.Empty(rows);
+    }
+}

--- a/tests/TextStack.UnitTests/RagIndexLogicTests.cs
+++ b/tests/TextStack.UnitTests/RagIndexLogicTests.cs
@@ -1,0 +1,64 @@
+using Application.Rag;
+using Domain.Enums;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// Phase 1 on-demand "Ask this book" indexing: the load-bearing state transitions. The endpoint's
+/// atomic claim SQL (<c>WHERE rag_status IN (0,3)</c>) and the embedding worker's Ready-flip SQL
+/// (<c>embedded = chunk AND chunk &gt; 0</c>) mirror these pure predicates — locking them here
+/// catches a regression in a fast test rather than only against the live DB.
+/// </summary>
+public class RagIndexLogicTests
+{
+    // ---- CanClaim: claim transition ----
+
+    [Theory]
+    [InlineData(RagIndexStatus.NotIndexed)]
+    [InlineData(RagIndexStatus.Failed)]
+    public void CanClaim_NotIndexedOrFailed_ReturnsTrue(RagIndexStatus status)
+        => Assert.True(RagIndexLogic.CanClaim(status));
+
+    [Theory]
+    [InlineData(RagIndexStatus.Indexing)]
+    [InlineData(RagIndexStatus.Ready)]
+    public void CanClaim_IndexingOrReady_ReturnsFalse(RagIndexStatus status)
+        => Assert.False(RagIndexLogic.CanClaim(status));
+
+    // ---- ShouldClearChunksBeforeChunking: every claim clears pre-existing chunks before re-chunk ----
+
+    // Both claimable priors must clear: Failed (stale partials) AND NotIndexed (legacy AI-019
+    // editions already carry chunks but were defaulted to NotIndexed by the migration). Not clearing
+    // on NotIndexed is the P1 double-chunk/double-embed/stuck-Indexing bug.
+    [Theory]
+    [InlineData(RagIndexStatus.Failed)]
+    [InlineData(RagIndexStatus.NotIndexed)]
+    public void ShouldClearChunksBeforeChunking_ClaimablePrior_ReturnsTrue(RagIndexStatus status)
+        => Assert.True(RagIndexLogic.ShouldClearChunksBeforeChunking(status));
+
+    // Indexing/Ready never reach the clear step (they no-op at the claim guard), but lock the
+    // predicate so a refactor that routes them here can't wipe a good index.
+    [Theory]
+    [InlineData(RagIndexStatus.Indexing)]
+    [InlineData(RagIndexStatus.Ready)]
+    public void ShouldClearChunksBeforeChunking_NonClaimable_ReturnsFalse(RagIndexStatus status)
+        => Assert.False(RagIndexLogic.ShouldClearChunksBeforeChunking(status));
+
+    // ---- IsReady: flip predicate ----
+
+    [Fact]
+    public void IsReady_AllChunksEmbedded_ReturnsTrue()
+        => Assert.True(RagIndexLogic.IsReady(embeddedCount: 12, chunkCount: 12));
+
+    [Fact]
+    public void IsReady_PartiallyEmbedded_ReturnsFalse()
+        => Assert.False(RagIndexLogic.IsReady(embeddedCount: 5, chunkCount: 12));
+
+    [Fact]
+    public void IsReady_ZeroChunks_ReturnsFalse()
+        => Assert.False(RagIndexLogic.IsReady(embeddedCount: 0, chunkCount: 0));
+
+    [Fact]
+    public void IsReady_EmbeddedExceedsChunkCount_ReturnsFalse()
+        => Assert.False(RagIndexLogic.IsReady(embeddedCount: 13, chunkCount: 12));
+}


### PR DESCRIPTION
On-demand per-book RAG indexing for the catalog. See commit. architect→backend+frontend→QA; 845 unit + 555 web green.