### PR TITLE
refactor(site): single-site EF query filters + ICurrentSite (R1a+R1b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Cross-platform TS code shared by **both** web and mobile, consumed via source pa
 
 **Middleware pipeline** (order matters): `ForwardedHeaders` → `Cors` → `RateLimiter` → `ExceptionMiddleware` → `StaticFiles(/storage)` → `/health` → `SiteContext` → `LanguageContext` → `GuestActivity` (LastActiveAt debounce hourly) → `Routing` → `AdminAuth` (conditional on `/admin/*`)
 
-**Site resolution**: Single-site now (ADR-007). `SiteContextMiddleware` still resolves host → SiteId. Dev mode: `?site=` query param override.
+**Site resolution**: Single-site permanent (ADR-007). `SiteContextMiddleware` resolves host → SiteId. The single site id is exposed process-wide via `ICurrentSite` (config `Site:Id`, default `SiteConstants.DefaultSiteId`); EF global query filters key on it (see `ISiteScoped`). The dev `?site=` override was removed (R1b) — internal host-less callers (e.g. `ssg-worker.mjs`) must send a resolvable `Host` header.
 
 **Patterns**:
 - Endpoints: `Map{Domain}Endpoints()` in `Api/Endpoints/`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <!-- Entity Framework -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />

--- a/apps/web/scripts/ssg-worker.mjs
+++ b/apps/web/scripts/ssg-worker.mjs
@@ -58,14 +58,19 @@ async function pollForJob() {
 }
 
 /**
- * Get routes from API
- * Uses ?site= query param instead of Host header (Node.js fetch doesn't pass Host properly)
+ * Get routes from API.
+ *
+ * Sends an explicit Host header so SiteContextMiddleware can resolve the site.
+ * The legacy `?site=` query-param override was removed in R1b (single-site); node
+ * fetch would otherwise default Host to the URL host (`api`) → 404 → silent job
+ * failure. API_HOST resolves to a seeded domain (`localhost` in compose, or the
+ * `general.localhost` default) → DefaultSiteId == ICurrentSite.Id.
  */
-async function getRoutesFromApi(siteCode) {
-  const url = `${API_URL}/ssg/routes?site=${siteCode}`;
-  console.log(`Fetching routes from ${url}`);
+async function getRoutesFromApi() {
+  const url = `${API_URL}/ssg/routes`;
+  console.log(`Fetching routes from ${url} (Host: ${API_HOST})`);
 
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: { host: API_HOST } });
 
   if (!res.ok) {
     throw new Error(`Failed to fetch routes: ${res.status} ${res.statusText}`);
@@ -113,8 +118,8 @@ async function processJob(job) {
   console.log(`Processing job ${jobId} for site ${siteCode} (${apiHost})`);
 
   try {
-    // 1. Get routes via API (uses ?site= query param)
-    const routes = await getRoutesFromApi(siteCode);
+    // 1. Get routes via API (site resolved from the Host header)
+    const routes = await getRoutesFromApi();
     console.log(`Got ${routes.length} routes to render`);
 
     if (routes.length === 0) {

--- a/backend/src/Api/Endpoints/AdminAutoPublishEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminAutoPublishEndpoints.cs
@@ -12,8 +12,6 @@ namespace Api.Endpoints;
 
 public static class AdminAutoPublishEndpoints
 {
-    private static readonly Guid GeneralSiteId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-
     public static void MapAdminAutoPublishEndpoints(this WebApplication app)
     {
         var group = app.MapGroup("/admin/autopublish").WithTags("Auto Publish");
@@ -145,7 +143,7 @@ public static class AdminAutoPublishEndpoints
         return Results.Ok();
     }
 
-    private static async Task<IResult> Trigger(IAppDbContext db, AdminSettingsService settings, CancellationToken ct)
+    private static async Task<IResult> Trigger(IAppDbContext db, AdminSettingsService settings, ICurrentSite site, CancellationToken ct)
     {
         var lang = await settings.GetAsync("autopublish.language", "", ct);
 
@@ -170,7 +168,7 @@ public static class AdminAutoPublishEndpoints
         var job = new AutoPublishJob
         {
             Id = Guid.NewGuid(),
-            SiteId = GeneralSiteId,
+            SiteId = site.Id,
             EditionId = edition.Id,
             Priority = true,
             CreatedAt = DateTimeOffset.UtcNow,
@@ -182,7 +180,7 @@ public static class AdminAutoPublishEndpoints
         return Results.Created($"/admin/autopublish/jobs/{job.Id}", new { id = job.Id });
     }
 
-    private static async Task<IResult> QueueEdition(Guid editionId, IAppDbContext db, CancellationToken ct)
+    private static async Task<IResult> QueueEdition(Guid editionId, IAppDbContext db, ICurrentSite site, CancellationToken ct)
     {
         var edition = await db.Editions.FirstOrDefaultAsync(e => e.Id == editionId, ct);
         if (edition == null) return Results.NotFound();
@@ -199,7 +197,7 @@ public static class AdminAutoPublishEndpoints
         var job = new AutoPublishJob
         {
             Id = Guid.NewGuid(),
-            SiteId = GeneralSiteId,
+            SiteId = site.Id,
             EditionId = editionId,
             Priority = true,
             CreatedAt = DateTimeOffset.UtcNow,

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -133,6 +133,9 @@ builder.Services.AddAuthSettings(builder.Configuration);
 var connectionString = builder.Configuration.GetConnectionString("Default")
     ?? throw new InvalidOperationException("ConnectionStrings:Default is required");
 
+builder.Services.AddSingleton<Application.Common.Interfaces.ICurrentSite>(
+    sp => new Infrastructure.Persistence.CurrentSite(sp.GetRequiredService<IConfiguration>()));
+
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(connectionString, o => o.UseVector())
         .UseSnakeCaseNamingConvention()

--- a/backend/src/Api/Sites/SiteContextMiddleware.cs
+++ b/backend/src/Api/Sites/SiteContextMiddleware.cs
@@ -36,12 +36,12 @@ public class SiteContextMiddleware
             return;
         }
 
-        // Dev mode: allow ?site= query param override
-        var siteOverride = context.Request.Query["site"].FirstOrDefault();
-
-        var host = !string.IsNullOrEmpty(siteOverride)
-            ? $"{siteOverride}.localhost"
-            : context.Request.Host.Host;
+        // Single-site (ADR-007): resolve strictly by request host. The legacy dev
+        // `?site=` override was removed in R1b — it could resolve a SiteContext whose
+        // Id diverged from the process-wide ICurrentSite.Id that the new EF global
+        // query filters key on, silently yielding zero rows. The one seeded site's
+        // host always resolves to SiteConstants.DefaultSiteId == ICurrentSite.Id.
+        var host = context.Request.Host.Host;
 
         var siteContext = await _resolver.ResolveAsync(host, context.RequestAborted);
 

--- a/backend/src/Application/Common/Interfaces/ICurrentSite.cs
+++ b/backend/src/Application/Common/Interfaces/ICurrentSite.cs
@@ -1,0 +1,11 @@
+namespace Application.Common.Interfaces;
+
+/// <summary>
+/// Resolves the id of the site this process serves. Single-site (ADR-007), so
+/// this is a process-wide constant sourced from config with a hard default.
+/// Future global query filters will scope EF queries to <see cref="Id"/>.
+/// </summary>
+public interface ICurrentSite
+{
+    Guid Id { get; }
+}

--- a/backend/src/Domain/Entities/Author.cs
+++ b/backend/src/Domain/Entities/Author.cs
@@ -2,7 +2,7 @@ using Domain.Enums;
 
 namespace Domain.Entities;
 
-public class Author
+public class Author : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid SiteId { get; set; }

--- a/backend/src/Domain/Entities/AutoPublishJob.cs
+++ b/backend/src/Domain/Entities/AutoPublishJob.cs
@@ -2,7 +2,7 @@ using Domain.Enums;
 
 namespace Domain.Entities;
 
-public class AutoPublishJob
+public class AutoPublishJob : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid SiteId { get; set; }

--- a/backend/src/Domain/Entities/Bookmark.cs
+++ b/backend/src/Domain/Entities/Bookmark.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class Bookmark
+public class Bookmark : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/Edition.cs
+++ b/backend/src/Domain/Entities/Edition.cs
@@ -2,7 +2,7 @@ using Domain.Enums;
 
 namespace Domain.Entities;
 
-public class Edition
+public class Edition : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid WorkId { get; set; }

--- a/backend/src/Domain/Entities/Genre.cs
+++ b/backend/src/Domain/Entities/Genre.cs
@@ -2,7 +2,7 @@ using Domain.Enums;
 
 namespace Domain.Entities;
 
-public class Genre
+public class Genre : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid SiteId { get; set; }

--- a/backend/src/Domain/Entities/Highlight.cs
+++ b/backend/src/Domain/Entities/Highlight.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class Highlight
+public class Highlight : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/ISiteScoped.cs
+++ b/backend/src/Domain/Entities/ISiteScoped.cs
@@ -1,0 +1,15 @@
+namespace Domain.Entities;
+
+/// <summary>
+/// Marker for entities scoped to a single site (ADR-007, single-site). Carries
+/// the <see cref="SiteId"/> that R1b's global query filters match on and that
+/// <c>AppDbContext.SaveChanges</c> stamps on insert when left empty.
+///
+/// NOT applied to <c>Site</c> / <c>SiteDomain</c>: the site resolver reads those
+/// to discover the current site, so a filter on them would be a chicken/egg
+/// deadlock (zero rows before the site is known).
+/// </summary>
+public interface ISiteScoped
+{
+    Guid SiteId { get; set; }
+}

--- a/backend/src/Domain/Entities/Note.cs
+++ b/backend/src/Domain/Entities/Note.cs
@@ -2,7 +2,7 @@ namespace Domain.Entities;
 
 // TODO: Notes feature partially implemented - entity/DB exists but API endpoints not wired.
 // Relationships: User, Site, Edition, Chapter - keep entity, implement API later.
-public class Note
+public class Note : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/PendingVocabularyWord.cs
+++ b/backend/src/Domain/Entities/PendingVocabularyWord.cs
@@ -4,7 +4,7 @@ namespace Domain.Entities;
 // reconciler promotes the highest-Priority pending rows once the day rolls
 // over and the active queue has headroom. Shape mirrors VocabularyWord minus
 // the SRS columns — SRS state is assigned at promotion time, not at save.
-public class PendingVocabularyWord
+public class PendingVocabularyWord : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/ReadingGoal.cs
+++ b/backend/src/Domain/Entities/ReadingGoal.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class ReadingGoal
+public class ReadingGoal : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/ReadingProgress.cs
+++ b/backend/src/Domain/Entities/ReadingProgress.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class ReadingProgress
+public class ReadingProgress : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/ReadingSession.cs
+++ b/backend/src/Domain/Entities/ReadingSession.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class ReadingSession
+public class ReadingSession : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/SsgRebuildJob.cs
+++ b/backend/src/Domain/Entities/SsgRebuildJob.cs
@@ -2,7 +2,7 @@ using Domain.Enums;
 
 namespace Domain.Entities;
 
-public class SsgRebuildJob
+public class SsgRebuildJob : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid SiteId { get; set; }

--- a/backend/src/Domain/Entities/TextStackImport.cs
+++ b/backend/src/Domain/Entities/TextStackImport.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class TextStackImport
+public class TextStackImport : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid SiteId { get; set; }

--- a/backend/src/Domain/Entities/TutorSession.cs
+++ b/backend/src/Domain/Entities/TutorSession.cs
@@ -8,7 +8,7 @@ namespace Domain.Entities;
 /// answers. <see cref="PlanJson"/> is the current ordered study set as jsonb (read whole, not queried per
 /// field). Plain POCO; EF mapping in AppDbContext.Agents.cs.
 /// </summary>
-public class TutorSession
+public class TutorSession : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/UserAchievement.cs
+++ b/backend/src/Domain/Entities/UserAchievement.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class UserAchievement
+public class UserAchievement : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/UserVocabularySettings.cs
+++ b/backend/src/Domain/Entities/UserVocabularySettings.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class UserVocabularySettings
+public class UserVocabularySettings : ISiteScoped
 {
     public Guid UserId { get; set; }
     public Guid SiteId { get; set; }

--- a/backend/src/Domain/Entities/VocabularyReview.cs
+++ b/backend/src/Domain/Entities/VocabularyReview.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class VocabularyReview
+public class VocabularyReview : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid VocabularyWordId { get; set; }

--- a/backend/src/Domain/Entities/VocabularyWord.cs
+++ b/backend/src/Domain/Entities/VocabularyWord.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class VocabularyWord
+public class VocabularyWord : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/WordCluster.cs
+++ b/backend/src/Domain/Entities/WordCluster.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class WordCluster
+public class WordCluster : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/WordLookup.cs
+++ b/backend/src/Domain/Entities/WordLookup.cs
@@ -5,7 +5,7 @@ namespace Domain.Entities;
 // flooding the review queue with words the user will likely never see again.
 // Mid-tier words sit here until TapCount >= LOOKUP_PROMOTION_TAPS, at which
 // point SaveWord auto-promotes into VocabularyWord.
-public class WordLookup
+public class WordLookup : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }

--- a/backend/src/Domain/Entities/Work.cs
+++ b/backend/src/Domain/Entities/Work.cs
@@ -1,6 +1,6 @@
 namespace Domain.Entities;
 
-public class Work
+public class Work : ISiteScoped
 {
     public Guid Id { get; set; }
     public Guid SiteId { get; set; }

--- a/backend/src/Domain/SiteConstants.cs
+++ b/backend/src/Domain/SiteConstants.cs
@@ -1,0 +1,14 @@
+namespace Domain;
+
+/// <summary>
+/// Single-site constants (ADR-007). The platform runs as one canonical site;
+/// this GUID is the one source of truth for its identity.
+///
+/// The same value is frozen into migration seed data — do NOT change it, and do
+/// NOT copy the literal elsewhere. Reference <see cref="DefaultSiteId"/> instead.
+/// </summary>
+public static class SiteConstants
+{
+    /// <summary>Canonical site id for the single-site deployment.</summary>
+    public static readonly Guid DefaultSiteId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Agents.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Agents.cs
@@ -10,7 +10,8 @@ namespace Infrastructure.Persistence;
 /// </summary>
 public partial class AppDbContext
 {
-    private static void ConfigureAgents(ModelBuilder modelBuilder)
+    // Instance (not static): the TutorSession query filter closes over _currentSite.
+    private void ConfigureAgents(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<AgentRun>(e =>
         {
@@ -56,6 +57,8 @@ public partial class AppDbContext
                 .WithMany()
                 .HasForeignKey(x => x.SiteId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
     }
 }

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Catalog.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Catalog.cs
@@ -15,7 +15,9 @@ namespace Infrastructure.Persistence;
 /// </summary>
 public partial class AppDbContext
 {
-    private static void ConfigureCatalog(ModelBuilder modelBuilder)
+    // Instance (not static): the site-scoped query filters below close over
+    // _currentSite so EF parameterizes them per context instance.
+    private void ConfigureCatalog(ModelBuilder modelBuilder)
     {
         // Site
         modelBuilder.Entity<Site>(e =>
@@ -43,6 +45,7 @@ public partial class AppDbContext
             e.HasIndex(x => x.SiteId);
             e.HasIndex(x => new { x.SiteId, x.Slug }).IsUnique();
             e.HasOne(x => x.Site).WithMany(x => x.Works).HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // Edition
@@ -77,6 +80,7 @@ public partial class AppDbContext
             e.HasOne(x => x.Work).WithMany(x => x.Editions).HasForeignKey(x => x.WorkId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
             e.HasOne(x => x.SourceEdition).WithMany(x => x.TranslatedEditions).HasForeignKey(x => x.SourceEditionId).OnDelete(DeleteBehavior.SetNull);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // Chapter
@@ -125,6 +129,7 @@ public partial class AppDbContext
             e.Property(x => x.Name).HasMaxLength(255);
             e.Property(x => x.ExternalLinksJson).HasColumnType("jsonb");
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // EditionAuthor (junction table with order + role)
@@ -147,6 +152,7 @@ public partial class AppDbContext
             e.Property(x => x.Name).HasMaxLength(100);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
             e.HasMany(x => x.Editions).WithMany(x => x.Genres).UsingEntity("edition_genres");
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // TextStackImport — provenance link for imported books.
@@ -158,6 +164,7 @@ public partial class AppDbContext
             e.Property(x => x.Identifier).HasMaxLength(500);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
             e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.Cascade);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // BookAsset — extracted images/etc tied to an edition.

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Ops.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Ops.cs
@@ -9,7 +9,8 @@ namespace Infrastructure.Persistence;
 /// </summary>
 public partial class AppDbContext
 {
-    private static void ConfigureOps(ModelBuilder modelBuilder)
+    // Instance (not static): site-scoped query filters close over _currentSite.
+    private void ConfigureOps(ModelBuilder modelBuilder)
     {
         // AdminSettings — key/value store, primary key is the key string.
         modelBuilder.Entity<AdminSettings>(e =>
@@ -31,6 +32,7 @@ public partial class AppDbContext
             e.Property(x => x.AuthorSlugsJson).HasColumnType("jsonb");
             e.Property(x => x.GenreSlugsJson).HasColumnType("jsonb");
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // SsgRebuildResult
@@ -50,6 +52,13 @@ public partial class AppDbContext
             e.Property(x => x.Severity).HasConversion<string>().HasMaxLength(20);
             e.Property(x => x.Code).HasMaxLength(10);
             e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // AutoPublishJob — otherwise convention-configured; here only to carry the
+        // R1b site-scoped query filter (no schema config, so no migration delta).
+        modelBuilder.Entity<AutoPublishJob>(e =>
+        {
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
     }
 }

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Reading.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Reading.cs
@@ -9,7 +9,8 @@ namespace Infrastructure.Persistence;
 /// </summary>
 public partial class AppDbContext
 {
-    private static void ConfigureReading(ModelBuilder modelBuilder)
+    // Instance (not static): site-scoped query filters close over _currentSite.
+    private void ConfigureReading(ModelBuilder modelBuilder)
     {
         // ReadingProgress
         modelBuilder.Entity<ReadingProgress>(e =>
@@ -22,6 +23,7 @@ public partial class AppDbContext
             e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Chapter).WithMany(x => x.ReadingProgresses).HasForeignKey(x => x.ChapterId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // Bookmark
@@ -35,6 +37,7 @@ public partial class AppDbContext
             e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Chapter).WithMany(x => x.Bookmarks).HasForeignKey(x => x.ChapterId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // Note
@@ -50,6 +53,7 @@ public partial class AppDbContext
             e.HasOne(x => x.Chapter).WithMany(x => x.Notes).HasForeignKey(x => x.ChapterId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
             e.HasOne(x => x.Highlight).WithOne(x => x.Note).HasForeignKey<Note>(x => x.HighlightId).OnDelete(DeleteBehavior.SetNull);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // Highlight — can attach to either an Edition+Chapter or a UserBook+UserChapter.
@@ -69,6 +73,7 @@ public partial class AppDbContext
             e.HasOne(x => x.UserBook).WithMany().HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.UserChapter).WithMany().HasForeignKey(x => x.UserChapterId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // ReadingSession
@@ -82,6 +87,7 @@ public partial class AppDbContext
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
             e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.UserBook).WithMany().HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.SetNull);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // ReadingGoal
@@ -92,6 +98,7 @@ public partial class AppDbContext
             e.Property(x => x.GoalType).HasMaxLength(50);
             e.HasOne(x => x.User).WithMany().HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // UserAchievement
@@ -102,6 +109,7 @@ public partial class AppDbContext
             e.Property(x => x.AchievementCode).HasMaxLength(50);
             e.HasOne(x => x.User).WithMany().HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
     }
 }

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Vocabulary.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Vocabulary.cs
@@ -11,7 +11,8 @@ namespace Infrastructure.Persistence;
 /// </summary>
 public partial class AppDbContext
 {
-    private static void ConfigureVocabulary(ModelBuilder modelBuilder)
+    // Instance (not static): site-scoped query filters close over _currentSite.
+    private void ConfigureVocabulary(ModelBuilder modelBuilder)
     {
         // VocabularyWord
         modelBuilder.Entity<VocabularyWord>(e =>
@@ -54,6 +55,7 @@ public partial class AppDbContext
             // (delete this user's concept clusters → recreate) nulls members cleanly.
             e.HasOne(x => x.ConceptCluster).WithMany(c => c.ConceptWords)
                 .HasForeignKey(x => x.ConceptClusterId).OnDelete(DeleteBehavior.SetNull);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // UserVocabularySettings — one row per (user, site).
@@ -62,6 +64,7 @@ public partial class AppDbContext
             e.HasKey(x => new { x.UserId, x.SiteId });
             e.HasOne(x => x.User).WithMany().HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // VocabularyReview
@@ -73,6 +76,7 @@ public partial class AppDbContext
             e.HasOne(x => x.VocabularyWord).WithMany(x => x.Reviews).HasForeignKey(x => x.VocabularyWordId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.User).WithMany().HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // PendingVocabularyWord (F2: over-cap buffer)
@@ -96,6 +100,7 @@ public partial class AppDbContext
             e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.Chapter).WithMany().HasForeignKey(x => x.ChapterId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.UserBook).WithMany().HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.SetNull);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // WordLookup (F1: rare-word reference bucket — taps that don't enter SRS)
@@ -115,6 +120,7 @@ public partial class AppDbContext
             e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.Chapter).WithMany().HasForeignKey(x => x.ChapterId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.UserBook).WithMany().HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.SetNull);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
 
         // WordFrequency (F1: reference data — seeded from wordfreq export at startup)
@@ -145,6 +151,7 @@ public partial class AppDbContext
             e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.UserBook).WithMany().HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.SetNull);
             e.HasMany(x => x.Words).WithOne().HasForeignKey(x => x.ClusterId).OnDelete(DeleteBehavior.SetNull);
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
         });
     }
 }

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -25,7 +25,8 @@ namespace Infrastructure.Persistence;
 /// </summary>
 public partial class AppDbContext : DbContext, IAppDbContext
 {
-    // Held for the upcoming site-scoped global query filters (R1b). Unused for now.
+    // R1b: drives the site-scoped global query filters (OnModelCreating) and the
+    // SaveChanges write-stamping above. Process-wide constant in single-site.
     private readonly ICurrentSite _currentSite;
 
     public AppDbContext(DbContextOptions<AppDbContext> options, ICurrentSite currentSite) : base(options)
@@ -35,6 +36,21 @@ public partial class AppDbContext : DbContext, IAppDbContext
 
     public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken ct = default)
         => Database.BeginTransactionAsync(ct);
+
+    // R1b write-stamping: fill SiteId on newly-added ISiteScoped entities that were
+    // left empty. Overriding the two "core" overloads covers the parameterless
+    // convenience overloads too — they funnel through these.
+    public override int SaveChanges(bool acceptAllChangesOnSuccess)
+    {
+        SiteScopedStamp.Apply(ChangeTracker, _currentSite.Id);
+        return base.SaveChanges(acceptAllChangesOnSuccess);
+    }
+
+    public override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+    {
+        SiteScopedStamp.Apply(ChangeTracker, _currentSite.Id);
+        return base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+    }
 
     public DbSet<Site> Sites => Set<Site>();
     public DbSet<SiteDomain> SiteDomains => Set<SiteDomain>();

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -25,7 +25,13 @@ namespace Infrastructure.Persistence;
 /// </summary>
 public partial class AppDbContext : DbContext, IAppDbContext
 {
-    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+    // Held for the upcoming site-scoped global query filters (R1b). Unused for now.
+    private readonly ICurrentSite _currentSite;
+
+    public AppDbContext(DbContextOptions<AppDbContext> options, ICurrentSite currentSite) : base(options)
+    {
+        _currentSite = currentSite;
+    }
 
     public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken ct = default)
         => Database.BeginTransactionAsync(ct);

--- a/backend/src/Infrastructure/Persistence/AppDbContextFactory.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContextFactory.cs
@@ -1,3 +1,4 @@
+using Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
@@ -13,6 +14,6 @@ public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
         var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
         optionsBuilder.UseNpgsql(connectionString, o => o.UseVector());
 
-        return new AppDbContext(optionsBuilder.Options);
+        return new AppDbContext(optionsBuilder.Options, new CurrentSite(SiteConstants.DefaultSiteId));
     }
 }

--- a/backend/src/Infrastructure/Persistence/CurrentSite.cs
+++ b/backend/src/Infrastructure/Persistence/CurrentSite.cs
@@ -1,0 +1,38 @@
+using Application.Common.Interfaces;
+using Domain;
+using Microsoft.Extensions.Configuration;
+
+namespace Infrastructure.Persistence;
+
+/// <summary>
+/// Process-wide <see cref="ICurrentSite"/>. Reads <c>Site:Id</c> from config,
+/// defaulting to <see cref="SiteConstants.DefaultSiteId"/> when unset.
+///
+/// Fail-fast: an empty/zero GUID throws at construction. A silent
+/// <see cref="Guid.Empty"/> would make future site-scoped query filters match
+/// zero rows — a data-invisible outage we'd rather turn into a boot crash.
+/// </summary>
+public sealed class CurrentSite : ICurrentSite
+{
+    public Guid Id { get; }
+
+    public CurrentSite(Guid id)
+    {
+        if (id == Guid.Empty)
+            throw new InvalidOperationException(
+                "Site:Id resolved to an empty GUID. Configure a valid Site:Id (or leave it unset to use the default).");
+        Id = id;
+    }
+
+    public CurrentSite(IConfiguration config) : this(Resolve(config)) { }
+
+    private static Guid Resolve(IConfiguration config)
+    {
+        var raw = config["Site:Id"];
+        if (string.IsNullOrWhiteSpace(raw))
+            return SiteConstants.DefaultSiteId;
+        if (!Guid.TryParse(raw, out var id))
+            throw new InvalidOperationException($"Site:Id is not a valid GUID: '{raw}'.");
+        return id;
+    }
+}

--- a/backend/src/Infrastructure/Persistence/SiteScopedStamp.cs
+++ b/backend/src/Infrastructure/Persistence/SiteScopedStamp.cs
@@ -1,0 +1,27 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Infrastructure.Persistence;
+
+/// <summary>
+/// Write-side site stamping (R1b). Fills <see cref="ISiteScoped.SiteId"/> on
+/// newly-added entities that don't already carry one, so call sites no longer
+/// need to set it by hand.
+///
+/// Only stamps <see cref="Guid.Empty"/> — an explicitly-set SiteId is respected,
+/// never overwritten. Extracted from <c>AppDbContext.SaveChanges</c> so the loop
+/// is unit-testable against a real EF provider (the full AppDbContext model only
+/// builds on Npgsql).
+/// </summary>
+public static class SiteScopedStamp
+{
+    public static void Apply(ChangeTracker changeTracker, Guid siteId)
+    {
+        foreach (var entry in changeTracker.Entries<ISiteScoped>())
+        {
+            if (entry.State == EntityState.Added && entry.Entity.SiteId == Guid.Empty)
+                entry.Entity.SiteId = siteId;
+        }
+    }
+}

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -25,6 +25,9 @@ builder.Logging.AddTelemetryLogging(builder.Configuration, "textstack-worker");
 var connectionString = builder.Configuration.GetConnectionString("Default")
     ?? "Host=localhost;Port=5432;Database=books;Username=app;Password=changeme";
 
+builder.Services.AddSingleton<Application.Common.Interfaces.ICurrentSite>(
+    sp => new Infrastructure.Persistence.CurrentSite(sp.GetRequiredService<IConfiguration>()));
+
 builder.Services.AddDbContextFactory<AppDbContext>(options =>
     options.UseNpgsql(connectionString, o => o.UseVector())
         .UseSnakeCaseNamingConvention()

--- a/tests/TextStack.IntegrationTests/SsgRoutesEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/SsgRoutesEndpointTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Guard for the R1b SSG regression (BUG-1). The SSG worker
+/// (apps/web/scripts/ssg-worker.mjs) fetches <c>/ssg/routes</c> with only a Host
+/// header — no <c>?site=</c> query param (that dev override was removed in R1b).
+/// If SiteContextMiddleware ever stops resolving the site from the Host header for
+/// this internal consumer, the request 404s in the middleware before reaching the
+/// handler and the SSG job fails silently.
+///
+/// This reproduces the worker's exact call (Host: localhost, a seeded domain →
+/// DefaultSiteId) and asserts 200 + routes. A 404 here == the regression.
+///
+/// Deliberately does NOT use <c>IntegrationSkip.Unavailable</c>: that skips on 404,
+/// which is precisely the failure we must catch. We only skip when the live API is
+/// unreachable (not started locally — Postgres/API down).
+/// </summary>
+public class SsgRoutesEndpointTests : IClassFixture<LiveApiFixture>
+{
+    private readonly LiveApiFixture _fixture;
+
+    public SsgRoutesEndpointTests(LiveApiFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task GetSsgRoutes_WithHostHeaderOnly_ResolvesSiteAndReturnsRoutes()
+    {
+        // LiveApiFixture.TestHost == "localhost" — the same seeded domain the SSG
+        // worker resolves against (API_HOST=localhost in docker-compose).
+        var request = _fixture.CreateRequest(HttpMethod.Get, "/ssg/routes");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            Assert.Skip("live API unavailable (start the stack to run this guard)");
+            return;
+        }
+
+        // NOT 404: a 404 means the middleware failed to resolve the site from the
+        // Host header — the exact BUG-1 regression that broke the SSG pipeline.
+        Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // Routes always include the static pages (/en/, /en/books, ...) even on an
+        // empty catalog, so a resolved site yields a non-empty list.
+        var payload = await response.Content.ReadFromJsonAsync<RoutesResponse>(TestContext.Current.CancellationToken);
+        Assert.NotNull(payload);
+        Assert.NotEmpty(payload!.Routes);
+    }
+
+    private sealed record RoutesResponse(string[] Routes, int Count);
+}

--- a/tests/TextStack.UnitTests/CurrentSiteTests.cs
+++ b/tests/TextStack.UnitTests/CurrentSiteTests.cs
@@ -1,0 +1,66 @@
+using Domain;
+using Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// R1a single-site fail-fast guard. <see cref="CurrentSite"/> is the rollback-safety
+/// gate for the R1b query filter: a silent <see cref="Guid.Empty"/> would make every
+/// site-scoped query match zero rows, so construction MUST crash instead.
+/// </summary>
+public class CurrentSiteTests
+{
+    private static IConfiguration Config(params (string key, string? value)[] pairs)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(pairs.Select(p => new KeyValuePair<string, string?>(p.key, p.value)))
+            .Build();
+
+    [Fact]
+    public void Resolve_NoConfig_UsesDefaultSiteId()
+    {
+        var site = new CurrentSite(Config());
+        Assert.Equal(SiteConstants.DefaultSiteId, site.Id);
+    }
+
+    [Fact]
+    public void Resolve_BlankSiteId_UsesDefaultSiteId()
+    {
+        var site = new CurrentSite(Config(("Site:Id", "   ")));
+        Assert.Equal(SiteConstants.DefaultSiteId, site.Id);
+    }
+
+    [Fact]
+    public void Resolve_ValidOverride_UsesOverride()
+    {
+        var overrideId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var site = new CurrentSite(Config(("Site:Id", overrideId.ToString())));
+        Assert.Equal(overrideId, site.Id);
+    }
+
+    [Fact]
+    public void Resolve_GarbageSiteId_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => new CurrentSite(Config(("Site:Id", "not-a-guid"))));
+        Assert.Contains("Site:Id", ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_EmptyGuidConfig_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => new CurrentSite(Config(("Site:Id", Guid.Empty.ToString()))));
+    }
+
+    [Fact]
+    public void Ctor_EmptyGuid_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => new CurrentSite(Guid.Empty));
+    }
+
+    [Fact]
+    public void Ctor_ValidGuid_SetsId()
+    {
+        Assert.Equal(SiteConstants.DefaultSiteId, new CurrentSite(SiteConstants.DefaultSiteId).Id);
+    }
+}

--- a/tests/TextStack.UnitTests/SiteScopedIsolationTests.cs
+++ b/tests/TextStack.UnitTests/SiteScopedIsolationTests.cs
@@ -1,0 +1,147 @@
+using Application.Common.Interfaces;
+using Domain.Entities;
+using Infrastructure.Persistence;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// R1b site isolation. The full AppDbContext model only builds on Npgsql (tsvector,
+/// pgvector, jsonb), so we exercise the R1b mechanism — the real
+/// <see cref="ISiteScoped"/> interface, the real <see cref="SiteScopedStamp.Apply"/>
+/// production stamping method, and the identical per-instance query-filter lambda —
+/// against a real Sqlite provider on a minimal context.
+///
+/// Proves: (a) filtered reads see only the context's site, (b) IgnoreQueryFilters
+/// bypasses the filter, (c) inserting an ISiteScoped row with no SiteId write-stamps
+/// the current site (and an explicit SiteId is respected).
+/// </summary>
+public class SiteScopedIsolationTests
+{
+    private static readonly Guid SiteA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid SiteB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    // Minimal ISiteScoped entity — uses the real Domain interface, no Postgres types.
+    private sealed class Widget : ISiteScoped
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public Guid SiteId { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    // Minimal context mirroring AppDbContext's R1b wiring: an instance-referenced
+    // site query filter + SaveChanges delegating to the real SiteScopedStamp.Apply.
+    private sealed class TestContext : DbContext
+    {
+        private readonly ICurrentSite _currentSite;
+        public TestContext(DbContextOptions<TestContext> options, ICurrentSite currentSite) : base(options)
+            => _currentSite = currentSite;
+
+        public DbSet<Widget> Widgets => Set<Widget>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Widget>().HasQueryFilter(x => x.SiteId == _currentSite.Id);
+
+        public override int SaveChanges(bool acceptAllChangesOnSuccess)
+        {
+            SiteScopedStamp.Apply(ChangeTracker, _currentSite.Id);
+            return base.SaveChanges(acceptAllChangesOnSuccess);
+        }
+    }
+
+    private static (SqliteConnection conn, DbContextOptions<TestContext> options) NewDb()
+    {
+        var conn = new SqliteConnection("Filename=:memory:");
+        conn.Open();
+        var options = new DbContextOptionsBuilder<TestContext>().UseSqlite(conn).Options;
+        return (conn, options);
+    }
+
+    private static TestContext Ctx(DbContextOptions<TestContext> options, Guid siteId)
+        => new(options, new CurrentSite(siteId));
+
+    [Fact]
+    public void QueryFilter_TwoSitesOneDb_SeesOnlyCurrentSite()
+    {
+        var (conn, options) = NewDb();
+        try
+        {
+            using (var init = Ctx(options, SiteA)) init.Database.EnsureCreated();
+
+            // Seed both sites through their own contexts (write-stamped, no explicit SiteId).
+            using (var a = Ctx(options, SiteA))
+            {
+                a.Widgets.Add(new Widget { Name = "a1" });
+                a.Widgets.Add(new Widget { Name = "a2" });
+                a.SaveChanges();
+            }
+            using (var b = Ctx(options, SiteB))
+            {
+                b.Widgets.Add(new Widget { Name = "b1" });
+                b.SaveChanges();
+            }
+
+            // (a) filtered read from a fresh site-A context sees only site A.
+            using var queryA = Ctx(options, SiteA);
+            var aRows = queryA.Widgets.AsNoTracking().ToList();
+            Assert.Equal(2, aRows.Count);
+            Assert.All(aRows, w => Assert.Equal(SiteA, w.SiteId));
+
+            // A fresh site-B context (same DB, same model) sees only site B — proves the
+            // filter re-evaluates per instance rather than baking one site into the model.
+            using var queryB = Ctx(options, SiteB);
+            var bRows = queryB.Widgets.AsNoTracking().ToList();
+            Assert.Single(bRows);
+            Assert.Equal(SiteB, bRows[0].SiteId);
+
+            // (b) IgnoreQueryFilters sees everything.
+            Assert.Equal(3, queryA.Widgets.AsNoTracking().IgnoreQueryFilters().Count());
+        }
+        finally { conn.Dispose(); }
+    }
+
+    [Fact]
+    public void WriteStamp_InsertWithoutSiteId_GetsCurrentSite()
+    {
+        var (conn, options) = NewDb();
+        try
+        {
+            using (var init = Ctx(options, SiteA)) init.Database.EnsureCreated();
+
+            using var a = Ctx(options, SiteA);
+            var w = new Widget { Name = "no-site" };
+            a.Widgets.Add(w);
+            a.SaveChanges();
+
+            // (c) write-stamping filled the empty SiteId with the current site.
+            Assert.Equal(SiteA, w.SiteId);
+        }
+        finally { conn.Dispose(); }
+    }
+
+    [Fact]
+    public void WriteStamp_InsertWithExplicitSiteId_IsRespected()
+    {
+        var (conn, options) = NewDb();
+        try
+        {
+            using (var init = Ctx(options, SiteA)) init.Database.EnsureCreated();
+
+            // Insert an explicit foreign SiteId through a site-A context: stamping must
+            // NOT overwrite it, and the row is then invisible to site-A's filter.
+            using (var a = Ctx(options, SiteA))
+            {
+                a.Widgets.Add(new Widget { Name = "explicit-b", SiteId = SiteB });
+                a.SaveChanges();
+            }
+
+            using var queryA = Ctx(options, SiteA);
+            Assert.Empty(queryA.Widgets.AsNoTracking().ToList());
+            var all = queryA.Widgets.AsNoTracking().IgnoreQueryFilters().ToList();
+            Assert.Single(all);
+            Assert.Equal(SiteB, all[0].SiteId);
+        }
+        finally { conn.Dispose(); }
+    }
+}

--- a/tests/TextStack.UnitTests/TextStack.UnitTests.csproj
+++ b/tests/TextStack.UnitTests/TextStack.UnitTests.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
## What & why

TextStack is single-site **permanently** (ADR-007). `SiteId` was a degenerate constant manually filtered in ~108 EF queries and hardcoded as a GUID literal in places. This neutralizes its manual-filtering cost via an **EF global query filter** and centralizes the site id — keeping the column (no risky 22-table removal migration) while closing the "forgot to filter → cross-tenant leak" hole.

Two slices of the R1 chain (R1c — removing the now-redundant manual `.Where(SiteId==)` — is a **follow-up PR**, intentionally deferred until this PR's filters are proven green in CI).

### R1a — `ICurrentSite` + kill hardcode (`f8eaf86e`)
- New `SiteConstants.DefaultSiteId` — single source of the canonical GUID.
- New `ICurrentSite` (singleton; config `Site:Id`, hard-default `DefaultSiteId`, **fail-fast on empty/invalid**), injected into `AppDbContext` ctor + design-time factory. Resolves identically in API (scoped `AddDbContext`) and Worker (`AddDbContextFactory`).
- Removed hardcoded `GeneralSiteId` from `AdminAutoPublishEndpoints`.
- Strictly behavior-preserving. 993 unit tests green.

### R1b — global query filters + write-stamping (`6b90d515`)
- `HasQueryFilter(e => e.SiteId == ICurrentSite.Id)` on **21 of 22** `ISiteScoped` entities. `SiteDomain` **excluded** — `SiteResolver` reads it to *discover* the site (chicken/egg).
- `SaveChanges/SaveChangesAsync` override stamps `SiteId` on Added `ISiteScoped` entities when empty (explicit values respected).
- Removed dev `?site=` override; fixed its only internal consumer (`ssg-worker.mjs` now sends a resolvable `Host` header) + added a guard integration test.
- Dapper/raw-SQL paths (search, RAG, similar-books) untouched — they still filter `SiteId` by hand (query filter doesn't cover them).
- 996 unit tests + a 3-fact Sqlite isolation test (per-instance filter re-eval, `IgnoreQueryFilters`, write-stamp). **No schema migration** (query-config).

## CI gate (must be green before merge)
The Sqlite unit test can't build the real 21-filter Npgsql model — the integration suite proves the actual wiring reads correctly. Watch especially:
`SearchEndpointTests`, `HybridCatalogSearchTests`, `SimilarBooksTests`, `BookIndexEndpointTests`, `HighlightsEndpointTests`, `BookStatsEndpointTests`, `Vocabulary{Practice,Spiral,AntiSpiral,Concepts,Embedding}Tests`, `UserBookEndpointTests`, `StudyBuddyEndpointTests`, `AskEndpointTests`, `AdminAgentRunsEndpointTests`, and the new `SsgRoutesEndpointTests` (host-less `/ssg/routes` regression guard).

## Rollback
- Each slice is one revert; **R1b (`6b90d515`) is the only behavioral commit** — reverting it restores pre-filter reads instantly (R1a can stay, harmless).
- Biggest failure mode: misconfigured `Site:Id` → filter returns 0 rows silently. Guarded by fail-fast on empty + canonical GUID default.

## Pre-deploy check
Run `SELECT DISTINCT site_id FROM <each scoped table>` on prod — confirm all rows = `11111111-1111-1111-1111-111111111111`. Any stray site row becomes invisible under the filter (seeds/merges all converge on this GUID, so expected clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
