### PR TITLE
chore(mobile): EAS submit track -> alpha (closed testing)

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -35,7 +35,7 @@
   "submit": {
     "production": {
       "android": {
-        "track": "internal",
+        "track": "alpha",
         "releaseStatus": "completed",
         "changesNotSentForReview": false
       }


### PR DESCRIPTION
Switches the `eas submit` production profile track from `internal` to **`alpha`** (Play Closed testing), as we move into the closed-testing phase required to unlock Production access (≥12 testers for ≥14 days) for the post-Nov-2023 developer account.

`eas build -p android --profile production --auto-submit` now uploads to the **Closed testing** track and sends the release for review.

(The current build `dac0ef2f` / versionCode 20 was already uploaded to the alpha track as a draft.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)