### PR TITLE
ci(mobile): one-run build+submit action (no tags)

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -6,6 +6,10 @@ name: Mobile Release (EAS)
 #   • build      — `eas build` only. Produces an artifact; does NOT touch the store.
 #   • submit     — `eas submit --latest` — pushes the latest build to the store.
 #                  Run this yourself, on purpose, when you've decided to release.
+#   • build-submit — one run, no tags: `eas build --auto-submit`. Builds on EAS,
+#                  waits, then pushes to the store in the same run. Submit track
+#                  follows eas.json (submit.production.android.track). Android-only
+#                  by default (only Android has a submit config in eas.json).
 #
 # Requires repo secret EXPO_TOKEN (expo.dev → Account → Access tokens).
 # workflow_dispatch ONLY — no push/tag/schedule triggers, so the store is never
@@ -16,7 +20,7 @@ on:
       action:
         description: What to do (store submit is its own explicit action)
         type: choice
-        options: [ota-update, build, submit]
+        options: [ota-update, build, submit, build-submit]
         default: ota-update
       platform:
         description: Target platform
@@ -91,4 +95,16 @@ jobs:
             --platform "${{ inputs.platform }}" \
             --profile "${{ inputs.profile }}" \
             --latest \
+            --non-interactive
+
+      # One run, no tags: build on EAS, wait, then push to the store. The submit
+      # track comes from eas.json (submit.<profile>.android.track). Android only —
+      # iOS has no submit config, so pick android for this action.
+      - name: Build + submit
+        if: ${{ inputs.action == 'build-submit' }}
+        run: |
+          eas build \
+            --platform android \
+            --profile "${{ inputs.profile }}" \
+            --auto-submit \
             --non-interactive


### PR DESCRIPTION
Adds a **`build-submit`** action to the existing `mobile-release.yml` (`workflow_dispatch`, no tags). One run → `eas build --auto-submit`: builds the AAB on EAS, waits, then pushes to the store in the same run.

- Trigger: **manual Run** in the Actions tab (no tags, no push). Pick `action = build-submit`, `profile = production`.
- Submit track follows **`eas.json`** (`submit.<profile>.android.track`). On `main` that's currently `internal` → so a run pushes build to **Internal testing** (instant, no review). Merge #391 to route it to `alpha` (Closed testing) instead.
- **Android only** for this action (iOS has no submit config in eas.json).
- Existing `ota-update` / `build` / `submit` actions unchanged.

## Needs (one-time, owner)
- Repo secret **`EXPO_TOKEN`** (expo.dev → Account → Access tokens) — required for any `eas` CI run. The Android submit uses the EAS-managed Google service-account key, so no extra secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)