### PR TITLE
ci(mobile): submit track as a run-time choice (internal | closed)

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -4,12 +4,12 @@ name: Mobile Release (EAS)
 # the store automatically; each run is a deliberate human click:
 #   • ota-update — `eas update` to the production channel (JS-only changes, instant).
 #   • build      — `eas build` only. Produces an artifact; does NOT touch the store.
-#   • submit     — `eas submit --latest` — pushes the latest build to the store.
-#                  Run this yourself, on purpose, when you've decided to release.
-#   • build-submit — one run, no tags: `eas build --auto-submit`. Builds on EAS,
-#                  waits, then pushes to the store in the same run. Submit track
-#                  follows eas.json (submit.production.android.track). Android-only
-#                  by default (only Android has a submit config in eas.json).
+#   • submit     — `eas submit --latest` — pushes the latest build to the store,
+#                  to the `track` input (internal | closed). Android-only.
+#   • build-submit — one run, no tags: `eas build --auto-submit-with-profile`.
+#                  Builds on EAS, waits, then pushes to the store in the same run,
+#                  to the `track` input (internal | closed). Android-only.
+# Submit destination = the `track` input → eas.json `submit.<track>` profile.
 #
 # Requires repo secret EXPO_TOKEN (expo.dev → Account → Access tokens).
 # workflow_dispatch ONLY — no push/tag/schedule triggers, so the store is never
@@ -28,10 +28,15 @@ on:
         options: [all, android, ios]
         default: all
       profile:
-        description: Build/submit profile
+        description: Build profile (build / ota / build-submit)
         type: choice
         options: [production, preview]
         default: production
+      track:
+        description: Submit track (submit / build-submit only)
+        type: choice
+        options: [internal, closed]
+        default: internal
       message:
         description: OTA message (ota-update only)
         type: string
@@ -92,8 +97,8 @@ jobs:
         if: ${{ inputs.action == 'submit' }}
         run: |
           eas submit \
-            --platform "${{ inputs.platform }}" \
-            --profile "${{ inputs.profile }}" \
+            --platform android \
+            --profile "${{ inputs.track }}" \
             --latest \
             --non-interactive
 
@@ -106,5 +111,5 @@ jobs:
           eas build \
             --platform android \
             --profile "${{ inputs.profile }}" \
-            --auto-submit \
+            --auto-submit-with-profile "${{ inputs.track }}" \
             --non-interactive

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -33,9 +33,16 @@
     }
   },
   "submit": {
-    "production": {
+    "internal": {
       "android": {
         "track": "internal",
+        "releaseStatus": "completed",
+        "changesNotSentForReview": false
+      }
+    },
+    "closed": {
+      "android": {
+        "track": "alpha",
         "releaseStatus": "completed",
         "changesNotSentForReview": false
       }


### PR DESCRIPTION
Makes the mobile pipeline's submit destination a **run-time choice** instead of a pinned `eas.json` track — so the same one-click `build-submit` / `submit` serves both the **instant Internal** test loop and the **Closed-testing (12×14)** push without editing config. Implements option **B** and **supersedes the held #391**.

## Changes
- `apps/mobile/eas.json`: one submit profile → **two** — `submit.internal` (track `internal`) + `submit.closed` (track `alpha`).
- `.github/workflows/mobile-release.yml`: new **`track`** input (`internal` | `closed`, default `internal`). `submit` → `eas submit --profile <track>`; `build-submit` → `eas build --profile <buildProfile> --auto-submit-with-profile <track>`. Both Android-only (only Android has a submit config).

## Use
Actions → Mobile Release (EAS) → Run → `action = build-submit`, `track = internal` (now) or `closed` (when you start the 12-tester closed test). No tags, no config edits. (Still needs the `EXPO_TOKEN` secret.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)