### PR TITLE
refactor(api): unify duplicated Entity→DTO projections into Api/Mapping (R4)

### DIFF
--- a/backend/src/Api/Endpoints/AdminAuthEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminAuthEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.Mapping;
 using Application.AdminAuth;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -37,7 +38,7 @@ public static class AdminAuthEndpoints
         await SetAuthCookiesAsync(httpContext, authService, accessToken, refreshToken, ct);
 
         return Results.Ok(new AdminAuthResponse(
-            new AdminUserDto(user.Id, user.Email, user.Role, user.CreatedAt)));
+            user.ToDto()));
     }
 
     private static async Task<IResult> RefreshToken(
@@ -63,7 +64,7 @@ public static class AdminAuthEndpoints
         await SetAuthCookiesAsync(httpContext, authService, newAccessToken, newRefreshToken, ct);
 
         return Results.Ok(new AdminAuthResponse(
-            new AdminUserDto(user.Id, user.Email, user.Role, user.CreatedAt)));
+            user.ToDto()));
     }
 
     private static async Task<IResult> Logout(
@@ -102,7 +103,7 @@ public static class AdminAuthEndpoints
             return Results.Unauthorized();
 
         return Results.Ok(new AdminAuthResponse(
-            new AdminUserDto(user.Id, user.Email, user.Role, user.CreatedAt)));
+            user.ToDto()));
     }
 
     private static async Task SetAuthCookiesAsync(

--- a/backend/src/Api/Endpoints/AuthEndpoints.cs
+++ b/backend/src/Api/Endpoints/AuthEndpoints.cs
@@ -1,4 +1,5 @@
 using Api.Extensions;
+using Api.Mapping;
 using Application.Auth;
 using Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
@@ -44,7 +45,7 @@ public static class AuthEndpoints
         {
             var existingUser = await authService.GetUserByIdAsync(existingUserId.Value, ct);
             if (existingUser != null)
-                return Results.Ok(new AuthResponse(ToDto(existingUser)));
+                return Results.Ok(new AuthResponse(existingUser.ToDto()));
         }
 
         var result = await authService.CreateGuestSessionAsync(ct);
@@ -176,7 +177,7 @@ public static class AuthEndpoints
             return Results.Unauthorized();
 
         var (user, newAccessToken, newRefreshToken) = result.Value;
-        return Results.Ok(new MobileAuthResponse(ToDto(user), newAccessToken, newRefreshToken));
+        return Results.Ok(new MobileAuthResponse(user.ToDto(), newAccessToken, newRefreshToken));
     }
 
     private static async Task<IResult> Logout(
@@ -205,7 +206,7 @@ public static class AuthEndpoints
         if (user == null)
             return Results.Unauthorized();
 
-        return Results.Ok(new AuthResponse(ToDto(user)));
+        return Results.Ok(new AuthResponse(user.ToDto()));
     }
 
     private static async Task<IResult> ForgotPassword(
@@ -244,15 +245,12 @@ public static class AuthEndpoints
         return Results.Ok();
     }
 
