### PR TITLE
fix(mobile): Library scroll + stale shelves; reader long-press word gate

### DIFF
--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -3,6 +3,7 @@ import {
   View, Text, StyleSheet, FlatList, TouchableOpacity, RefreshControl, ScrollView, useWindowDimensions,
 } from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Image } from 'expo-image'
 import { useRouter, useFocusEffect } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
@@ -33,6 +34,7 @@ import { useLibrarySearch } from '../../src/hooks/useLibrarySearch'
 import { matchesQuery } from '../../src/lib/searchUtils'
 import { LibrarySearch } from '../../src/components/library/LibrarySearch'
 import { useBookActions } from '../../src/hooks/useBookActions'
+import { clearLibraryShelvesCache } from '../../src/hooks/useLibraryShelves'
 
 const NEW_BADGE_TTL_MS = 24 * 60 * 60 * 1000
 const isNewUpload = (createdAt?: string): boolean => {
@@ -153,6 +155,11 @@ export default function LibraryScreen() {
 
   const onRefresh = async () => {
     setRefreshing(true)
+    // Pull-to-refresh is an explicit "give me fresh data" intent: invalidate
+    // the shelves TTL cache too (it fires an immediate refetch in the live
+    // LibraryShelves via the pub/sub) so the carousels aren't left stale while
+    // the rest of the screen reloads (FIX 3).
+    clearLibraryShelvesCache()
     await loadData()
     setRefreshing(false)
   }
@@ -195,6 +202,13 @@ export default function LibraryScreen() {
     : tab
   const showTabs = source === 'all'
 
+  // Rendered inside each list's ListHeaderComponent so the shelf carousels
+  // scroll together with the rest of the screen (they used to sit in a fixed
+  // top region, which cut off "Quick reads" and below with no way to scroll).
+  const shelvesHeader = (
+    <LibraryShelves hasAnyContent={library.length > 0 || userBooks.length > 0} />
+  )
+
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.sidebarHeader}>
@@ -208,7 +222,6 @@ export default function LibraryScreen() {
           {user.isGuest ? getAnonymousReaderName(user.id) : user.email}
         </Text>
       )}
-      <LibraryShelves hasAnyContent={library.length > 0 || userBooks.length > 0} />
       <View style={{ flexDirection: 'row', alignItems: 'center', borderBottomWidth: 1, borderBottomColor: colors.border }}>
         {showTabs && (
           <View style={[styles.tabs, { flex: 1, borderBottomWidth: 0 }]}>
@@ -235,9 +248,9 @@ export default function LibraryScreen() {
       </View>
 
       {effectiveTab === 'saved' ? (
-        <SavedList library={library} setLibrary={setLibrary} progressMap={progressMap} setProgressMap={setProgressMap} refreshing={refreshing} onRefresh={onRefresh} viewMode={viewMode} collectionFilterIds={collectionSavedIds} />
+        <SavedList library={library} setLibrary={setLibrary} progressMap={progressMap} setProgressMap={setProgressMap} refreshing={refreshing} onRefresh={onRefresh} viewMode={viewMode} collectionFilterIds={collectionSavedIds} shelvesHeader={shelvesHeader} hasAnyContent={library.length > 0 || userBooks.length > 0} />
       ) : (
-        <UploadsList books={userBooks} refreshing={refreshing} onRefresh={onRefresh} viewMode={viewMode} collectionFilterIds={collectionUploadIds} />
+        <UploadsList books={userBooks} refreshing={refreshing} onRefresh={onRefresh} viewMode={viewMode} collectionFilterIds={collectionUploadIds} shelvesHeader={shelvesHeader} />
       )}
       <LibrarySidebarDrawer
         visible={drawerOpen}
@@ -268,14 +281,18 @@ function formatTimeAgo(dateStr: string): string {
   return `${days}d ago`
 }
 
-function SavedList({ library, setLibrary, progressMap, setProgressMap, refreshing, onRefresh, viewMode, collectionFilterIds }: {
-  library: UserLibraryItem[]; setLibrary: React.Dispatch<React.SetStateAction<UserLibraryItem[]>>; progressMap: Record<string, ReadingProgressDto>; setProgressMap: React.Dispatch<React.SetStateAction<Record<string, ReadingProgressDto>>>; refreshing: boolean; onRefresh: () => void; viewMode: ViewMode; collectionFilterIds: Set<string> | null
+function SavedList({ library, setLibrary, progressMap, setProgressMap, refreshing, onRefresh, viewMode, collectionFilterIds, shelvesHeader, hasAnyContent }: {
+  library: UserLibraryItem[]; setLibrary: React.Dispatch<React.SetStateAction<UserLibraryItem[]>>; progressMap: Record<string, ReadingProgressDto>; setProgressMap: React.Dispatch<React.SetStateAction<Record<string, ReadingProgressDto>>>; refreshing: boolean; onRefresh: () => void; viewMode: ViewMode; collectionFilterIds: Set<string> | null; shelvesHeader: React.ReactNode; hasAnyContent: boolean
 }) {
   const router = useRouter()
   const { colors } = useTheme()
   const { t } = useLanguage()
   const { show: showToast } = useToast()
   const { width } = useWindowDimensions()
+  const insets = useSafeAreaInsets()
+  // Clear the floating tab bar (~56 + bottom inset) so the last row/card isn't
+  // hidden behind it or the raised "+" button.
+  const bottomPad = 56 + insets.bottom + 24
   const { sort, setSort } = useLibrarySort('saved')
   const { status: filter, setStatus: setFilter } = useLibraryStatus()
   const { query, debouncedQuery, setQuery, clear: clearQuery } = useLibrarySearch('saved')
@@ -292,15 +309,27 @@ function SavedList({ library, setLibrary, progressMap, setProgressMap, refreshin
 
   if (library.length === 0) {
     return (
-      <View style={styles.center}>
-        <EmptyState
-          icon="book-outline"
-          title={t('library.emptyLibrary')}
-          subtitle={t('library.browseBooks')}
-          buttonLabel={t('library.browseBooks')}
-          onButtonPress={() => router.push('/(tabs)/search')}
-        />
-      </View>
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: bottomPad }}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* When nothing exists anywhere, LibraryShelves renders its own empty
+            placeholder (with a browse CTA) — stacking it above this EmptyState
+            gives two CTAs. Suppress the shelves header in that all-empty case
+            and let the single EmptyState stand. If uploads exist, keep the
+            shelves so their carousels still render here (FIX 6). */}
+        {hasAnyContent && shelvesHeader}
+        <View style={styles.center}>
+          <EmptyState
+            icon="book-outline"
+            title={t('library.emptyLibrary')}
+            subtitle={t('library.browseBooks')}
+            buttonLabel={t('library.browseBooks')}
+            onButtonPress={() => router.push('/(tabs)/search')}
+          />
+        </View>
+      </ScrollView>
     )
   }
 
@@ -318,6 +347,7 @@ function SavedList({ library, setLibrary, progressMap, setProgressMap, refreshin
         keyExtractor={item => item.editionId}
         ListHeaderComponent={
           <View>
+            {shelvesHeader}
             <LibrarySearch value={query} onChange={setQuery} onClear={clearQuery} />
             <LibraryStatusTabs value={filter} onChange={setFilter} counts={counts} />
             <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.savedSortRow}>
@@ -349,7 +379,7 @@ function SavedList({ library, setLibrary, progressMap, setProgressMap, refreshin
           </View>
         }
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />}
-        contentContainerStyle={viewMode === 'grid' ? styles.gridContent : styles.listContent}
+        contentContainerStyle={[viewMode === 'grid' ? styles.gridContent : styles.listContent, { paddingBottom: bottomPad }]}
         columnWrapperStyle={viewMode === 'grid' ? { gap: 10 } : undefined}
         renderItem={({ item }) => {
           const progress = progressMap[item.editionId]
@@ -485,14 +515,16 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
 }
 
-function UploadsList({ books, refreshing, onRefresh, viewMode, collectionFilterIds }: {
-  books: UserBookDto[]; refreshing: boolean; onRefresh: () => void; viewMode: ViewMode; collectionFilterIds: Set<string> | null
+function UploadsList({ books, refreshing, onRefresh, viewMode, collectionFilterIds, shelvesHeader }: {
+  books: UserBookDto[]; refreshing: boolean; onRefresh: () => void; viewMode: ViewMode; collectionFilterIds: Set<string> | null; shelvesHeader: React.ReactNode
 }) {
   const router = useRouter()
   const { colors } = useTheme()
   const { t } = useLanguage()
   const { show: showToast } = useToast()
   const { width } = useWindowDimensions()
+  const insets = useSafeAreaInsets()
+  const bottomPad = 56 + insets.bottom + 24
   const { sort, setSort } = useLibrarySort('uploads')
   const { status: filter, setStatus: setFilter } = useLibraryStatus()
   const { query, debouncedQuery, setQuery, clear: clearQuery } = useLibrarySearch('uploads')
@@ -535,6 +567,7 @@ function UploadsList({ books, refreshing, onRefresh, viewMode, collectionFilterI
 
   const listHeader = (
     <>
+      {shelvesHeader}
       <TouchableOpacity
         style={[styles.uploadBtn, { borderColor: colors.primary }]}
         onPress={() => router.push('/my-books/upload')}
@@ -579,7 +612,12 @@ function UploadsList({ books, refreshing, onRefresh, viewMode, collectionFilterI
 
   if (sorted.length === 0) {
     return (
-      <View style={{ flex: 1 }}>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: bottomPad }}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />}
+        showsVerticalScrollIndicator={false}
+      >
         {listHeader}
         {books.length === 0 ? (
           <View style={styles.center}>
@@ -604,7 +642,7 @@ function UploadsList({ books, refreshing, onRefresh, viewMode, collectionFilterI
             </TouchableOpacity>
           </View>
         )}
-      </View>
+      </ScrollView>
     )
   }
 
@@ -617,7 +655,7 @@ function UploadsList({ books, refreshing, onRefresh, viewMode, collectionFilterI
         keyExtractor={item => item.id}
         ListHeaderComponent={listHeader}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />}
-        contentContainerStyle={viewMode === 'grid' ? styles.gridContent : styles.listContent}
+        contentContainerStyle={[viewMode === 'grid' ? styles.gridContent : styles.listContent, { paddingBottom: bottomPad }]}
         columnWrapperStyle={viewMode === 'grid' ? { gap: 10 } : undefined}
           renderItem={({ item }) => {
             const s = item.status.toLowerCase()

--- a/apps/mobile/app/book/[slug].tsx
+++ b/apps/mobile/app/book/[slug].tsx
@@ -11,6 +11,7 @@ import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
 import { useToast } from '../../src/context/ToastContext'
 import { AddToCollectionSheet } from '../../src/components/library/AddToCollectionSheet'
+import { clearLibraryShelvesCache } from '../../src/hooks/useLibraryShelves'
 import {
   isBookFullyCached,
   getAllCachedBooks,
@@ -280,6 +281,9 @@ export default function BookDetailScreen() {
                   } else {
                     await libraryApi.addToLibrary(book.id)
                   }
+                  // Library membership changed — drop the cached shelves so the
+                  // book appears in / disappears from the shelves on next focus.
+                  clearLibraryShelvesCache()
                 } catch (err) {
                   console.warn('library toggle failed:', err)
                   setInLibrary(wasInLibrary)

--- a/apps/mobile/app/my-books/[id].tsx
+++ b/apps/mobile/app/my-books/[id].tsx
@@ -12,6 +12,7 @@ import { fonts } from '../../src/theme/typography'
 import { LoadingScreen } from '../../src/components/ui/LoadingScreen'
 import { trackBookOpened } from '../../src/lib/analytics'
 import { AddToCollectionSheet } from '../../src/components/library/AddToCollectionSheet'
+import { clearLibraryShelvesCache } from '../../src/hooks/useLibraryShelves'
 
 export default function UserBookDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>()
@@ -138,6 +139,9 @@ export default function UserBookDetailScreen() {
           setDeleting(true)
           try {
             await userBooksApi.deleteUserBook(id)
+            // Invalidate the library shelves cache so the deleted book is gone
+            // from Continue reading / Recently added when we land back on Library.
+            clearLibraryShelvesCache()
             // Don't reset `deleting` on success — the screen unmounts on router.back()
             // and any lingering state change would warn. (P2-2)
             router.back()

--- a/apps/mobile/src/components/reader/ReaderShell.tsx
+++ b/apps/mobile/src/components/reader/ReaderShell.tsx
@@ -296,6 +296,10 @@ export function ReaderShell(props: ReaderShellProps) {
       } else if (data.type === 'highlightTap') {
         const hl = highlightsRef.current.find(h => h.id === data.highlightId)
         if (hl) setEditingHighlight(hl)
+      } else if (data.type === 'wordEngage') {
+        // Word resolved via deliberate long-press (Item A). Light selection
+        // impact confirms the hold registered before the WordCard opens.
+        haptics.play('flip')
       } else if (data.type === 'selection') {
         const mode: 'tap' | 'drag' = data.mode === 'tap' ? 'tap' : 'drag'
         const nextId = openSelection(data.text ? { ...data, mode } : null)
@@ -307,7 +311,7 @@ export function ReaderShell(props: ReaderShellProps) {
       if (__DEV__) console.warn('[reader] postMessage handler threw', err, event?.nativeEvent?.data)
     }
   }, [chapters, chapterSlug, language, settings.ttsSpeed, toggleTts, toggleBars, showBars, hideBars,
-      setEditingHighlight, updateSessionProgress, onChapterLoaded, onRequestNextChapter, openSelection, bumpProgress])
+      setEditingHighlight, updateSessionProgress, onChapterLoaded, onRequestNextChapter, openSelection, bumpProgress, haptics])
 
   const navigateChapter = (slug: string) => {
     saveProgress()

--- a/apps/mobile/src/hooks/useBookActions.ts
+++ b/apps/mobile/src/hooks/useBookActions.ts
@@ -6,6 +6,7 @@ import {
 } from '@textstack/shared'
 import { useLanguage } from '../context/LanguageContext'
 import { useToast } from '../context/ToastContext'
+import { clearLibraryShelvesCache } from './useLibraryShelves'
 
 interface SavedCtx {
   progressMap: Record<string, ReadingProgressDto>
@@ -73,6 +74,9 @@ export function useBookActions() {
       onPress: async () => {
         const snapshot = ctx.library
         ctx.setLibrary(prev => prev.filter(l => l.editionId !== item.editionId))
+        // Drop the shelves cache so Continue reading / Recently added don't
+        // keep showing the removed book on the next focus (TTL is 60s).
+        clearLibraryShelvesCache()
         try {
           await libraryApi.removeFromLibrary(item.editionId)
         } catch (e) {
@@ -111,7 +115,12 @@ export function useBookActions() {
       buttons.push({
         text: isFinished ? t('library.actions.markUnfinished') : t('library.actions.markFinished'),
         onPress: () => run(
-          () => isFinished ? userBooksApi.unmarkUserBookComplete(item.id) : userBooksApi.markUserBookComplete(item.id),
+          async () => {
+            await (isFinished ? userBooksApi.unmarkUserBookComplete(item.id) : userBooksApi.markUserBookComplete(item.id))
+            // Completion toggles shelf membership (continueReading ↔
+            // finishedThisMonth) — invalidate so the live carousel refetches.
+            clearLibraryShelvesCache()
+          },
           isFinished ? 'Mark as unfinished' : 'Mark as finished',
         ),
       })
@@ -132,7 +141,12 @@ export function useBookActions() {
       buttons.push({
         text: t('library.actions.cancel'),
         style: 'destructive',
-        onPress: () => run(() => userBooksApi.cancelUserBook(item.id), 'Cancel upload'),
+        onPress: () => run(async () => {
+          await userBooksApi.cancelUserBook(item.id)
+          // Cancelling removes the in-progress upload from recentlyAdded /
+          // continueReading — invalidate so the live carousel refetches.
+          clearLibraryShelvesCache()
+        }, 'Cancel upload'),
       })
     }
     buttons.push({
@@ -147,7 +161,12 @@ export function useBookActions() {
             {
               text: t('library.actions.confirmDeleteConfirm'),
               style: 'destructive',
-              onPress: () => run(() => userBooksApi.deleteUserBook(item.id), 'Delete book'),
+              onPress: () => run(async () => {
+                await userBooksApi.deleteUserBook(item.id)
+                // Invalidate shelves so the deleted upload disappears from
+                // Continue reading / Recently added immediately.
+                clearLibraryShelvesCache()
+              }, 'Delete book'),
             },
           ],
         )

--- a/apps/mobile/src/hooks/useLibraryShelves.ts
+++ b/apps/mobile/src/hooks/useLibraryShelves.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useFocusEffect } from 'expo-router'
 import { libraryApi } from '@textstack/shared'
 import type { LibraryShelves } from '@textstack/shared'
@@ -7,6 +7,19 @@ import { useAuth } from '../context/AuthContext'
 const CACHE_TTL_MS = 60_000
 
 let cache: { value: LibraryShelves; at: number } | null = null
+
+// Module-level pub/sub. clearLibraryShelvesCache() bumps the version and
+// notifies every mounted useLibraryShelves so the live carousel re-fetches
+// immediately — not just on the next focus. This is the root-cause fix for
+// the headline bug: a mutation (remove-from-library / delete-upload) happens
+// ON the focused Library tab, so there is no focus transition to trigger the
+// useFocusEffect refetch (FIX 2).
+let invalidateVersion = 0
+const subscribers = new Set<() => void>()
+
+function notifySubscribers() {
+  subscribers.forEach((fn) => fn())
+}
 
 export interface UseLibraryShelves {
   shelves: LibraryShelves | null
@@ -21,7 +34,35 @@ export function useLibraryShelves(): UseLibraryShelves {
   )
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Tracks the in-flight request so a fresh fetch (e.g. cache-invalidation)
+  // supersedes a slower one and we never set state on a stale resolution.
+  const fetchGenRef = useRef(0)
 
+  const fetchShelves = useCallback(() => {
+    if (!isAuthenticated) {
+      setShelves(null)
+      return
+    }
+    const myGen = ++fetchGenRef.current
+    setLoading(true)
+    setError(null)
+    libraryApi.getLibraryShelves()
+      .then((value) => {
+        if (myGen !== fetchGenRef.current) return
+        cache = { value, at: Date.now() }
+        setShelves(value)
+      })
+      .catch((e) => {
+        if (myGen !== fetchGenRef.current) return
+        setError(e?.message ?? 'Failed to load shelves')
+      })
+      .finally(() => {
+        if (myGen === fetchGenRef.current) setLoading(false)
+      })
+  }, [isAuthenticated])
+
+  // Focus: serve the TTL cache if warm, else fetch. Keeps the 60s perf cache
+  // for normal tab navigation.
   useFocusEffect(useCallback(() => {
     if (!isAuthenticated) {
       setShelves(null)
@@ -31,28 +72,28 @@ export function useLibraryShelves(): UseLibraryShelves {
       setShelves(cache.value)
       return
     }
-    let cancelled = false
-    setLoading(true)
-    setError(null)
-    libraryApi.getLibraryShelves()
-      .then((value) => {
-        if (cancelled) return
-        cache = { value, at: Date.now() }
-        setShelves(value)
-      })
-      .catch((e) => {
-        if (cancelled) return
-        setError(e?.message ?? 'Failed to load shelves')
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => { cancelled = true }
-  }, [isAuthenticated]))
+    fetchShelves()
+  }, [isAuthenticated, fetchShelves]))
+
+  // Subscribe to cache invalidations so a clear() forces an immediate refetch
+  // in the live (focused) component without waiting for a focus transition.
+  useEffect(() => {
+    let lastVersion = invalidateVersion
+    const onInvalidate = () => {
+      // Guard against redundant fires; only react when the version advanced.
+      if (invalidateVersion === lastVersion) return
+      lastVersion = invalidateVersion
+      fetchShelves()
+    }
+    subscribers.add(onInvalidate)
+    return () => { subscribers.delete(onInvalidate) }
+  }, [fetchShelves])
 
   return { shelves, loading, error }
 }
 
 export function clearLibraryShelvesCache(): void {
   cache = null
+  invalidateVersion++
+  notifySubscribers()
 }

--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -547,12 +547,97 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
     var tapTimeout = null;
     var touchStartX = 0, touchStartY = 0;
     var touchStartTime = 0;
+
+    // Word-action gate (Item A): a deliberate held press — not a brushing
+    // tap — resolves the word and opens the WordCard. A quick tap on a word
+    // does nothing, so accidental screen brushes no longer auto-fire TTS /
+    // translate / Explain (LLM token spend).
+    //   LONGPRESS_MS  — hold duration before the word fires.
+    //   DRAG_TOLERANCE — movement (px) that reclassifies the touch as a
+    //                    scroll / swipe / page-turn and cancels the hold.
+    var LONGPRESS_MS = 450;
+    var DRAG_TOLERANCE = 8;
+    // After the timer has fired a single-word selection, a drag past this
+    // larger threshold means the finger is extending a native multi-word
+    // selection — release the suppression window so the extension's
+    // selectionchange is honoured rather than swallowed (FIX 4).
+    var SELECT_EXTEND_TOLERANCE = 16;
+    var wordPressTimer = null;
+    var _wordPressFired = false;
+
+    // Single cancel path so every abort (drag past tolerance, touchend,
+    // touchcancel) clears the pending hold the same way and resets the
+    // fired flag — prevents a stale timer firing a WordCard for a word the
+    // finger already left (FIX 1).
+    function cancelWordPress() {
+      if (wordPressTimer) { clearTimeout(wordPressTimer); wordPressTimer = null; }
+      _wordPressFired = false;
+    }
+
     document.addEventListener('touchstart', function(e) {
       touchStartX = e.changedTouches[0].clientX;
       touchStartY = e.changedTouches[0].clientY;
       touchStartTime = Date.now();
+      cancelWordPress();
+
+      var target = e.target;
+      var onLink = target && (target.tagName === 'A' || (target.closest && target.closest('a')));
+      // Don't arm the hold over links — let the anchor own the gesture.
+      if (onLink) return;
+      // Capture start coords now; the timer resolves the word at the point
+      // where the finger first landed (not wherever it drifts to).
+      var startX = touchStartX, startY = touchStartY;
+      wordPressTimer = setTimeout(function() {
+        wordPressTimer = null;
+        // Highlight tap just fired — skip word-select so a hold doesn't
+        // open both the highlight editor and the WordCard.
+        if (_hlOverlayer && _hlOverlayer.isJustAnchored && _hlOverlayer.isJustAnchored()) return;
+        if (selectWordAtPoint(startX, startY)) {
+          _wordPressFired = true;
+          // RN can't reach expo-haptics from inside the WebView — ask it to
+          // buzz a light/selection impact so the hold feels deliberate.
+          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'wordEngage' }));
+        }
+      }, LONGPRESS_MS);
     }, { passive: true });
+
+    document.addEventListener('touchmove', function(e) {
+      var mx = e.changedTouches[0].clientX;
+      var my = e.changedTouches[0].clientY;
+      var movedX = Math.abs(mx - touchStartX);
+      var movedY = Math.abs(my - touchStartY);
+      // After the timer fired its single-word selection, a clear drag means
+      // the user is extending a native selection. Cancel the suppression
+      // window so the extension's selectionchange isn't swallowed for 1.5s
+      // (FIX 4). Needs on-device validation of the extend-from-tap gesture.
+      if (_wordPressFired) {
+        if (movedX > SELECT_EXTEND_TOLERANCE || movedY > SELECT_EXTEND_TOLERANCE) {
+          _suppressSelectionChangeUntil = 0;
+        }
+        return;
+      }
+      if (!wordPressTimer) return;
+      if (movedX > DRAG_TOLERANCE || movedY > DRAG_TOLERANCE) {
+        // Scroll / swipe / page-turn — not a deliberate hold. Cancel.
+        cancelWordPress();
+      }
+    }, { passive: true });
+
+    // touchcancel — the OS took the gesture (incoming call, notification
+    // shade, scroll takeover, WebView losing the touch). touchend never
+    // fires here, so without this the pending timer would open a WordCard
+    // (+ haptic + auto-TTS) for a word the finger already left (FIX 1).
+    document.addEventListener('touchcancel', function() {
+      cancelWordPress();
+    }, { passive: true });
+
     document.addEventListener('touchend', function(e) {
+      if (wordPressTimer) { clearTimeout(wordPressTimer); wordPressTimer = null; }
+
+      // The hold already resolved the word on the timer — don't also run the
+      // immersive-toggle / page-turn fallback for this same touch.
+      if (_wordPressFired) { _wordPressFired = false; return; }
+
       var tx = e.changedTouches[0].clientX;
       var ty = e.changedTouches[0].clientY;
       var dx = tx - touchStartX;
@@ -564,9 +649,11 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
       // a tap and call removeAllRanges() we destroy the selection the
       // user just made. selectionchange already dispatched it to RN, so
       // bail out here and let the native handles + RN SelectionActionBar
-      // own the lifecycle. 350ms is below Android's 500ms long-press
-      // threshold but above any plausible normal tap.
-      if (dur > 350) return;
+      // own the lifecycle. Use LONGPRESS_MS so a release in the old
+      // 351–449ms dead band still falls through to quick-tap handling
+      // (word-swallow / immersive toggle). The hold timer is already
+      // cleared at the top of touchend, so this can't double-fire (FIX 5).
+      if (dur > LONGPRESS_MS) return;
       var target = e.target;
       if (target.tagName === 'A' || target.closest('a')) return;
 
@@ -584,13 +671,13 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
         return;
       }
 
-      // Highlight tap just fired — skip word-select so a single tap doesn't
-      // open both the highlight editor and the WordCard.
+      // Highlight tap just fired — skip the fallback so a single tap doesn't
+      // open the highlight editor twice.
       if (_hlOverlayer && _hlOverlayer.isJustAnchored && _hlOverlayer.isJustAnchored()) return;
 
-      // Try selecting the word under the tap. If it hits a word, the
-      // selectionchange listener takes over (pulse + RN message + save).
-      if (selectWordAtPoint(tx, ty)) return;
+      // Quick tap on a word does nothing now (word action requires a hold).
+      // If the tap landed on a word, swallow it so a brush can't toggle bars.
+      if (wordRangeAtPoint(tx, ty)) return;
 
       // Not on a word — empty space / between paragraphs. Fall back to
       // immersive toggle, keeping double-tap suppression.

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -525,8 +525,8 @@
     "toastWordAdded": "Added to vocabulary",
     "toastWordAddedCount": "Added · {count} this session",
     "toastTapToReview": "Tap to review",
-    "coachmarkTitle": "Tap any word",
-    "coachmarkSubtitle": "Tap a word to see its translation, then tap Save to add it to your vocabulary.",
+    "coachmarkTitle": "Press and hold a word",
+    "coachmarkSubtitle": "Press and hold a word to see its translation, then tap Save to add it to your vocabulary.",
     "coachmarkDismiss": "Got it",
     "vocab": {
       "queuedForTomorrow": "Daily cap reached — queued for tomorrow",


### PR DESCRIPTION
Two mobile fixes (PM → architect → engineer → adversarial QA → fix cycle).

## Library tab
- **Scroll** — the whole body now scrolls (the shelves carousels moved into the FlatList `ListHeaderComponent`; empty states use a ScrollView; safe-area bottom padding so the last row clears the tab bar + floating "+").
- **Stale shelves** — deleted/changed books lingered in "Continue reading"/"Recently added" because a 60s module-level cache wasn't invalidated. Now `clearLibraryShelvesCache()` bumps a version + notifies subscribers (`useSyncExternalStore`-style), so the **live** carousel refetches immediately — not only on refocus. Covers remove-from-library, delete-upload, mark-complete/uncomplete, cancel-upload, and pull-to-refresh.

## Reader — long-press word gate
The word action (translation/Explain sheet + auto-TTS) used to fire on a light ≤350ms tap, causing accidental translations and wasted LLM tokens. Now:
- Fires only on a deliberate **~450ms long-press** with <8px drift (haptic on engage).
- Quick tap **on a word** is swallowed (0 sheets, **0 LLM calls**); quick tap on empty space still toggles the reading bars.
- `touchcancel` clears the timer (no ghost WordCard after an interrupted gesture); a drag past 16px after engage releases the selection-suppression window so native multi-word selection still works.
- Coachmark copy → "Press and hold a word". Mobile-only (injected `readerHtml.ts`); no web/`reader-overlay` change.

## Verification
- `apps/mobile` `tsc --noEmit` clean; `packages/shared` vitest 149 green.
- Adversarial QA pass applied (touchcancel blocker, live-refresh, missed mutation sites, multi-select interference, dead-band all fixed).
- **On-device validation owed** (WebView not e2e-drivable): interrupted-gesture (no ghost card), native multi-word selection extend, in-tab delete → carousel updates without leaving the tab, haptic on engage, 450ms feel in scroll mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)