### PR TITLE
refactor(api): extract GetStats/Summary/Pace into ReadingStatsService (R5 slice-3)

### DIFF
--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Sessions.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Sessions.cs
@@ -87,8 +87,8 @@ public static partial class ReadingTrackingEndpoints
         List<string> newAchievements = [];
         try
         {
-            var streakMinMinutes = await GetStreakMinMinutes(db, userId.Value, siteId, ct);
-            var currentStreak = await CalculateStreak(db, userId.Value, siteId, streakMinMinutes, request.EndedAt, ct);
+            var streakMinMinutes = await StreakCalculator.GetStreakMinMinutes(db, userId.Value, ct);
+            var currentStreak = await StreakCalculator.CalculateStreak(db, userId.Value, streakMinMinutes, request.EndedAt, ct);
 
             var checker = new AchievementChecker(db);
             newAchievements = await checker.CheckAfterSession(userId.Value, siteId, session, currentStreak, ct);

--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Stats.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Stats.cs
@@ -1,10 +1,7 @@
 using Api.Extensions;
-using Api.Sites;
 using Application.Auth;
-using Application.Common.Interfaces;
 using Application.ReadingTracking;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace Api.Endpoints;
 
@@ -13,105 +10,18 @@ public static partial class ReadingTrackingEndpoints
     private static async Task<IResult> GetStats(
         HttpContext httpContext,
         AuthService authService,
-        IAppDbContext db,
+        ReadingStatsService statsService,
         [FromQuery] string? tz,
         CancellationToken ct)
     {
         var userId = httpContext.GetUserId(authService);
         if (userId == null) return Results.Unauthorized();
-        var siteId = httpContext.GetSiteId();
 
         var tzOffset = ParseTzOffset(tz);
         var now = DateTimeOffset.UtcNow;
 
-        var allSessions = db.ReadingSessions
-            .Where(s => s.UserId == userId.Value);
-
-        var totalSeconds = await allSessions.SumAsync(s => (long)s.DurationSeconds, ct);
-        var totalWords = await allSessions.SumAsync(s => (long)s.WordsRead, ct);
-        var sessionCount = await allSessions.CountAsync(ct);
-
-        var booksFinished = await allSessions
-            .Where(s => s.EndPercent >= 0.99)
-            .Select(s => s.EditionId ?? s.UserBookId)
-            .Distinct()
-            .CountAsync(ct);
-
-        // Time-period sums (calculate in user tz, convert to UTC for PostgreSQL)
-        var todayLocal = GetDayStart(now, tzOffset);
-        var todayStart = todayLocal.ToUniversalTime();
-        var weekStart = todayLocal.AddDays(-(int)todayLocal.DayOfWeek).ToUniversalTime();
-        var monthStart = new DateTimeOffset(todayLocal.Year, todayLocal.Month, 1, 0, 0, 0, tzOffset).ToUniversalTime();
-
-        var todaySeconds = await allSessions
-            .Where(s => s.StartedAt >= todayStart)
-            .SumAsync(s => (long)s.DurationSeconds, ct);
-        var weekSeconds = await allSessions
-            .Where(s => s.StartedAt >= weekStart)
-            .SumAsync(s => (long)s.DurationSeconds, ct);
-        var monthSeconds = await allSessions
-            .Where(s => s.StartedAt >= monthStart)
-            .SumAsync(s => (long)s.DurationSeconds, ct);
-
-        // Streak
-        var streakMinMinutes = await GetStreakMinMinutes(db, userId.Value, siteId, ct);
-        var currentStreak = await CalculateStreak(db, userId.Value, siteId, streakMinMinutes, now, ct, tzOffset);
-        var longestStreak = await CalculateLongestStreak(db, userId.Value, siteId, streakMinMinutes, ct, tzOffset);
-
-        // Averages
-        double avgDailyMinutes = 0;
-        double avgWordsPerMinute = 0;
-        if (sessionCount > 0)
-        {
-            var firstSession = await allSessions
-                .OrderBy(s => s.StartedAt)
-                .Select(s => s.StartedAt)
-                .FirstOrDefaultAsync(ct);
-            var daysSinceFirst = Math.Max(1, (now - firstSession).TotalDays);
-            avgDailyMinutes = totalSeconds / 60.0 / daysSinceFirst;
-
-            if (totalSeconds > 0)
-                avgWordsPerMinute = totalWords / (totalSeconds / 60.0);
-        }
-
-        // Vocab reviews today
-        var todayVocabReviews = await db.VocabularyReviews
-            .Where(r => r.UserId == userId.Value && r.CreatedAt >= todayStart)
-            .CountAsync(ct);
-
-        // Daily goal (reading + vocab reviews as effective minutes)
-        var dailyGoal = await db.ReadingGoals
-            .Where(g => g.UserId == userId.Value && g.GoalType == "daily_minutes" && g.IsActive)
-            .FirstOrDefaultAsync(ct);
-
-        object? dailyGoalObj = null;
-        if (dailyGoal != null)
-        {
-            var effectiveTodayMinutes = todaySeconds / 60.0 + todayVocabReviews * 0.5;
-            dailyGoalObj = new
-            {
-                target = dailyGoal.TargetValue,
-                today = Math.Round(effectiveTodayMinutes, 1),
-                met = effectiveTodayMinutes >= dailyGoal.TargetValue,
-            };
-        }
-
-        return Results.Ok(new
-        {
-            totalSeconds,
-            totalWords,
-            booksFinished,
-            currentStreak,
-            longestStreak,
-            streakMinMinutes,
-            avgDailyMinutes = Math.Round(avgDailyMinutes, 1),
-            avgWordsPerMinute = Math.Round(avgWordsPerMinute, 1),
-            todaySeconds,
-            todayVocabReviews,
-            weekSeconds,
-            monthSeconds,
-            dailyGoal = dailyGoalObj,
-        });
+        var resp = await statsService.GetStatsAsync(userId.Value, tzOffset, now, ct);
+        return Results.Ok(resp);
     }
 
     private static async Task<IResult> GetDailyStats(

--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Summary.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Summary.cs
@@ -1,26 +1,21 @@
 using Api.Extensions;
 using Api.Sites;
 using Application.Auth;
-using Application.Common.Interfaces;
+using Application.ReadingTracking;
+using Contracts.ReadingTracking;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Api.Endpoints;
 
 public static partial class ReadingTrackingEndpoints
 {
-    // --- Reading Pace (slice 19) ---
-
-    private const int PaceMinSessions = 3;
-    private const int FallbackPaceWpm = 200;
-
     // --- Library Summary (slice 20) ---
 
     private static async Task<IResult> GetLibrarySummary(
         HttpContext httpContext,
         AuthService authService,
-        IAppDbContext db,
+        ReadingStatsService statsService,
         IMemoryCache cache,
         [FromQuery] string? tz,
         CancellationToken ct)
@@ -35,68 +30,19 @@ public static partial class ReadingTrackingEndpoints
 
         var tzOffset = ParseTzOffset(tz);
         var now = DateTimeOffset.UtcNow;
-        var todayLocal = GetDayStart(now, tzOffset);
-        var monthStart = new DateTimeOffset(todayLocal.Year, todayLocal.Month, 1, 0, 0, 0, tzOffset).ToUniversalTime();
-        var yearStart = new DateTimeOffset(todayLocal.Year, 1, 1, 0, 0, 0, tzOffset).ToUniversalTime();
 
-        var monthAgg = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.StartedAt >= monthStart)
-            .GroupBy(_ => 1)
-            .Select(g => new { Words = g.Sum(s => (long)s.WordsRead), Seconds = g.Sum(s => (long)s.DurationSeconds) })
-            .FirstOrDefaultAsync(ct);
-
-        var pagesThisMonth = (int)((monthAgg?.Words ?? 0) / 250);
-        var minutesThisMonth = (int)((monthAgg?.Seconds ?? 0) / 60);
-
-        var streakMinMinutes = await GetStreakMinMinutes(db, userId.Value, siteId, ct);
-        var currentStreak = await CalculateStreak(db, userId.Value, siteId, streakMinMinutes, now, ct, tzOffset);
-
-        var booksFinishedYtd = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.EndPercent >= 0.99 && s.EndedAt >= yearStart)
-            .Select(s => s.EditionId ?? s.UserBookId)
-            .Distinct()
-            .CountAsync(ct);
-
-        var dailyGoal = await db.ReadingGoals
-            .Where(g => g.UserId == userId.Value && g.GoalType == "daily_minutes" && g.IsActive)
-            .Select(g => new { g.TargetValue, g.StreakMinMinutes })
-            .FirstOrDefaultAsync(ct);
-        var yearlyGoal = await db.ReadingGoals
-            .Where(g => g.UserId == userId.Value && g.GoalType == "books_per_year" && g.IsActive)
-            .Select(g => new { g.TargetValue, g.Year })
-            .FirstOrDefaultAsync(ct);
-
-        GoalSummaryDto? goal = null;
-        if (dailyGoal != null)
-        {
-            var todayStart = todayLocal.ToUniversalTime();
-            var todaySeconds = await db.ReadingSessions
-                .Where(s => s.UserId == userId.Value && s.StartedAt >= todayStart)
-                .SumAsync(s => (long)s.DurationSeconds, ct);
-            goal = new GoalSummaryDto("daily_minutes", (int)(todaySeconds / 60), dailyGoal.TargetValue);
-        }
-        else if (yearlyGoal != null)
-        {
-            goal = new GoalSummaryDto("books_per_year", booksFinishedYtd, yearlyGoal.TargetValue);
-        }
-
-        var dto = new LibrarySummaryDto(
-            PagesThisMonth: pagesThisMonth,
-            MinutesThisMonth: minutesThisMonth,
-            CurrentStreak: currentStreak,
-            StreakMinMinutes: streakMinMinutes,
-            BooksFinishedYtd: booksFinishedYtd,
-            Goal: goal
-        );
+        var dto = await statsService.GetLibrarySummaryAsync(userId.Value, tzOffset, now, ct);
 
         cache.Set(cacheKey, dto, TimeSpan.FromMinutes(5));
         return Results.Ok(dto);
     }
 