-    private static UserDto ToDto(User user) =>
-        new(user.Id, user.Email, user.Name, user.Picture, user.IsGuest, user.CreatedAt, user.NativeLanguage);
-
     private static IResult ReturnAuthResult(
         (User user, string accessToken, string refreshToken) result,
         HttpContext httpContext)
     {
         var (user, accessToken, refreshToken) = result;
-        var dto = ToDto(user);
+        var dto = user.ToDto();
 
         if (IsMobileClient(httpContext))
             return Results.Ok(new MobileAuthResponse(dto, accessToken, refreshToken));

--- a/backend/src/Api/Endpoints/HighlightsEndpoints.cs
+++ b/backend/src/Api/Endpoints/HighlightsEndpoints.cs
@@ -1,4 +1,5 @@
 using Api.Extensions;
+using Api.Mapping;
 using Api.Sites;
 using Application.Auth;
 using Application.Common.Interfaces;
@@ -38,11 +39,7 @@ public static class HighlightsEndpoints
         var highlights = await db.Highlights
             .Where(h => h.UserId == userId.Value && h.EditionId == editionId)
             .OrderByDescending(h => h.CreatedAt)
-            .Select(h => new HighlightDto(
-                h.Id, h.EditionId, h.ChapterId, h.UserBookId, h.UserChapterId,
-                h.AnchorJson, h.Color, h.SelectedText, h.NoteText,
-                h.Version, h.CreatedAt, h.UpdatedAt
-            ))
+            .Select(HighlightMappings.Project)
             .ToListAsync(ct);
 
         return Results.Ok(highlights);
@@ -65,11 +62,7 @@ public static class HighlightsEndpoints
         var highlights = await db.Highlights
             .Where(h => h.UserId == userId.Value && h.UserBookId == userBookId)
             .OrderByDescending(h => h.CreatedAt)
-            .Select(h => new HighlightDto(
-                h.Id, h.EditionId, h.ChapterId, h.UserBookId, h.UserChapterId,
-                h.AnchorJson, h.Color, h.SelectedText, h.NoteText,
-                h.Version, h.CreatedAt, h.UpdatedAt
-            ))
+            .Select(HighlightMappings.Project)
             .ToListAsync(ct);
 
         return Results.Ok(highlights);
@@ -269,7 +262,7 @@ public static class HighlightsEndpoints
         db.Highlights.Add(highlight);
         await db.SaveChangesAsync(ct);
 
-        return Results.Created($"/me/highlights/{highlight.Id}", ToDto(highlight));
+        return Results.Created($"/me/highlights/{highlight.Id}", highlight.ToDto());
     }
 
     private static async Task<IResult> UpdateHighlight(
@@ -290,7 +283,7 @@ public static class HighlightsEndpoints
         if (highlight == null) return Results.NotFound();
 
         if (request.Version.HasValue && request.Version.Value != highlight.Version)
-            return Results.Conflict(ToDto(highlight));
+            return Results.Conflict(highlight.ToDto());
 
         if (request.Color != null)
             highlight.Color = request.Color;
@@ -308,7 +301,7 @@ public static class HighlightsEndpoints
 
         await db.SaveChangesAsync(ct);
 
-        return Results.Ok(ToDto(highlight));
+        return Results.Ok(highlight.ToDto());
     }
 
     private static async Task<IResult> DeleteHighlight(
@@ -332,12 +325,6 @@ public static class HighlightsEndpoints
 
         return Results.NoContent();
     }
-
-    private static HighlightDto ToDto(Highlight h) => new(
-        h.Id, h.EditionId, h.ChapterId, h.UserBookId, h.UserChapterId,
-        h.AnchorJson, h.Color, h.SelectedText, h.NoteText,
-        h.Version, h.CreatedAt, h.UpdatedAt
-    );
 }
 
 // DTOs

--- a/backend/src/Api/Endpoints/ProfileEndpoints.cs
+++ b/backend/src/Api/Endpoints/ProfileEndpoints.cs
@@ -1,4 +1,5 @@
 using Api.Extensions;
+using Api.Mapping;
 using Application.Auth;
 using Application.Common.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -40,7 +41,7 @@ public static class ProfileEndpoints
         var user = await authService.GetUserByIdAsync(userId.Value, ct);
         if (user == null) return Results.Unauthorized();
 
