### PR TITLE
feat(account): full account deletion (GDPR / Play + Apple compliance)

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -15,6 +15,7 @@ import { getLanguage, getFlagEmoji } from '../../src/data/languages'
 import { LanguagePickerModal } from '../../src/components/LanguagePickerModal'
 import { VocabReminderSettingsRow } from '../../src/components/profile/VocabReminderSettingsRow'
 import { supportedLanguages, type Language, authApi, getStorageUrl, getAnonymousReader } from '@textstack/shared'
+import { deleteAccount } from '../../src/lib/api'
 import { getAnonAvatarSource } from '../../src/lib/anonAvatarSource'
 import { fonts } from '../../src/theme/typography'
 
@@ -34,6 +35,7 @@ export default function ProfileScreen() {
   const [editName, setEditName] = useState('')
   const [saving, setSaving] = useState(false)
   const [langPickerOpen, setLangPickerOpen] = useState(false)
+  const [deleting, setDeleting] = useState(false)
 
   const online = useOnline()
   const isGuest = !!user?.isGuest
@@ -107,6 +109,61 @@ export default function ProfileScreen() {
     } finally {
       setSaving(false)
     }
+  }
+
+  // Permanently delete the account. Two-step confirm before the
+  // irreversible network call: a warning explaining what's lost, then a
+  // final confirm. On success we sign out (clears SecureStore token/user
+  // + per-user caches) and the (tabs) layout drops back to the signed-out
+  // state; on failure we keep the user signed in and surface the error.
+  const performDelete = async () => {
+    setDeleting(true)
+    try {
+      const token = await getAccessToken()
+      if (!token) {
+        Alert.alert('Not signed in', 'Your session expired. Sign in again and retry.')
+        return
+      }
+      await deleteAccount(token)
+      await signOut()
+      router.replace('/(tabs)')
+    } catch (e: any) {
+      const status: number | undefined = e?.status
+      let message = e?.message || 'Something went wrong. Please try again.'
+      if (status === 401 || status === 403) {
+        message = 'Your session expired. Sign in again and retry.'
+      } else if (typeof status === 'number' && status >= 500) {
+        message = 'Our servers are having trouble. Please try again in a minute.'
+      } else if (!status) {
+        message = 'Check your connection and try again.'
+      }
+      Alert.alert('Delete failed', message)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const confirmDelete = () => {
+    Alert.alert(
+      'Delete account?',
+      'This permanently deletes your account and ALL your data — uploaded books, highlights, vocabulary, and reading history. This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Continue',
+          style: 'destructive',
+          onPress: () =>
+            Alert.alert(
+              'Are you absolutely sure?',
+              'There is no way to recover your account or data after this.',
+              [
+                { text: 'Keep my account', style: 'cancel' },
+                { text: 'Delete account', style: 'destructive', onPress: performDelete },
+              ],
+            ),
+        },
+      ],
+    )
   }
 
   if (!isAuthenticated) {
@@ -317,6 +374,33 @@ export default function ProfileScreen() {
           <Ionicons name="log-out-outline" size={20} color={colors.error} style={styles.menuIcon} />
           <Text style={[styles.menuText, { color: colors.error }]}>Sign Out</Text>
         </TouchableOpacity>
+
+        {/* Danger zone — destructive, visually separated from normal settings.
+            Hidden for guest accounts (nothing server-side to delete). */}
+        {!isGuest && (
+          <View style={[styles.dangerZone, { borderColor: colors.error }]}>
+            <Text style={[styles.sectionLabel, { color: colors.error, marginTop: 0 }]}>Danger zone</Text>
+            <TouchableOpacity
+              style={styles.dangerRow}
+              onPress={confirmDelete}
+              disabled={deleting}
+              activeOpacity={0.7}
+              accessibilityLabel="Delete account"
+            >
+              {deleting ? (
+                <ActivityIndicator size="small" color={colors.error} style={styles.menuIcon} />
+              ) : (
+                <Ionicons name="trash-outline" size={20} color={colors.error} style={styles.menuIcon} />
+              )}
+              <View style={{ flex: 1 }}>
+                <Text style={[styles.menuText, { color: colors.error }]}>Delete account</Text>
+                <Text style={[styles.dangerHint, { color: colors.textSecondary }]}>
+                  Permanently removes your account and all data. Cannot be undone.
+                </Text>
+              </View>
+            </TouchableOpacity>
+          </View>
+        )}
       </View>
 
       <LanguagePickerModal
@@ -407,4 +491,17 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: 8,
   },
+  dangerZone: {
+    marginTop: 32,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  dangerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  dangerHint: { fontFamily: fonts.sans, fontSize: 12, marginTop: 2 },
 })

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -109,4 +109,25 @@ export function setupApi() {
   initApi({ baseUrl: API_URL, getAccessToken, onUnauthorized })
 }
 
+/**
+ * Permanently delete the signed-in user and ALL their data
+ * (`DELETE /me/account` → 204). Irreversible. The caller is responsible
+ * for signing the user out on success. The Bearer token is passed
+ * explicitly (same pattern as `authApi.logout`/`deleteAvatar`) so this
+ * works regardless of the shared client's getAccessToken wiring.
+ */
+export async function deleteAccount(accessToken: string): Promise<void> {
+  const res = await fetch(`${API_URL}/me/account`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw Object.assign(
+      new Error(data?.error || `Failed to delete account: ${res.status}`),
+      { status: res.status },
+    )
+  }
+}
+
 export { API_URL }