+    // --- Reading Pace (slice 19) ---
+
     private static async Task<IResult> GetPace(
         HttpContext httpContext,
         AuthService authService,
-        IAppDbContext db,
+        ReadingStatsService statsService,
         IMemoryCache cache,
         CancellationToken ct)
     {
@@ -108,24 +54,7 @@ public static partial class ReadingTrackingEndpoints
         if (cache.TryGetValue<ReadingPaceDto>(cacheKey, out var cached) && cached != null)
             return Results.Ok(cached);
 
-        var agg = await db.ReadingSessions
-            .Where(s => s.UserId == userId.Value && s.WordsRead > 0 && s.DurationSeconds > 0)
-            .GroupBy(_ => 1)
-            .Select(g => new { Sessions = g.Count(), Words = g.Sum(s => (long)s.WordsRead), Seconds = g.Sum(s => (long)s.DurationSeconds) })
-            .FirstOrDefaultAsync(ct);
-
-        ReadingPaceDto dto;
-        if (agg == null || agg.Sessions < PaceMinSessions || agg.Seconds <= 0)
-        {
-            dto = new ReadingPaceDto(FallbackPaceWpm, agg?.Sessions ?? 0, false);
-        }
-        else
-        {
-            var wpm = (int)Math.Round(agg.Words / (agg.Seconds / 60.0));
-            // Clamp to sane range — guards against ultra-short sessions skewing avg
-            wpm = Math.Clamp(wpm, 50, 800);
-            dto = new ReadingPaceDto(wpm, agg.Sessions, true);
-        }
+        var dto = await statsService.GetPaceAsync(userId.Value, ct);
 
         cache.Set(cacheKey, dto, TimeSpan.FromHours(1));
         return Results.Ok(dto);

--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
@@ -1,6 +1,3 @@
-using Application.Common.Interfaces;
-using Microsoft.EntityFrameworkCore;
-
 namespace Api.Endpoints;
 
 /// <summary>
@@ -14,8 +11,10 @@ namespace Api.Endpoints;
 ///   - ReadingTrackingEndpoints.BookStats.cs     GetBookStats
 ///   - ReadingTrackingEndpoints.Summary.cs       GetLibrarySummary, GetPace
 ///
-/// This file keeps the route table + shared streak/tz helpers + DTOs. Splits use C#
-/// `partial` — compile-identical to the original monolithic file.
+/// This file keeps the route table + the tz query-parse helper + the session/goal request DTOs.
+/// The stats aggregations live in <see cref="Application.ReadingTracking.ReadingStatsService"/> and the
+/// streak/local-day helpers in <see cref="Application.ReadingTracking.StreakCalculator"/> (R5). Splits use
+/// C# `partial` — compile-identical to the original monolithic file.
 /// </summary>
 public static partial class ReadingTrackingEndpoints
 {
@@ -45,110 +44,6 @@ public static partial class ReadingTrackingEndpoints
             return TimeSpan.FromMinutes(minutes);
         return TimeSpan.Zero;
     }
-
-    private static DateTimeOffset GetDayStart(DateTimeOffset now, TimeSpan tzOffset)
-    {
-        var local = now.ToOffset(tzOffset);
-        return new DateTimeOffset(local.Year, local.Month, local.Day, 0, 0, 0, tzOffset);
-    }
-
-    internal static async Task<int> GetStreakMinMinutes(IAppDbContext db, Guid userId, Guid siteId, CancellationToken ct)
-    {
-        var goal = await db.ReadingGoals
-            .Where(g => g.UserId == userId && g.GoalType == "daily_minutes" && g.IsActive)
-            .Select(g => (int?)g.StreakMinMinutes)
-            .FirstOrDefaultAsync(ct);
-        return goal ?? 5;
-    }
-
-    /// Combines reading sessions + vocab reviews into effective seconds per local date.
-    /// Each vocab review counts as 30 equivalent seconds (0.5 min).
-    private static async Task<Dictionary<DateTime, int>> GetDailyEffectiveSeconds(
-        IAppDbContext db, Guid userId, Guid siteId,
-        DateTimeOffset since, TimeSpan tzOffset, CancellationToken ct)
-    {
-        var sessions = await db.ReadingSessions
-            .Where(s => s.UserId == userId && s.StartedAt >= since)
-            .Select(s => new { s.StartedAt, s.DurationSeconds })
-            .ToListAsync(ct);
-
-        var daily = sessions
-            .GroupBy(s => s.StartedAt.ToOffset(tzOffset).Date)
-            .ToDictionary(g => g.Key, g => g.Sum(s => s.DurationSeconds));
-
-        var reviews = await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.CreatedAt >= since)
-            .Select(r => r.CreatedAt)
-            .ToListAsync(ct);
-
-        foreach (var g in reviews.GroupBy(r => r.ToOffset(tzOffset).Date))
-        {
-            daily.TryGetValue(g.Key, out var existing);
-            daily[g.Key] = existing + g.Count() * 30;
-        }
-
-        return daily;
-    }
-
-    internal static async Task<int> CalculateStreak(
-        IAppDbContext db, Guid userId, Guid siteId, int streakMinMinutes,
-        DateTimeOffset now, CancellationToken ct, TimeSpan tzOffset = default)
-    {
-        var since = now.AddDays(-365);
-        var daily = await GetDailyEffectiveSeconds(db, userId, siteId, since, tzOffset, ct);
-
-        if (daily.Count == 0) return 0;
-
-        var thresholdSeconds = streakMinMinutes * 60;
-        var qualifyingDates = daily
-            .Where(d => d.Value >= thresholdSeconds)
-            .Select(d => d.Key)
-            .ToHashSet();
-
-        var today = now.ToOffset(tzOffset).Date;
-        var streak = 0;
-        var checkDate = today;
-
-        // If today doesn't qualify, start from yesterday
-        if (!qualifyingDates.Contains(checkDate))
-            checkDate = checkDate.AddDays(-1);
-
-        while (qualifyingDates.Contains(checkDate))
-        {
-            streak++;
-            checkDate = checkDate.AddDays(-1);
-        }
-
-        return streak;
-    }
-
-    private static async Task<int> CalculateLongestStreak(
-        IAppDbContext db, Guid userId, Guid siteId, int streakMinMinutes, CancellationToken ct, TimeSpan tzOffset = default)
-    {
-        var daily = await GetDailyEffectiveSeconds(db, userId, siteId, DateTimeOffset.MinValue, tzOffset, ct);
-
-        if (daily.Count == 0) return 0;
-
-        var thresholdSeconds = streakMinMinutes * 60;
-        var sorted = daily.Where(d => d.Value >= thresholdSeconds).Select(d => d.Key).OrderBy(d => d).ToList();
-
-        if (sorted.Count == 0) return 0;
-
-        var longest = 1;
-        var current = 1;
-
-        for (var i = 1; i < sorted.Count; i++)
-        {
-            if ((sorted[i] - sorted[i - 1]).Days == 1)
-                current++;
-            else
-                current = 1;
-
-            if (current > longest) longest = current;
-        }
-
-        return longest;
-    }
 }
 
 // DTOs
@@ -177,15 +72,3 @@ public record GoalDto(Guid Id, string GoalType, int TargetValue, int Year, int S
 public record CreateGoalRequest(string GoalType, int TargetValue, int Year, int? StreakMinMinutes);
 
 public record AchievementDto(string Code, DateTimeOffset UnlockedAt);
-
-public record ReadingPaceDto(int Wpm, int SessionCount, bool IsUserSpecific);
-
-public record GoalSummaryDto(string Type, int Current, int Target);
-public record LibrarySummaryDto(
-    int PagesThisMonth,
-    int MinutesThisMonth,
-    int CurrentStreak,
-    int StreakMinMinutes,
-    int BooksFinishedYtd,
-    GoalSummaryDto? Goal
-);

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.cs
@@ -666,8 +666,8 @@ public static partial class VocabularyEndpoints
         // here prevents grinding "1000 reviews"-style achievements.
         if (!isPractice)
         {
-            var streakMinMinutes = await ReadingTrackingEndpoints.GetStreakMinMinutes(db, userId, siteId, ct);
-            var currentStreak = await ReadingTrackingEndpoints.CalculateStreak(db, userId, siteId, streakMinMinutes, now, ct);
+            var streakMinMinutes = await StreakCalculator.GetStreakMinMinutes(db, userId, ct);
+            var currentStreak = await StreakCalculator.CalculateStreak(db, userId, streakMinMinutes, now, ct);
             await new AchievementChecker(db).CheckAfterReview(userId, siteId, currentStreak, ct);
         }
 

--- a/backend/src/Application/ReadingTracking/ReadingStatsService.cs
+++ b/backend/src/Application/ReadingTracking/ReadingStatsService.cs
@@ -209,6 +209,103 @@ public class ReadingStatsService(IAppDbContext db)
     }
 
     /// <summary>
