### PR TITLE
refactor(api): extract SubmitSession into ReadingSessionService (R5 slice-4, final)

### DIFF
--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Sessions.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.Sessions.cs
@@ -3,7 +3,7 @@ using Api.Sites;
 using Application.Auth;
 using Application.Common.Interfaces;
 using Application.ReadingTracking;
-using Domain.Entities;
+using Contracts.ReadingTracking;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -15,8 +15,7 @@ public static partial class ReadingTrackingEndpoints
         [FromBody] SubmitSessionRequest request,
         HttpContext httpContext,
         AuthService authService,
-        IAppDbContext db,
-        ILogger<Program> logger,
+        ReadingSessionService sessionService,
         CancellationToken ct)
     {
         var userId = httpContext.GetUserId(authService);
@@ -36,69 +35,7 @@ public static partial class ReadingTrackingEndpoints
         if (elapsed < request.DurationSeconds)
             return Results.BadRequest("EndedAt - StartedAt must be >= DurationSeconds");
 
-        // Pre-check the unique-by-(user, user_book, started_at) constraint
-        // for user-book sessions. The DB constraint is the source of truth
-        // and the catch below still covers a race; this just keeps the
-        // happy path off the "SQL error level: ERROR" log line that
-        // Npgsql emits before the catch can swallow it. The constraint is
-        // partial (WHERE user_book_id IS NOT NULL), so edition-only
-        // sessions skip the check entirely.
-        if (request.UserBookId != null)
-        {
-            var dup = await db.ReadingSessions.AnyAsync(
-                s => s.UserId == userId.Value
-                  && s.UserBookId == request.UserBookId
-                  && s.StartedAt == request.StartedAt,
-                ct);
-            if (dup) return Results.Ok(new SubmitSessionResponse(Guid.Empty, []));
-        }
-
-        var session = new ReadingSession
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId.Value,
-            SiteId = siteId,
-            EditionId = request.EditionId,
-            UserBookId = request.UserBookId,
-            StartedAt = request.StartedAt,
-            EndedAt = request.EndedAt,
-            DurationSeconds = request.DurationSeconds,
-            WordsRead = request.WordsRead,
-            StartPercent = request.StartPercent,
-            EndPercent = request.EndPercent,
-            CreatedAt = DateTimeOffset.UtcNow,
-        };
-
-        db.ReadingSessions.Add(session);
-
-        try
-        {
-            await db.SaveChangesAsync(ct);
-        }
-        catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
-        {
-            // Race-window fallback: another concurrent request slipped in
-            // between our pre-check and SaveChanges. The first one won; we
-            // ack idempotently.
-            return Results.Ok(new SubmitSessionResponse(session.Id, []));
-        }
-
-        // Achievement check is best-effort — never fail the session submit because of it.
-        List<string> newAchievements = [];
-        try
-        {
-            var streakMinMinutes = await StreakCalculator.GetStreakMinMinutes(db, userId.Value, ct);
-            var currentStreak = await StreakCalculator.CalculateStreak(db, userId.Value, streakMinMinutes, request.EndedAt, ct);
-
-            var checker = new AchievementChecker(db);
-            newAchievements = await checker.CheckAfterSession(userId.Value, siteId, session, currentStreak, ct);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "AchievementChecker failed for session {SessionId}, session still saved", session.Id);
-        }
-
-        return Results.Ok(new SubmitSessionResponse(session.Id, newAchievements));
+        return Results.Ok(await sessionService.SubmitAsync(userId.Value, siteId, request, ct));
     }
 
     private static async Task<IResult> GetSessions(

--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
@@ -47,19 +47,8 @@ public static partial class ReadingTrackingEndpoints
 }
 
 // DTOs
