### PR TITLE
chore(ai): close Librarian/agent QA follow-ups

### DIFF
--- a/backend/src/Application/Tools/LibraryToolShared.cs
+++ b/backend/src/Application/Tools/LibraryToolShared.cs
@@ -18,10 +18,16 @@ public static class LibraryToolShared
 {
     public const int DefaultLimit = 8;
 
-    /// <summary>The catalog is single-site (ADR-007); resolve the one site so the FTS query can scope to it.</summary>
+    /// <summary>
+    /// The catalog is single-site (ADR-007); resolve the one site so the FTS query can scope to it. The
+    /// <see cref="OrderBy"/> on <c>Id</c> makes the pick deterministic (not "whatever row comes first").
+    /// SINGLE-SITE ASSUMPTION: if multi-site is ever reintroduced, the agent runs OUTSIDE
+    /// <c>SiteContextMiddleware</c>, so picking the first site here would be a cross-site leak — the agent
+    /// must instead be handed the resolved <c>SiteId</c> from the request context. Not plumbed now by design.
+    /// </summary>
     public static async Task<Guid?> ResolveSiteIdAsync(IAppDbContext db, CancellationToken ct)
     {
-        var site = await db.Sites.AsNoTracking().FirstOrDefaultAsync(ct);
+        var site = await db.Sites.AsNoTracking().OrderBy(s => s.Id).FirstOrDefaultAsync(ct);
         return site?.Id;
     }
 
@@ -51,4 +57,11 @@ public static class LibraryToolShared
     /// <summary>Empty-but-successful result (no DB site → degrade as data, never throw — the agent recovers).</summary>
     public static JsonElement NoSite(string query) =>
         ToolJson.Result(new { found = false, query, results = Array.Empty<object>(), message = "Catalog unavailable." });
+
+    /// <summary>
+    /// Error-as-data when <see cref="LibrarySearchService"/> isn't registered in the host (Worker, not API).
+    /// Matches the tools' error-as-data shape so a future Worker agent gets a clean result, not an NRE.
+    /// </summary>
+    public static JsonElement Unavailable() =>
+        ToolJson.Result(new { ok = false, error = "library search unavailable in this host" });
 }

--- a/backend/src/Application/Tools/SearchLibrarySemanticTool.cs
+++ b/backend/src/Application/Tools/SearchLibrarySemanticTool.cs
@@ -49,7 +49,13 @@ public sealed class SearchLibrarySemanticTool : ITool
         if (siteId is null)
             return LibraryToolShared.NoSite(query);
 
-        var service = ctx.Services.GetRequiredService<LibrarySearchService>();
+        // API-host-only: LibrarySearchService is wired in the API DI but NOT in the Worker. The Worker's
+        // assembly tool-scan still constructs this tool, so resolve defensively (GetService, not GetRequired)
+        // and degrade as data rather than NRE if a future Worker agent ever allow-lists it.
+        var service = ctx.Services.GetService<LibrarySearchService>();
+        if (service is null)
+            return LibraryToolShared.Unavailable();
+
         var books = await service.SearchSemanticAsync(query, siteId.Value, language, limit, ct);
         return LibraryToolShared.Shape(books, query);
     }

--- a/backend/src/Application/Tools/SearchLibraryTool.cs
+++ b/backend/src/Application/Tools/SearchLibraryTool.cs
@@ -49,7 +49,13 @@ public sealed class SearchLibraryTool : ITool
         if (siteId is null)
             return LibraryToolShared.NoSite(query);
 
-        var service = ctx.Services.GetRequiredService<LibrarySearchService>();
+        // API-host-only: LibrarySearchService is wired in the API DI but NOT in the Worker. The Worker's
+        // assembly tool-scan still constructs this tool, so resolve defensively (GetService, not GetRequired)
+        // and degrade as data rather than NRE if a future Worker agent ever allow-lists it.
+        var service = ctx.Services.GetService<LibrarySearchService>();
+        if (service is null)
+            return LibraryToolShared.Unavailable();
+
         var books = await service.SearchAsync(query, siteId.Value, language, limit, ct);
         return LibraryToolShared.Shape(books, query);
     }

--- a/tests/TextStack.AiEvals/LibrarianEvalRunnerTests.cs
+++ b/tests/TextStack.AiEvals/LibrarianEvalRunnerTests.cs
@@ -7,7 +7,7 @@ using TextStack.Ai.Core;
 using TextStack.Ai.EvalSuite;
 using TextStack.Ai.Tools;
 
-namespace TextStack.UnitTests;
+namespace TextStack.AiEvals;
 
 /// <summary>
 /// AI-Agent-3 LibrarianEvalRunner — the deterministic scoring (recall@k, constraint-satisfaction, coverage


### PR DESCRIPTION
Low-severity cleanup from the Enrichment/Librarian adversarial QA passes (no behavior change beyond guards).

- **Library tools fail as data, not NRE** — `search_library`/`search_library_semantic` now resolve `LibrarySearchService` via `GetService` + null guard → `{ok:false,error:"library search unavailable in this host"}` (they're swept into the Worker's tool-scan but it doesn't register the service; unreachable today, but future-proofed). API-host happy path unchanged.
- **Deterministic single-site resolution** — `ResolveSiteIdAsync` orders by `Id` + documents the ADR-007 single-site assumption and the multi-site leak risk (agent must take the request-context `SiteId` if multi-site returns).
- **Convention** — moved `LibrarianEvalRunnerTests` from `TextStack.UnitTests` → `TextStack.AiEvals` (where eval-runner tests live; clean move, no fixture coupling).

`dotnet build` + `dotnet format` clean; 50 unit + 8 AiEvals (Librarian|Enrichment) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)