+    /// Aggregate reading stats (R5 slice-3). Body moved verbatim from the former
+    /// <c>ReadingTrackingEndpoints.GetStats</c> handler; the caller resolves the tz offset and passes
+    /// <paramref name="now"/> (was <c>DateTimeOffset.UtcNow</c> inline) so the time-window boundaries are
+    /// deterministic under test. Every server-side aggregate keeps its <c>(long)</c> cast and the daily-goal
+    /// effective-minutes math is preserved, so the JSON is byte-identical. Site scope is enforced by the
+    /// R1b EF query filter (no explicit SiteId here).
+    /// </summary>
+    public async Task<ReadingStatsResponse> GetStatsAsync(
+        Guid userId, TimeSpan tzOffset, DateTimeOffset now, CancellationToken ct)
+    {
+        var allSessions = db.ReadingSessions
+            .Where(s => s.UserId == userId);
+
+        var totalSeconds = await allSessions.SumAsync(s => (long)s.DurationSeconds, ct);
+        var totalWords = await allSessions.SumAsync(s => (long)s.WordsRead, ct);
+        var sessionCount = await allSessions.CountAsync(ct);
+
+        var booksFinished = await allSessions
+            .Where(s => s.EndPercent >= 0.99)
+            .Select(s => s.EditionId ?? s.UserBookId)
+            .Distinct()
+            .CountAsync(ct);
+
+        // Time-period sums (calculate in user tz, convert to UTC for PostgreSQL)
+        var todayLocal = StreakCalculator.GetDayStart(now, tzOffset);
+        var todayStart = todayLocal.ToUniversalTime();
+        var weekStart = todayLocal.AddDays(-(int)todayLocal.DayOfWeek).ToUniversalTime();
+        var monthStart = new DateTimeOffset(todayLocal.Year, todayLocal.Month, 1, 0, 0, 0, tzOffset).ToUniversalTime();
+
+        var todaySeconds = await allSessions
+            .Where(s => s.StartedAt >= todayStart)
+            .SumAsync(s => (long)s.DurationSeconds, ct);
+        var weekSeconds = await allSessions
+            .Where(s => s.StartedAt >= weekStart)
+            .SumAsync(s => (long)s.DurationSeconds, ct);
+        var monthSeconds = await allSessions
+            .Where(s => s.StartedAt >= monthStart)
+            .SumAsync(s => (long)s.DurationSeconds, ct);
+
+        // Streak
+        var streakMinMinutes = await StreakCalculator.GetStreakMinMinutes(db, userId, ct);
+        var currentStreak = await StreakCalculator.CalculateStreak(db, userId, streakMinMinutes, now, ct, tzOffset);
+        var longestStreak = await StreakCalculator.CalculateLongestStreak(db, userId, streakMinMinutes, ct, tzOffset);
+
+        // Averages
+        double avgDailyMinutes = 0;
+        double avgWordsPerMinute = 0;
+        if (sessionCount > 0)
+        {
+            var firstSession = await allSessions
+                .OrderBy(s => s.StartedAt)
+                .Select(s => s.StartedAt)
+                .FirstOrDefaultAsync(ct);
+            var daysSinceFirst = Math.Max(1, (now - firstSession).TotalDays);
+            avgDailyMinutes = totalSeconds / 60.0 / daysSinceFirst;
+
+            if (totalSeconds > 0)
+                avgWordsPerMinute = totalWords / (totalSeconds / 60.0);
+        }
+
+        // Vocab reviews today
+        var todayVocabReviews = await db.VocabularyReviews
+            .Where(r => r.UserId == userId && r.CreatedAt >= todayStart)
+            .CountAsync(ct);
+
+        // Daily goal (reading + vocab reviews as effective minutes)
+        var dailyGoal = await db.ReadingGoals
+            .Where(g => g.UserId == userId && g.GoalType == "daily_minutes" && g.IsActive)
+            .FirstOrDefaultAsync(ct);
+
+        DailyGoalStatusDto? dailyGoalObj = null;
+        if (dailyGoal != null)
+        {
+            var effectiveTodayMinutes = todaySeconds / 60.0 + todayVocabReviews * 0.5;
+            dailyGoalObj = new DailyGoalStatusDto(
+                Target: dailyGoal.TargetValue,
+                Today: Math.Round(effectiveTodayMinutes, 1),
+                Met: effectiveTodayMinutes >= dailyGoal.TargetValue);
+        }
+
+        return new ReadingStatsResponse(
+            TotalSeconds: totalSeconds,
+            TotalWords: totalWords,
+            BooksFinished: booksFinished,
+            CurrentStreak: currentStreak,
+            LongestStreak: longestStreak,
+            StreakMinMinutes: streakMinMinutes,
+            AvgDailyMinutes: Math.Round(avgDailyMinutes, 1),
+            AvgWordsPerMinute: Math.Round(avgWordsPerMinute, 1),
+            TodaySeconds: todaySeconds,
+            TodayVocabReviews: todayVocabReviews,
+            WeekSeconds: weekSeconds,
+            MonthSeconds: monthSeconds,
+            DailyGoal: dailyGoalObj);
+    }
+
+    /// <summary>
     /// Daily reading buckets (R5 slice-2). Body moved verbatim from the former
     /// <c>ReadingTrackingEndpoints.GetDailyStats</c> handler. The caller resolves the tz offset and
     /// the <paramref name="from"/>/<paramref name="to"/> defaults from the query string; here the
@@ -237,5 +334,106 @@ public class ReadingStatsService(IAppDbContext db)
             .ToList();
 
         return daily;
+    }
+
+    // Reading-pace tuning (slice 19). Moved verbatim from the Api handler.
+    private const int PaceMinSessions = 3;
+    private const int FallbackPaceWpm = 200;
+
+    /// <summary>
+    /// Library summary card (slice 20 / R5 slice-3). Body moved verbatim from the former
+    /// <c>ReadingTrackingEndpoints.GetLibrarySummary</c> handler; the <c>IMemoryCache</c> lookup/store stays
+    /// in the caller (this service is cache-free). The caller resolves the tz offset and passes
+    /// <paramref name="now"/> so the month/year window boundaries are deterministic. The integer division
+    /// (words/250 → pages, seconds/60 → minutes) and the daily→yearly goal precedence are preserved so the
+    /// JSON is byte-identical.
+    /// </summary>
+    public async Task<LibrarySummaryDto> GetLibrarySummaryAsync(
+        Guid userId, TimeSpan tzOffset, DateTimeOffset now, CancellationToken ct)
+    {
+        var todayLocal = StreakCalculator.GetDayStart(now, tzOffset);
+        var monthStart = new DateTimeOffset(todayLocal.Year, todayLocal.Month, 1, 0, 0, 0, tzOffset).ToUniversalTime();
+        var yearStart = new DateTimeOffset(todayLocal.Year, 1, 1, 0, 0, 0, tzOffset).ToUniversalTime();
+
+        var monthAgg = await db.ReadingSessions
+            .Where(s => s.UserId == userId && s.StartedAt >= monthStart)
+            .GroupBy(_ => 1)
+            .Select(g => new { Words = g.Sum(s => (long)s.WordsRead), Seconds = g.Sum(s => (long)s.DurationSeconds) })
+            .FirstOrDefaultAsync(ct);
+
+        var pagesThisMonth = (int)((monthAgg?.Words ?? 0) / 250);
+        var minutesThisMonth = (int)((monthAgg?.Seconds ?? 0) / 60);
+
+        var streakMinMinutes = await StreakCalculator.GetStreakMinMinutes(db, userId, ct);
+        var currentStreak = await StreakCalculator.CalculateStreak(db, userId, streakMinMinutes, now, ct, tzOffset);
+
+        var booksFinishedYtd = await db.ReadingSessions
+            .Where(s => s.UserId == userId && s.EndPercent >= 0.99 && s.EndedAt >= yearStart)
+            .Select(s => s.EditionId ?? s.UserBookId)
+            .Distinct()
+            .CountAsync(ct);
+
+        var dailyGoal = await db.ReadingGoals
+            .Where(g => g.UserId == userId && g.GoalType == "daily_minutes" && g.IsActive)
+            .Select(g => new { g.TargetValue, g.StreakMinMinutes })
+            .FirstOrDefaultAsync(ct);
+        var yearlyGoal = await db.ReadingGoals
+            .Where(g => g.UserId == userId && g.GoalType == "books_per_year" && g.IsActive)
+            .Select(g => new { g.TargetValue, g.Year })
+            .FirstOrDefaultAsync(ct);
+
+        GoalSummaryDto? goal = null;
+        if (dailyGoal != null)
+        {
+            var todayStart = todayLocal.ToUniversalTime();
+            var todaySeconds = await db.ReadingSessions
+                .Where(s => s.UserId == userId && s.StartedAt >= todayStart)
+                .SumAsync(s => (long)s.DurationSeconds, ct);
+            goal = new GoalSummaryDto("daily_minutes", (int)(todaySeconds / 60), dailyGoal.TargetValue);
+        }
+        else if (yearlyGoal != null)
+        {
+            goal = new GoalSummaryDto("books_per_year", booksFinishedYtd, yearlyGoal.TargetValue);
+        }
+
+        return new LibrarySummaryDto(
+            PagesThisMonth: pagesThisMonth,
+            MinutesThisMonth: minutesThisMonth,
+            CurrentStreak: currentStreak,
+            StreakMinMinutes: streakMinMinutes,
+            BooksFinishedYtd: booksFinishedYtd,
+            Goal: goal
+        );
+    }
+
+    /// <summary>
+    /// Reading pace (slice 19 / R5 slice-3). Body moved verbatim from the former
+    /// <c>ReadingTrackingEndpoints.GetPace</c> handler; not tz-dependent. The <c>IMemoryCache</c> lookup/store
+    /// stays in the caller. Fallback returns <see cref="FallbackPaceWpm"/> when there are fewer than
+    /// <see cref="PaceMinSessions"/> qualifying sessions or no seconds; otherwise wpm is rounded and clamped
+    /// to [50, 800]. Byte-identical to the pre-refactor response.
+    /// </summary>
+    public async Task<ReadingPaceDto> GetPaceAsync(Guid userId, CancellationToken ct)
+    {
+        var agg = await db.ReadingSessions
+            .Where(s => s.UserId == userId && s.WordsRead > 0 && s.DurationSeconds > 0)
+            .GroupBy(_ => 1)
+            .Select(g => new { Sessions = g.Count(), Words = g.Sum(s => (long)s.WordsRead), Seconds = g.Sum(s => (long)s.DurationSeconds) })
+            .FirstOrDefaultAsync(ct);
+
+        ReadingPaceDto dto;
+        if (agg == null || agg.Sessions < PaceMinSessions || agg.Seconds <= 0)
+        {
+            dto = new ReadingPaceDto(FallbackPaceWpm, agg?.Sessions ?? 0, false);
+        }
+        else
+        {
+            var wpm = (int)Math.Round(agg.Words / (agg.Seconds / 60.0));
+            // Clamp to sane range — guards against ultra-short sessions skewing avg
+            wpm = Math.Clamp(wpm, 50, 800);
+            dto = new ReadingPaceDto(wpm, agg.Sessions, true);
+        }
+
+        return dto;
     }
 }