-public record SubmitSessionRequest(
-    Guid? EditionId,
-    Guid? UserBookId,
-    DateTimeOffset StartedAt,
-    DateTimeOffset EndedAt,
-    int DurationSeconds,
-    int WordsRead,
-    double StartPercent,
-    double EndPercent
-);
-
-public record SubmitSessionResponse(Guid SessionId, List<string> NewAchievements);
-
+// SubmitSessionRequest/SubmitSessionResponse moved to Contracts.ReadingTracking (R5 slice-4),
+// beside the ReadingSessionService that consumes them.
 public record SessionDto(
     Guid Id, Guid? EditionId, Guid? UserBookId,
     DateTimeOffset StartedAt, DateTimeOffset EndedAt,

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -28,6 +28,7 @@ public static class DependencyInjection
         services.AddScoped<AuthorsService>();
         services.AddScoped<BookService>();
         services.AddScoped<ReadingStatsService>();
+        services.AddScoped<ReadingSessionService>();
         services.AddScoped<SeoService>();
 
         // SEO Backfill Automation

--- a/backend/src/Application/ReadingTracking/ReadingSessionService.cs
+++ b/backend/src/Application/ReadingTracking/ReadingSessionService.cs
@@ -1,0 +1,91 @@
+using Application.Common.Interfaces;
+using Contracts.ReadingTracking;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Application.ReadingTracking;
+
+/// <summary>
+/// Mutating reading-session submit (R5 slice-4). Body moved verbatim from the former
+/// <c>ReadingTrackingEndpoints.SubmitSession</c> handler — kept separate from the read-only
+/// <see cref="ReadingStatsService"/>. The side-effect ordering is load-bearing and preserved exactly:
+/// dedup pre-check (user-book only) → build session (SiteId set by hand) → Add → SaveChanges (with the
+/// 23505 race fallback) → best-effort achievement award. Note the asymmetry the original relied on:
+/// the pre-check duplicate returns <c>Guid.Empty</c> (nothing was inserted) while the race fallback
+/// returns <c>session.Id</c> (our row lost the insert race but the caller acks idempotently). The
+/// achievement block runs strictly AFTER the save because the checker reads persisted state (the just-
+/// saved session must already be in the table for e.g. <c>first_session</c> to unlock), and it is
+/// best-effort: any exception there is logged and swallowed so the submit still succeeds. The HTTP
+/// validations + auth stay in the thin handler.
+/// </summary>
+public class ReadingSessionService(IAppDbContext db, ILogger<ReadingSessionService> logger)
+{
+    public async Task<SubmitSessionResponse> SubmitAsync(
+        Guid userId, Guid siteId, SubmitSessionRequest request, CancellationToken ct)
+    {
+        // Pre-check the unique-by-(user, user_book, started_at) constraint
+        // for user-book sessions. The DB constraint is the source of truth
+        // and the catch below still covers a race; this just keeps the
+        // happy path off the "SQL error level: ERROR" log line that
+        // Npgsql emits before the catch can swallow it. The constraint is
+        // partial (WHERE user_book_id IS NOT NULL), so edition-only
+        // sessions skip the check entirely.
+        if (request.UserBookId != null)
+        {
+            var dup = await db.ReadingSessions.AnyAsync(
+                s => s.UserId == userId
+                  && s.UserBookId == request.UserBookId
+                  && s.StartedAt == request.StartedAt,
+                ct);
+            if (dup) return new SubmitSessionResponse(Guid.Empty, []);
+        }
+
+        var session = new ReadingSession
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            SiteId = siteId,
+            EditionId = request.EditionId,
+            UserBookId = request.UserBookId,
+            StartedAt = request.StartedAt,
+            EndedAt = request.EndedAt,
+            DurationSeconds = request.DurationSeconds,
+            WordsRead = request.WordsRead,
+            StartPercent = request.StartPercent,
+            EndPercent = request.EndPercent,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        db.ReadingSessions.Add(session);
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+        {
+            // Race-window fallback: another concurrent request slipped in
+            // between our pre-check and SaveChanges. The first one won; we
+            // ack idempotently.
+            return new SubmitSessionResponse(session.Id, []);
+        }
+
+        // Achievement check is best-effort — never fail the session submit because of it.
+        List<string> newAchievements = [];
+        try
+        {
+            var streakMinMinutes = await StreakCalculator.GetStreakMinMinutes(db, userId, ct);
+            var currentStreak = await StreakCalculator.CalculateStreak(db, userId, streakMinMinutes, request.EndedAt, ct);
+
+            var checker = new AchievementChecker(db);
+            newAchievements = await checker.CheckAfterSession(userId, siteId, session, currentStreak, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "AchievementChecker failed for session {SessionId}, session still saved", session.Id);
+        }
+
+        return new SubmitSessionResponse(session.Id, newAchievements);
+    }
+}

--- a/backend/src/Contracts/ReadingTracking/SubmitSessionDtos.cs
+++ b/backend/src/Contracts/ReadingTracking/SubmitSessionDtos.cs
@@ -1,0 +1,17 @@
+namespace Contracts.ReadingTracking;
+
+// Submit-reading-session request/response (R5 slice-4). Moved verbatim from Api.Endpoints so they
+// live beside the ReadingSessionService that consumes/produces them. Field names/casing/order
+// unchanged — the wire contract for POST /me/reading/sessions is byte-identical.
+public record SubmitSessionRequest(
+    Guid? EditionId,
+    Guid? UserBookId,
+    DateTimeOffset StartedAt,
+    DateTimeOffset EndedAt,
+    int DurationSeconds,
+    int WordsRead,
+    double StartPercent,
+    double EndPercent
+);
+
+public record SubmitSessionResponse(Guid SessionId, List<string> NewAchievements);

--- a/tests/TextStack.IntegrationTests/ReadingSessionsEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/ReadingSessionsEndpointTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace TextStack.IntegrationTests;
+
+// R5 slice-4 wire-equivalence gate for POST /me/reading/sessions (the mutating submit).
+// Live data is non-deterministic, so we assert status + response shape + the two behaviours the
+// refactor must preserve: a fresh user-book session gets a non-empty sessionId, and re-POSTing the
+// SAME (userBook, startedAt) idempotently acks with sessionId == Guid.Empty (the dedup pre-check).
+// Plus one validation 400. Never asserts concrete values. Skips (not fails) when unavailable.
+public class ReadingSessionsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixture<AuthenticatedApiFixture>
+{
+    private readonly LiveApiFixture _anon;
+    private readonly AuthenticatedApiFixture _auth;
+
+    public ReadingSessionsEndpointTests(LiveApiFixture anon, AuthenticatedApiFixture auth)
+    {
+        _anon = anon;
+        _auth = auth;
+    }
+
+    private HttpRequestMessage PostSession(object body)
+    {
+        var req = _auth.CreateRequest(HttpMethod.Post, "/me/reading/sessions");
+        req.Content = JsonContent.Create(body);
+        return req;
+    }
+
+    [Fact]
+    public async Task SubmitSession_WithoutAuth_Returns401()
+    {
+        var req = _anon.CreateRequest(HttpMethod.Post, "/me/reading/sessions");
+        req.Content = JsonContent.Create(new { editionId = Guid.NewGuid(), startedAt = DateTimeOffset.UtcNow.AddMinutes(-5), endedAt = DateTimeOffset.UtcNow, durationSeconds = 60, wordsRead = 10, startPercent = 0.0, endPercent = 0.1 });
+        var response = await _anon.Client.SendAsync(req, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SubmitSession_ValidUserBookSession_Returns200WithSessionIdAndAchievementsArray()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Create a user book to attach the session to (clip flow — same as AccountDeletion test).
+        var clipReq = _auth.CreateRequest(HttpMethod.Post, "/me/books/clip");
+        clipReq.Content = JsonContent.Create(new
+        {
+            title = $"Clip {Guid.NewGuid():N}"[..16],
+            html = "<p>Hello world. This is a clipped article body for the sessions test.</p>",
+            language = "en"
+        });
+        var clipResp = await _auth.Client.SendAsync(clipReq, ct);
+        Assert.SkipWhen(IntegrationSkip.Unavailable(clipResp), "clip endpoint unavailable");
+        Assert.True(clipResp.IsSuccessStatusCode, $"clip failed: {clipResp.StatusCode}");
+        var userBookId = (await clipResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct)).GetProperty("userBookId").GetGuid();
+
+        var startedAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var endedAt = DateTimeOffset.UtcNow;
+        var body = new
+        {
+            userBookId,
+            startedAt,
+            endedAt,
+            durationSeconds = 300,
+            wordsRead = 100,
+            startPercent = 0.0,
+            endPercent = 0.5
+        };
+
+        var first = await _auth.Client.SendAsync(PostSession(body), ct);
+        Assert.SkipWhen(IntegrationSkip.Unavailable(first), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+
+        var firstResult = await first.Content.ReadFromJsonAsync<SubmitResult>(cancellationToken: ct);
+        Assert.NotNull(firstResult);
+        Assert.NotEqual(Guid.Empty, firstResult.SessionId);   // fresh insert → real id
+        Assert.NotNull(firstResult.NewAchievements);          // always an array (maybe empty)
+
+        // Re-POST the SAME (userBook, startedAt) → dedup pre-check acks idempotently with Guid.Empty.
+        var second = await _auth.Client.SendAsync(PostSession(body), ct);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        var secondResult = await second.Content.ReadFromJsonAsync<SubmitResult>(cancellationToken: ct);
+        Assert.NotNull(secondResult);
+        Assert.Equal(Guid.Empty, secondResult.SessionId);     // duplicate → Guid.Empty
+        Assert.NotNull(secondResult.NewAchievements);
+        Assert.Empty(secondResult.NewAchievements);
+    }
+
+    [Fact]
+    public async Task SubmitSession_ZeroDuration_Returns400()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var body = new
+        {
+            editionId = Guid.NewGuid(),
+            startedAt = now.AddMinutes(-5),
+            endedAt = now,
+            durationSeconds = 0,   // invalid: must be 1-14400
+            wordsRead = 10,
+            startPercent = 0.0,
+            endPercent = 0.1
+        };
+
+        var response = await _auth.Client.SendAsync(PostSession(body), TestContext.Current.CancellationToken);
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    // Local deserialization mirror of Contracts.ReadingTracking.SubmitSessionResponse — field names
+    // drive the camelCase wire contract this gate protects.
+    private record SubmitResult(Guid SessionId, List<string> NewAchievements);
+}

--- a/tests/TextStack.UnitTests/ReadingSessionServiceTests.cs
+++ b/tests/TextStack.UnitTests/ReadingSessionServiceTests.cs
@@ -1,0 +1,217 @@
+using Application.Common.Interfaces;
+using Application.ReadingTracking;
+using Contracts.ReadingTracking;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace TextStack.UnitTests;
+
+// R5 slice-4: ReadingSessionService.SubmitAsync over a Moq IAppDbContext whose sets are backed by
+// plain List<T>. Unlike the read-only ReadingStatsServiceTests harness, this FakeSet is MUTABLE —
+// Add() appends to the backing list via Callback — so the achievement checker (run on the same Moq db,
+// NOT mocked) sees the just-saved session. That is what lets the "ordering" test prove the save-before-
+// check contract: `first_session` only unlocks if the session is already in the backing list when the
+// checker counts sessions. The mutation, dedup asymmetry (pre-check → Guid.Empty, race → session.Id),
+// best-effort swallow, and the 23505 race fallback are all exercised with hand-computed values.
+public class ReadingSessionServiceTests
+{
+    private sealed class Harness
+    {
+        public List<ReadingSession> Sessions { get; } = [];
+        public List<UserAchievement> Achievements { get; } = [];
+        public List<ReadingGoal> Goals { get; } = [];
+        public List<VocabularyReview> Reviews { get; } = [];
+        public int SaveCalls { get; private set; }
+        public Mock<IAppDbContext> Db { get; } = new();
+        public Mock<ILogger<ReadingSessionService>> Logger { get; } = new();
+        public ReadingSessionService Service { get; }
+
+        /// <summary>When set, SaveChangesAsync throws this on the Nth (1-based) call.</summary>
+        public Exception? ThrowOnSaveCall { get; set; }
+        public int ThrowOnSaveCallNumber { get; set; } = 1;
+
+        public Harness()
+        {
+            Db.Setup(x => x.ReadingSessions).Returns(() => FakeSet(Sessions).Object);
+            Db.Setup(x => x.UserAchievements).Returns(() => FakeSet(Achievements).Object);
+            Db.Setup(x => x.ReadingGoals).Returns(() => FakeSet(Goals).Object);
+            Db.Setup(x => x.VocabularyReviews).Returns(() => FakeSet(Reviews).Object);
+            Db.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    SaveCalls++;
+                    if (ThrowOnSaveCall is not null && SaveCalls == ThrowOnSaveCallNumber)
+                        throw ThrowOnSaveCall;
+                    return 1;
+                });
+            Service = new ReadingSessionService(Db.Object, Logger.Object);
+        }
+    }
+
+    // Mutable DbSet<T> mock backed by `data`: queryable (sync + async) + Add() appends to the list.
+    private static Mock<DbSet<T>> FakeSet<T>(List<T> data) where T : class
+    {
+        var q = new TestAsyncEnumerable<T>(data);
+        var set = new Mock<DbSet<T>>();
+        var iq = set.As<IQueryable<T>>();
+        iq.Setup(m => m.Provider).Returns(((IQueryable<T>)q).Provider);
+        iq.Setup(m => m.Expression).Returns(((IQueryable<T>)q).Expression);
+        iq.Setup(m => m.ElementType).Returns(((IQueryable<T>)q).ElementType);
+        iq.Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
+        set.As<IAsyncEnumerable<T>>()
+            .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+            .Returns(() => new TestAsyncEnumerator<T>(data.GetEnumerator()));
+        set.Setup(m => m.Add(It.IsAny<T>())).Callback<T>(e => data.Add(e));
+        return set;
+    }
+
+    private static SubmitSessionRequest EditionReq(
+        Guid editionId, DateTimeOffset started, DateTimeOffset ended, int dur = 300, int words = 100,
+        double endPct = 0.5) =>
+        new(EditionId: editionId, UserBookId: null, StartedAt: started, EndedAt: ended,
+            DurationSeconds: dur, WordsRead: words, StartPercent: 0, EndPercent: endPct);
+
+    private static SubmitSessionRequest UserBookReq(
+        Guid userBookId, DateTimeOffset started, DateTimeOffset ended, int dur = 300, int words = 100,
+        double endPct = 0.5) =>
+        new(EditionId: null, UserBookId: userBookId, StartedAt: started, EndedAt: ended,
+            DurationSeconds: dur, WordsRead: words, StartPercent: 0, EndPercent: endPct);
+
+    private static ReadingSession SeedSession(Guid userId, Guid? editionId, Guid? userBookId, DateTimeOffset started) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        EditionId = editionId,
+        UserBookId = userBookId,
+        StartedAt = started,
+        EndedAt = started.AddMinutes(5),
+        DurationSeconds = 300,
+        WordsRead = 100,
+        StartPercent = 0,
+        EndPercent = 0.5,
+        CreatedAt = started,
+    };
+
+    // ── Ordering (main): save-before-check ──────────────────────────────────────────────────────
+    // Empty db → submit → the achievement checker runs on the SAME Moq db and must see the just-added
+    // session (sessionCount == 1) to unlock "first_session". Values are chosen so ONLY first_session
+    // unlocks: endPct 0.5 (not finished), 12:00 hour (not early_bird/night_owl), 20 wpm (< 400),
+    // 300s (< 1h, streak=1 < 3, < 2h marathon).
+    [Fact]
+    public async Task SubmitAsync_EmptyDb_UnlocksFirstSession_ProvingSaveBeforeCheck()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var siteId = Guid.NewGuid();
+        var started = new DateTimeOffset(2025, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        var req = EditionReq(Guid.NewGuid(), started, started.AddMinutes(5));
+
+        var r = await h.Service.SubmitAsync(userId, siteId, req, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, r.SessionId);
+        Assert.Contains("first_session", r.NewAchievements);   // only unlocks if session already persisted
+        Assert.Equal(new[] { "first_session" }, r.NewAchievements.ToArray());
+        Assert.Single(h.Sessions);
+        Assert.Equal(r.SessionId, h.Sessions[0].Id);
+        h.Db.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    // ── Dedup: user-book pre-check returns Guid.Empty, inserts nothing, never saves ──────────────
+    [Fact]
+    public async Task SubmitAsync_DuplicateUserBookSession_ReturnsGuidEmpty_NoInsertNoSave()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var siteId = Guid.NewGuid();
+        var userBookId = Guid.NewGuid();
+        var started = new DateTimeOffset(2025, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        h.Sessions.Add(SeedSession(userId, editionId: null, userBookId: userBookId, started: started));
+
+        var r = await h.Service.SubmitAsync(userId, siteId, UserBookReq(userBookId, started, started.AddMinutes(5)), CancellationToken.None);
+
+        Assert.Equal(Guid.Empty, r.SessionId);                 // pre-check → Guid.Empty (asymmetry vs race)
+        Assert.Empty(r.NewAchievements);
+        Assert.Single(h.Sessions);                             // no new row
+        h.Db.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Edition-only sessions SKIP the dedup pre-check (partial constraint) ──────────────────────
+    [Fact]
+    public async Task SubmitAsync_TwoIdenticalEditionSessions_BothInserted()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var siteId = Guid.NewGuid();
+        var editionId = Guid.NewGuid();
+        var started = new DateTimeOffset(2025, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        var req = EditionReq(editionId, started, started.AddMinutes(5));
+
+        var r1 = await h.Service.SubmitAsync(userId, siteId, req, CancellationToken.None);
+        var r2 = await h.Service.SubmitAsync(userId, siteId, req, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, r1.SessionId);
+        Assert.NotEqual(Guid.Empty, r2.SessionId);
+        Assert.NotEqual(r1.SessionId, r2.SessionId);
+        Assert.Equal(2, h.Sessions.Count);                     // edition-only never dedups
+    }
+
+    // ── Best-effort: achievement path throws → session still saved, no rethrow, warning logged ───
+    [Fact]
+    public async Task SubmitAsync_AchievementCheckThrows_SwallowsAndReturnsSavedSession()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var siteId = Guid.NewGuid();
+        var started = new DateTimeOffset(2025, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        // Make the achievement phase blow up (checker's first read is _db.UserAchievements).
+        h.Db.Setup(x => x.UserAchievements).Throws(new InvalidOperationException("boom"));
+
+        var r = await h.Service.SubmitAsync(userId, siteId, EditionReq(Guid.NewGuid(), started, started.AddMinutes(5)), CancellationToken.None);
+
+        Assert.Equal(h.Sessions[0].Id, r.SessionId);           // session was saved (step 7 ran before the throw)
+        Assert.Empty(r.NewAchievements);                       // stays [] on swallow
+        Assert.Single(h.Sessions);
+        h.Logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+            Times.Once);
+    }
+
+    // ── Race 23505: SaveChanges throws unique-violation → ack idempotently with session.Id ───────
+    [Fact]
+    public async Task SubmitAsync_SaveThrows23505_ReturnsSessionId_NoRethrow()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var siteId = Guid.NewGuid();
+        var started = new DateTimeOffset(2025, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        var inner = new Npgsql.PostgresException("duplicate key", "ERROR", "ERROR", "23505");
+        h.ThrowOnSaveCall = new DbUpdateException("unique violation", inner);
+
+        var r = await h.Service.SubmitAsync(userId, siteId, EditionReq(Guid.NewGuid(), started, started.AddMinutes(5)), CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, r.SessionId);              // race → session.Id (asymmetry vs pre-check Guid.Empty)
+        Assert.Equal(h.Sessions[0].Id, r.SessionId);
+        Assert.Empty(r.NewAchievements);
+    }
+
+    // ── Non-23505 save failures are NOT swallowed — they propagate ───────────────────────────────
+    [Fact]
+    public async Task SubmitAsync_SaveThrowsOtherException_Propagates()
+    {
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var siteId = Guid.NewGuid();
+        var started = new DateTimeOffset(2025, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        h.ThrowOnSaveCall = new InvalidOperationException("db down");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => h.Service.SubmitAsync(userId, siteId, EditionReq(Guid.NewGuid(), started, started.AddMinutes(5)), CancellationToken.None));
+    }
+}