-        return Results.Ok(new AuthResponse(new UserDto(user.Id, user.Email, user.Name, user.Picture, user.IsGuest, user.CreatedAt, user.NativeLanguage)));
+        return Results.Ok(new AuthResponse(user.ToDto()));
     }
 
     private static async Task<IResult> UpdateProfile(
@@ -80,7 +81,7 @@ public static class ProfileEndpoints
 
         await db.SaveChangesAsync(ct);
 
-        return Results.Ok(new AuthResponse(new UserDto(user.Id, user.Email, user.Name, user.Picture, user.IsGuest, user.CreatedAt, user.NativeLanguage)));
+        return Results.Ok(new AuthResponse(user.ToDto()));
     }
 
     private static async Task<IResult> UploadAvatar(
@@ -126,7 +127,7 @@ public static class ProfileEndpoints
         user.Picture = relativePath;
         await db.SaveChangesAsync(ct);
 
-        return Results.Ok(new AuthResponse(new UserDto(user.Id, user.Email, user.Name, user.Picture, user.IsGuest, user.CreatedAt, user.NativeLanguage)));
+        return Results.Ok(new AuthResponse(user.ToDto()));
     }
 
     private static async Task<IResult> DeleteAvatar(

--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Goals.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Goals.cs
@@ -1,4 +1,5 @@
 using Api.Extensions;
+using Api.Mapping;
 using Api.Sites;
 using Application.Auth;
 using Application.Common.Interfaces;
@@ -21,7 +22,7 @@ public static partial class ReadingTrackingEndpoints
 
         var goals = await db.ReadingGoals
             .Where(g => g.UserId == userId.Value && g.IsActive)
-            .Select(g => new GoalDto(g.Id, g.GoalType, g.TargetValue, g.Year, g.StreakMinMinutes, g.UpdatedAt))
+            .Select(ReadingMappings.Project)
             .ToListAsync(ct);
 
         return Results.Ok(goals);
@@ -75,8 +76,7 @@ public static partial class ReadingTrackingEndpoints
 
         await db.SaveChangesAsync(ct);
 
-        return Results.Ok(new GoalDto(existing.Id, existing.GoalType, existing.TargetValue,
-            existing.Year, existing.StreakMinMinutes, existing.UpdatedAt));
+        return Results.Ok(existing.ToDto());
     }
 
     private static async Task<IResult> DeleteGoal(

--- a/backend/src/Api/Endpoints/UserDataEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserDataEndpoints.cs
@@ -1,4 +1,5 @@
 using Api.Extensions;
+using Api.Mapping;
 using Api.Sites;
 using Application.Auth;
 using Application.Common.Interfaces;
@@ -229,14 +230,7 @@ public static class UserDataEndpoints
         var items = await query
             .Skip(offset ?? 0)
             .Take(limit ?? 100)
-            .Select(b => new BookmarkDto(
-                b.Id,
-                b.EditionId,
-                b.ChapterId,
-                b.Locator,
-                b.Title,
-                b.CreatedAt
-            ))
+            .Select(BookmarkMappings.Project)
             .ToListAsync(ct);
 
         return Results.Ok(new { total, items });
@@ -256,14 +250,7 @@ public static class UserDataEndpoints
         var bookmarks = await db.Bookmarks
             .Where(b => b.UserId == userId.Value && b.EditionId == editionId)
             .OrderByDescending(b => b.CreatedAt)
-            .Select(b => new BookmarkDto(
-                b.Id,
-                b.EditionId,
-                b.ChapterId,
-                b.Locator,
-                b.Title,
-                b.CreatedAt
-            ))
+            .Select(BookmarkMappings.Project)
             .ToListAsync(ct);
 
         return Results.Ok(bookmarks);
@@ -310,14 +297,7 @@ public static class UserDataEndpoints
         db.Bookmarks.Add(bookmark);
         await db.SaveChangesAsync(ct);
 
-        return Results.Created($"/me/bookmarks/{bookmark.Id}", new BookmarkDto(
-            bookmark.Id,
-            bookmark.EditionId,
-            bookmark.ChapterId,
-            bookmark.Locator,
-            bookmark.Title,
-            bookmark.CreatedAt
-        ));
+        return Results.Created($"/me/bookmarks/{bookmark.Id}", bookmark.ToDto());
     }
 
     private static async Task<IResult> DeleteBookmark(

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.Clusters.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.Clusters.cs
@@ -1,3 +1,4 @@
+using Api.Mapping;
 using Application.Auth;
 using Application.Common.Interfaces;
 using Application.Vocabulary;
@@ -158,15 +159,10 @@ public static partial class VocabularyEndpoints
                      && languages.Contains(w.Language))
             .OrderBy(_ => EF.Functions.Random())
             .Take(MaxDistractorPoolSize)
-            .Select(w => new DistractorPoolEntry(w.Word, w.Language))
+            .Select(VocabularyMappings.DistractorPoolProject)
             .ToListAsync(ct);
 