--- a/backend/src/Application/ReadingTracking/StreakCalculator.cs
+++ b/backend/src/Application/ReadingTracking/StreakCalculator.cs
@@ -1,0 +1,119 @@
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.ReadingTracking;
+
+/// <summary>
+/// Reading-streak + local-day helpers (R5 slice-3). Moved verbatim from the former
+/// <c>ReadingTrackingEndpoints</c> static helpers so the streak logic is reachable from both the
+/// <see cref="ReadingStatsService"/> and the achievement-award paths (session + vocab review) without
+/// leaking EF query composition into the Api layer. Behaviour is byte-identical: the dead
+/// <c>siteId</c> parameter (site scope is enforced by the R1b EF query filter, never read here) was
+/// dropped, otherwise every aggregation and threshold is preserved.
+/// </summary>
+public static class StreakCalculator
+{
+    public static DateTimeOffset GetDayStart(DateTimeOffset now, TimeSpan tzOffset)
+    {
+        var local = now.ToOffset(tzOffset);
+        return new DateTimeOffset(local.Year, local.Month, local.Day, 0, 0, 0, tzOffset);
+    }
+
+    public static async Task<int> GetStreakMinMinutes(IAppDbContext db, Guid userId, CancellationToken ct)
+    {
+        var goal = await db.ReadingGoals
+            .Where(g => g.UserId == userId && g.GoalType == "daily_minutes" && g.IsActive)
+            .Select(g => (int?)g.StreakMinMinutes)
+            .FirstOrDefaultAsync(ct);
+        return goal ?? 5;
+    }
+
+    /// Combines reading sessions + vocab reviews into effective seconds per local date.
+    /// Each vocab review counts as 30 equivalent seconds (0.5 min).
+    private static async Task<Dictionary<DateTime, int>> GetDailyEffectiveSeconds(
+        IAppDbContext db, Guid userId,
+        DateTimeOffset since, TimeSpan tzOffset, CancellationToken ct)
+    {
+        var sessions = await db.ReadingSessions
+            .Where(s => s.UserId == userId && s.StartedAt >= since)
+            .Select(s => new { s.StartedAt, s.DurationSeconds })
+            .ToListAsync(ct);
+
+        var daily = sessions
+            .GroupBy(s => s.StartedAt.ToOffset(tzOffset).Date)
+            .ToDictionary(g => g.Key, g => g.Sum(s => s.DurationSeconds));
+
+        var reviews = await db.VocabularyReviews
+            .Where(r => r.UserId == userId && r.CreatedAt >= since)
+            .Select(r => r.CreatedAt)
+            .ToListAsync(ct);
+
+        foreach (var g in reviews.GroupBy(r => r.ToOffset(tzOffset).Date))
+        {
+            daily.TryGetValue(g.Key, out var existing);
+            daily[g.Key] = existing + g.Count() * 30;
+        }
+
+        return daily;
+    }
+
+    public static async Task<int> CalculateStreak(
+        IAppDbContext db, Guid userId, int streakMinMinutes,
+        DateTimeOffset now, CancellationToken ct, TimeSpan tzOffset = default)
+    {
+        var since = now.AddDays(-365);
+        var daily = await GetDailyEffectiveSeconds(db, userId, since, tzOffset, ct);
+
+        if (daily.Count == 0) return 0;
+
+        var thresholdSeconds = streakMinMinutes * 60;
+        var qualifyingDates = daily
+            .Where(d => d.Value >= thresholdSeconds)
+            .Select(d => d.Key)
+            .ToHashSet();
+
+        var today = now.ToOffset(tzOffset).Date;
+        var streak = 0;
+        var checkDate = today;
+
+        // If today doesn't qualify, start from yesterday
+        if (!qualifyingDates.Contains(checkDate))
+            checkDate = checkDate.AddDays(-1);
+
+        while (qualifyingDates.Contains(checkDate))
+        {
+            streak++;
+            checkDate = checkDate.AddDays(-1);
+        }
+
+        return streak;
+    }
+
+    public static async Task<int> CalculateLongestStreak(
+        IAppDbContext db, Guid userId, int streakMinMinutes, CancellationToken ct, TimeSpan tzOffset = default)
+    {
+        var daily = await GetDailyEffectiveSeconds(db, userId, DateTimeOffset.MinValue, tzOffset, ct);
+
+        if (daily.Count == 0) return 0;
+
+        var thresholdSeconds = streakMinMinutes * 60;
+        var sorted = daily.Where(d => d.Value >= thresholdSeconds).Select(d => d.Key).OrderBy(d => d).ToList();
+
+        if (sorted.Count == 0) return 0;
+
+        var longest = 1;
+        var current = 1;
+
+        for (var i = 1; i < sorted.Count; i++)
+        {
+            if ((sorted[i] - sorted[i - 1]).Days == 1)
+                current++;
+            else
+                current = 1;
+
+            if (current > longest) longest = current;
+        }
+
+        return longest;
+    }
+}

--- a/backend/src/Contracts/ReadingTracking/LibrarySummaryDto.cs
+++ b/backend/src/Contracts/ReadingTracking/LibrarySummaryDto.cs
@@ -1,0 +1,16 @@
+namespace Contracts.ReadingTracking;
+
+// Reading-pace + library-summary DTOs (R5 slice-3). Moved verbatim from Api.Endpoints so they live
+// beside the ReadingStatsService that produces them. Field names/casing/order unchanged.
+public record ReadingPaceDto(int Wpm, int SessionCount, bool IsUserSpecific);
+
+public record GoalSummaryDto(string Type, int Current, int Target);
+
+public record LibrarySummaryDto(
+    int PagesThisMonth,
+    int MinutesThisMonth,
+    int CurrentStreak,
+    int StreakMinMinutes,
+    int BooksFinishedYtd,
+    GoalSummaryDto? Goal
+);

