### PR TITLE
refactor(site): drop redundant manual SiteId filters + metamodel guard (R1c)

### DIFF
--- a/backend/src/Api/Endpoints/AdminAuthorsEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminAuthorsEndpoints.cs
@@ -62,7 +62,7 @@ public static class AdminAuthorsEndpoints
         if (siteId is null)
             return Results.BadRequest(new { error = "siteId is required" });
 
-        var authors = db.Authors.Where(a => a.SiteId == siteId.Value);
+        var authors = db.Authors.AsQueryable();
 
         var total = await authors.CountAsync(ct);
 
@@ -92,8 +92,7 @@ public static class AdminAuthorsEndpoints
 
         var take = Math.Min(limit ?? 10, 20);
 
-        var query = db.Authors
-            .Where(a => a.SiteId == siteId.Value);
+        var query = db.Authors.AsQueryable();
 
         if (!string.IsNullOrWhiteSpace(q))
         {
@@ -126,7 +125,7 @@ public static class AdminAuthorsEndpoints
 
         // Check for existing author with exact name (case-insensitive)
         var existing = await db.Authors
-            .FirstOrDefaultAsync(a => a.SiteId == req.SiteId && a.Name.ToLower() == trimmedName.ToLower(), ct);
+            .FirstOrDefaultAsync(a => a.Name.ToLower() == trimmedName.ToLower(), ct);
 
         if (existing is not null)
         {
@@ -138,7 +137,7 @@ public static class AdminAuthorsEndpoints
         var slug = baseSlug;
         var suffix = 2;
 
-        while (await db.Authors.AnyAsync(a => a.SiteId == req.SiteId && a.Slug == slug, ct))
+        while (await db.Authors.AnyAsync(a => a.Slug == slug, ct))
         {
             slug = $"{baseSlug}-{suffix}";
             suffix++;
@@ -180,7 +179,7 @@ public static class AdminAuthorsEndpoints
         var skip = offset ?? 0;
         var take = Math.Min(limit ?? 20, 100);
 
-        var query = db.Authors.Where(a => a.SiteId == siteId.Value);
+        var query = db.Authors.AsQueryable();
 
         if (!string.IsNullOrWhiteSpace(search))
             query = query.Where(a => EF.Functions.ILike(a.Name, $"%{search}%"));
@@ -304,7 +303,7 @@ public static class AdminAuthorsEndpoints
 
         // Check for duplicate name (case-insensitive, exclude current author)
         var duplicate = await db.Authors
-            .AnyAsync(a => a.SiteId == author.SiteId && a.Id != id && a.Name.ToLower() == trimmedName.ToLower(), ct);
+            .AnyAsync(a => a.Id != id && a.Name.ToLower() == trimmedName.ToLower(), ct);
         if (duplicate)
             return Results.BadRequest(new { error = "An author with this name already exists" });
 
@@ -314,7 +313,7 @@ public static class AdminAuthorsEndpoints
             var baseSlug = SlugGenerator.GenerateSlug(trimmedName);
             var slug = baseSlug;
             var suffix = 2;
-            while (await db.Authors.AnyAsync(a => a.SiteId == author.SiteId && a.Id != id && a.Slug == slug, ct))
+            while (await db.Authors.AnyAsync(a => a.Id != id && a.Slug == slug, ct))
             {
                 slug = $"{baseSlug}-{suffix}";
                 suffix++;

--- a/backend/src/Api/Endpoints/AdminGenresEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminGenresEndpoints.cs
@@ -52,7 +52,7 @@ public static class AdminGenresEndpoints
         if (siteId is null)
             return Results.BadRequest(new { error = "siteId is required" });
 
-        var genres = db.Genres.Where(g => g.SiteId == siteId.Value);
+        var genres = db.Genres.AsQueryable();
 
         var total = await genres.CountAsync(ct);
 
@@ -82,8 +82,7 @@ public static class AdminGenresEndpoints
 
         var take = Math.Min(limit ?? 10, 20);
 
-        var query = db.Genres
-            .Where(g => g.SiteId == siteId.Value);
+        var query = db.Genres.AsQueryable();
 
         if (!string.IsNullOrWhiteSpace(q))
         {
@@ -116,7 +115,7 @@ public static class AdminGenresEndpoints
 
         // Check for existing genre with exact name (case-insensitive)
         var existing = await db.Genres
-            .FirstOrDefaultAsync(g => g.SiteId == req.SiteId && g.Name.ToLower() == trimmedName.ToLower(), ct);
+            .FirstOrDefaultAsync(g => g.Name.ToLower() == trimmedName.ToLower(), ct);
 
         if (existing is not null)
         {
@@ -128,7 +127,7 @@ public static class AdminGenresEndpoints
         var slug = baseSlug;
         var suffix = 2;
 
-        while (await db.Genres.AnyAsync(g => g.SiteId == req.SiteId && g.Slug == slug, ct))
+        while (await db.Genres.AnyAsync(g => g.Slug == slug, ct))
         {
             slug = $"{baseSlug}-{suffix}";
             suffix++;
@@ -168,7 +167,7 @@ public static class AdminGenresEndpoints
         var skip = offset ?? 0;
         var take = Math.Min(limit ?? 20, 100);
 
-        var query = db.Genres.Where(g => g.SiteId == siteId.Value);
+        var query = db.Genres.AsQueryable();
 
         if (!string.IsNullOrWhiteSpace(search))
             query = query.Where(g => EF.Functions.ILike(g.Name, $"%{search}%")
@@ -261,7 +260,7 @@ public static class AdminGenresEndpoints
 
         // Check for duplicate name (case-insensitive, exclude current genre)
         var duplicate = await db.Genres
-            .AnyAsync(g => g.SiteId == genre.SiteId && g.Id != id && g.Name.ToLower() == trimmedName.ToLower(), ct);
+            .AnyAsync(g => g.Id != id && g.Name.ToLower() == trimmedName.ToLower(), ct);
         if (duplicate)
             return Results.BadRequest(new { error = "A genre with this name already exists" });
 
@@ -271,7 +270,7 @@ public static class AdminGenresEndpoints
             var baseSlug = SlugGenerator.GenerateSlug(trimmedName);
             var slug = baseSlug;
             var suffix = 2;
-            while (await db.Genres.AnyAsync(g => g.SiteId == genre.SiteId && g.Id != id && g.Slug == slug, ct))
+            while (await db.Genres.AnyAsync(g => g.Id != id && g.Slug == slug, ct))
             {
                 slug = $"{baseSlug}-{suffix}";
                 suffix++;

--- a/backend/src/Api/Endpoints/AskEndpoints.cs
+++ b/backend/src/Api/Endpoints/AskEndpoints.cs
@@ -45,7 +45,7 @@ public static class AskEndpoints
 
         var siteId = httpContext.GetSiteId();
 
-        var editionExists = await db.Editions.AnyAsync(e => e.Id == editionId && e.SiteId == siteId, ct);
+        var editionExists = await db.Editions.AnyAsync(e => e.Id == editionId, ct);
         if (!editionExists) return Results.NotFound("Edition not found");
 
         // RagAskService construction pulls in the embedder, which throws without an OpenAI key —

--- a/backend/src/Api/Endpoints/BookIndexEndpoints.cs
+++ b/backend/src/Api/Endpoints/BookIndexEndpoints.cs
@@ -44,12 +44,11 @@ public static class BookIndexEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
 
         // Validate the edition exists + belongs to this site (mirror AskEndpoints). Read the prior
         // status to drive the (pure, tested) claim decision; the actual transition is still atomic.
         var prior = await db.Editions
-            .Where(e => e.Id == editionId && e.SiteId == siteId)
+            .Where(e => e.Id == editionId)
             .Select(e => (RagIndexStatus?)e.RagStatus)
             .FirstOrDefaultAsync(ct);
         if (prior is null) return Results.NotFound("Edition not found");
@@ -117,8 +116,7 @@ public static class BookIndexEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
-        var exists = await db.Editions.AnyAsync(e => e.Id == editionId && e.SiteId == siteId, ct);
+        var exists = await db.Editions.AnyAsync(e => e.Id == editionId, ct);
         if (!exists) return Results.NotFound("Edition not found");
 
         var status = await ReadStatusAsync(db, editionId, ct);

--- a/backend/src/Api/Endpoints/GenresEndpoints.cs
+++ b/backend/src/Api/Endpoints/GenresEndpoints.cs
@@ -24,12 +24,11 @@ public static class GenresEndpoints
         [FromQuery] string? language,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
         var take = Math.Min(limit ?? 50, 100);
         var skip = offset ?? 0;
 
         var query = db.Genres
-            .Where(g => g.SiteId == siteId && g.Indexable)
+            .Where(g => g.Indexable)
             .AsQueryable();
 
         // Filter to genres with published editions (optionally in a specific language)
@@ -62,10 +61,9 @@ public static class GenresEndpoints
         string slug,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
 
         var genre = await db.Genres
-            .Where(g => g.SiteId == siteId && g.Slug == slug)
+            .Where(g => g.Slug == slug)
             .Select(g => new GenreDetailDto(
                 g.Id,
                 g.Slug,

--- a/backend/src/Api/Endpoints/HighlightsEndpoints.cs
+++ b/backend/src/Api/Endpoints/HighlightsEndpoints.cs
@@ -34,10 +34,9 @@ public static class HighlightsEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
 
         var highlights = await db.Highlights
-            .Where(h => h.UserId == userId.Value && h.SiteId == siteId && h.EditionId == editionId)
+            .Where(h => h.UserId == userId.Value && h.EditionId == editionId)
             .OrderByDescending(h => h.CreatedAt)
             .Select(h => new HighlightDto(
                 h.Id, h.EditionId, h.ChapterId, h.UserBookId, h.UserChapterId,
@@ -59,13 +58,12 @@ public static class HighlightsEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
 
         var owns = await db.UserBooks.AnyAsync(b => b.Id == userBookId && b.UserId == userId.Value, ct);
         if (!owns) return Results.NotFound();
 
         var highlights = await db.Highlights
-            .Where(h => h.UserId == userId.Value && h.SiteId == siteId && h.UserBookId == userBookId)
+            .Where(h => h.UserId == userId.Value && h.UserBookId == userBookId)
             .OrderByDescending(h => h.CreatedAt)
             .Select(h => new HighlightDto(
                 h.Id, h.EditionId, h.ChapterId, h.UserBookId, h.UserChapterId,
@@ -92,11 +90,10 @@ public static class HighlightsEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
         limit = Math.Clamp(limit, 1, 100);
 
         var query = db.Highlights
-            .Where(h => h.UserId == userId.Value && h.SiteId == siteId);
+            .Where(h => h.UserId == userId.Value);
 
         if (bookType == "edition")
             query = query.Where(h => h.EditionId != null);
@@ -153,14 +150,12 @@ public static class HighlightsEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
         limit = Math.Clamp(limit, 1, 30);
 
         var cutoff = DateTimeOffset.UtcNow.AddHours(-24);
 
         var highlights = await db.Highlights
-            .Where(h => h.UserId == userId.Value && h.SiteId == siteId
-                && (h.LastReviewedAt == null || h.LastReviewedAt < cutoff))
+            .Where(h => h.UserId == userId.Value && (h.LastReviewedAt == null || h.LastReviewedAt < cutoff))
             .OrderBy(h => h.LastReviewedAt ?? DateTimeOffset.MinValue)
             .ThenBy(h => h.CreatedAt)
             .Take(limit)
@@ -226,7 +221,7 @@ public static class HighlightsEndpoints
             var editionId = request.EditionId!.Value;
             var chapterId = request.ChapterId!.Value;
             var edition = await db.Editions
-                .Where(e => e.Id == editionId && e.SiteId == siteId)
+                .Where(e => e.Id == editionId)
                 .FirstOrDefaultAsync(ct);
             if (edition == null) return Results.NotFound("Edition not found");
 

--- a/backend/src/Api/Endpoints/PodcastEndpoints.cs
+++ b/backend/src/Api/Endpoints/PodcastEndpoints.cs
@@ -94,11 +94,10 @@ public static class PodcastEndpoints
         IAppDbContext db,
         CancellationToken ct)
     {
-        var siteId = httpContext.GetSiteId();
         var language = httpContext.GetLanguage();
 
         var edition = await db.Editions.FirstOrDefaultAsync(
-            e => e.SiteId == siteId && e.Slug == slug && e.Language == language && e.Status == EditionStatus.Published, ct);
+            e => e.Slug == slug && e.Language == language && e.Status == EditionStatus.Published, ct);
         if (edition is null)
             return Results.NotFound();
 

--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
@@ -54,7 +54,7 @@ public static class ReadingTrackingEndpoints
         var yearStart = new DateTimeOffset(todayLocal.Year, 1, 1, 0, 0, 0, tzOffset).ToUniversalTime();
 
         var monthAgg = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId && s.StartedAt >= monthStart)
+            .Where(s => s.UserId == userId.Value && s.StartedAt >= monthStart)
             .GroupBy(_ => 1)
             .Select(g => new { Words = g.Sum(s => (long)s.WordsRead), Seconds = g.Sum(s => (long)s.DurationSeconds) })
             .FirstOrDefaultAsync(ct);
@@ -66,17 +66,17 @@ public static class ReadingTrackingEndpoints
         var currentStreak = await CalculateStreak(db, userId.Value, siteId, streakMinMinutes, now, ct, tzOffset);
 
         var booksFinishedYtd = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId && s.EndPercent >= 0.99 && s.EndedAt >= yearStart)
+            .Where(s => s.UserId == userId.Value && s.EndPercent >= 0.99 && s.EndedAt >= yearStart)
             .Select(s => s.EditionId ?? s.UserBookId)
             .Distinct()
             .CountAsync(ct);
 
         var dailyGoal = await db.ReadingGoals
-            .Where(g => g.UserId == userId.Value && g.SiteId == siteId && g.GoalType == "daily_minutes" && g.IsActive)
+            .Where(g => g.UserId == userId.Value && g.GoalType == "daily_minutes" && g.IsActive)
             .Select(g => new { g.TargetValue, g.StreakMinMinutes })
             .FirstOrDefaultAsync(ct);
         var yearlyGoal = await db.ReadingGoals
-            .Where(g => g.UserId == userId.Value && g.SiteId == siteId && g.GoalType == "books_per_year" && g.IsActive)
+            .Where(g => g.UserId == userId.Value && g.GoalType == "books_per_year" && g.IsActive)
             .Select(g => new { g.TargetValue, g.Year })
             .FirstOrDefaultAsync(ct);
 
@@ -85,7 +85,7 @@ public static class ReadingTrackingEndpoints
         {
             var todayStart = todayLocal.ToUniversalTime();
             var todaySeconds = await db.ReadingSessions
-                .Where(s => s.UserId == userId.Value && s.SiteId == siteId && s.StartedAt >= todayStart)
+                .Where(s => s.UserId == userId.Value && s.StartedAt >= todayStart)
                 .SumAsync(s => (long)s.DurationSeconds, ct);
             goal = new GoalSummaryDto("daily_minutes", (int)(todaySeconds / 60), dailyGoal.TargetValue);
         }
@@ -128,7 +128,7 @@ public static class ReadingTrackingEndpoints
             return Results.Ok(cached);
 
         var agg = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId && s.WordsRead > 0 && s.DurationSeconds > 0)
+            .Where(s => s.UserId == userId.Value && s.WordsRead > 0 && s.DurationSeconds > 0)
             .GroupBy(_ => 1)
             .Select(g => new { Sessions = g.Count(), Words = g.Sum(s => (long)s.WordsRead), Seconds = g.Sum(s => (long)s.DurationSeconds) })
             .FirstOrDefaultAsync(ct);
@@ -253,10 +253,9 @@ public static class ReadingTrackingEndpoints
     {
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
-        var siteId = httpContext.GetSiteId();
 
         var query = db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId);
+            .Where(s => s.UserId == userId.Value);
 
         if (from.HasValue) query = query.Where(s => s.StartedAt >= from.Value);
         if (to.HasValue) query = query.Where(s => s.StartedAt <= to.Value);
@@ -290,7 +289,7 @@ public static class ReadingTrackingEndpoints
         var now = DateTimeOffset.UtcNow;
 
         var allSessions = db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId);
+            .Where(s => s.UserId == userId.Value);
 
         var totalSeconds = await allSessions.SumAsync(s => (long)s.DurationSeconds, ct);
         var totalWords = await allSessions.SumAsync(s => (long)s.WordsRead, ct);
@@ -341,13 +340,12 @@ public static class ReadingTrackingEndpoints
 
         // Vocab reviews today
         var todayVocabReviews = await db.VocabularyReviews
-            .Where(r => r.UserId == userId.Value && r.SiteId == siteId && r.CreatedAt >= todayStart)
+            .Where(r => r.UserId == userId.Value && r.CreatedAt >= todayStart)
             .CountAsync(ct);
 
         // Daily goal (reading + vocab reviews as effective minutes)
         var dailyGoal = await db.ReadingGoals
-            .Where(g => g.UserId == userId.Value && g.SiteId == siteId
-                && g.GoalType == "daily_minutes" && g.IsActive)
+            .Where(g => g.UserId == userId.Value && g.GoalType == "daily_minutes" && g.IsActive)
             .FirstOrDefaultAsync(ct);
 
         object? dailyGoalObj = null;
@@ -391,7 +389,6 @@ public static class ReadingTrackingEndpoints
     {
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
-        var siteId = httpContext.GetSiteId();
 
         var tzOffset = ParseTzOffset(tz);
         var now = DateTimeOffset.UtcNow;
@@ -400,8 +397,7 @@ public static class ReadingTrackingEndpoints
 
         // Get raw sessions in range
         var sessions = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId
-                && s.StartedAt >= start && s.StartedAt <= end)
+            .Where(s => s.UserId == userId.Value && s.StartedAt >= start && s.StartedAt <= end)
             .Select(s => new { s.StartedAt, s.DurationSeconds, s.WordsRead })
             .ToListAsync(ct);
 
@@ -429,10 +425,9 @@ public static class ReadingTrackingEndpoints
     {
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
-        var siteId = httpContext.GetSiteId();
 
         var goals = await db.ReadingGoals
-            .Where(g => g.UserId == userId.Value && g.SiteId == siteId && g.IsActive)
+            .Where(g => g.UserId == userId.Value && g.IsActive)
             .Select(g => new GoalDto(g.Id, g.GoalType, g.TargetValue, g.Year, g.StreakMinMinutes, g.UpdatedAt))
             .ToListAsync(ct);
 
@@ -456,8 +451,7 @@ public static class ReadingTrackingEndpoints
             return Results.BadRequest("TargetValue must be positive");
 
         var existing = await db.ReadingGoals
-            .FirstOrDefaultAsync(g => g.UserId == userId.Value && g.SiteId == siteId
-                && g.GoalType == request.GoalType, ct);
+            .FirstOrDefaultAsync(g => g.UserId == userId.Value && g.GoalType == request.GoalType, ct);
 
         if (existing != null)
         {
@@ -522,10 +516,9 @@ public static class ReadingTrackingEndpoints
     {
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
-        var siteId = httpContext.GetSiteId();
 
         var unlocked = await db.UserAchievements
-            .Where(a => a.UserId == userId.Value && a.SiteId == siteId)
+            .Where(a => a.UserId == userId.Value)
             .Select(a => new AchievementDto(a.AchievementCode, a.UnlockedAt))
             .ToListAsync(ct);
 
@@ -543,18 +536,17 @@ public static class ReadingTrackingEndpoints
     {
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
-        var siteId = httpContext.GetSiteId();
 
         // 1. Find finished editions: first session where EndPercent >= 0.99 per edition
         var finishEvents = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId && s.EditionId != null && s.EndPercent >= 0.99)
+            .Where(s => s.UserId == userId.Value && s.EditionId != null && s.EndPercent >= 0.99)
             .GroupBy(s => s.EditionId!.Value)
             .Select(g => new { EditionId = g.Key, FinishedAt = g.Min(s => s.EndedAt) })
             .ToListAsync(ct);
 
         // Also find finished user books (with metadata for breakdowns)
         var userBookFinishEvents = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId && s.UserBookId != null && s.EndPercent >= 0.99)
+            .Where(s => s.UserId == userId.Value && s.UserBookId != null && s.EndPercent >= 0.99)
             .GroupBy(s => s.UserBookId!.Value)
             .Select(g => new { UserBookId = g.Key, FinishedAt = g.Min(s => s.EndedAt) })
             .ToListAsync(ct);
@@ -605,7 +597,7 @@ public static class ReadingTrackingEndpoints
 
         // 4. First session per edition (for avg days to finish)
         var firstSessions = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId && s.EditionId != null && editionIds.Contains(s.EditionId!.Value))
+            .Where(s => s.UserId == userId.Value && s.EditionId != null && editionIds.Contains(s.EditionId!.Value))
             .GroupBy(s => s.EditionId!.Value)
             .Select(g => new { EditionId = g.Key, FirstStarted = g.Min(s => s.StartedAt) })
             .ToListAsync(ct);
@@ -613,7 +605,7 @@ public static class ReadingTrackingEndpoints
 
         // 5. Reading time per edition (for pace + time-by-genre/author)
         var sessionsByEdition = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.SiteId == siteId && s.EditionId != null && editionIds.Contains(s.EditionId!.Value))
+            .Where(s => s.UserId == userId.Value && s.EditionId != null && editionIds.Contains(s.EditionId!.Value))
             .GroupBy(s => s.EditionId!.Value)
             .Select(g => new { EditionId = g.Key, TotalSeconds = g.Sum(s => s.DurationSeconds), TotalWords = g.Sum(s => s.WordsRead) })
             .ToListAsync(ct);
@@ -758,7 +750,7 @@ public static class ReadingTrackingEndpoints
     internal static async Task<int> GetStreakMinMinutes(IAppDbContext db, Guid userId, Guid siteId, CancellationToken ct)
     {
         var goal = await db.ReadingGoals
-            .Where(g => g.UserId == userId && g.SiteId == siteId && g.GoalType == "daily_minutes" && g.IsActive)
+            .Where(g => g.UserId == userId && g.GoalType == "daily_minutes" && g.IsActive)
             .Select(g => (int?)g.StreakMinMinutes)
             .FirstOrDefaultAsync(ct);
         return goal ?? 5;
@@ -771,7 +763,7 @@ public static class ReadingTrackingEndpoints
         DateTimeOffset since, TimeSpan tzOffset, CancellationToken ct)
     {
         var sessions = await db.ReadingSessions
-            .Where(s => s.UserId == userId && s.SiteId == siteId && s.StartedAt >= since)
+            .Where(s => s.UserId == userId && s.StartedAt >= since)
             .Select(s => new { s.StartedAt, s.DurationSeconds })
             .ToListAsync(ct);
 
@@ -780,7 +772,7 @@ public static class ReadingTrackingEndpoints
             .ToDictionary(g => g.Key, g => g.Sum(s => s.DurationSeconds));
 
         var reviews = await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.SiteId == siteId && r.CreatedAt >= since)
+            .Where(r => r.UserId == userId && r.CreatedAt >= since)
             .Select(r => r.CreatedAt)
             .ToListAsync(ct);
 

--- a/backend/src/Api/Endpoints/SeoEndpoints.cs
+++ b/backend/src/Api/Endpoints/SeoEndpoints.cs
@@ -133,7 +133,7 @@ public static class SeoEndpoints
 
         // Only include authors who have at least one published book
         var authors = await db.Authors
-            .Where(a => a.SiteId == site.SiteId && a.Indexable)
+            .Where(a => a.Indexable)
             .Where(a => a.EditionAuthors.Any(ea =>
                 ea.Edition.Status == EditionStatus.Published &&
                 ea.Edition.Indexable))
@@ -172,7 +172,7 @@ public static class SeoEndpoints
 
         // Only include genres that have at least one published book
         var genres = await db.Genres
-            .Where(g => g.SiteId == site.SiteId && g.Indexable)
+            .Where(g => g.Indexable)
             .Where(g => g.Editions.Any(e =>
                 e.Status == EditionStatus.Published &&
                 e.Indexable))

--- a/backend/src/Api/Endpoints/SsgEndpoints.cs
+++ b/backend/src/Api/Endpoints/SsgEndpoints.cs
@@ -49,8 +49,7 @@ public static class SsgEndpoints
         // would leave nginx serving a hard 404 — see the matching change
         // in SsgRouteProvider.AddBookRoutesAsync.
         var books = await db.Editions
-            .Where(e => e.SiteId == site.SiteId &&
-                        e.Status == EditionStatus.Published &&
+            .Where(e => e.Status == EditionStatus.Published &&
                         e.Chapters.Any())
             .Select(e => new { e.Slug, e.Language })
             .ToListAsync(ct);
@@ -74,7 +73,7 @@ public static class SsgEndpoints
         // Primary signal is "has at least one Published+Indexable edition" —
         // that's why orphan-author-from-non-indexable-book is impossible.
         var authors = await db.Authors
-            .Where(a => a.SiteId == site.SiteId && a.Indexable)
+            .Where(a => a.Indexable)
             .Where(a => a.EditionAuthors.Any(ea =>
                 ea.Edition.Status == EditionStatus.Published &&
                 ea.Edition.Indexable))
@@ -88,7 +87,7 @@ public static class SsgEndpoints
 
         // Genres (use default language)
         var genres = await db.Genres
-            .Where(g => g.SiteId == site.SiteId && g.Indexable)
+            .Where(g => g.Indexable)
             .Where(g => g.Editions.Any(e =>
                 e.Status == EditionStatus.Published &&
                 e.Indexable))
@@ -111,8 +110,7 @@ public static class SsgEndpoints
         var site = httpContext.GetSiteContext();
 
         var books = await db.Editions
-            .Where(e => e.SiteId == site.SiteId &&
-                        e.Status == EditionStatus.Published &&
+            .Where(e => e.Status == EditionStatus.Published &&
                         e.Indexable &&
                         e.Chapters.Any())
             .OrderBy(e => e.Title)
@@ -130,7 +128,7 @@ public static class SsgEndpoints
         var site = httpContext.GetSiteContext();
 
         var authors = await db.Authors
-            .Where(a => a.SiteId == site.SiteId && a.Indexable)
+            .Where(a => a.Indexable)
             .Where(a => a.EditionAuthors.Any(ea =>
                 ea.Edition.Status == EditionStatus.Published &&
                 ea.Edition.Indexable))
@@ -149,7 +147,7 @@ public static class SsgEndpoints
         var site = httpContext.GetSiteContext();
 
         var genres = await db.Genres
-            .Where(g => g.SiteId == site.SiteId && g.Indexable)
+            .Where(g => g.Indexable)
             .Where(g => g.Editions.Any(e =>
                 e.Status == EditionStatus.Published &&
                 e.Indexable))

--- a/backend/src/Api/Endpoints/StudyBuddyEndpoints.cs
+++ b/backend/src/Api/Endpoints/StudyBuddyEndpoints.cs
@@ -53,8 +53,7 @@ public static class StudyBuddyEndpoints
         if (request.Passage.Length > MaxPassageLength)
             return Results.BadRequest(new { error = $"Passage exceeds {MaxPassageLength} chars." });
 
-        var siteId = httpContext.GetSiteId();
-        var editionExists = await db.Editions.AnyAsync(e => e.Id == editionId && e.SiteId == siteId, ct);
+        var editionExists = await db.Editions.AnyAsync(e => e.Id == editionId, ct);
         if (!editionExists) return Results.NotFound("Edition not found");
 
         // Cloudflare/nginx must not buffer the stream (same Phase 5 risk as Explain SSE).

--- a/backend/src/Api/Endpoints/UserDataEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserDataEndpoints.cs
@@ -45,10 +45,9 @@ public static class UserDataEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
 
         var query = db.ReadingProgresses
-            .Where(p => p.UserId == userId.Value && p.SiteId == siteId)
+            .Where(p => p.UserId == userId.Value)
             .OrderByDescending(p => p.UpdatedAt);
 
         var total = await query.CountAsync(ct);
@@ -79,10 +78,9 @@ public static class UserDataEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
 
         var progress = await db.ReadingProgresses
-            .Where(p => p.UserId == userId.Value && p.SiteId == siteId && p.EditionId == editionId)
+            .Where(p => p.UserId == userId.Value && p.EditionId == editionId)
             .Join(db.Chapters, p => p.ChapterId, c => c.Id, (p, c) => new { p, c })
             .Select(x => new ReadingProgressDto(
                 x.p.EditionId,
@@ -112,7 +110,7 @@ public static class UserDataEndpoints
 
         // Validate edition exists
         var edition = await db.Editions
-            .Where(e => e.Id == editionId && e.SiteId == siteId)
+            .Where(e => e.Id == editionId)
             .FirstOrDefaultAsync(ct);
 
         if (edition == null) return Results.NotFound("Edition not found");
@@ -125,7 +123,7 @@ public static class UserDataEndpoints
         if (chapter == null) return Results.NotFound("Chapter not found");
 
         var existing = await db.ReadingProgresses
-            .Where(p => p.UserId == userId.Value && p.SiteId == siteId && p.EditionId == editionId)
+            .Where(p => p.UserId == userId.Value && p.EditionId == editionId)
             .FirstOrDefaultAsync(ct);
 
         if (existing != null)
@@ -196,10 +194,9 @@ public static class UserDataEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
 
         var progress = await db.ReadingProgresses
-            .Where(p => p.UserId == userId.Value && p.SiteId == siteId && p.EditionId == editionId)
+            .Where(p => p.UserId == userId.Value && p.EditionId == editionId)
             .FirstOrDefaultAsync(ct);
 
         if (progress == null) return Results.NotFound();
@@ -223,10 +220,9 @@ public static class UserDataEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
 
         var query = db.Bookmarks
-            .Where(b => b.UserId == userId.Value && b.SiteId == siteId)
+            .Where(b => b.UserId == userId.Value)
             .OrderByDescending(b => b.CreatedAt);
 
         var total = await query.CountAsync(ct);
@@ -256,10 +252,9 @@ public static class UserDataEndpoints
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
 
-        var siteId = httpContext.GetSiteId();
 
         var bookmarks = await db.Bookmarks
-            .Where(b => b.UserId == userId.Value && b.SiteId == siteId && b.EditionId == editionId)
+            .Where(b => b.UserId == userId.Value && b.EditionId == editionId)
             .OrderByDescending(b => b.CreatedAt)
             .Select(b => new BookmarkDto(
                 b.Id,
@@ -288,7 +283,7 @@ public static class UserDataEndpoints
 
         // Validate edition exists
         var edition = await db.Editions
-            .Where(e => e.Id == request.EditionId && e.SiteId == siteId)
+            .Where(e => e.Id == request.EditionId)
             .FirstOrDefaultAsync(ct);
 
         if (edition == null) return Results.NotFound("Edition not found");

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.Clusters.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.Clusters.cs
@@ -24,7 +24,6 @@ public static partial class VocabularyEndpoints
 
         var clusters = await db.WordClusters
             .Where(c => c.UserId == userId
-                     && c.SiteId == siteId
                      && !c.IsDismissed
                      && c.CompletedAt == null)
             .OrderByDescending(c => c.CreatedAt)
@@ -79,8 +78,7 @@ public static partial class VocabularyEndpoints
         // user's most-developed themes.
         var clusters = await db.WordClusters
             .Where(c => c.Kind == "concept"
-                     && c.UserId == userId
-                     && c.SiteId == siteId)
+                     && c.UserId == userId)
             .OrderByDescending(c => c.MemberCount)
             .ThenByDescending(c => c.CohesionScore)
             .Take(ConceptClustersTake)
@@ -103,8 +101,7 @@ public static partial class VocabularyEndpoints
         var words = await db.VocabularyWords
             .Where(w => w.ConceptClusterId != null
                      && clusterIds.Contains(w.ConceptClusterId.Value)
-                     && w.UserId == userId
-                     && w.SiteId == siteId)
+                     && w.UserId == userId)
             .Select(w => new { ClusterId = w.ConceptClusterId!.Value, w.Word })
             .ToListAsync(ct);
 
@@ -140,7 +137,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var cluster = await db.WordClusters
-            .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId && c.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId, ct);
         if (cluster == null) return Results.NotFound();
         if (cluster.IsDismissed || cluster.CompletedAt != null) return Results.Conflict();
 
@@ -148,7 +145,6 @@ public static partial class VocabularyEndpoints
         var members = await db.VocabularyWords
             .Where(w => w.ClusterId == id
                      && w.UserId == userId
-                     && w.SiteId == siteId
                      && !w.IsRetired)
             .ToListAsync(ct);
 
@@ -158,8 +154,7 @@ public static partial class VocabularyEndpoints
         var languages = members.Select(w => w.Language).Distinct().ToList();
         var memberIds = members.Select(w => w.Id).ToHashSet();
         var pool = await db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId
-                     && !memberIds.Contains(w.Id)
+            .Where(w => w.UserId == userId && !memberIds.Contains(w.Id)
                      && languages.Contains(w.Language))
             .OrderBy(_ => EF.Functions.Random())
             .Take(MaxDistractorPoolSize)
@@ -196,7 +191,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var cluster = await db.WordClusters
-            .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId && c.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId, ct);
         if (cluster == null) return Results.NotFound();
 
         cluster.IsDismissed = true;
@@ -216,7 +211,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var cluster = await db.WordClusters
-            .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId && c.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId, ct);
         if (cluster == null) return Results.NotFound();
 
         cluster.CompletedAt = DateTimeOffset.UtcNow;

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.Lookups.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.Lookups.cs
@@ -28,7 +28,7 @@ public static partial class VocabularyEndpoints
         var skip = Math.Max(0, offset ?? 0);
 
         var baseQuery = db.WordLookups
-            .Where(l => l.UserId == userId && l.SiteId == siteId);
+            .Where(l => l.UserId == userId);
 
         var total = await baseQuery.CountAsync(ct);
         var items = await baseQuery
@@ -60,14 +60,13 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var lookup = await db.WordLookups
-            .FirstOrDefaultAsync(l => l.Id == id && l.UserId == userId && l.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(l => l.Id == id && l.UserId == userId, ct);
         if (lookup == null) return Results.NotFound();
 
         // Guard against a race where the word was saved via another path between
         // the list render and the promote click.
         var already = await db.VocabularyWords
-            .FirstOrDefaultAsync(w => w.UserId == userId && w.SiteId == siteId
-                && w.Word == lookup.Word && w.Language == lookup.Language, ct);
+            .FirstOrDefaultAsync(w => w.UserId == userId && w.Word == lookup.Word && w.Language == lookup.Language, ct);
         if (already != null)
         {
             db.WordLookups.Remove(lookup);
@@ -79,9 +78,9 @@ public static partial class VocabularyEndpoints
         // the 5000-word vocabulary limit. Counts both active SRS + pending
         // so a user can't exceed the cap via the lookup bypass.
         var count = await db.VocabularyWords.CountAsync(
-            w => w.UserId == userId && w.SiteId == siteId, ct);
+            w => w.UserId == userId, ct);
         count += await db.PendingVocabularyWords.CountAsync(
-            p => p.UserId == userId && p.SiteId == siteId, ct);
+            p => p.UserId == userId, ct);
         if (count >= MaxWordsPerUser)
             return Results.Problem("Vocabulary limit reached (5000 words)", statusCode: 429);
 
@@ -139,7 +138,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var lookup = await db.WordLookups
-            .FirstOrDefaultAsync(l => l.Id == id && l.UserId == userId && l.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(l => l.Id == id && l.UserId == userId, ct);
         if (lookup == null) return Results.NotFound();
 
         db.WordLookups.Remove(lookup);

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.Pending.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.Pending.cs
@@ -23,7 +23,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var items = await db.PendingVocabularyWords
-            .Where(p => p.UserId == userId && p.SiteId == siteId)
+            .Where(p => p.UserId == userId)
             .OrderByDescending(p => p.Priority)
             .ThenBy(p => p.CreatedAt)
             .Select(p => new PendingVocabWordDto(
@@ -52,7 +52,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var pending = await db.PendingVocabularyWords
-            .FirstOrDefaultAsync(p => p.Id == id && p.UserId == userId && p.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(p => p.Id == id && p.UserId == userId, ct);
         if (pending == null) return Results.NotFound();
 
         // Capture enrichment inputs before PromoteAsync disposes the pending row.
@@ -87,7 +87,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var pending = await db.PendingVocabularyWords
-            .FirstOrDefaultAsync(p => p.Id == id && p.UserId == userId && p.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(p => p.Id == id && p.UserId == userId, ct);
         if (pending == null) return Results.NotFound();
 
         db.PendingVocabularyWords.Remove(pending);

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.Settings.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.Settings.cs
@@ -23,7 +23,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var settings = await db.UserVocabularySettings
-            .FirstOrDefaultAsync(s => s.UserId == userId && s.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(s => s.UserId == userId, ct);
 
         // First-time read: return defaults without persisting — settings row is
         // created lazily on first PUT to avoid a write on every new user.
@@ -51,7 +51,7 @@ public static partial class VocabularyEndpoints
             return Results.BadRequest("WeeklyReviewBudget must be 10–500");
 
         var settings = await db.UserVocabularySettings
-            .FirstOrDefaultAsync(s => s.UserId == userId && s.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(s => s.UserId == userId, ct);
         var now = DateTimeOffset.UtcNow;
 
         if (settings is null)

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.Stats.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.Stats.cs
@@ -31,7 +31,7 @@ public static partial class VocabularyEndpoints
         // keep retired rows (user still wants to see "2000 mastered" even if
         // they no longer appear in the queue).
         var words = db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId);
+            .Where(w => w.UserId == userId);
 
         var totalWords = await words.CountAsync(ct);
 
@@ -48,7 +48,7 @@ public static partial class VocabularyEndpoints
 
         // Single query for today's review stats
         var todayStats = await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.SiteId == siteId && r.CreatedAt >= todayStart)
+            .Where(r => r.UserId == userId && r.CreatedAt >= todayStart)
             .GroupBy(_ => 1)
             .Select(g => new
             {
@@ -68,7 +68,7 @@ public static partial class VocabularyEndpoints
 
         // Single query for all-time review stats
         var allStats = await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.SiteId == siteId)
+            .Where(r => r.UserId == userId)
             .GroupBy(_ => 1)
             .Select(g => new { Total = g.Count(), Correct = g.Count(r => r.IsCorrect) })
             .FirstOrDefaultAsync(ct);
@@ -78,7 +78,7 @@ public static partial class VocabularyEndpoints
 
         // Streak: consecutive days with reviews (HashSet for O(1) lookup)
         var reviewDays = (await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.SiteId == siteId)
+            .Where(r => r.UserId == userId)
             .Select(r => r.CreatedAt.Date)
             .Distinct()
             .OrderByDescending(d => d)
@@ -107,12 +107,11 @@ public static partial class VocabularyEndpoints
         var weeklyProgress = ToDto(await weeklyBudget.GetProgressAsync(userId, siteId, ct));
         var capStatus = await dailyCap.GetStatusAsync(userId, siteId, ct);
         var pendingCount = await db.PendingVocabularyWords
-            .CountAsync(p => p.UserId == userId && p.SiteId == siteId, ct);
+            .CountAsync(p => p.UserId == userId, ct);
         var lookupCount = await db.WordLookups
-            .CountAsync(l => l.UserId == userId && l.SiteId == siteId, ct);
+            .CountAsync(l => l.UserId == userId, ct);
         var clusterCount = await db.WordClusters
-            .CountAsync(c => c.UserId == userId && c.SiteId == siteId
-                          && !c.IsDismissed && c.CompletedAt == null, ct);
+            .CountAsync(c => c.UserId == userId && !c.IsDismissed && c.CompletedAt == null, ct);
 
         return Results.Ok(new
         {
@@ -174,8 +173,7 @@ public static partial class VocabularyEndpoints
 
         // Reviews per day
         var reviews = await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.SiteId == siteId
-                && r.CreatedAt >= start && r.CreatedAt <= end)
+            .Where(r => r.UserId == userId && r.CreatedAt >= start && r.CreatedAt <= end)
             .Select(r => new { r.CreatedAt, r.IsCorrect, r.ReviewMode })
             .ToListAsync(ct);
 
@@ -193,8 +191,7 @@ public static partial class VocabularyEndpoints
 
         // Words added per day
         var words = await db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId
-                && w.CreatedAt >= start && w.CreatedAt <= end)
+            .Where(w => w.UserId == userId && w.CreatedAt >= start && w.CreatedAt <= end)
             .Select(w => w.CreatedAt)
             .ToListAsync(ct);
 

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.cs
@@ -113,23 +113,21 @@ public static partial class VocabularyEndpoints
         // Dedup: SRS table first, then pending buffer. A word in either bucket
         // is "already saved" from the user's perspective — don't double-insert.
         var existing = await db.VocabularyWords
-            .FirstOrDefaultAsync(w => w.UserId == userId && w.SiteId == siteId
-                && w.Word == word && w.Language == request.Language, ct);
+            .FirstOrDefaultAsync(w => w.UserId == userId && w.Word == word && w.Language == request.Language, ct);
         if (existing != null)
             return Results.Ok(SaveWordResponse.AlreadySaved(ToDto(existing)));
 
         var existingPending = await db.PendingVocabularyWords
-            .FirstOrDefaultAsync(p => p.UserId == userId && p.SiteId == siteId
-                && p.Word == word && p.Language == request.Language, ct);
+            .FirstOrDefaultAsync(p => p.UserId == userId && p.Word == word && p.Language == request.Language, ct);
         if (existingPending != null)
             return Results.Ok(SaveWordResponse.AlreadyPending(existingPending.Id));
 
         // Hard ceiling — counts both active + pending. Keeps one user from
         // bloating the pending bucket past the vocabulary cap.
         var count = await db.VocabularyWords.CountAsync(
-            w => w.UserId == userId && w.SiteId == siteId, ct);
+            w => w.UserId == userId, ct);
         count += await db.PendingVocabularyWords.CountAsync(
-            p => p.UserId == userId && p.SiteId == siteId, ct);
+            p => p.UserId == userId, ct);
         if (count >= MaxWordsPerUser)
             return Results.Problem("Vocabulary limit reached (5000 words)", statusCode: 429);
 
@@ -142,15 +140,14 @@ public static partial class VocabularyEndpoints
         // default. Every tapped word goes straight to SRS unless the user has
         // explicitly turned the frequency filter back on.
         var filterEnabled = await db.UserVocabularySettings
-            .Where(s => s.UserId == userId && s.SiteId == siteId)
+            .Where(s => s.UserId == userId)
             .Select(s => (bool?)s.FrequencyFilterEnabled)
             .FirstOrDefaultAsync(ct) ?? false;
 
         // Query unconditionally so a user who flips the filter off doesn't leave
         // orphan lookups behind when the same word is next saved to SRS.
         var existingLookup = await db.WordLookups
-            .FirstOrDefaultAsync(l => l.UserId == userId && l.SiteId == siteId
-                && l.Word == word && l.Language == request.Language, ct);
+            .FirstOrDefaultAsync(l => l.UserId == userId && l.Word == word && l.Language == request.Language, ct);
 
         int? zipfRank = null;
         double? zipfScore = null;
@@ -366,7 +363,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var query = db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId);
+            .Where(w => w.UserId == userId);
 
         if (!string.IsNullOrEmpty(stage))
         {
@@ -453,7 +450,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var words = await db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId)
+            .Where(w => w.UserId == userId)
             .ToListAsync(ct);
 
         db.VocabularyWords.RemoveRange(words);
@@ -520,7 +517,7 @@ public static partial class VocabularyEndpoints
 
         // Retired rows (F4) are hidden from the queue — they already graduated.
         var baseQuery = db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId && !w.IsRetired);
+            .Where(w => w.UserId == userId && !w.IsRetired);
 
         var totalDue = await baseQuery
             .CountAsync(w => w.NextReviewAt <= now, ct);
@@ -559,8 +556,7 @@ public static partial class VocabularyEndpoints
         var dueWordIds = dueWords.Select(w => w.Id).ToHashSet();
 
         var distractorPool = await db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId
-                && !dueWordIds.Contains(w.Id)
+            .Where(w => w.UserId == userId && !dueWordIds.Contains(w.Id)
                 && languages.Contains(w.Language))
             .OrderBy(_ => EF.Functions.Random())
             .Take(MaxDistractorPoolSize)
@@ -638,7 +634,7 @@ public static partial class VocabularyEndpoints
             if (!word.IsRetired && srsEngine.ShouldAutoRetire(word.Stage, word.ConsecutiveCorrect, word.IntervalDays))
             {
                 var autoRetireEnabled = await db.UserVocabularySettings
-                    .Where(s => s.UserId == userId && s.SiteId == siteId)
+                    .Where(s => s.UserId == userId)
                     .Select(s => (bool?)s.AutoRetireEnabled)
                     .FirstOrDefaultAsync(ct) ?? true;
                 if (autoRetireEnabled)
@@ -696,7 +692,7 @@ public static partial class VocabularyEndpoints
             return Results.Unauthorized();
 
         var words = await db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId)
+            .Where(w => w.UserId == userId)
             .OrderBy(w => w.Word)
             .Take(MaxWordsPerUser)
             .Select(w => new ReaderVocabWordDto(w.Id, w.Word, w.Stage, w.Translation))
@@ -749,7 +745,7 @@ public static partial class VocabularyEndpoints
     private static Task<VocabularyWord?> FindUserWordAsync(
         IAppDbContext db, Guid id, Guid userId, Guid siteId, CancellationToken ct)
         => db.VocabularyWords.FirstOrDefaultAsync(
-            w => w.Id == id && w.UserId == userId && w.SiteId == siteId, ct);
+            w => w.Id == id && w.UserId == userId, ct);
 
     private static VocabWordDto ToDto(VocabularyWord w) => new(
         w.Id, w.Word, w.Language, w.Translation, w.Definition,

--- a/backend/src/Application/Admin/AdminService.Editions.cs
+++ b/backend/src/Application/Admin/AdminService.Editions.cs
@@ -28,12 +28,15 @@ public partial class AdminService
         var authorQuery = db.Authors.AsQueryable();
         var chapterQuery = db.Chapters.AsQueryable();
 
+        // Chapter is not ISiteScoped, so it carries no query filter of its own.
+        // This query also references Edition nowhere else, so EF has no reason to
+        // join editions and Edition's query filter cannot propagate here. The
+        // explicit c.Edition.SiteId term is therefore required to keep the chapter
+        // count site-scoped. (Contrast BookService.GetChapterAsync, where Edition
+        // is already joined via Slug/Language/Status, so its query filter applies
+        // and the manual term was dropped.)
         if (siteId.HasValue)
-        {
-            editionQuery = editionQuery.Where(e => e.SiteId == siteId.Value);
-            authorQuery = authorQuery.Where(a => a.SiteId == siteId.Value);
             chapterQuery = chapterQuery.Where(c => c.Edition.SiteId == siteId.Value);
-        }
 
         var totalEditions = await editionQuery.CountAsync(ct);
         var publishedEditions = await editionQuery.Where(e => e.Status == EditionStatus.Published).CountAsync(ct);
@@ -56,9 +59,6 @@ public partial class AdminService
         Guid? siteId, int offset, int limit, EditionStatus? status, string? search, string? language, bool? indexable, bool? seoReady, string? sort, string? sortOrder, CancellationToken ct)
     {
         var query = db.Editions.AsQueryable();
-
-        if (siteId.HasValue)
-            query = query.Where(e => e.SiteId == siteId.Value);
 
         if (status.HasValue)
             query = query.Where(e => e.Status == status.Value);
@@ -246,7 +246,7 @@ public partial class AdminService
             if (request.GenreIds.Count > 0)
             {
                 var genres = await db.Genres
-                    .Where(g => request.GenreIds.Contains(g.Id) && g.SiteId == edition.SiteId)
+                    .Where(g => request.GenreIds.Contains(g.Id))
                     .ToListAsync(ct);
 
                 foreach (var genre in genres)

--- a/backend/src/Application/Admin/AdminService.Upload.cs
+++ b/backend/src/Application/Admin/AdminService.Upload.cs
@@ -54,7 +54,7 @@ public partial class AdminService
 
         var slug = SlugGenerator.GenerateSlug(title);
         var existingWork = await db.Works
-            .FirstOrDefaultAsync(w => w.SiteId == siteId && w.Slug == slug, ct);
+            .FirstOrDefaultAsync(w => w.Slug == slug, ct);
         if (existingWork is not null)
             return (true, null, existingWork);
 
@@ -319,19 +319,19 @@ public partial class AdminService
     {
         var baseSlug = SlugGenerator.GenerateSlug(title);
         var slug = baseSlug;
-        var exists = await db.Editions.AnyAsync(e => e.SiteId == siteId && e.Language == language && e.Slug == slug, ct);
+        var exists = await db.Editions.AnyAsync(e => e.Language == language && e.Slug == slug, ct);
 
         if (exists)
         {
             slug = $"{baseSlug}-{language}";
-            exists = await db.Editions.AnyAsync(e => e.SiteId == siteId && e.Language == language && e.Slug == slug, ct);
+            exists = await db.Editions.AnyAsync(e => e.Language == language && e.Slug == slug, ct);
         }
 
         var counter = 2;
         while (exists)
         {
             slug = $"{baseSlug}-{language}-{counter}";
-            exists = await db.Editions.AnyAsync(e => e.SiteId == siteId && e.Language == language && e.Slug == slug, ct);
+            exists = await db.Editions.AnyAsync(e => e.Language == language && e.Slug == slug, ct);
             counter++;
         }
 

--- a/backend/src/Application/Authors/AuthorsService.cs
+++ b/backend/src/Application/Authors/AuthorsService.cs
@@ -12,7 +12,7 @@ public class AuthorsService(IAppDbContext db)
         Guid siteId, int offset, int limit, string? language, string? sort, string? search, CancellationToken ct)
     {
         var query = db.Authors
-            .Where(a => a.SiteId == siteId && a.Indexable)
+            .Where(a => a.Indexable)
             .Where(a => a.EditionAuthors.Any(ea => ea.Edition.Status == EditionStatus.Published));
 
         if (!string.IsNullOrEmpty(language))
@@ -54,7 +54,7 @@ public class AuthorsService(IAppDbContext db)
     public async Task<AuthorDetailDto?> GetAuthorAsync(Guid siteId, string slug, CancellationToken ct)
     {
         var author = await db.Authors
-            .Where(a => a.SiteId == siteId && a.Slug == slug)
+            .Where(a => a.Slug == slug)
             .Select(a => new AuthorDetailDto(
                 a.Id,
                 a.Slug,

--- a/backend/src/Application/Books/BookService.cs
+++ b/backend/src/Application/Books/BookService.cs
@@ -14,7 +14,7 @@ public class BookService(IAppDbContext db)
         string? search, string? genreSlug, string? sort, CancellationToken ct)
     {
         var query = db.Editions
-            .Where(e => e.SiteId == siteId && e.Status == EditionStatus.Published)
+            .Where(e => e.Status == EditionStatus.Published)
             // Only show books with at least one chapter
             .Where(e => e.Chapters.Any())
             .AsQueryable();
@@ -72,7 +72,7 @@ public class BookService(IAppDbContext db)
     public async Task<BookDetailDto?> GetBookAsync(Guid siteId, string slug, string language, CancellationToken ct)
     {
         var result = await db.Editions
-            .Where(e => e.SiteId == siteId && e.Slug == slug && e.Language == language && e.Status == EditionStatus.Published)
+            .Where(e => e.Slug == slug && e.Language == language && e.Status == EditionStatus.Published)
             .Select(e => new
             {
                 e.Id,
@@ -129,8 +129,7 @@ public class BookService(IAppDbContext db)
 
         // More books by same author(s)
         var moreByAuthor = await db.Editions
-            .Where(e => e.SiteId == siteId
-                && e.Id != result.Id
+            .Where(e => e.Id != result.Id
                 && e.Language == result.Language
                 && e.Status == EditionStatus.Published
                 && e.Chapters.Any()
@@ -185,7 +184,7 @@ public class BookService(IAppDbContext db)
     public async Task<string?> FindBookLanguageAsync(Guid siteId, string slug, CancellationToken ct)
     {
         return await db.Editions
-            .Where(e => e.SiteId == siteId && e.Slug == slug && e.Status == EditionStatus.Published)
+            .Where(e => e.Slug == slug && e.Status == EditionStatus.Published)
             .Select(e => e.Language)
             .FirstOrDefaultAsync(ct);
     }
@@ -194,8 +193,7 @@ public class BookService(IAppDbContext db)
         Guid siteId, string bookSlug, string chapterSlug, string language, CancellationToken ct)
     {
         var chapter = await db.Chapters
-            .Where(c => c.Edition.SiteId == siteId
-                && c.Edition.Slug == bookSlug
+            .Where(c => c.Edition.Slug == bookSlug
                 && c.Edition.Language == language
                 && c.Slug == chapterSlug
                 && c.Edition.Status == EditionStatus.Published)

--- a/backend/src/Application/Export/EpubExportService.cs
+++ b/backend/src/Application/Export/EpubExportService.cs
@@ -16,7 +16,7 @@ public class EpubExportService(IAppDbContext db, IFileStorageService storage)
             .Include(e => e.EditionAuthors).ThenInclude(ea => ea.Author)
             .Include(e => e.Chapters)
             .Include(e => e.Assets)
-            .Where(e => e.SiteId == siteId && e.Slug == slug && e.Language == language
+            .Where(e => e.Slug == slug && e.Language == language
                         && e.Status == EditionStatus.Published)
             .FirstOrDefaultAsync(ct);
 

--- a/backend/src/Application/Library/LibraryShelvesService.cs
+++ b/backend/src/Application/Library/LibraryShelvesService.cs
@@ -79,9 +79,8 @@ public class LibraryShelvesService(IAppDbContext db)
             from ul in db.UserLibraries
             where ul.UserId == userId
             join e in db.Editions on ul.EditionId equals e.Id
-            where e.SiteId == siteId
             let latestProgress = db.ReadingProgresses
-                .Where(p => p.UserId == userId && p.SiteId == siteId && p.EditionId == e.Id)
+                .Where(p => p.UserId == userId && p.EditionId == e.Id)
                 .OrderByDescending(p => p.UpdatedAt)
                 .Select(p => new { p.Percent, p.UpdatedAt, p.ChapterId, p.Locator })
                 .FirstOrDefault()
@@ -172,9 +171,8 @@ public class LibraryShelvesService(IAppDbContext db)
             from ul in db.UserLibraries
             where ul.UserId == userId && ul.CreatedAt >= cutoff
             join e in db.Editions on ul.EditionId equals e.Id
-            where e.SiteId == siteId
             let latest = db.ReadingProgresses
-                .Where(p => p.UserId == userId && p.SiteId == siteId && p.EditionId == e.Id)
+                .Where(p => p.UserId == userId && p.EditionId == e.Id)
                 .OrderByDescending(p => p.UpdatedAt)
                 .Select(p => new { p.Percent, p.UpdatedAt, p.ChapterId, p.Locator })
                 .FirstOrDefault()
@@ -261,12 +259,11 @@ public class LibraryShelvesService(IAppDbContext db)
             from ul in db.UserLibraries
             where ul.UserId == userId
             join e in db.Editions on ul.EditionId equals e.Id
-            where e.SiteId == siteId
             let totalWords = db.Chapters
                 .Where(c => c.EditionId == e.Id)
                 .Sum(c => (int?)c.WordCount ?? 0)
             let latest = db.ReadingProgresses
-                .Where(p => p.UserId == userId && p.SiteId == siteId && p.EditionId == e.Id)
+                .Where(p => p.UserId == userId && p.EditionId == e.Id)
                 .OrderByDescending(p => p.UpdatedAt)
                 .Select(p => new { p.Percent, p.UpdatedAt, p.ChapterId, p.Locator })
                 .FirstOrDefault()
@@ -349,9 +346,8 @@ public class LibraryShelvesService(IAppDbContext db)
             from ul in db.UserLibraries
             where ul.UserId == userId
             join e in db.Editions on ul.EditionId equals e.Id
-            where e.SiteId == siteId
             let latest = db.ReadingProgresses
-                .Where(p => p.UserId == userId && p.SiteId == siteId && p.EditionId == e.Id)
+                .Where(p => p.UserId == userId && p.EditionId == e.Id)
                 .OrderByDescending(p => p.UpdatedAt)
                 .Select(p => new { p.Percent, p.UpdatedAt })
                 .FirstOrDefault()

--- a/backend/src/Application/Rag/RagContextService.cs
+++ b/backend/src/Application/Rag/RagContextService.cs
@@ -101,7 +101,7 @@ public sealed class RagContextService(IAppDbContext db, IRagService rag)
         Guid userId, Guid siteId, Guid editionId, CancellationToken ct)
     {
         var row = await db.ReadingProgresses
-            .Where(p => p.UserId == userId && p.SiteId == siteId && p.EditionId == editionId)
+            .Where(p => p.UserId == userId && p.EditionId == editionId)
             .Join(db.Chapters, p => p.ChapterId, c => c.Id,
                 (p, c) => new { p.MaxChapterNumber, c.ChapterNumber })
             .FirstOrDefaultAsync(ct);
@@ -119,7 +119,7 @@ public sealed class RagContextService(IAppDbContext db, IRagService rag)
 
         // Materialize raw fields first — HighlightToText is a C# method EF can't translate.
         var highlightRows = await db.Highlights
-            .Where(h => h.UserId == userId && h.SiteId == siteId && h.EditionId == editionId
+            .Where(h => h.UserId == userId && h.EditionId == editionId
                         && h.ChapterId != null && h.Chapter!.ChapterNumber <= maxOrd)
             .Select(h => new { h.ChapterId, Ord = h.Chapter!.ChapterNumber, h.SelectedText, h.NoteText })
             .ToListAsync(ct);
@@ -127,7 +127,7 @@ public sealed class RagContextService(IAppDbContext db, IRagService rag)
         // Only free-standing notes — a note attached to a highlight (HighlightId set) is already
         // represented via that highlight's inline NoteText, so including it again would double-count.
         var noteRows = await db.Notes
-            .Where(n => n.UserId == userId && n.SiteId == siteId && n.EditionId == editionId
+            .Where(n => n.UserId == userId && n.EditionId == editionId
                         && n.HighlightId == null && n.Chapter.ChapterNumber <= maxOrd)
             .Select(n => new { ChapterId = (Guid?)n.ChapterId, Ord = n.Chapter.ChapterNumber, n.Text })
             .ToListAsync(ct);

--- a/backend/src/Application/ReadingTracking/AchievementChecker.cs
+++ b/backend/src/Application/ReadingTracking/AchievementChecker.cs
@@ -18,7 +18,7 @@ public class AchievementChecker
         CancellationToken ct)
     {
         var unlocked = await _db.UserAchievements
-            .Where(a => a.UserId == userId && a.SiteId == siteId)
+            .Where(a => a.UserId == userId)
             .Select(a => a.AchievementCode)
             .ToHashSetAsync(ct);
 
@@ -41,12 +41,12 @@ public class AchievementChecker
 
         // First session
         var sessionCount = await _db.ReadingSessions
-            .CountAsync(s => s.UserId == userId && s.SiteId == siteId, ct);
+            .CountAsync(s => s.UserId == userId, ct);
         if (sessionCount == 1) TryUnlock("first_session");
 
         // Books finished (sessions that end at >= 99%)
         var booksFinished = await _db.ReadingSessions
-            .Where(s => s.UserId == userId && s.SiteId == siteId && s.EndPercent >= 0.99)
+            .Where(s => s.UserId == userId && s.EndPercent >= 0.99)
             .Select(s => s.EditionId ?? s.UserBookId)
             .Distinct()
             .CountAsync(ct);
@@ -62,7 +62,7 @@ public class AchievementChecker
 
         // Total hours
         var totalSeconds = await _db.ReadingSessions
-            .Where(s => s.UserId == userId && s.SiteId == siteId)
+            .Where(s => s.UserId == userId)
             .SumAsync(s => (long)s.DurationSeconds, ct);
         var totalHours = totalSeconds / 3600.0;
 
@@ -97,7 +97,7 @@ public class AchievementChecker
         Guid userId, Guid siteId, int currentStreak, CancellationToken ct)
     {
         var unlocked = await _db.UserAchievements
-            .Where(a => a.UserId == userId && a.SiteId == siteId)
+            .Where(a => a.UserId == userId)
             .Select(a => a.AchievementCode)
             .ToHashSetAsync(ct);
 

--- a/backend/src/Application/Reprocessing/ReprocessingService.cs
+++ b/backend/src/Application/Reprocessing/ReprocessingService.cs
@@ -47,9 +47,6 @@ public class ReprocessingService(IAppDbContext db, ILogger<ReprocessingService> 
             .Include(e => e.BookFiles)
             .Where(e => e.Status == EditionStatus.Published);
 
-        if (siteId.HasValue)
-            query = query.Where(e => e.SiteId == siteId.Value);
-
         var editions = await query.ToListAsync(ct);
 
         var results = new List<ReprocessedEditionInfo>();

--- a/backend/src/Application/Search/LibrarySearchService.cs
+++ b/backend/src/Application/Search/LibrarySearchService.cs
@@ -118,8 +118,7 @@ public sealed class LibrarySearchService(
     {
         var rows = await db.Editions
             .AsNoTracking()
-            .Where(e => e.SiteId == siteId
-                        && e.Status == EditionStatus.Published
+            .Where(e => e.Status == EditionStatus.Published
                         && editionIds.Contains(e.Id))
             .Select(e => new
             {

--- a/backend/src/Application/Seo/SeoService.cs
+++ b/backend/src/Application/Seo/SeoService.cs
@@ -12,7 +12,7 @@ public class SeoService(IAppDbContext db)
     {
         // Get all published, indexable editions with their Work's other editions
         var editions = await db.Editions
-            .Where(e => e.SiteId == siteId && e.Status == EditionStatus.Published && e.Indexable)
+            .Where(e => e.Status == EditionStatus.Published && e.Indexable)
             .Include(e => e.Work)
                 .ThenInclude(w => w.Editions.Where(oe => oe.Status == EditionStatus.Published && oe.Indexable))
             .OrderByDescending(e => e.UpdatedAt)

--- a/backend/src/Application/SsgRebuild/SsgRebuildService.cs
+++ b/backend/src/Application/SsgRebuild/SsgRebuildService.cs
@@ -95,9 +95,6 @@ public class SsgRebuildService : ISsgJobService
             .Include(j => j.Site)
             .AsQueryable();
 
-        if (siteId.HasValue)
-            query = query.Where(j => j.SiteId == siteId.Value);
-
         if (!string.IsNullOrEmpty(status) && Enum.TryParse<SsgRebuildJobStatus>(status, true, out var statusEnum))
             query = query.Where(j => j.Status == statusEnum);
 
@@ -230,8 +227,7 @@ public class SsgRebuildService : ISsgJobService
 
         // Dedup: skip if identical job already queued or running
         var duplicateQuery = _db.SsgRebuildJobs
-            .Where(j => j.SiteId == request.SiteId
-                && j.Mode == mode
+            .Where(j => j.Mode == mode
                 && (j.Status == SsgRebuildJobStatus.Queued || j.Status == SsgRebuildJobStatus.Running));
 
         if (mode == SsgRebuildMode.Specific)

--- a/backend/src/Application/SsgRebuild/SsgRouteProvider.cs
+++ b/backend/src/Application/SsgRebuild/SsgRouteProvider.cs
@@ -68,7 +68,7 @@ public class SsgRouteProvider : ISsgRouteProvider
         // traffic) still get the static page. Filtering Indexable here
         // would just leave nginx serving a hard 404 for the slug.
         var query = _db.Editions
-            .Where(e => e.SiteId == siteId && e.Status == EditionStatus.Published);
+            .Where(e => e.Status == EditionStatus.Published);
 
         if (mode == SsgRebuildMode.Specific && slugs?.Length > 0)
             query = query.Where(e => slugs.Contains(e.Slug));
@@ -93,7 +93,7 @@ public class SsgRouteProvider : ISsgRouteProvider
         // same filter shape here on purpose: both route producers must agree
         // or the periodic worker and the build-time prerender will drift.
         var query = _db.Authors
-            .Where(a => a.SiteId == siteId && a.Indexable)
+            .Where(a => a.Indexable)
             .Where(a => a.EditionAuthors.Any(ea =>
                 ea.Edition.Status == EditionStatus.Published &&
                 ea.Edition.Indexable));
@@ -114,7 +114,7 @@ public class SsgRouteProvider : ISsgRouteProvider
         CancellationToken ct)
     {
         var query = _db.Genres
-            .Where(g => g.SiteId == siteId && g.Indexable)
+            .Where(g => g.Indexable)
             .Where(g => g.Editions.Any(e =>
                 e.Status == EditionStatus.Published &&
                 e.Indexable));

--- a/backend/src/Application/TextStack/StandardEbooksSyncService.cs
+++ b/backend/src/Application/TextStack/StandardEbooksSyncService.cs
@@ -107,7 +107,6 @@ public class StandardEbooksSyncService
     public async Task<HashSet<string>> GetImportedIdentifiersAsync(Guid siteId, CancellationToken ct)
     {
         var identifiers = await _db.TextStackImports
-            .Where(i => i.SiteId == siteId)
             .Select(i => i.Identifier)
             .ToListAsync(ct);
 

--- a/backend/src/Application/TextStack/TextStackImportService.cs
+++ b/backend/src/Application/TextStack/TextStackImportService.cs
@@ -34,7 +34,7 @@ public class TextStackImportService
     public async Task<bool> IsAlreadyImportedAsync(Guid siteId, string identifier, CancellationToken ct)
     {
         return await _db.TextStackImports
-            .AnyAsync(i => i.SiteId == siteId && i.Identifier == identifier, ct);
+            .AnyAsync(i => i.Identifier == identifier, ct);
     }
 
     public async Task<ImportResult> ImportBookAsync(Guid siteId, string bookPath, CancellationToken ct)
@@ -81,7 +81,7 @@ public class TextStackImportService
                 ? SlugGenerator.GenerateSlug(metadata.AuthorNames[0])
                 : "unknown";
             var workSlug = $"{authorSlug}-{SlugGenerator.GenerateSlug(metadata.Title)}";
-            var work = await _db.Works.FirstOrDefaultAsync(w => w.SiteId == siteId && w.Slug == workSlug, ct);
+            var work = await _db.Works.FirstOrDefaultAsync(w => w.Slug == workSlug, ct);
 
             if (work == null)
             {
@@ -224,19 +224,19 @@ public class TextStackImportService
             var edition = await _db.Editions
                 .Include(e => e.Chapters)
                 .Include(e => e.Assets)
-                .FirstOrDefaultAsync(e => e.SiteId == siteId && e.Slug == expectedSlug, ct);
+                .FirstOrDefaultAsync(e => e.Slug == expectedSlug, ct);
 
             // Fallback to contains if exact match not found
             edition ??= await _db.Editions
                 .Include(e => e.Chapters)
                 .Include(e => e.Assets)
-                .FirstOrDefaultAsync(e => e.SiteId == siteId && e.Slug.Contains(expectedSlug), ct);
+                .FirstOrDefaultAsync(e => e.Slug.Contains(expectedSlug), ct);
 
             // Fallback to title match (case-insensitive)
             edition ??= await _db.Editions
                 .Include(e => e.Chapters)
                 .Include(e => e.Assets)
-                .FirstOrDefaultAsync(e => e.SiteId == siteId && e.Title.ToLower() == metadata.Title.ToLower(), ct);
+                .FirstOrDefaultAsync(e => e.Title.ToLower() == metadata.Title.ToLower(), ct);
 
             if (edition == null)
             {
@@ -330,7 +330,7 @@ public class TextStackImportService
     {
         var slug = SlugGenerator.GenerateSlug(name);
         var existing = await _db.Authors
-            .FirstOrDefaultAsync(a => a.SiteId == siteId && a.Slug == slug, ct);
+            .FirstOrDefaultAsync(a => a.Slug == slug, ct);
 
         if (existing is not null)
             return existing;
@@ -353,7 +353,7 @@ public class TextStackImportService
     {
         var slug = SlugGenerator.GenerateSlug(name);
         var existing = await _db.Genres
-            .FirstOrDefaultAsync(g => g.SiteId == siteId && g.Slug == slug, ct);
+            .FirstOrDefaultAsync(g => g.Slug == slug, ct);
 
         if (existing is not null)
             return existing;
@@ -379,7 +379,7 @@ public class TextStackImportService
         var slug = baseSlug;
         var counter = 1;
 
-        while (await _db.Editions.AnyAsync(e => e.SiteId == siteId && e.Language == language && e.Slug == slug, ct))
+        while (await _db.Editions.AnyAsync(e => e.Language == language && e.Slug == slug, ct))
         {
             slug = $"{baseSlug}-{counter}";
             counter++;

--- a/backend/src/Application/Vocabulary/ClusterCandidateService.cs
+++ b/backend/src/Application/Vocabulary/ClusterCandidateService.cs
@@ -17,7 +17,7 @@ public class ClusterCandidateService(IAppDbContext db, IClusterBuilder builder)
     public async Task<int> BuildForUserAsync(Guid userId, Guid siteId, CancellationToken ct)
     {
         var settings = await db.UserVocabularySettings
-            .FirstOrDefaultAsync(s => s.UserId == userId && s.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(s => s.UserId == userId, ct);
         if (settings is { ClusteringEnabled: false }) return 0;
 
         var user = await db.Users
@@ -30,7 +30,6 @@ public class ClusterCandidateService(IAppDbContext db, IClusterBuilder builder)
 
         var recent = await db.VocabularyWords
             .Where(w => w.UserId == userId
-                     && w.SiteId == siteId
                      && !w.IsRetired
                      && w.ClusterId == null
                      && w.ActivatedAt != null
@@ -61,7 +60,6 @@ public class ClusterCandidateService(IAppDbContext db, IClusterBuilder builder)
             // Skip if an active (undismissed, uncompleted) cluster already exists for this book.
             var existing = await db.WordClusters.AnyAsync(c =>
                 c.UserId == userId
-                && c.SiteId == siteId
                 && c.EditionId == group.Key.EditionId
                 && c.UserBookId == group.Key.UserBookId
                 && !c.IsDismissed
@@ -93,7 +91,7 @@ public class ClusterCandidateService(IAppDbContext db, IClusterBuilder builder)
             // Assign cluster id to each matched word.
             var matched = members.Where(m => candidate.MemberWordIds.Contains(m.Id)).Select(m => m.Id).ToHashSet();
             var words = await db.VocabularyWords
-                .Where(w => matched.Contains(w.Id) && w.UserId == userId && w.SiteId == siteId)
+                .Where(w => matched.Contains(w.Id) && w.UserId == userId)
                 .ToListAsync(ct);
             foreach (var w in words)
                 w.ClusterId = cluster.Id;

--- a/backend/src/Application/Vocabulary/ConceptClusteringService.cs
+++ b/backend/src/Application/Vocabulary/ConceptClusteringService.cs
@@ -46,7 +46,6 @@ public class ConceptClusteringService(IAppDbContext db, IConfiguration config, I
         // EF can't translate the float[] null check the same across providers, and the set is small.)
         var candidates = await db.VocabularyWords
             .Where(w => w.UserId == userId
-                     && w.SiteId == siteId
                      && !w.IsRetired
                      && w.Embedding != null)
             .Select(w => new { w.Id, w.Embedding })
@@ -68,7 +67,7 @@ public class ConceptClusteringService(IAppDbContext db, IConfiguration config, I
         // OnDelete(SetNull), so deleting the cluster rows nulls every member's ConceptClusterId
         // (including words that drop to noise this run). The book-grouper ClusterId is untouched.
         var existing = await db.WordClusters
-            .Where(c => c.UserId == userId && c.SiteId == siteId && c.Kind == "concept")
+            .Where(c => c.UserId == userId && c.Kind == "concept")
             .ToListAsync(ct);
         if (existing.Count > 0)
         {
@@ -117,7 +116,7 @@ public class ConceptClusteringService(IAppDbContext db, IConfiguration config, I
         // and keep ConceptClusterId == null (already nulled by the full-replace delete above).
         var memberIds = assignment.Keys.ToHashSet();
         var members = await db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId && memberIds.Contains(w.Id))
+            .Where(w => w.UserId == userId && memberIds.Contains(w.Id))
             .ToListAsync(ct);
         foreach (var w in members)
             w.ConceptClusterId = assignment[w.Id];

--- a/backend/src/Application/Vocabulary/DailyCapService.cs
+++ b/backend/src/Application/Vocabulary/DailyCapService.cs
@@ -25,7 +25,7 @@ public class DailyCapService(IAppDbContext db)
     public async Task<DailyCapStatus> GetStatusAsync(Guid userId, Guid siteId, CancellationToken ct)
     {
         var cap = await db.UserVocabularySettings
-            .Where(s => s.UserId == userId && s.SiteId == siteId)
+            .Where(s => s.UserId == userId)
             .Select(s => (int?)s.DailyNewCap)
             .FirstOrDefaultAsync(ct) ?? DefaultDailyCap;
 
@@ -37,8 +37,7 @@ public class DailyCapService(IAppDbContext db)
     {
         var todayStart = new DateTimeOffset(now.UtcDateTime.Date, TimeSpan.Zero);
         return db.VocabularyWords
-            .Where(w => w.UserId == userId && w.SiteId == siteId
-                && w.ActivatedAt != null && w.ActivatedAt >= todayStart)
+            .Where(w => w.UserId == userId && w.ActivatedAt != null && w.ActivatedAt >= todayStart)
             .CountAsync(ct);
     }
 
@@ -93,7 +92,7 @@ public class DailyCapService(IAppDbContext db)
         if (status.Remaining <= 0) return 0;
 
         var toPromote = await db.PendingVocabularyWords
-            .Where(p => p.UserId == userId && p.SiteId == siteId)
+            .Where(p => p.UserId == userId)
             .OrderByDescending(p => p.Priority)
             .ThenBy(p => p.CreatedAt)
             .Take(status.Remaining)

--- a/backend/src/Application/Vocabulary/RetirementSweeper.cs
+++ b/backend/src/Application/Vocabulary/RetirementSweeper.cs
@@ -15,7 +15,7 @@ public class RetirementSweeper(IAppDbContext db, ISrsEngine srs)
     public async Task<int> SweepAsync(Guid userId, Guid siteId, CancellationToken ct)
     {
         var settings = await db.UserVocabularySettings
-            .FirstOrDefaultAsync(s => s.UserId == userId && s.SiteId == siteId, ct);
+            .FirstOrDefaultAsync(s => s.UserId == userId, ct);
         if (settings is { AutoRetireEnabled: false }) return 0;
 
         // Pull candidates — Mastered + not already retired. Evaluating the rule
@@ -23,7 +23,6 @@ public class RetirementSweeper(IAppDbContext db, ISrsEngine srs)
         // the threshold (avoid duplicating 3/14 constants in an EF expression).
         var candidates = await db.VocabularyWords
             .Where(w => w.UserId == userId
-                     && w.SiteId == siteId
                      && !w.IsRetired
                      && w.Stage == 4
                      && w.ConsecutiveCorrect >= 3

--- a/backend/src/Application/Vocabulary/WeeklyBudgetService.cs
+++ b/backend/src/Application/Vocabulary/WeeklyBudgetService.cs
@@ -20,19 +20,19 @@ public class WeeklyBudgetService(IAppDbContext db)
         // Practice rows (ReviewMode prefixed `practice_`) are excluded — they
         // bypass the budget by design, so they must not feed back into it.
         var used = await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.SiteId == siteId && r.CreatedAt >= since
+            .Where(r => r.UserId == userId && r.CreatedAt >= since
                 && !r.ReviewMode.StartsWith("practice_"))
             .CountAsync(ct);
 
         var budget = await db.UserVocabularySettings
-            .Where(s => s.UserId == userId && s.SiteId == siteId)
+            .Where(s => s.UserId == userId)
             .Select(s => (int?)s.WeeklyReviewBudget)
             .FirstOrDefaultAsync(ct) ?? DefaultWeeklyBudget;
 
         // ResetAt = oldest review in window rolls off → window opens up.
         // If no reviews in window, budget resets immediately (now).
         var oldestInWindow = await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.SiteId == siteId && r.CreatedAt >= since
+            .Where(r => r.UserId == userId && r.CreatedAt >= since
                 && !r.ReviewMode.StartsWith("practice_"))
             .OrderBy(r => r.CreatedAt)
             .Select(r => (DateTimeOffset?)r.CreatedAt)

--- a/tests/TextStack.UnitTests/ConceptClustersQueryTests.cs
+++ b/tests/TextStack.UnitTests/ConceptClustersQueryTests.cs
@@ -89,8 +89,9 @@ public class ConceptClustersQueryTests
         h.Clusters.Add(new WordCluster { Id = Guid.NewGuid(), UserId = UserId, SiteId = SiteId, Kind = "book", Title = "Dracula vocab", MemberCount = 9 });
         // Concept cluster owned by another user must be excluded.
         h.Clusters.Add(new WordCluster { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), SiteId = SiteId, Kind = "concept", Title = "Other user", MemberCount = 5 });
-        // Concept cluster on another site must be excluded.
-        h.Clusters.Add(new WordCluster { Id = Guid.NewGuid(), UserId = UserId, SiteId = Guid.NewGuid(), Kind = "concept", Title = "Other site", MemberCount = 5 });
+        // Note: cross-site exclusion is now enforced by the EF global query filter
+        // (R1b), not by this endpoint's LINQ, so it is not exercised by this
+        // list-backed mock. Site isolation is covered by the R1b isolation test.
 
         var result = await VocabularyEndpoints.QueryConceptsAsync(h.Db, UserId, SiteId, CancellationToken.None);
 

--- a/tests/TextStack.UnitTests/SiteScopedFilterRegistrationTests.cs
+++ b/tests/TextStack.UnitTests/SiteScopedFilterRegistrationTests.cs
@@ -1,0 +1,72 @@
+using Domain.Entities;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace TextStack.UnitTests;
+
+// R1c metamodel guard. R1b delegated all single-site row scoping to EF global
+// query filters (HasQueryFilter(x => x.SiteId == _currentSite.Id)) on every
+// ISiteScoped entity, and R1c removed the now-redundant manual .Where(SiteId==)
+// terms that used to back that up. If a future entity implements ISiteScoped
+// but forgets its HasQueryFilter, it would silently leak rows across sites with
+// no compile error — this test turns that into a red build.
+//
+// Builds the REAL production model (AppDbContextFactory wires UseNpgsql +
+// UseVector). Model construction does not open a connection, so no live DB is
+// needed. Query filters are read via the EF 10 API IReadOnlyEntityType
+// .GetDeclaredQueryFilters() (named-filter aware; the parameterless
+// GetQueryFilter() is the legacy single-filter accessor).
+public class SiteScopedFilterRegistrationTests
+{
+    private static IModel BuildModel()
+    {
+        using var ctx = new AppDbContextFactory().CreateDbContext([]);
+        return ctx.Model;
+    }
+
+    [Fact]
+    public void EverySiteScopedEntity_HasGlobalQueryFilter()
+    {
+        var model = BuildModel();
+
+        var siteScoped = model.GetEntityTypes()
+            .Where(et => typeof(ISiteScoped).IsAssignableFrom(et.ClrType))
+            .ToList();
+
+        // Guard against a silent no-op: the model must actually contain
+        // ISiteScoped entities (21 as of R1b), otherwise the check below is vacuous.
+        Assert.NotEmpty(siteScoped);
+
+        var missing = siteScoped
+            .Where(et => !et.GetDeclaredQueryFilters().Any())
+            .Select(et => et.ClrType.Name)
+            .OrderBy(n => n)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            $"ISiteScoped entities missing an EF global query filter (add HasQueryFilter): {string.Join(", ", missing)}");
+    }
+
+    [Theory]
+    [InlineData("Site")]
+    [InlineData("SiteDomain")]
+    public void SiteResolverEntities_AreNotSiteScoped_AndHaveNoFilter(string entityName)
+    {
+        var model = BuildModel();
+
+        var et = model.GetEntityTypes().FirstOrDefault(e => e.ClrType.Name == entityName);
+
+        // The entity must exist in the model (else this test rots into a no-op
+        // if the type is renamed).
+        Assert.NotNull(et);
+
+        // Deliberately excluded from site scoping: the site resolver reads these
+        // to discover the current site, so filtering them would deadlock at zero rows.
+        Assert.False(
+            typeof(ISiteScoped).IsAssignableFrom(et!.ClrType),
+            $"{entityName} must not implement ISiteScoped.");
+        Assert.Empty(et.GetDeclaredQueryFilters());
+    }
+}


### PR DESCRIPTION
## What & why

Follow-up to #402 (R1a+R1b). Now that the EF global query filter is proven in CI, this removes the **redundant manual `SiteId` filters** it replaced — the "belt" once the "suspenders" (query filter) is trusted.

## Changes (R1c)
- Removed **168** redundant `.Where(x => x.SiteId == …)` terms from EF-LINQ (`.SiteId ==` count **169 → 1**). Compound predicates had only the SiteId conjunct stripped; all other conditions preserved verbatim.
- The **1 kept** term (`AdminService.Editions` chapter count) is required: `Chapter` is not `ISiteScoped` (no query filter) and `Edition` isn't otherwise joined there, so the filter can't propagate — documented inline (contrast `BookService.GetChapterAsync`, where Edition *is* joined so the term was dropped safely).
- Removed 19 now-dead `siteId` locals. `GetSiteId()` plumbing and unused method params left for a later cleanup.
- **Dapper/raw-SQL untouched** (search, indexer, RAG, similar-books, hybrid) — the query filter doesn't cover raw SQL; those keep explicit `site_id`.
- **New `SiteScopedFilterRegistrationTests`** — asserts every `ISiteScoped` entity has a registered EF query filter (guards a future entity silently missing one), and that `Site`/`SiteDomain` stay unscoped. Proven non-vacuous (fails if any filter is removed).

## Verification
- `dotnet test tests/TextStack.UnitTests` → **999 passed** (996 + 3 guard cases). Build + `dotnet format` clean.
- Adversarial QA walked all 40 files: no transform mis-cut, no scope removed from a non-`ISiteScoped` entity, Dapper integrity confirmed.
- Runtime equivalence proven by the same CI integration suite as #402.

## Rollback
One revert. This removes only the *redundant* manual filters — reverting restores them; the R1b query filter (already on main) keeps scoping regardless.

## ⚠️ Pre-merge / pre-deploy check
This is the slice that removes the manual "belt", so scoping now relies solely on the query filter. Before deploy, confirm no stray-site rows exist in prod:
```sql
-- run per ISiteScoped table; all rows must be 11111111-1111-1111-1111-111111111111
SELECT DISTINCT site_id FROM editions;   -- authors, highlights, reading_sessions, vocabulary_words, ...
```
Seeds + all merge migrations converge on that GUID, so expected clean — but verify, since a stray row would become invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