--- a/apps/web/e2e/tests/delete-account.spec.ts
+++ b/apps/web/e2e/tests/delete-account.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect } from '../fixtures/auth.fixture'
+import type { Page } from '@playwright/test'
+
+// E2E coverage for the destructive account-deletion flow:
+//   User menu → Edit profile (ProfileModal) → Danger zone → Delete account
+//   → DeleteAccountDialog (type DELETE to arm) → DELETE /api/me/account
+//   → session cleared → redirect to localized home /:lang/.
+//
+// SAFETY: we NEVER let a real DELETE reach the backend. The shared e2e test user
+// is created once in global-setup and reused by every other spec — actually
+// deleting it would break the whole suite. So the destructive happy-path and the
+// error-path both stub `**/me/account` via page.route(); the gating + public-page
+// tests touch no network at all.
+
+const CONFIRM_PHRASE = 'DELETE'
+
+// Opens the user menu and clicks "Edit profile" to mount the ProfileModal.
+async function openProfileModal(page: Page) {
+  await page.goto('/en/')
+  await page.waitForLoadState('networkidle')
+
+  // The signed-in header renders the UserMenu trigger; click to open the dropdown.
+  const trigger = page.locator('.user-menu__trigger')
+  await expect(trigger).toBeVisible({ timeout: 15_000 })
+  await trigger.click()
+
+  await page.getByRole('button', { name: 'Edit profile' }).click()
+  await expect(page.locator('.profile-modal').first()).toBeVisible()
+}
+
+// Opens the destructive DeleteAccountDialog from within the ProfileModal.
+async function openDeleteDialog(page: Page) {
+  await openProfileModal(page)
+
+  // Danger zone only renders for non-guest users (the test-login user is non-guest).
+  const dangerTitle = page.locator('.profile-modal__danger-title')
+  await expect(dangerTitle).toBeVisible()
+  await expect(dangerTitle).toHaveText('Danger zone')
+
+  await page.locator('.profile-modal__danger-zone .profile-modal__btn--danger').click()
+
+  // The dialog (role="dialog", aria-labelledby) mounts on top.
+  const dialog = page.getByRole('dialog', { name: /delete your account\?/i })
+  await expect(dialog).toBeVisible()
+  return dialog
+}
+
+test.describe('Account deletion flow', () => {
+  test('danger zone + Delete account button visible for authed user', async ({ authedPage: page }) => {
+    await openProfileModal(page)
+
+    const dangerZone = page.locator('.profile-modal__danger-zone')
+    await expect(dangerZone).toBeVisible()
+    await expect(dangerZone.locator('.profile-modal__danger-title')).toHaveText('Danger zone')
+    await expect(
+      dangerZone.getByRole('button', { name: 'Delete account' }),
+    ).toBeVisible()
+  })
+
+  test('confirm button disabled until exact DELETE phrase typed', async ({ authedPage: page }) => {
+    const dialog = await openDeleteDialog(page)
+
+    const confirmBtn = dialog.locator('.profile-modal__btn--danger')
+    const input = dialog.locator('#delete-account-confirm')
+
+    // Disabled on open (empty input).
+    await expect(confirmBtn).toBeDisabled()
+
+    // Wrong / partial phrase keeps it disabled.
+    await input.fill('delete')
+    await expect(confirmBtn).toBeDisabled()
+    await input.fill('DELETE ME')
+    await expect(confirmBtn).toBeDisabled()
+
+    // Exact phrase arms it. (Trailing whitespace is trimmed → still armed.)
+    await input.fill(CONFIRM_PHRASE)
+    await expect(confirmBtn).toBeEnabled()
+    await input.fill(`  ${CONFIRM_PHRASE}  `)
+    await expect(confirmBtn).toBeEnabled()
+
+    // Clearing disarms again.
+    await input.fill('')
+    await expect(confirmBtn).toBeDisabled()
+  })
+
+  test('confirm with stubbed 204 → signs out and redirects home', async ({ authedPage: page }) => {
+    let deleteCalled = false
+    // Stub the destructive call so NO real deletion happens; assert it was hit.
+    await page.route('**/me/account', async route => {
+      if (route.request().method() === 'DELETE') {
+        deleteCalled = true
+        await route.fulfill({ status: 204, body: '' })
+      } else {
+        await route.continue()
+      }
+    })
+
+    const dialog = await openDeleteDialog(page)
+    await dialog.locator('#delete-account-confirm').fill(CONFIRM_PHRASE)
+    await dialog.locator('.profile-modal__btn--danger').click()
+
+    // Redirect to localized home.
+    await page.waitForURL(/\/en\/?($|\?)/, { timeout: 15_000 })
+    expect(deleteCalled).toBe(true)
+
+    // Signed-out header: UserMenu trigger gone, Sign in icon button present.
+    // (exact match — "Sign in to upload" also exists in the signed-out header.)
+    await expect(page.locator('.user-menu__trigger')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible()
+  })
+
+  test('confirm with stubbed 500 → stays signed in, error shown', async ({ authedPage: page }) => {
+    await page.route('**/me/account', async route => {
+      if (route.request().method() === 'DELETE') {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'boom' }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    const dialog = await openDeleteDialog(page)
+    await dialog.locator('#delete-account-confirm').fill(CONFIRM_PHRASE)
+    await dialog.locator('.profile-modal__btn--danger').click()
+
+    // Error surfaced inside the dialog; dialog stays open.
+    await expect(dialog.locator('.profile-modal__error')).toBeVisible({ timeout: 15_000 })
+    await expect(dialog).toBeVisible()
+
+    // Still on a non-home route is not guaranteed, but the user must remain
+    // signed in — the UserMenu trigger is still mountable. Reload to confirm
+    // the session survived (no navigation occurred, user not nulled).
+    await expect(page.locator('.user-menu__trigger')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toHaveCount(0)
+  })
+})
+
+test.describe('Public delete-account info page', () => {
+  // No auth needed — this is the public GDPR/Play-Store info page.
+  test('renders irreversibility + what-gets-deleted copy', async ({ page }) => {
+    await page.goto('/en/delete-account')
+    await page.waitForLoadState('networkidle')
+
+    await expect(
+      page.getByRole('heading', { name: 'Delete your account', level: 1 }),
+    ).toBeVisible()
+
+    // Key sections from en.json deleteAccount.*
+    await expect(page.getByRole('heading', { name: 'Delete in the app' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'What gets deleted' })).toBeVisible()
+
+    // Irreversibility copy must be present.
+    await expect(page.getByText('This action cannot be undone.')).toBeVisible()
+    // Enumerates deleted data so users know the blast radius.
+    await expect(
+      page.getByText(/highlights and notes, saved vocabulary, reading progress/i),
+    ).toBeVisible()
+  })
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,6 +19,7 @@ import { AboutPage } from './pages/AboutPage'
 import { PrivacyPage } from './pages/PrivacyPage'
 import { TermsPage } from './pages/TermsPage'
 import { DmcaPage } from './pages/DmcaPage'
+import { DeleteAccountPage } from './pages/DeleteAccountPage'
 import { ContactPage } from './pages/ContactPage'
 import { McpLandingPage } from './pages/McpLandingPage'
 import { ResetPasswordPage } from './pages/ResetPasswordPage'
@@ -95,6 +96,7 @@ function LanguageRoutes() {
           <Route path="/privacy" element={<PrivacyPage />} />
           <Route path="/terms" element={<TermsPage />} />
           <Route path="/dmca" element={<DmcaPage />} />
+          <Route path="/delete-account" element={<DeleteAccountPage />} />
           <Route path="/contact" element={<ContactPage />} />
           <Route path="/mcp" element={<McpLandingPage />} />
           <Route path="/library" element={<LibraryPage />} />
@@ -149,6 +151,7 @@ function AppRoutes() {
       <Route path="/privacy" element={<LegacyRedirect />} />
       <Route path="/terms" element={<LegacyRedirect />} />
       <Route path="/dmca" element={<LegacyRedirect />} />
+      <Route path="/delete-account" element={<LegacyRedirect />} />
       <Route path="/contact" element={<LegacyRedirect />} />
       <Route path="/library" element={<LegacyRedirect />} />
       <Route path="/stats" element={<LegacyRedirect />} />

--- a/apps/web/src/api/__tests__/deleteAccount.test.ts
+++ b/apps/web/src/api/__tests__/deleteAccount.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { deleteAccount } from '../auth'
+
+describe('deleteAccount', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('DELETEs /me/account with credentials and resolves on 204', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => '',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(deleteAccount()).resolves.toBeUndefined()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain('/me/account')
+    expect(opts.method).toBe('DELETE')
+    expect(opts.credentials).toBe('include')
+
+    vi.unstubAllGlobals()
+  })
+
+  it('rejects on a non-ok response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'boom' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(deleteAccount()).rejects.toThrow('boom')
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -157,6 +157,11 @@ export async function deleteAvatar(): Promise<void> {
   await authFetch<void>('/me/profile/avatar', { method: 'DELETE' })
 }
 
+// Permanently deletes the authenticated user and ALL their data. Backend → 204.
+export async function deleteAccount(): Promise<void> {
+  await authFetch<void>('/me/account', { method: 'DELETE' })
+}
+
 // Reading Progress API
 export interface ReadingProgressDto {
   editionId: string

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -19,6 +19,7 @@ export function Footer() {
           <LocalizedLink to="/privacy" className="site-footer__link">{t('footer.privacy')}</LocalizedLink>
           <LocalizedLink to="/terms" className="site-footer__link">{t('footer.terms')}</LocalizedLink>
           <LocalizedLink to="/dmca" className="site-footer__link">{t('footer.dmca')}</LocalizedLink>
+          <LocalizedLink to="/delete-account" className="site-footer__link">{t('footer.deleteAccount')}</LocalizedLink>
           <LocalizedLink to="/contact" className="site-footer__link">{t('footer.contact')}</LocalizedLink>
           <LocalizedLink to="/sitemap" className="site-footer__link">{t('footer.sitemap')}</LocalizedLink>
         </nav>

--- a/apps/web/src/components/auth/DeleteAccountDialog.tsx
+++ b/apps/web/src/components/auth/DeleteAccountDialog.tsx
@@ -1,0 +1,101 @@
+import { useState, FormEvent } from 'react'
+import { createPortal } from 'react-dom'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../../context/AuthContext'
+import { useLanguage } from '../../context/LanguageContext'
+import { useTranslation } from '../../hooks/useTranslation'
+
+/** The exact phrase the user must type to arm the destructive confirm button. */
+export const DELETE_CONFIRM_PHRASE = 'DELETE'
+
+/** Pure gate: confirm is enabled only when the typed phrase matches exactly (trimmed). */
+export function isDeleteConfirmed(input: string): boolean {
+  return input.trim() === DELETE_CONFIRM_PHRASE
+}
+
+export function DeleteAccountDialog({ onClose }: { onClose: () => void }) {
+  const { deleteAccount } = useAuth()
+  const { getLocalizedPath } = useLanguage()
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [confirmText, setConfirmText] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const armed = isDeleteConfirmed(confirmText)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!armed || loading) return
+    setError('')
+    setLoading(true)
+    try {
+      await deleteAccount()
+      // Session cleared by deleteAccount() — leave to home.
+      navigate(getLocalizedPath('/'), { replace: true })
+    } catch (err: any) {
+      setError(err?.message || t('deleteAccount.error'))
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div className="profile-overlay" onClick={loading ? undefined : onClose}>
+      <div
+        className="profile-modal profile-modal--danger"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-account-title"
+      >
+        {!loading && (
+          <button className="profile-modal__close" onClick={onClose} aria-label={t('deleteAccount.cancel')}>
+            &times;
+          </button>
+        )}
+        <div className="profile-modal__body">
+          <h2 className="profile-modal__title" id="delete-account-title">
+            {t('deleteAccount.title')}
+          </h2>
+          <form onSubmit={handleSubmit}>
+            <p className="profile-modal__danger-warning">{t('deleteAccount.warning')}</p>
+            <label className="profile-modal__label" htmlFor="delete-account-confirm">
+              {t('deleteAccount.confirmLabel', { phrase: DELETE_CONFIRM_PHRASE })}
+            </label>
+            <input
+              id="delete-account-confirm"
+              type="text"
+              className="profile-modal__input"
+              value={confirmText}
+              onChange={e => setConfirmText(e.target.value)}
+              placeholder={DELETE_CONFIRM_PHRASE}
+              autoComplete="off"
+              autoCapitalize="characters"
+              spellCheck={false}
+              disabled={loading}
+            />
+            {error && <p className="profile-modal__error">{error}</p>}
+            <div className="profile-modal__danger-actions">
+              <button
+                type="button"
+                className="profile-modal__btn profile-modal__btn--secondary"
+                onClick={onClose}
+                disabled={loading}
+              >
+                {t('deleteAccount.cancel')}
+              </button>
+              <button
+                type="submit"
+                className="profile-modal__btn profile-modal__btn--danger"
+                disabled={!armed || loading}
+              >
+                {loading ? t('deleteAccount.deleting') : t('deleteAccount.confirm')}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/apps/web/src/components/auth/ProfileModal.tsx
+++ b/apps/web/src/components/auth/ProfileModal.tsx
@@ -4,9 +4,13 @@ import { useAuth } from '../../context/AuthContext'
 import { POPULAR_LANGUAGES, getLanguage, getFlagUrl } from '../../data/languages'
 import { getAnonymousReader } from '@textstack/shared'
 import { getUserInitials } from '../../lib/userInitials'
+import { useTranslation } from '../../hooks/useTranslation'
+import { DeleteAccountDialog } from './DeleteAccountDialog'
 
 export function ProfileModal({ onClose }: { onClose: () => void }) {
   const { user, updateProfile, updateAvatar, deleteAvatar } = useAuth()
+  const { t } = useTranslation()
+  const [showDeleteAccount, setShowDeleteAccount] = useState(false)
   const [name, setName] = useState(user?.name || '')
   const [nativeLanguage, setNativeLanguage] = useState(user?.nativeLanguage || '')
   const [preview, setPreview] = useState<string | null>(null)
@@ -174,8 +178,22 @@ export function ProfileModal({ onClose }: { onClose: () => void }) {
               {loading ? 'Saving...' : 'Save changes'}
             </button>
           </form>
+          {!isGuest && (
+            <section className="profile-modal__danger-zone">
+              <h3 className="profile-modal__danger-title">{t('deleteAccount.dangerZone')}</h3>
+              <p className="profile-modal__danger-desc">{t('deleteAccount.sectionDesc')}</p>
+              <button
+                type="button"
+                className="profile-modal__btn profile-modal__btn--danger"
+                onClick={() => setShowDeleteAccount(true)}
+              >
+                {t('deleteAccount.openButton')}
+              </button>
+            </section>
+          )}
         </div>
       </div>
+      {showDeleteAccount && <DeleteAccountDialog onClose={() => setShowDeleteAccount(false)} />}
     </div>,
     document.body,
   )

--- a/apps/web/src/components/auth/__tests__/DeleteAccountDialog.test.tsx
+++ b/apps/web/src/components/auth/__tests__/DeleteAccountDialog.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { isDeleteConfirmed, DELETE_CONFIRM_PHRASE } from '../DeleteAccountDialog'
+
+describe('isDeleteConfirmed', () => {
+  it('arms only on the exact phrase', () => {
+    expect(isDeleteConfirmed(DELETE_CONFIRM_PHRASE)).toBe(true)
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(isDeleteConfirmed('  DELETE  ')).toBe(true)
+  })
+
+  it('rejects empty, partial, and wrong-case input', () => {
+    expect(isDeleteConfirmed('')).toBe(false)
+    expect(isDeleteConfirmed('DELET')).toBe(false)
+    expect(isDeleteConfirmed('delete')).toBe(false)
+    expect(isDeleteConfirmed('DELETE ME')).toBe(false)
+  })
+})

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import {
   User, UpdateProfilePayload, getCurrentUser, loginWithGoogle, logout as logoutApi, refreshToken,
   loginWithEmail as loginWithEmailApi, registerWithEmail as registerWithEmailApi,
   updateProfile as updateProfileApi, uploadAvatar as uploadAvatarApi, deleteAvatar as deleteAvatarApi,
+  deleteAccount as deleteAccountApi,
   createGuestSession as createGuestSessionApi,
 } from '../api/auth'
 import { flushLocalProgress } from '../lib/progressSync'
@@ -26,6 +27,8 @@ interface AuthContextValue {
   updateProfile: (payload: UpdateProfilePayload) => Promise<void>
   updateAvatar: (file: File) => Promise<void>
   deleteAvatar: () => Promise<void>
+  /** Permanently deletes the account + all data, then clears the session locally. Rejects on error (caller stays signed in). */
+  deleteAccount: () => Promise<void>
   /** Set to true after a successful register/login. Consumer shows toast then calls dismissAuthSuccessToast. */
   authSuccessToast: boolean
   dismissAuthSuccessToast: () => void
@@ -48,6 +51,7 @@ const AuthContext = createContext<AuthContextValue>({
   updateProfile: async () => {},
   updateAvatar: async () => {},
   deleteAvatar: async () => {},
+  deleteAccount: async () => {},
   authSuccessToast: false,
   dismissAuthSuccessToast: () => {},
 })
@@ -265,6 +269,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(prev => prev ? { ...prev, picture: null } : null)
   }, [])
 
+  // Permanently deletes the account server-side, then clears the local session.
+  // Mirrors logout's anonymous-after sign-out: no guest re-create here. Rethrows
+  // on failure so the caller keeps the user signed in and surfaces an error.
+  const deleteAccount = useCallback(async () => {
+    await deleteAccountApi()
+    if (typeof google !== 'undefined') {
+      google.accounts.id.disableAutoSelect()
+    }
+    setUser(null)
+  }, [])
+
   // Public: create a guest session if not authenticated. Routes through the single-flight
   // helper so concurrent callers (e.g. HeroSection upload + bootstrap) share one network call.
   const ensureSession = useCallback(async () => {
@@ -307,6 +322,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         updateProfile,
         updateAvatar,
         deleteAvatar,
+        deleteAccount,
         authSuccessToast,
         dismissAuthSuccessToast,
       }}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2,6 +2,28 @@
   "userMenu": {
     "anonymousReader": "Anonymous reader"
   },
+  "deleteAccount": {
+    "dangerZone": "Danger zone",
+    "sectionDesc": "Permanently delete your account and everything in it.",
+    "openButton": "Delete account",
+    "title": "Delete your account?",
+    "warning": "This permanently deletes your account and all data — books, highlights, vocabulary, and reading history. This cannot be undone.",
+    "confirmLabel": "Type {{phrase}} to confirm",
+    "cancel": "Cancel",
+    "confirm": "Delete account",
+    "deleting": "Deleting…",
+    "error": "Could not delete your account. Please try again.",
+    "seoTitle": "Delete your account - TextStack",
+    "seoDesc": "How to permanently delete your TextStack account and all associated data.",
+    "pageTitle": "Delete your account",
+    "intro": "You can permanently delete your TextStack account and all associated data at any time.",
+    "inAppHeading": "Delete in the app",
+    "inAppBody": "Sign in, open the user menu in the top-right corner, choose \"Edit profile\", then scroll to the \"Danger zone\" section and select \"Delete account\". You'll be asked to type DELETE to confirm.",
+    "dataHeading": "What gets deleted",
+    "dataBody": "Deleting your account permanently removes your profile, uploaded books, highlights and notes, saved vocabulary, reading progress, and reading history. This action cannot be undone.",
+    "contactHeading": "Need help?",
+    "contactBody": "If you can't access your account but want it deleted, contact us at"
+  },
   "home": {
     "hero": {
       "title": "Finish the book you keep quitting.",
@@ -383,6 +405,7 @@
     "privacy": "Privacy Policy",
     "terms": "Terms of Service",
     "dmca": "DMCA",
+    "deleteAccount": "Delete Account",
     "authors": "Authors",
     "contact": "Contact Us",
     "sitemap": "Sitemap"

--- a/apps/web/src/pages/DeleteAccountPage.tsx
+++ b/apps/web/src/pages/DeleteAccountPage.tsx
@@ -1,0 +1,47 @@
+import { SeoHead } from '../components/SeoHead'
+import { Footer } from '../components/Footer'
+import { useTranslation } from '../hooks/useTranslation'
+import { useObfuscatedEmail } from '../hooks/useObfuscatedEmail'
+import './LegalPage.css'
+
+export function DeleteAccountPage() {
+  const { t } = useTranslation()
+  const { email, mailto } = useObfuscatedEmail()
+
+  return (
+    <>
+      <div className="legal-page">
+        <SeoHead
+          title={t('deleteAccount.seoTitle')}
+          description={t('deleteAccount.seoDesc')}
+        />
+
+        <header className="legal-page__header">
+          <h1 className="legal-page__title">{t('deleteAccount.pageTitle')}</h1>
+          <div className="legal-page__accent-bar" />
+        </header>
+
+        <p className="legal-page__intro">{t('deleteAccount.intro')}</p>
+
+        <section className="legal-page__section">
+          <h2>{t('deleteAccount.inAppHeading')}</h2>
+          <p>{t('deleteAccount.inAppBody')}</p>
+        </section>
+
+        <section className="legal-page__section">
+          <h2>{t('deleteAccount.dataHeading')}</h2>
+          <p>{t('deleteAccount.dataBody')}</p>
+        </section>
+
+        <section className="legal-page__section">
+          <h2>{t('deleteAccount.contactHeading')}</h2>
+          <p>
+            {t('deleteAccount.contactBody')}{' '}
+            <a href={mailto}>{email}</a>.
+          </p>
+        </section>
+      </div>
+      <Footer />
+    </>
+  )
+}

--- a/apps/web/src/styles/profile.css
+++ b/apps/web/src/styles/profile.css
@@ -211,3 +211,67 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+/* Danger zone — destructive account actions, visually separated */
+.profile-modal__danger-zone {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--color-border, rgba(239, 68, 68, 0.25));
+}
+
+.profile-modal__danger-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #ef4444;
+  margin: 0 0 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.profile-modal__danger-desc {
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+  margin: 0 0 0.9rem;
+  line-height: 1.4;
+}
+
+.profile-modal__btn--danger {
+  background: #ef4444;
+}
+
+.profile-modal__btn--danger:hover:not(:disabled) {
+  background: #dc2626;
+}
+
+.profile-modal__btn--secondary {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.15));
+}
+
+.profile-modal__btn--secondary:hover:not(:disabled) {
+  background: var(--color-bg-hover, rgba(0, 0, 0, 0.04));
+}
+
+/* Delete-account confirm dialog */
+.profile-modal--danger {
+  border-top: 3px solid #ef4444;
+}
+
+.profile-modal__danger-warning {
+  font-size: 0.85rem;
+  color: var(--color-text);
+  line-height: 1.5;
+  margin: 0 0 1.1rem;
+}
+
+.profile-modal__danger-actions {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+.profile-modal__danger-actions .profile-modal__btn {
+  width: auto;
+  flex: 1;
+}

--- a/backend/src/Api/Endpoints/AccountEndpoints.cs
+++ b/backend/src/Api/Endpoints/AccountEndpoints.cs
@@ -1,0 +1,101 @@
+using Api.Extensions;
+using Application.Auth;
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Endpoints;
+
+/// <summary>
+/// Account-level operations for the currently authenticated user.
+/// Hosts the GDPR / Google-Play "delete my account + all data" hard delete.
+/// </summary>
+public static class AccountEndpoints
+{
+    public static void MapAccountEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/me/account").WithTags("Account");
+
+        group.MapDelete("/", DeleteAccount)
+            .WithName("DeleteAccount")
+            .RequireRateLimiting("account-delete");
+    }
+
+    /// <summary>
+    /// Hard-deletes the authenticated user and ALL data linked to them.
+    ///
+    /// Strategy: every user-owned entity has a configured FK to <c>users</c>.
+    /// Owned data (library, progress, bookmarks, notes, highlights, reading
+    /// sessions / goals / achievements, vocabulary words+reviews+settings+
+    /// pending+lookups+clusters, user books → chapters/files/ingestion jobs/
+    /// bookmarks/chunks/quality jobs, collections → book-collections, refresh
+    /// tokens, password-reset tokens) is configured ON DELETE CASCADE, so a
+    /// single <c>Users.Remove</c> + SaveChanges removes it all in FK-safe order.
+    /// Audit rows (llm_traces, shadow_runs, agent_run, device_authorizations)
+    /// are ON DELETE SET NULL — their user_id is nulled, preserving the trace
+    /// while removing the personal link.
+    ///
+    /// Wrapped in a transaction so it is all-or-nothing. Disk files (avatar +
+    /// uploaded book files) are not in the DB, so they are removed via the
+    /// storage service AFTER the DB commit (DB is the source of truth; an orphan
+    /// file is recoverable, an orphan row is a compliance failure).
+    /// </summary>
+    private static async Task<IResult> DeleteAccount(
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        IFileStorageService storage,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId.Value, ct);
+        if (user == null) return Results.Unauthorized();
+
+        // Capture disk locations before the row is gone. Local-file avatar only
+        // (external picture URLs like Google are not ours to delete).
+        var avatarPath = !string.IsNullOrEmpty(user.Picture) && !user.Picture.StartsWith("http")
+            ? user.Picture
+            : null;
+
+        await using var tx = await db.BeginTransactionAsync(ct);
+
+        db.Users.Remove(user);
+        await db.SaveChangesAsync(ct);
+
+        await tx.CommitAsync(ct);
+
+        // Best-effort disk cleanup post-commit. Removes the whole
+        // users/{shard}/{userId} tree (all uploaded book files) + the avatar.
+        // Failures here must not resurrect the account (DB is the source of truth),
+        // so they are logged as warnings instead of failing the request — an orphan
+        // file is recoverable, but it must be observable.
+        try
+        {
+            await storage.DeleteUserDirectoryAsync(user.Id, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Account {UserId} deleted but storage cleanup failed for {Operation}",
+                userId.Value, "DeleteUserDirectory");
+        }
+
+        if (avatarPath != null)
+        {
+            try
+            {
+                await storage.DeleteFileAsync(avatarPath, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Account {UserId} deleted but storage cleanup failed for {Operation} ({Path})",
+                    userId.Value, "DeleteAvatar", avatarPath);
+            }
+        }
+
+        return Results.NoContent();
+    }
+}

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -485,6 +485,20 @@ builder.Services.AddRateLimiter(options =>
             QueueLimit = 0,
         });
     });
+    // Account deletion — destructive and irreversible (GDPR hard delete). A user
+    // never needs to call this more than once, so a tight per-IP cap blocks abuse
+    // (e.g. scripted churn against the cascade delete) while staying out of the way
+    // of a legitimate retry after a transient failure.
+    options.AddPolicy("account-delete", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromMinutes(5),
+            PermitLimit = 3,
+            QueueLimit = 0,
+        });
+    });
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
     // Emit Retry-After so clients can back off intelligently instead of
     // hammering in a tight retry loop. RateLimiter exposes the metadata
@@ -676,6 +690,7 @@ app.MapAuthEndpoints();
 app.MapDeviceAuthEndpoints();
 app.MapMcpManifestEndpoints();
 app.MapProfileEndpoints();
+app.MapAccountEndpoints();
 app.MapUserDataEndpoints();
 app.MapHighlightsEndpoints();
 app.MapTranslationEndpoints();

--- a/tests/TextStack.IntegrationTests/AccountDeletionEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/AccountDeletionEndpointTests.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// GDPR / Google-Play hard-delete contract for <c>DELETE /me/account</c>.
+///
+/// Each test provisions its OWN throwaway user (unique test-login email) so the
+/// destructive delete never touches the shared <see cref="AuthenticatedApiFixture"/>
+/// user. The throwaway user authenticates with a Bearer access token (returned in
+/// the body when the request advertises <c>X-Client: mobile</c>), populates
+/// representative dependent rows (vocabulary word, catalog highlight, user book via
+/// clip, reading session), then deletes the account and verifies everything is gone.
+///
+/// Requires: docker compose up with ENABLE_TEST_AUTH=true.
+/// </summary>
+public class AccountDeletionEndpointTests : IClassFixture<LiveApiFixture>
+{
+    private readonly LiveApiFixture _fixture;
+    private const string TestHost = "localhost";
+
+    public AccountDeletionEndpointTests(LiveApiFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task DeleteAccount_WithoutAuth_Returns401()
+    {
+        var req = _fixture.CreateRequest(HttpMethod.Delete, "/me/account");
+        var resp = await _fixture.Client.SendAsync(req, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteAccount_RemovesUserAndAllData_TokenNoLongerWorks()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // 1. Provision an isolated throwaway user → Bearer token.
+        var token = await CreateThrowawayUserAsync(ct);
+        Assert.SkipWhen(token is null, "test auth unavailable");
+
+        // 2. Discover a catalog edition + chapter (for the highlight).
+        var (editionId, chapterId) = await DiscoverEditionChapterAsync(ct);
+        Assert.SkipWhen(editionId is null, "no catalog book available");
+
+        // 3. Populate representative dependent rows.
+
+        // Vocabulary word — no edition FK required.
+        var vocabResp = await SendAsync(HttpMethod.Post, "/me/vocabulary/words", token!,
+            new { word = $"w{Guid.NewGuid():N}"[..12], language = "de", nativeLanguage = "en" }, ct);
+        Assert.SkipWhen(IntegrationSkip.Unavailable(vocabResp), "vocabulary endpoint unavailable");
+        Assert.True(vocabResp.IsSuccessStatusCode, $"save word failed: {vocabResp.StatusCode}");
+
+        // Catalog highlight.
+        var highlightResp = await SendAsync(HttpMethod.Post, "/me/highlights", token!, new
+        {
+            editionId,
+            chapterId,
+            anchorJson = """{"prefix":"a","exact":"b","suffix":"c","startOffset":0,"endOffset":1,"chapterId":"x"}""",
+            color = "yellow",
+            selectedText = "b"
+        }, ct);
+        Assert.True(highlightResp.IsSuccessStatusCode, $"create highlight failed: {highlightResp.StatusCode}");
+
+        // User book via clip (synchronous row creation, no file upload needed).
+        var clipResp = await SendAsync(HttpMethod.Post, "/me/books/clip", token!, new
+        {
+            title = $"Clip {Guid.NewGuid():N}"[..16],
+            html = "<p>Hello world. This is a clipped article body for the deletion test.</p>",
+            language = "en"
+        }, ct);
+        Assert.True(clipResp.IsSuccessStatusCode, $"clip failed: {clipResp.StatusCode}");
+        var clipBody = await clipResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        var userBookId = clipBody.GetProperty("userBookId").GetGuid();
+
+        // Reading session against the clipped user book.
+        var now = DateTimeOffset.UtcNow;
+        var sessionResp = await SendAsync(HttpMethod.Post, "/me/reading/sessions", token!, new
+        {
+            userBookId,
+            startedAt = now.AddMinutes(-5),
+            endedAt = now,
+            durationSeconds = 300,
+            wordsRead = 100,
+            startPercent = 0.0,
+            endPercent = 0.5
+        }, ct);
+        Assert.True(sessionResp.IsSuccessStatusCode, $"session failed: {sessionResp.StatusCode}");
+
+        // Sanity: the data is actually visible before deletion.
+        Assert.True(await CountAsync("/me/vocabulary/words?search=", token!, ct) > 0, "vocab not present pre-delete");
+        Assert.True(await CountAsync($"/me/highlights/{editionId}", token!, ct) > 0, "highlight not present pre-delete");
+        Assert.True((await GetUserBooksAsync(token!, ct)).Contains(userBookId), "user book not present pre-delete");
+
+        // 4. Delete the account.
+        var delResp = await SendAsync(HttpMethod.Delete, "/me/account", token!, null, ct);
+        Assert.Equal(HttpStatusCode.NoContent, delResp.StatusCode);
+
+        // 5. The old access token is still signature-valid (60-min TTL) but the user
+        // row is gone. Endpoints that load the user must treat it as unauthenticated
+        // rather than acting on a dangling userId. /me/profile loads the user →
+        // expect 401. A repeat DELETE (also loads the user) must likewise be a clean
+        // 401, not a 500 from operating on a missing row.
+        var profileResp = await SendAsync(HttpMethod.Get, "/me/profile", token!, null, ct);
+        Assert.Equal(HttpStatusCode.Unauthorized, profileResp.StatusCode);
+
+        var repeatDelResp = await SendAsync(HttpMethod.Delete, "/me/account", token!, null, ct);
+        Assert.Equal(HttpStatusCode.Unauthorized, repeatDelResp.StatusCode);
+
+        // 6. Representative dependent rows are gone (read via a FRESH login on the
+        // same email — re-creates an empty user, proving the data didn't survive).
+        var freshToken = await TestLoginAsync(_lastEmail!, ct);
+        Assert.False(string.IsNullOrEmpty(freshToken), "re-login failed");
+
+        Assert.Equal(0, await CountAsync("/me/vocabulary/words?search=", freshToken!, ct));
+        Assert.Equal(0, await CountAsync($"/me/highlights/{editionId}", freshToken!, ct));
+        Assert.DoesNotContain(userBookId, await GetUserBooksAsync(freshToken!, ct));
+
+        // Cleanup the re-created empty user so we don't leak rows.
+        await SendAsync(HttpMethod.Delete, "/me/account", freshToken!, null, ct);
+    }
+
+    // --- helpers ---
+
+    private string? _lastEmail;
+
+    private async Task<string?> CreateThrowawayUserAsync(CancellationToken ct)
+    {
+        _lastEmail = $"acct-delete-{Guid.NewGuid():N}@textstack.test";
+        return await TestLoginAsync(_lastEmail, ct);
+    }
+
+    private async Task<string?> TestLoginAsync(string email, CancellationToken ct)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/auth/test-login");
+        req.Headers.Host = TestHost;
+        req.Headers.Add("X-Client", "mobile"); // → access token returned in body
+        req.Content = JsonContent.Create(new { email });
+        var resp = await _fixture.Client.SendAsync(req, ct);
+        if (resp.StatusCode == HttpStatusCode.NotFound) return null; // test auth disabled
+        if (!resp.IsSuccessStatusCode) return null;
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        return body.TryGetProperty("accessToken", out var t) ? t.GetString() : null;
+    }
+
+    private async Task<(Guid? editionId, Guid? chapterId)> DiscoverEditionChapterAsync(CancellationToken ct)
+    {
+        var listReq = new HttpRequestMessage(HttpMethod.Get, "/books?limit=1");
+        listReq.Headers.Host = TestHost;
+        var listResp = await _fixture.Client.SendAsync(listReq, ct);
+        if (!listResp.IsSuccessStatusCode) return (null, null);
+        var list = await listResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        var items = list.GetProperty("items");
+        if (items.GetArrayLength() == 0) return (null, null);
+        var slug = items[0].GetProperty("slug").GetString();
+
+        var bookReq = new HttpRequestMessage(HttpMethod.Get, $"/books/{slug}");
+        bookReq.Headers.Host = TestHost;
+        var bookResp = await _fixture.Client.SendAsync(bookReq, ct);
+        if (!bookResp.IsSuccessStatusCode) return (null, null);
+        var book = await bookResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        var editionId = book.GetProperty("id").GetGuid();
+        if (!book.TryGetProperty("chapters", out var chapters) || chapters.GetArrayLength() == 0)
+            return (null, null);
+        var chapterId = chapters[0].GetProperty("id").GetGuid();
+        return (editionId, chapterId);
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(
+        HttpMethod method, string path, string token, object? body, CancellationToken ct)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Host = TestHost;
+        req.Headers.Add("Authorization", $"Bearer {token}");
+        if (body != null) req.Content = JsonContent.Create(body);
+        return await _fixture.Client.SendAsync(req, ct);
+    }
+
+    private async Task<int> CountAsync(string listPath, string token, CancellationToken ct)
+    {
+        var resp = await SendAsync(HttpMethod.Get, listPath, token, null, ct);
+        if (!resp.IsSuccessStatusCode) return -1;
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        // /me/vocabulary/words → { total, items }; /me/highlights/{id} → array.
+        if (body.ValueKind == JsonValueKind.Array) return body.GetArrayLength();
+        if (body.TryGetProperty("items", out var items)) return items.GetArrayLength();
+        return -1;
+    }
+
+    private async Task<List<Guid>> GetUserBooksAsync(string token, CancellationToken ct)
+    {
+        // Clipped books live on the "read later" shelf (IsClip = true).
+        var resp = await SendAsync(HttpMethod.Get, "/me/books?shelf=readlater", token, null, ct);
+        var result = new List<Guid>();
+        if (!resp.IsSuccessStatusCode) return result;
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        var arr = body.ValueKind == JsonValueKind.Array ? body
+            : body.TryGetProperty("items", out var items) ? items : default;
+        if (arr.ValueKind == JsonValueKind.Array)
+            foreach (var b in arr.EnumerateArray())
+                if (b.TryGetProperty("id", out var id) && id.TryGetGuid(out var g))
+                    result.Add(g);
+        return result;
+    }
+}


### PR DESCRIPTION
## Why
Google Play (and Apple) require apps with sign-in to let users **delete their account + all data** in-app. We had no such flow — a hard blocker for the Play **Data safety** declaration and production access. This adds it end-to-end.

## What
**Backend** — `DELETE /me/account` (auth, rate-limit 3/5min). Transactional cascade delete of every user-owned entity (books/files/chapters/ingestion jobs, reading progress, bookmarks, highlights, vocabulary + reviews + settings/clusters, reading sessions/goals/achievements, library/collections, refresh & password-reset tokens) + best-effort disk cleanup (avatar + user storage dir), now **logged on failure** instead of swallowed. Audit telemetry (`LlmTrace`/`ShadowRun`/`AgentRun`/`DeviceAuthorization`) → `user_id = NULL` (non-PII retention). No migration (relies on existing cascade FKs).

**Web** — Profile → Edit profile → **Danger zone** → dialog requiring the user to type `DELETE` → `AuthContext.deleteAccount()` → clears session → redirect home. Public `/:lang/delete-account` info page + footer link. i18n strings added.

**Mobile** — Profile → **Danger zone** → two-step destructive `Alert` → `signOut()` → Home. Honors theme/dark mode; hidden for guests. (Also satisfies Apple's in-app deletion requirement.)

## Security note
A short-lived access JWT stays signature-valid after deletion. Treated as **bounded, acceptable**: refresh-token rows cascade-delete (no new tokens), access TTL ≤60min, no data leakage (owned data gone, reads empty, writes fail at FK). No per-request DB guard added (would tax the hot path). Documented; proper fix (revocation set / shorter TTL) noted if the threat model tightens.

## Tests
- Backend: 2 integration tests (cascade delete + token-no-longer-works, incl. repeat-DELETE → 401).
- Web: unit (api method + confirm-gating) + **5 Playwright e2e** (danger zone, gating, stubbed-204 happy path → logout+redirect, 500 error → session survives, public page). Full chromium suite 44 passed.
- Mobile: `tsc --noEmit` clean.

## Verify after merge
- Auto-deploy carries web `/delete-account` page + endpoint.
- Rebuild production AAB for the mobile delete button (next Closed-test build).
- Then Play → Data safety can honestly answer "Yes" (in-app + URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)