--- a/backend/src/Contracts/ReadingTracking/ReadingStatsResponse.cs
+++ b/backend/src/Contracts/ReadingTracking/ReadingStatsResponse.cs
@@ -1,0 +1,26 @@
+namespace Contracts.ReadingTracking;
+
+// Aggregate reading-stats response (R5 slice-3). Field names/order/types mirror the former
+// anonymous object returned by ReadingTrackingEndpoints.GetStats byte-for-byte so the camelCase JSON
+// is identical. Server-side SumAsync over int columns widens to `long` (each aggregate is cast
+// `(long)` in the query), so the seconds/words totals are `long`; the two rounded averages are
+// `double`. DailyGoal is null when the user has no active daily_minutes goal.
+public record ReadingStatsResponse(
+    long TotalSeconds,
+    long TotalWords,
+    int BooksFinished,
+    int CurrentStreak,
+    int LongestStreak,
+    int StreakMinMinutes,
+    double AvgDailyMinutes,
+    double AvgWordsPerMinute,
+    long TodaySeconds,
+    int TodayVocabReviews,
+    long WeekSeconds,
+    long MonthSeconds,
+    DailyGoalStatusDto? DailyGoal
+);
+
+// Nested daily-goal status. Mirrors the former inline anonymous object { target, today, met }:
+// target is the goal's TargetValue (int), today is Round(effectiveMinutes, 1) (double), met is bool.
+public record DailyGoalStatusDto(int Target, double Today, bool Met);

--- a/tests/TextStack.IntegrationTests/LibrarySummaryEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/LibrarySummaryEndpointTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace TextStack.IntegrationTests;
+
+// R5 slice-3 wire-equivalence gate for GET /me/reading/library-summary (mirrors DailyStatsEndpointTests).
+// Live data is non-deterministic — assert status + deserialization into the local record mirror + tz
+// variants don't 500, never concrete values. Skips when the stack is unavailable.
+public class LibrarySummaryEndpointTests : IClassFixture<LiveApiFixture>, IClassFixture<AuthenticatedApiFixture>
+{
+    private readonly LiveApiFixture _anon;
+    private readonly AuthenticatedApiFixture _auth;
+
+    public LibrarySummaryEndpointTests(LiveApiFixture anon, AuthenticatedApiFixture auth)
+    {
+        _anon = anon;
+        _auth = auth;
+    }
+
+    [Fact]
+    public async Task GetLibrarySummary_WithoutAuth_Returns401()
+    {
+        var request = _anon.CreateRequest(HttpMethod.Get, "/me/reading/library-summary");
+        var response = await _anon.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetLibrarySummary_NoParams_Returns200AndDeserializes()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/library-summary");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var summary = await response.Content.ReadFromJsonAsync<LibrarySummary>(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(summary);
+        Assert.True(summary.PagesThisMonth >= 0);
+        Assert.True(summary.MinutesThisMonth >= 0);
+        Assert.True(summary.CurrentStreak >= 0);
+        Assert.True(summary.StreakMinMinutes >= 0);
+        Assert.True(summary.BooksFinishedYtd >= 0);
+        // goal is nullable — present only when the user has an active daily or yearly goal.
+        if (summary.Goal is not null)
+            Assert.False(string.IsNullOrEmpty(summary.Goal.Type));
+    }
+
+    [Fact]
+    public async Task GetLibrarySummary_NegativeTzOffset_Returns200()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/library-summary?tz=-60");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetLibrarySummary_LargePositiveTzOffset_Returns200()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/library-summary?tz=720");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetLibrarySummary_ResponseShape_HasCamelCaseFields()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/library-summary");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("pagesThisMonth", json);
+        Assert.Contains("minutesThisMonth", json);
+        Assert.Contains("currentStreak", json);
+        Assert.Contains("streakMinMinutes", json);
+        Assert.Contains("booksFinishedYtd", json);
+        Assert.Contains("goal", json);
+    }
+
+    // Local deserialization mirror of Contracts.ReadingTracking.LibrarySummaryDto / GoalSummaryDto.
+    private record LibrarySummary(
+        int PagesThisMonth,
+        int MinutesThisMonth,
+        int CurrentStreak,
+        int StreakMinMinutes,
+        int BooksFinishedYtd,
+        Goal? Goal);
+
+    private record Goal(string Type, int Current, int Target);
+}

--- a/tests/TextStack.IntegrationTests/ReadingPaceEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/ReadingPaceEndpointTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace TextStack.IntegrationTests;
+
+// R5 slice-3 wire-equivalence gate for GET /me/reading/pace (mirrors DailyStatsEndpointTests).
+// Pace is not tz-dependent. Live data is non-deterministic, but the wpm invariant holds for every
+// response: fallback (200) and any user-specific value are both clamped to >= 50. Skips when
+// the stack is unavailable.
+public class ReadingPaceEndpointTests : IClassFixture<LiveApiFixture>, IClassFixture<AuthenticatedApiFixture>
+{
+    private readonly LiveApiFixture _anon;
+    private readonly AuthenticatedApiFixture _auth;
+
+    public ReadingPaceEndpointTests(LiveApiFixture anon, AuthenticatedApiFixture auth)
+    {
+        _anon = anon;
+        _auth = auth;
+    }
+
+    [Fact]
+    public async Task GetPace_WithoutAuth_Returns401()
+    {
+        var request = _anon.CreateRequest(HttpMethod.Get, "/me/reading/pace");
+        var response = await _anon.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPace_NoParams_Returns200AndWpmInSaneRange()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/pace");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var pace = await response.Content.ReadFromJsonAsync<ReadingPace>(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(pace);
+        // Fallback is 200; user-specific values are clamped to [50, 800]. Either way >= 50.
+        Assert.True(pace.Wpm >= 50);
+        Assert.True(pace.Wpm <= 800);
+        Assert.True(pace.SessionCount >= 0);
+    }
+
+    [Fact]
+    public async Task GetPace_ResponseShape_HasCamelCaseFields()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/pace");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("wpm", json);
+        Assert.Contains("sessionCount", json);
+        Assert.Contains("isUserSpecific", json);
+    }
+
+    // Local deserialization mirror of Contracts.ReadingTracking.ReadingPaceDto.
+    private record ReadingPace(int Wpm, int SessionCount, bool IsUserSpecific);
+}

--- a/tests/TextStack.IntegrationTests/ReadingStatsEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/ReadingStatsEndpointTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace TextStack.IntegrationTests;
+
+// R5 slice-3 wire-equivalence gate for GET /me/reading/stats (mirrors DailyStatsEndpointTests).
+// Live data is non-deterministic, so we assert status + that the JSON deserializes into the local
+// record mirror (which locks field names/types) + tz variants don't 500 — never concrete values.
+// Skips (not fails) when the stack is unavailable.
+public class ReadingStatsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixture<AuthenticatedApiFixture>
+{
+    private readonly LiveApiFixture _anon;
+    private readonly AuthenticatedApiFixture _auth;
+
+    public ReadingStatsEndpointTests(LiveApiFixture anon, AuthenticatedApiFixture auth)
+    {
+        _anon = anon;
+        _auth = auth;
+    }
+
+    [Fact]
+    public async Task GetStats_WithoutAuth_Returns401()
+    {
+        var request = _anon.CreateRequest(HttpMethod.Get, "/me/reading/stats");
+        var response = await _anon.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetStats_NoParams_Returns200AndDeserializes()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/stats");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var stats = await response.Content.ReadFromJsonAsync<ReadingStats>(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(stats);
+        Assert.True(stats.TotalSeconds >= 0);
+        Assert.True(stats.TotalWords >= 0);
+        Assert.True(stats.BooksFinished >= 0);
+        Assert.True(stats.CurrentStreak >= 0);
+        Assert.True(stats.LongestStreak >= 0);
+        Assert.True(stats.StreakMinMinutes >= 0);
+        // dailyGoal is nullable — present only when the user has an active daily_minutes goal.
+        if (stats.DailyGoal is not null)
+            Assert.True(stats.DailyGoal.Target >= 0);
+    }
+
+    [Fact]
+    public async Task GetStats_NegativeTzOffset_Returns200()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/stats?tz=-60");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetStats_LargePositiveTzOffset_Returns200()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/stats?tz=720");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetStats_ResponseShape_HasCamelCaseFields()
+    {
+        var request = _auth.CreateRequest(HttpMethod.Get, "/me/reading/stats");
+        var response = await _auth.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("totalSeconds", json);
+        Assert.Contains("totalWords", json);
+        Assert.Contains("booksFinished", json);
+        Assert.Contains("currentStreak", json);
+        Assert.Contains("longestStreak", json);
+        Assert.Contains("streakMinMinutes", json);
+        Assert.Contains("avgDailyMinutes", json);
+        Assert.Contains("avgWordsPerMinute", json);
+        Assert.Contains("todaySeconds", json);
+        Assert.Contains("todayVocabReviews", json);
+        Assert.Contains("weekSeconds", json);
+        Assert.Contains("monthSeconds", json);
+        Assert.Contains("dailyGoal", json);
+    }
+
+    // Local deserialization mirror of Contracts.ReadingTracking.ReadingStatsResponse — field
+    // names/types drive the camelCase wire contract this gate protects.
+    private record ReadingStats(
+        long TotalSeconds,
+        long TotalWords,
+        int BooksFinished,
+        int CurrentStreak,
+        int LongestStreak,
+        int StreakMinMinutes,
+        double AvgDailyMinutes,
+        double AvgWordsPerMinute,
+        long TodaySeconds,
+        int TodayVocabReviews,
+        long WeekSeconds,
+        long MonthSeconds,
+        DailyGoal? DailyGoal);
+
+    private record DailyGoal(int Target, double Today, bool Met);
+}