### PR DESCRIPTION
## What & why
Final R5 slice — the **mutating** `SubmitSession` endpoint. Highest-risk slice (write + achievements + dedup + side-effect ordering), taken with maximum care and behavioral verification.

## Changes
- New `Application/ReadingTracking/ReadingSessionService.SubmitAsync` (separate from the read-only `ReadingStatsService` — keeps that one pure). Body moved **verbatim**, preserving the exact 9-step order:
  1. dedup pre-check (userBook-only) → `(Guid.Empty, [])`
  2. create + manual `SiteId` stamp → `Add` → `SaveChanges` (narrow `23505` race catch → `(session.Id, [])`)
  3. achievements in a **best-effort try/catch AFTER save** → `return`
- Load-bearing details kept: return **asymmetry** (dedup Empty vs race session.Id), **edition-only sessions skip dedup**, `CalculateStreak(request.EndedAt)` (not UtcNow), `AchievementChecker` still site-scoped, no transaction, `ct` threaded everywhere.
- Thin handler keeps auth + 5 validations. `SubmitSessionRequest/Response` → `Contracts.ReadingTracking`.

## Verification
- Adversarial QA: **verbatim** line-by-line diff vs origin (only `userId.Value`→`userId` + `Ok`-hoist); confirmed the two catch blocks, asymmetric returns, edition-skip, EndedAt arg, validation order.
- 6 mutation unit tests incl. an **ordering test that genuinely fails on a save/check reversal** (`first_session` unlocks only when the session is in the backing list before the checker's `CountAsync`), race-23505, best-effort-swallow (session persists, warning logged, request doesn't fail), dedup asymmetry, other-exception-rethrows.
- New `ReadingSessionsEndpointTests` integration (endpoint was uncovered): POST→200+sessionId, dedup POST→Guid.Empty, 400 validation.
- `dotnet build` 0 errors; `dotnet test tests/TextStack.UnitTests` → **1039 passed**; format clean.

## Completes R5
Slices 1-3 (read-only GetBookStats/GetDailyStats/GetStats+Summary+Pace) already in prod; this is the last handler.

## Rollback
One revert (verbatim move, no logic change). No schema/data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)