-        var wordsForReview = members.Select(w => new WordForReview(
-            w.Id, w.Word, w.Language,
-            w.Translation, w.Definition,
-            w.Sentence, w.BookTitle, w.Hint,
-            w.Explanation, w.Distractors,
-            w.Stage, w.TotalReviews)).ToList();
+        var wordsForReview = members.Select(VocabularyMappings.ToWordForReview).ToList();
 
         var cards = cardBuilder.BuildCards(wordsForReview, pool);
         var cardDtos = cards.Select(c => new ReviewCardDto(

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Api.Extensions;
+using Api.Mapping;
 using Api.Sites;
 using Application.Auth;
 using Application.Common.Interfaces;
@@ -560,15 +561,10 @@ public static partial class VocabularyEndpoints
                 && languages.Contains(w.Language))
             .OrderBy(_ => EF.Functions.Random())
             .Take(MaxDistractorPoolSize)
-            .Select(w => new DistractorPoolEntry(w.Word, w.Language))
+            .Select(VocabularyMappings.DistractorPoolProject)
             .ToListAsync(ct);
 
-        var wordsForReview = dueWords.Select(w => new WordForReview(
-            w.Id, w.Word, w.Language,
-            w.Translation, w.Definition,
-            w.Sentence, w.BookTitle, w.Hint,
-            w.Explanation, w.Distractors,
-            w.Stage, w.TotalReviews)).ToList();
+        var wordsForReview = dueWords.Select(VocabularyMappings.ToWordForReview).ToList();
 
         var cards = cardBuilder.BuildCards(wordsForReview, distractorPool);
 

--- a/backend/src/Api/Mapping/AdminAuthMappings.cs
+++ b/backend/src/Api/Mapping/AdminAuthMappings.cs
@@ -1,0 +1,11 @@
+using Application.AdminAuth;
+using Domain.Entities;
+
+namespace Api.Mapping;
+
+// R4: single source of truth for AdminUser -> AdminUserDto. In-memory only.
+public static class AdminAuthMappings
+{
+    public static AdminUserDto ToDto(this AdminUser user) =>
+        new(user.Id, user.Email, user.Role, user.CreatedAt);
+}

--- a/backend/src/Api/Mapping/AuthMappings.cs
+++ b/backend/src/Api/Mapping/AuthMappings.cs
@@ -1,0 +1,12 @@
+using Application.Auth;
+using Domain.Entities;
+
+namespace Api.Mapping;
+
+// R4: single source of truth for User -> UserDto. In-memory only (User is always
+// materialised before mapping), so just the extension method — no EF Project needed.
+public static class AuthMappings
+{
+    public static UserDto ToDto(this User user) =>
+        new(user.Id, user.Email, user.Name, user.Picture, user.IsGuest, user.CreatedAt, user.NativeLanguage);
+}

--- a/backend/src/Api/Mapping/BookmarkMappings.cs
+++ b/backend/src/Api/Mapping/BookmarkMappings.cs
@@ -1,0 +1,17 @@
+using System.Linq.Expressions;
+using Api.Endpoints;
+using Domain.Entities;
+
+namespace Api.Mapping;
+
+// R4: single source of truth for Bookmark -> BookmarkDto. Used both as an EF projection
+// (.Select(BookmarkMappings.Project)) and in-memory (bookmark.ToDto()).
+public static class BookmarkMappings
+{
+    public static readonly Expression<Func<Bookmark, BookmarkDto>> Project = b => new BookmarkDto(
+        b.Id, b.EditionId, b.ChapterId, b.Locator, b.Title, b.CreatedAt);
+
+    private static readonly Func<Bookmark, BookmarkDto> _compiled = Project.Compile();
+
+    public static BookmarkDto ToDto(this Bookmark b) => _compiled(b);
+}

--- a/backend/src/Api/Mapping/HighlightMappings.cs
+++ b/backend/src/Api/Mapping/HighlightMappings.cs
@@ -1,0 +1,21 @@
+using System.Linq.Expressions;
+using Api.Endpoints;
+using Domain.Entities;
+
+namespace Api.Mapping;
+
+// R4: single source of truth for Highlight -> HighlightDto. Used both as an EF
+// projection (.Select(HighlightMappings.Project) — translated to SQL) and in-memory
+// (highlight.ToDto()). The compiled delegate is built once so the two forms can never
+// drift: the field list lives in exactly one place (Project).
+public static class HighlightMappings
+{
+    public static readonly Expression<Func<Highlight, HighlightDto>> Project = h => new HighlightDto(
+        h.Id, h.EditionId, h.ChapterId, h.UserBookId, h.UserChapterId,
+        h.AnchorJson, h.Color, h.SelectedText, h.NoteText,
+        h.Version, h.CreatedAt, h.UpdatedAt);
+
+    private static readonly Func<Highlight, HighlightDto> _compiled = Project.Compile();
+
+    public static HighlightDto ToDto(this Highlight h) => _compiled(h);
+}

--- a/backend/src/Api/Mapping/ReadingMappings.cs
+++ b/backend/src/Api/Mapping/ReadingMappings.cs
@@ -1,0 +1,17 @@
+using System.Linq.Expressions;
+using Api.Endpoints;
+using Domain.Entities;
+
+namespace Api.Mapping;
+
+// R4: single source of truth for ReadingGoal -> GoalDto. Used both as an EF projection
+// (.Select(ReadingMappings.Project)) and in-memory (goal.ToDto()).
+public static class ReadingMappings
+{
+    public static readonly Expression<Func<ReadingGoal, GoalDto>> Project = g => new GoalDto(
+        g.Id, g.GoalType, g.TargetValue, g.Year, g.StreakMinMinutes, g.UpdatedAt);
+
+    private static readonly Func<ReadingGoal, GoalDto> _compiled = Project.Compile();
+
+    public static GoalDto ToDto(this ReadingGoal g) => _compiled(g);
+}

--- a/backend/src/Api/Mapping/VocabularyMappings.cs
+++ b/backend/src/Api/Mapping/VocabularyMappings.cs
@@ -1,0 +1,22 @@
+using System.Linq.Expressions;
+using Domain.Entities;
+using TextStack.Vocabulary.Contracts;
+
+namespace Api.Mapping;
+
+// R4: single source of truth for the two mechanical VocabularyWord projections that were
+// duplicated between the main review queue and the concept-cluster review endpoints.
+// - DistractorPoolProject: EF projection (.Select(...) translated to SQL).
+// - ToWordForReview: in-memory (the due-words list is materialised before mapping).
+public static class VocabularyMappings
+{
+    public static readonly Expression<Func<VocabularyWord, DistractorPoolEntry>> DistractorPoolProject =
+        w => new DistractorPoolEntry(w.Word, w.Language);
+
+    public static WordForReview ToWordForReview(this VocabularyWord w) => new(
+        w.Id, w.Word, w.Language,
+        w.Translation, w.Definition,
+        w.Sentence, w.BookTitle, w.Hint,
+        w.Explanation, w.Distractors,
+        w.Stage, w.TotalReviews);
+}

--- a/tests/TextStack.UnitTests/MappingTests.cs
+++ b/tests/TextStack.UnitTests/MappingTests.cs
@@ -1,0 +1,283 @@
+using System.Text.Json;
+using Api.Endpoints;
+using Api.Mapping;
+using Application.AdminAuth;
+using Application.Auth;
+using Domain.Entities;
+using Domain.Enums;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using TextStack.Vocabulary.Contracts;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// R4 mapping-layer guard. Two things are proven per extracted projection:
+///  (1) JSON snapshot — a fixture entity mapped via the mapping layer serialises to the
+///      exact expected JSON (byte-identical field mapping, no accidental drift), and
+///  (2) form parity — for DTOs mapped in both forms, the compiled <c>Project</c> expression
+///      produces the same JSON as the in-memory <c>ToDto()</c> extension (single source of
+///      truth, the two forms can never diverge).
+/// A separate SQLite fixture proves every <c>Project</c> used on an IQueryable actually
+/// translates to SQL (no silent client-eval). Full SQL translation is re-checked in CI
+/// integration against Postgres.
+/// </summary>
+public class MappingTests
+{
+    private static readonly Guid G1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid G2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid G3 = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid G4 = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid G5 = Guid.Parse("55555555-5555-5555-5555-555555555555");
+    private static readonly DateTimeOffset T1 = new(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+    private static readonly DateTimeOffset T2 = new(2026, 6, 7, 8, 9, 10, TimeSpan.Zero);
+
+    private static string Json<T>(T value) => JsonSerializer.Serialize(value);
+
+    // ---- Fixtures -------------------------------------------------------------
+
+    private static Highlight NewHighlight() => new()
+    {
+        Id = G1,
+        UserId = G2,
+        SiteId = G3,
+        EditionId = G4,
+        ChapterId = G5,
+        UserBookId = null,
+        UserChapterId = null,
+        AnchorJson = "{\"a\":1}",
+        Color = "yellow",
+        SelectedText = "hello world",
+        NoteText = "my note",
+        Version = 3,
+        CreatedAt = T1,
+        UpdatedAt = T2,
+        LastReviewedAt = null,
+    };
+
+    private static Bookmark NewBookmark() => new()
+    {
+        Id = G1,
+        UserId = G2,
+        SiteId = G3,
+        EditionId = G4,
+        ChapterId = G5,
+        Locator = "loc-1",
+        Title = "chapter one",
+        CreatedAt = T1,
+    };
+
+    private static ReadingGoal NewGoal() => new()
+    {
+        Id = G1,
+        UserId = G2,
+        SiteId = G3,
+        GoalType = "daily_minutes",
+        TargetValue = 30,
+        Year = 0,
+        IsActive = true,
+        StreakMinMinutes = 5,
+        CreatedAt = T1,
+        UpdatedAt = T2,
+    };
+
+    private static User NewUser() => new()
+    {
+        Id = G1,
+        Email = "u@example.com",
+        Name = "Jane",
+        Picture = "pic.png",
+        IsGuest = false,
+        CreatedAt = T1,
+        NativeLanguage = "uk",
+    };
+
+    private static AdminUser NewAdmin() => new()
+    {
+        Id = G1,
+        Email = "admin@example.com",
+        PasswordHash = "hash",
+        Role = AdminRole.Editor,
+        CreatedAt = T1,
+    };
+
+    private static VocabularyWord NewWord() => new()
+    {
+        Id = G1,
+        UserId = G2,
+        SiteId = G3,
+        Word = "serendipity",
+        Language = "en",
+        Translation = "щасливий випадок",
+        Definition = "a happy accident",
+        Sentence = "It was pure serendipity.",
+        BookTitle = "Some Book",
+        Hint = "a lucky find",
+        Explanation = "when good things happen by chance",
+        Distractors = "[\"a\",\"b\"]",
+        Stage = 2,
+        TotalReviews = 7,
+    };
+
+    // ---- JSON snapshots -------------------------------------------------------
+
+    [Fact]
+    public void HighlightToDto_Fixture_MatchesSnapshot()
+    {
+        var expected =
+            "{\"Id\":\"11111111-1111-1111-1111-111111111111\"," +
+            "\"EditionId\":\"44444444-4444-4444-4444-444444444444\"," +
+            "\"ChapterId\":\"55555555-5555-5555-5555-555555555555\"," +
+            "\"UserBookId\":null,\"UserChapterId\":null," +
+            "\"AnchorJson\":\"{\\u0022a\\u0022:1}\",\"Color\":\"yellow\"," +
+            "\"SelectedText\":\"hello world\",\"NoteText\":\"my note\",\"Version\":3," +
+            "\"CreatedAt\":\"2026-01-02T03:04:05+00:00\",\"UpdatedAt\":\"2026-06-07T08:09:10+00:00\"}";
+        Assert.Equal(expected, Json(NewHighlight().ToDto()));
+    }
+
+    [Fact]
+    public void BookmarkToDto_Fixture_MatchesSnapshot()
+    {
+        var expected =
+            "{\"Id\":\"11111111-1111-1111-1111-111111111111\"," +
+            "\"EditionId\":\"44444444-4444-4444-4444-444444444444\"," +
+            "\"ChapterId\":\"55555555-5555-5555-5555-555555555555\"," +
+            "\"Locator\":\"loc-1\",\"Title\":\"chapter one\"," +
+            "\"CreatedAt\":\"2026-01-02T03:04:05+00:00\"}";
+        Assert.Equal(expected, Json(NewBookmark().ToDto()));
+    }
+
+    [Fact]
+    public void GoalToDto_Fixture_MatchesSnapshot()
+    {
+        var expected =
+            "{\"Id\":\"11111111-1111-1111-1111-111111111111\"," +
+            "\"GoalType\":\"daily_minutes\",\"TargetValue\":30,\"Year\":0," +
+            "\"StreakMinMinutes\":5,\"UpdatedAt\":\"2026-06-07T08:09:10+00:00\"}";
+        Assert.Equal(expected, Json(NewGoal().ToDto()));
+    }
+
+    [Fact]
+    public void UserToDto_Fixture_MatchesSnapshot()
+    {
+        var expected =
+            "{\"Id\":\"11111111-1111-1111-1111-111111111111\"," +
+            "\"Email\":\"u@example.com\",\"Name\":\"Jane\",\"Picture\":\"pic.png\"," +
+            "\"IsGuest\":false,\"CreatedAt\":\"2026-01-02T03:04:05+00:00\"," +
+            "\"NativeLanguage\":\"uk\"}";
+        Assert.Equal(expected, Json(NewUser().ToDto()));
+    }
+
+    [Fact]
+    public void AdminUserToDto_Fixture_MatchesSnapshot()
+    {
+        var expected =
+            "{\"Id\":\"11111111-1111-1111-1111-111111111111\"," +
+            "\"Email\":\"admin@example.com\",\"Role\":1," +
+            "\"CreatedAt\":\"2026-01-02T03:04:05+00:00\"}";
+        Assert.Equal(expected, Json(NewAdmin().ToDto()));
+    }
+
+    [Fact]
+    public void WordForReview_Fixture_MatchesSnapshot()
+    {
+        var expected =
+            "{\"Id\":\"11111111-1111-1111-1111-111111111111\"," +
+            "\"Word\":\"serendipity\",\"Language\":\"en\"," +
+            "\"Translation\":\"\\u0449\\u0430\\u0441\\u043B\\u0438\\u0432\\u0438\\u0439 \\u0432\\u0438\\u043F\\u0430\\u0434\\u043E\\u043A\"," +
+            "\"Definition\":\"a happy accident\"," +
+            "\"Sentence\":\"It was pure serendipity.\",\"BookTitle\":\"Some Book\"," +
+            "\"Hint\":\"a lucky find\"," +
+            "\"Explanation\":\"when good things happen by chance\"," +
+            "\"DistractorsJson\":\"[\\u0022a\\u0022,\\u0022b\\u0022]\"," +
+            "\"Stage\":2,\"TotalReviews\":7}";
+        Assert.Equal(expected, Json(NewWord().ToWordForReview()));
+    }
+
+    [Fact]
+    public void DistractorPoolProject_Fixture_MatchesSnapshot()
+    {
+        var project = VocabularyMappings.DistractorPoolProject.Compile();
+        var expected = "{\"Word\":\"serendipity\",\"Language\":\"en\"}";
+        Assert.Equal(expected, Json(project(NewWord())));
+    }
+
+    // Note: no Project-vs-ToDto parity test — ToDto IS Project.Compile() (single
+    // source of truth), so such a test is tautological. The JSON snapshots above
+    // are the real guard for both forms.
+
+    // ---- EF translation guard (SQLite) ---------------------------------------
+
+    private sealed class MappingDb : DbContext
+    {
+        public MappingDb(DbContextOptions<MappingDb> options) : base(options) { }
+
+        public DbSet<Highlight> Highlights => Set<Highlight>();
+        public DbSet<Bookmark> Bookmarks => Set<Bookmark>();
+        public DbSet<ReadingGoal> ReadingGoals => Set<ReadingGoal>();
+        public DbSet<VocabularyWord> VocabularyWords => Set<VocabularyWord>();
+
+        protected override void OnModelCreating(ModelBuilder b)
+        {
+            // Map only the scalar columns the R4 projections touch; drop every navigation
+            // and Postgres-only column (pgvector float[]) so the minimal model builds on Sqlite.
+            b.Entity<Highlight>(e =>
+            {
+                e.Ignore(x => x.User); e.Ignore(x => x.Site); e.Ignore(x => x.Edition);
+                e.Ignore(x => x.Chapter); e.Ignore(x => x.UserBook); e.Ignore(x => x.UserChapter);
+                e.Ignore(x => x.Note);
+            });
+            b.Entity<Bookmark>(e =>
+            {
+                e.Ignore(x => x.User); e.Ignore(x => x.Site);
+                e.Ignore(x => x.Edition); e.Ignore(x => x.Chapter);
+            });
+            b.Entity<ReadingGoal>(e =>
+            {
+                e.Ignore(x => x.User); e.Ignore(x => x.Site);
+            });
+            b.Entity<VocabularyWord>(e =>
+            {
+                e.Ignore(x => x.User); e.Ignore(x => x.Site); e.Ignore(x => x.Edition);
+                e.Ignore(x => x.Chapter); e.Ignore(x => x.UserBook); e.Ignore(x => x.Reviews);
+                e.Ignore(x => x.ConceptCluster); e.Ignore(x => x.Embedding);
+            });
+        }
+    }
+
+    private static MappingDb NewMappingDb(SqliteConnection conn)
+    {
+        var options = new DbContextOptionsBuilder<MappingDb>().UseSqlite(conn).Options;
+        var db = new MappingDb(options);
+        db.Database.EnsureCreated();
+        return db;
+    }
+
+    [Fact]
+    public void Projects_TranslateToSql_NoClientEval()
+    {
+        using var conn = new SqliteConnection("Filename=:memory:");
+        conn.Open();
+        using var db = NewMappingDb(conn);
+
+        db.Highlights.Add(NewHighlight());
+        db.Bookmarks.Add(NewBookmark());
+        db.ReadingGoals.Add(NewGoal());
+        db.VocabularyWords.Add(NewWord());
+        db.SaveChanges();
+
+        // Each Select(Project) executes server-side; an un-translatable expression would
+        // throw InvalidOperationException here rather than silently client-evaluate.
+        var highlight = db.Highlights.Select(HighlightMappings.Project).Single();
+        Assert.Equal(Json(NewHighlight().ToDto()), Json(highlight));
+
+        var bookmark = db.Bookmarks.Select(BookmarkMappings.Project).Single();
+        Assert.Equal(Json(NewBookmark().ToDto()), Json(bookmark));
+
+        var goal = db.ReadingGoals.Select(ReadingMappings.Project).Single();
+        Assert.Equal(Json(NewGoal().ToDto()), Json(goal));
+
+        var pool = db.VocabularyWords.Select(VocabularyMappings.DistractorPoolProject).Single();
+        Assert.Equal(new DistractorPoolEntry("serendipity", "en"), pool);
+    }
+}


### PR DESCRIPTION
## What & why

Quality refactor (R4): unify duplicated `new XxxDto(...)` Entity→DTO projections into a single mapping layer so a DTO change touches one place. **Byte-identical behavior.**

## What changed
- New `backend/src/Api/Mapping/` (6 classes). Chosen home because `Api` is the only project that sees both Domain entities and every DTO (103 in `Contracts` + 56 Api-local); `Contracts` stays free of any `Domain` dependency.
- **7 identical multi-site DTOs consolidated**: Highlight, Bookmark, Goal, User, AdminUser, DistractorPoolEntry, WordForReview.
- **Two-form API without drift**: DTOs used both in-memory and inside `IQueryable.Select` expose an `Expression<Func<T,TDto>> Project` (single source of truth) + a once-compiled delegate for the ergonomic `.ToDto()`. **IQueryable sites use `Project`** (stay SQL-translatable — an extension method there would break EF translation / client-eval); in-memory sites (post-`ToListAsync`) use `.ToDto()`.
- 7 IQueryable sites → `.Select(Mappings.Project)`, 17 in-memory → `.ToDto()`, 2 ad-hoc local `ToDto` helpers deleted.

## Deliberately NOT merged
Divergent or aggregating projections stay in place (would risk silent field regressions): `ReadingProgressDto` (nullable slug source), `LibraryItemDto` (`string.Join`), `CollectionDto` (`i.Count` vs `0`), `BookIndexStatusDto`, `ModelRegistrationDto`, `RagCitationDto`, reading-stats aggregations, plus all wrapper/envelope responses. Single-use projections left as-is (no dedup value).

## Verification
- Adversarial QA pulled every `new <Dto>(...)` from `origin/main` and compared **field-by-field** across all sites for the 7 merged DTOs → all byte-identical (no divergent source/default/order). `UserDto` (7 sites) and `HighlightDto` (5 sites) explicitly checked.
- Confirmed no IQueryable site got the delegate form (no client-eval).
- New `MappingTests.cs`: JSON-snapshot tests (pin field names/order/values) + an EF-translation guard that executes each `Project` server-side on SQLite (throws if untranslatable). SQL translation against Postgres re-verified by CI integration.
- `dotnet build` 0 errors; `dotnet test tests/TextStack.UnitTests` → **1007 passed**; `dotnet format` clean.

## Rollback
One revert. Pure transport refactor — no schema, DI, or data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