--- a/tests/TextStack.UnitTests/ReadingStatsServiceTests.cs
+++ b/tests/TextStack.UnitTests/ReadingStatsServiceTests.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using Application.Common.Interfaces;
 using Application.ReadingTracking;
+using Contracts.ReadingTracking;
 using Domain.Entities;
 using Domain.Enums;
 using Microsoft.EntityFrameworkCore;
@@ -20,6 +22,8 @@ public class ReadingStatsServiceTests
         public List<ReadingSession> Sessions { get; } = [];
         public List<Edition> Editions { get; } = [];
         public List<UserBook> UserBooks { get; } = [];
+        public List<ReadingGoal> Goals { get; } = [];
+        public List<VocabularyReview> Reviews { get; } = [];
         public Mock<IAppDbContext> Db { get; } = new();
         public ReadingStatsService Service { get; }
 
@@ -28,9 +32,33 @@ public class ReadingStatsServiceTests
             Db.Setup(x => x.ReadingSessions).Returns(() => FakeSet(Sessions).Object);
             Db.Setup(x => x.Editions).Returns(() => FakeSet(Editions).Object);
             Db.Setup(x => x.UserBooks).Returns(() => FakeSet(UserBooks).Object);
+            Db.Setup(x => x.ReadingGoals).Returns(() => FakeSet(Goals).Object);
+            Db.Setup(x => x.VocabularyReviews).Returns(() => FakeSet(Reviews).Object);
             Service = new ReadingStatsService(Db.Object);
         }
     }
+
+    private static ReadingGoal Goal(
+        Guid userId, string type, int target, int year = 0, int streakMin = 5, bool active = true) => new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            GoalType = type,
+            TargetValue = target,
+            Year = year,
+            IsActive = active,
+            StreakMinMinutes = streakMin,
+        };
+
+    private static VocabularyReview Review(Guid userId, DateTimeOffset at) => new()
+    {
+        Id = Guid.NewGuid(),
+        VocabularyWordId = Guid.NewGuid(),
+        UserId = userId,
+        ReviewMode = "multiple_choice",
+        IsCorrect = true,
+        CreatedAt = at,
+    };
 
     // Builds a DbSet<T> mock backed by `data`: queryable (sync + async). (Read-only service — no
     // Add/Remove needed.) Mirrors ConceptClusteringServiceTests.FakeSet.
@@ -360,6 +388,290 @@ public class ReadingStatsServiceTests
         Assert.Equal((600, 100, 1), (plus[0].TotalSeconds, plus[0].TotalWords, plus[0].SessionCount));
         Assert.Equal(new DateTime(2025, 3, 16), plus[1].Date);
         Assert.Equal((300, 50, 1), (plus[1].TotalSeconds, plus[1].TotalWords, plus[1].SessionCount));
+    }
+
+    // ── R5 slice-3: GetStatsAsync ───────────────────────────────────────────────────────────────
+
+    // now is fixed at 2025-03-15 08:00Z (a Saturday → DayOfWeek 6, so weekStart = 2025-03-09).
+    // firstSession (u1) is exactly 69 days earlier (2025-01-05 08:00Z) so the avg-days divisor is exact.
+    [Fact]
+    public async Task GetStats_FixedNowAndTz_AggregatesEveryFieldExactly()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var e1 = Guid.NewGuid();
+        var e2 = Guid.NewGuid();
+        var u1 = Guid.NewGuid();
+
+        // Finished distinct books: e1 (via two finishing sessions) + u1 → 2. e2 never finished.
+        h.Sessions.Add(Session(userId, endPct: 1.0, start: UtcT(2025, 3, 15, 6, 0), end: UtcT(2025, 3, 15, 6, 10), dur: 600, words: 1500, editionId: e1));
+        h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, 10, 8, 0), end: UtcT(2025, 3, 10, 8, 20), dur: 1200, words: 2000, editionId: e2));
+        h.Sessions.Add(Session(userId, endPct: 0.99, start: UtcT(2025, 3, 2, 8, 0), end: UtcT(2025, 3, 2, 8, 5), dur: 300, words: 400, editionId: e1));
+        h.Sessions.Add(Session(userId, endPct: 1.0, start: UtcT(2025, 1, 5, 8, 0), end: UtcT(2025, 1, 6, 8, 0), dur: 900, words: 1000, userBookId: u1));
+        // Two more consecutive days to build a 3-day current streak (03-13, 03-14, 03-15).
+        h.Sessions.Add(Session(userId, endPct: 0.6, start: UtcT(2025, 3, 14, 8, 0), end: UtcT(2025, 3, 14, 8, 10), dur: 600, words: 500, editionId: e2));
+        h.Sessions.Add(Session(userId, endPct: 0.6, start: UtcT(2025, 3, 13, 8, 0), end: UtcT(2025, 3, 13, 8, 10), dur: 600, words: 500, editionId: e2));
+
+        // Two vocab reviews today (2025-03-15) → todayVocabReviews = 2, +60 effective streak seconds.
+        h.Reviews.Add(Review(userId, UtcT(2025, 3, 15, 7, 0)));
+        h.Reviews.Add(Review(userId, UtcT(2025, 3, 15, 7, 30)));
+
+        // Active daily goal: 20 min target, streak threshold 5 min.
+        h.Goals.Add(Goal(userId, "daily_minutes", target: 20, streakMin: 5));
+
+        var now = UtcT(2025, 3, 15, 8, 0);
+        var r = await h.Service.GetStatsAsync(userId, TimeSpan.Zero, now, CancellationToken.None);
+
+        Assert.Equal(4200L, r.TotalSeconds);            // 600+1200+300+900+600+600
+        Assert.Equal(5900L, r.TotalWords);              // 1500+2000+400+1000+500+500
+        Assert.Equal(2, r.BooksFinished);               // distinct {e1, u1}
+        Assert.Equal(3, r.CurrentStreak);               // 03-15,03-14,03-13 all qualify
+        Assert.Equal(3, r.LongestStreak);               // longest consecutive run is that same 3
+        Assert.Equal(5, r.StreakMinMinutes);
+        Assert.Equal(1.0, r.AvgDailyMinutes);           // 4200/60/69 = 1.0145 → 1.0
+        Assert.Equal(84.3, r.AvgWordsPerMinute);        // 5900/(4200/60) = 84.2857 → 84.3
+        Assert.Equal(600L, r.TodaySeconds);             // only 03-15 session
+        Assert.Equal(2, r.TodayVocabReviews);
+        Assert.Equal(3000L, r.WeekSeconds);             // 03-15,03-14,03-13,03-10 (>=03-09)
+        Assert.Equal(3300L, r.MonthSeconds);            // all March sessions (>=03-01)
+
+        Assert.NotNull(r.DailyGoal);
+        Assert.Equal(20, r.DailyGoal!.Target);
+        Assert.Equal(11.0, r.DailyGoal.Today);          // 600/60 + 2*0.5 = 11.0
+        Assert.False(r.DailyGoal.Met);                  // 11 < 20
+    }
+
+    [Fact]
+    public async Task GetStats_NoActiveDailyGoal_DailyGoalIsNull()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        h.Sessions.Add(Session(userId, endPct: 1.0, start: UtcT(2025, 3, 15, 6, 0), end: UtcT(2025, 3, 15, 6, 10), dur: 600, words: 1500, editionId: Guid.NewGuid()));
+        // Only an inactive daily goal + a books_per_year goal → GetStats daily-goal query finds nothing.
+        h.Goals.Add(Goal(userId, "daily_minutes", target: 30, active: false));
+        h.Goals.Add(Goal(userId, "books_per_year", target: 12, year: 2025));
+
+        var now = UtcT(2025, 3, 15, 8, 0);
+        var r = await h.Service.GetStatsAsync(userId, TimeSpan.Zero, now, CancellationToken.None);
+
+        Assert.Null(r.DailyGoal);
+        Assert.Equal(5, r.StreakMinMinutes); // default when no active daily goal
+    }
+
+    [Fact]
+    public async Task GetStats_NoSessions_ZeroTotalsAndAverages()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+
+        var now = UtcT(2025, 3, 15, 8, 0);
+        var r = await h.Service.GetStatsAsync(userId, TimeSpan.Zero, now, CancellationToken.None);
+
+        Assert.Equal(0L, r.TotalSeconds);
+        Assert.Equal(0L, r.TotalWords);
+        Assert.Equal(0, r.BooksFinished);
+        Assert.Equal(0, r.CurrentStreak);
+        Assert.Equal(0, r.LongestStreak);
+        Assert.Equal(0.0, r.AvgDailyMinutes);
+        Assert.Equal(0.0, r.AvgWordsPerMinute);
+        Assert.Null(r.DailyGoal);
+    }
+
+    // ── R5 slice-3: GetLibrarySummaryAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetLibrarySummary_DailyGoalPrecedence_IntDivFloorsPagesAndMinutes()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var e1 = Guid.NewGuid();
+        var e2 = Guid.NewGuid();
+
+        // This-month session lands exactly on the floor edges: 249 words → 0 pages, 59s → 0 min.
+        h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, 10, 8, 0), end: UtcT(2025, 3, 10, 8, 1), dur: 59, words: 249, editionId: e1));
+        // Earlier-this-year finish (outside the current month) → counts toward booksFinishedYtd only.
+        h.Sessions.Add(Session(userId, endPct: 1.0, start: UtcT(2025, 2, 1, 8, 0), end: UtcT(2025, 2, 2, 8, 0), dur: 100, words: 100, editionId: e2));
+
+        // Both goals present → daily wins.
+        h.Goals.Add(Goal(userId, "daily_minutes", target: 30, streakMin: 5));
+        h.Goals.Add(Goal(userId, "books_per_year", target: 12, year: 2025));
+
+        var now = UtcT(2025, 3, 15, 8, 0);
+        var s = await h.Service.GetLibrarySummaryAsync(userId, TimeSpan.Zero, now, CancellationToken.None);
+
+        Assert.Equal(0, s.PagesThisMonth);       // 249/250
+        Assert.Equal(0, s.MinutesThisMonth);      // 59/60
+        Assert.Equal(0, s.CurrentStreak);         // 59s < 300s threshold → no qualifying day
+        Assert.Equal(5, s.StreakMinMinutes);
+        Assert.Equal(1, s.BooksFinishedYtd);      // e2 finished this year
+        Assert.NotNull(s.Goal);
+        Assert.Equal("daily_minutes", s.Goal!.Type);
+        Assert.Equal(0, s.Goal.Current);          // no session today → 0 min
+        Assert.Equal(30, s.Goal.Target);
+    }
+
+    [Fact]
+    public async Task GetLibrarySummary_NoDailyGoal_UsesYearlyGoal()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var e1 = Guid.NewGuid();
+
+        // 500 words → 2 pages, 120s → 2 min; finished this year.
+        h.Sessions.Add(Session(userId, endPct: 1.0, start: UtcT(2025, 3, 5, 8, 0), end: UtcT(2025, 3, 6, 8, 0), dur: 120, words: 500, editionId: e1));
+        h.Goals.Add(Goal(userId, "books_per_year", target: 12, year: 2025));
+
+        var now = UtcT(2025, 3, 15, 8, 0);
+        var s = await h.Service.GetLibrarySummaryAsync(userId, TimeSpan.Zero, now, CancellationToken.None);
+
+        Assert.Equal(2, s.PagesThisMonth);
+        Assert.Equal(2, s.MinutesThisMonth);
+        Assert.Equal(1, s.BooksFinishedYtd);
+        Assert.Equal(5, s.StreakMinMinutes);      // default (no active daily goal)
+        Assert.NotNull(s.Goal);
+        Assert.Equal("books_per_year", s.Goal!.Type);
+        Assert.Equal(1, s.Goal.Current);          // booksFinishedYtd
+        Assert.Equal(12, s.Goal.Target);
+    }
+
+    [Fact]
+    public async Task GetLibrarySummary_NoGoals_GoalIsNull()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, 10, 8, 0), end: UtcT(2025, 3, 10, 8, 5), dur: 200, words: 300, editionId: Guid.NewGuid()));
+
+        var now = UtcT(2025, 3, 15, 8, 0);
+        var s = await h.Service.GetLibrarySummaryAsync(userId, TimeSpan.Zero, now, CancellationToken.None);
+
+        Assert.Equal(1, s.PagesThisMonth);        // 300/250
+        Assert.Equal(3, s.MinutesThisMonth);      // 200/60
+        Assert.Equal(0, s.BooksFinishedYtd);
+        Assert.Null(s.Goal);
+    }
+
+    // ── R5 slice-3: GetPaceAsync ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPace_NoSessions_ReturnsFallback200ZeroCountNotUserSpecific()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+
+        var p = await h.Service.GetPaceAsync(userId, CancellationToken.None);
+
+        Assert.Equal(200, p.Wpm);
+        Assert.Equal(0, p.SessionCount);
+        Assert.False(p.IsUserSpecific);
+    }
+
+    [Fact]
+    public async Task GetPace_FewerThanThreeSessions_ReturnsFallbackWithRealCount()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, 1, 8, 0), end: UtcT(2025, 3, 1, 8, 10), dur: 600, words: 1000, editionId: Guid.NewGuid()));
+        h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, 2, 8, 0), end: UtcT(2025, 3, 2, 8, 10), dur: 600, words: 1000, editionId: Guid.NewGuid()));
+
+        var p = await h.Service.GetPaceAsync(userId, CancellationToken.None);
+
+        Assert.Equal(200, p.Wpm);      // fallback
+        Assert.Equal(2, p.SessionCount); // but real count surfaces
+        Assert.False(p.IsUserSpecific);
+    }
+
+    [Fact]
+    public async Task GetPace_ThreeSessions_RoundsWpm()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        // Totals: 1000 words / 190s. wpm = 1000 / (190/60) = 315.789 → Round → 316.
+        h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, 1, 8, 0), end: UtcT(2025, 3, 1, 8, 1), dur: 60, words: 400, editionId: Guid.NewGuid()));
+        h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, 2, 8, 0), end: UtcT(2025, 3, 2, 8, 1), dur: 60, words: 400, editionId: Guid.NewGuid()));
+        h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, 3, 8, 0), end: UtcT(2025, 3, 3, 8, 1), dur: 70, words: 200, editionId: Guid.NewGuid()));
+
+        var p = await h.Service.GetPaceAsync(userId, CancellationToken.None);
+
+        Assert.Equal(316, p.Wpm);
+        Assert.Equal(3, p.SessionCount);
+        Assert.True(p.IsUserSpecific);
+    }
+
+    [Fact]
+    public async Task GetPace_UltraSlow_ClampsToFifty()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        // 3 sessions, 300 words / 600s → 30 wpm → clamp up to 50.
+        for (var i = 0; i < 3; i++)
+            h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, i + 1, 8, 0), end: UtcT(2025, 3, i + 1, 8, 3), dur: 200, words: 100, editionId: Guid.NewGuid()));
+
+        var p = await h.Service.GetPaceAsync(userId, CancellationToken.None);
+
+        Assert.Equal(50, p.Wpm);
+        Assert.True(p.IsUserSpecific);
+    }
+
+    [Fact]
+    public async Task GetPace_UltraFast_ClampsToEightHundred()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        // 3 sessions, 30000 words / 180s → 10000 wpm → clamp down to 800.
+        for (var i = 0; i < 3; i++)
+            h.Sessions.Add(Session(userId, endPct: 0.5, start: UtcT(2025, 3, i + 1, 8, 0), end: UtcT(2025, 3, i + 1, 8, 1), dur: 60, words: 10000, editionId: Guid.NewGuid()));
+
+        var p = await h.Service.GetPaceAsync(userId, CancellationToken.None);
+
+        Assert.Equal(800, p.Wpm);
+        Assert.True(p.IsUserSpecific);
+    }
+
+    // ── R5 slice-3: golden JSON snapshot ────────────────────────────────────────────────────────
+    // Locks field order + camelCase + null serialization for the /me/reading/stats wire contract.
+    // Uses the ASP.NET Core minimal-API default (JsonSerializerDefaults.Web → camelCase).
+
+    private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void ReadingStatsResponse_SerializesToStableCamelCaseJson_WithDailyGoal()
+    {
+        var resp = new ReadingStatsResponse(
+            TotalSeconds: 3600,
+            TotalWords: 6000,
+            BooksFinished: 2,
+            CurrentStreak: 4,
+            LongestStreak: 9,
+            StreakMinMinutes: 5,
+            AvgDailyMinutes: 12.5,
+            AvgWordsPerMinute: 100.0,
+            TodaySeconds: 600,
+            TodayVocabReviews: 3,
+            WeekSeconds: 1800,
+            MonthSeconds: 7200,
+            DailyGoal: new DailyGoalStatusDto(20, 10.5, false));
+
+        var json = JsonSerializer.Serialize(resp, WebJson);
+
+        Assert.Equal(
+            "{\"totalSeconds\":3600,\"totalWords\":6000,\"booksFinished\":2,\"currentStreak\":4," +
+            "\"longestStreak\":9,\"streakMinMinutes\":5,\"avgDailyMinutes\":12.5,\"avgWordsPerMinute\":100," +
+            "\"todaySeconds\":600,\"todayVocabReviews\":3,\"weekSeconds\":1800,\"monthSeconds\":7200," +
+            "\"dailyGoal\":{\"target\":20,\"today\":10.5,\"met\":false}}",
+            json);
+    }
+
+    [Fact]
+    public void ReadingStatsResponse_SerializesNullDailyGoal_AsJsonNull()
+    {
+        var resp = new ReadingStatsResponse(
+            TotalSeconds: 0, TotalWords: 0, BooksFinished: 0, CurrentStreak: 0, LongestStreak: 0,
+            StreakMinMinutes: 5, AvgDailyMinutes: 0, AvgWordsPerMinute: 0, TodaySeconds: 0,
+            TodayVocabReviews: 0, WeekSeconds: 0, MonthSeconds: 0, DailyGoal: null);
+
+        var json = JsonSerializer.Serialize(resp, WebJson);
+
+        Assert.EndsWith("\"dailyGoal\":null}", json);
     }
 
     // Small helpers to make genre tuple asserts read cleanly.

--- a/tests/TextStack.UnitTests/StreakCalculatorTests.cs
+++ b/tests/TextStack.UnitTests/StreakCalculatorTests.cs
@@ -1,0 +1,165 @@
+using Application.Common.Interfaces;
+using Application.ReadingTracking;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace TextStack.UnitTests;
+
+// R5 slice-3: StreakCalculator.* over a Moq IAppDbContext whose ReadingSessions / VocabularyReviews
+// DbSets are backed by List<T> (async LINQ via TestAsyncQueryable). Behaviour-preservation tests for
+// the streak helpers moved verbatim out of ReadingTrackingEndpoints (siteId parameter dropped).
+public class StreakCalculatorTests
+{
+    private sealed class Harness
+    {
+        public List<ReadingSession> Sessions { get; } = [];
+        public List<VocabularyReview> Reviews { get; } = [];
+        public Mock<IAppDbContext> Db { get; } = new();
+
+        public Harness()
+        {
+            Db.Setup(x => x.ReadingSessions).Returns(() => FakeSet(Sessions).Object);
+            Db.Setup(x => x.VocabularyReviews).Returns(() => FakeSet(Reviews).Object);
+        }
+    }
+
+    private static Mock<DbSet<T>> FakeSet<T>(List<T> data) where T : class
+    {
+        var q = new TestAsyncEnumerable<T>(data);
+        var set = new Mock<DbSet<T>>();
+        var iq = set.As<IQueryable<T>>();
+        iq.Setup(m => m.Provider).Returns(((IQueryable<T>)q).Provider);
+        iq.Setup(m => m.Expression).Returns(((IQueryable<T>)q).Expression);
+        iq.Setup(m => m.ElementType).Returns(((IQueryable<T>)q).ElementType);
+        iq.Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
+        set.As<IAsyncEnumerable<T>>()
+            .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+            .Returns(() => new TestAsyncEnumerator<T>(data.GetEnumerator()));
+        return set;
+    }
+
+    private static DateTimeOffset UtcT(int y, int mo, int d, int h, int mi)
+        => new(y, mo, d, h, mi, 0, TimeSpan.Zero);
+
+    private static ReadingSession Session(Guid userId, DateTimeOffset start, int dur) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        StartedAt = start,
+        EndedAt = start,
+        DurationSeconds = dur,
+        WordsRead = 0,
+        StartPercent = 0,
+        EndPercent = 0,
+        CreatedAt = start,
+    };
+
+    private static VocabularyReview Review(Guid userId, DateTimeOffset at) => new()
+    {
+        Id = Guid.NewGuid(),
+        VocabularyWordId = Guid.NewGuid(),
+        UserId = userId,
+        ReviewMode = "multiple_choice",
+        IsCorrect = true,
+        CreatedAt = at,
+    };
+
+    // now = 2025-03-15 12:00Z; streak threshold 5 min = 300s throughout.
+    private static readonly DateTimeOffset Now = UtcT(2025, 3, 15, 12, 0);
+    private const int Threshold = 5;
+
+    [Fact]
+    public async Task CalculateStreak_NoActivity_ReturnsZero()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+
+        var streak = await StreakCalculator.CalculateStreak(h.Db.Object, userId, Threshold, Now, CancellationToken.None);
+        Assert.Equal(0, streak);
+    }
+
+    [Fact]
+    public async Task CalculateLongestStreak_NoActivity_ReturnsZero()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+
+        var longest = await StreakCalculator.CalculateLongestStreak(h.Db.Object, userId, Threshold, CancellationToken.None);
+        Assert.Equal(0, longest);
+    }
+
+    [Fact]
+    public async Task CalculateStreak_SingleQualifyingToday_ReturnsOne()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        h.Sessions.Add(Session(userId, UtcT(2025, 3, 15, 8, 0), 600)); // 10 min today
+
+        var current = await StreakCalculator.CalculateStreak(h.Db.Object, userId, Threshold, Now, CancellationToken.None);
+        var longest = await StreakCalculator.CalculateLongestStreak(h.Db.Object, userId, Threshold, CancellationToken.None);
+
+        Assert.Equal(1, current);
+        Assert.Equal(1, longest);
+    }
+
+    [Fact]
+    public async Task Streaks_GapResetsLongest_CurrentCountsBackFromToday()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        // Run of 3 (Mar 1-3), an isolated day (Mar 10), a run of 2 ending today (Mar 14-15).
+        foreach (var d in new[] { 1, 2, 3, 10, 14, 15 })
+            h.Sessions.Add(Session(userId, UtcT(2025, 3, d, 8, 0), 600));
+
+        var current = await StreakCalculator.CalculateStreak(h.Db.Object, userId, Threshold, Now, CancellationToken.None);
+        var longest = await StreakCalculator.CalculateLongestStreak(h.Db.Object, userId, Threshold, CancellationToken.None);
+
+        Assert.Equal(2, current);  // 03-15, 03-14, then 03-13 gap stops it
+        Assert.Equal(3, longest);  // 03-01..03-03 — the gap resets the running count
+    }
+
+    [Fact]
+    public async Task CalculateStreak_TodayBelowThreshold_CountsFromYesterday()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        h.Sessions.Add(Session(userId, UtcT(2025, 3, 13, 8, 0), 600));
+        h.Sessions.Add(Session(userId, UtcT(2025, 3, 14, 8, 0), 600));
+        h.Sessions.Add(Session(userId, UtcT(2025, 3, 15, 8, 0), 120)); // 2 min today → does NOT qualify
+
+        var current = await StreakCalculator.CalculateStreak(h.Db.Object, userId, Threshold, Now, CancellationToken.None);
+        Assert.Equal(2, current); // today skipped, streak runs 03-14, 03-13
+    }
+
+    [Fact]
+    public async Task CalculateStreak_TzShiftAcrossMidnight_ChangesQualifyingDay()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        h.Sessions.Add(Session(userId, UtcT(2025, 3, 15, 0, 30), 600));  // just after UTC midnight
+        h.Sessions.Add(Session(userId, UtcT(2025, 3, 14, 12, 0), 600));
+
+        // tz 0: sessions land on 03-15 + 03-14 → streak 2 back from today.
+        var utc = await StreakCalculator.CalculateStreak(h.Db.Object, userId, Threshold, Now, CancellationToken.None, TimeSpan.Zero);
+        Assert.Equal(2, utc);
+
+        // tz -60: the 00:30 session shifts to 03-14, both merge onto 03-14; today (03-15) no longer
+        // qualifies, so the streak counts only 03-14 → 1.
+        var minus = await StreakCalculator.CalculateStreak(h.Db.Object, userId, Threshold, Now, CancellationToken.None, TimeSpan.FromMinutes(-60));
+        Assert.Equal(1, minus);
+    }
+
+    [Fact]
+    public async Task CalculateStreak_VocabReviewsPushSubThresholdDayOverThreshold()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        h.Sessions.Add(Session(userId, UtcT(2025, 3, 15, 8, 0), 200)); // 200s < 300s alone
+        for (var i = 0; i < 4; i++)
+            h.Reviews.Add(Review(userId, UtcT(2025, 3, 15, 9, i)));    // +4*30 = 120s → 320s total
+
+        var current = await StreakCalculator.CalculateStreak(h.Db.Object, userId, Threshold, Now, CancellationToken.None);
+        Assert.Equal(1, current);
+    }
+}


### PR DESCRIPTION
## What & why
Third R5 slice — the coupled read-only cluster `GetStats` + `GetLibrarySummary` + `GetPace`, one PR because they share streak/tz helpers. Biggest R5 slice.

## Changes
- 3 handler bodies → `ReadingStatsService` (verbatim). Handlers thin (auth → parse tz → `now` → service → `Results.Ok`); **`IMemoryCache` stays in the Summary/Pace handlers** (service cache-free).
- Shared streak/tz helpers → new `Application/ReadingTracking/StreakCalculator` (public static). Dead `siteId` param dropped (never read — site scope is the R1b query filter); **5 call-sites updated incl. `SubmitSession`/`SubmitReview`** (AchievementChecker still receives siteId, mutation ordering unchanged).
- `GetStats` anonymous object → `ReadingStatsResponse` + nested `DailyGoalStatusDto` records — **byte-identical JSON**: `long` sums preserved (not int), field order/camelCase/`dailyGoal:null` locked by a hand-written golden snapshot.
- `LibrarySummaryDto`/`GoalSummaryDto`/`ReadingPaceDto` → `Contracts.ReadingTracking`.

## Verification
- Adversarial QA: field-by-field byte-identity of the new record vs the old anon object; **verbatim** diff of all 5 streak helpers + 3 handlers vs origin; confirmed `siteId` truly dead in every streak body; mutation call-sites preserve `AchievementChecker` site-scope + ordering; **all golden values hand-recomputed** (84.3 wpm, streak=3, weekSeconds=3000, dailyGoal today=11.0, pace 316 + clamp 50/800, int-div 249→0).
- Tests: +26 unit (deterministic goldens + StreakCalculator edges + golden JSON snapshot) + 3 new endpoint integration tests (were uncovered). `dotnet build` 0 errors; `dotnet test tests/TextStack.UnitTests` → **1033 passed**; format clean.

## Rollback
One revert; JSON identical either direction (no frontend coordination). No schema/data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)