### PR TITLE
refactor(web): split LibraryPage god-file into presentational components (R6 slice-1)

### DIFF
--- a/apps/web/src/components/library/LibraryShelfTabs.tsx
+++ b/apps/web/src/components/library/LibraryShelfTabs.tsx
@@ -1,0 +1,37 @@
+// Shelf switcher (Books vs Read later). Extracted verbatim from LibraryPage.tsx
+// (R6 slice-1) — presentational; parent owns the `shelf` state.
+
+type Shelf = 'books' | 'readlater'
+
+export function LibraryShelfTabs({
+  shelf,
+  onSelect,
+  t,
+}: {
+  shelf: Shelf
+  onSelect: (shelf: Shelf) => void
+  t: (key: string) => string
+}) {
+  return (
+    <div className="library-shelf-tabs" role="tablist" aria-label={t('library.title')}>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={shelf === 'books'}
+        className={`library-shelf-tab${shelf === 'books' ? ' library-shelf-tab--active' : ''}`}
+        onClick={() => onSelect('books')}
+      >
+        {t('library.readLater.tabBooks')}
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={shelf === 'readlater'}
+        className={`library-shelf-tab${shelf === 'readlater' ? ' library-shelf-tab--active' : ''}`}
+        onClick={() => onSelect('readlater')}
+      >
+        {t('library.readLater.tab')}
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/library/LibraryToolbar.tsx
+++ b/apps/web/src/components/library/LibraryToolbar.tsx
@@ -1,0 +1,60 @@
+// Library grid toolbar: sort menu + (uploads) select toggle + list/grid view
+// switch. Extracted verbatim from LibraryPage.tsx (R6 slice-1) — presentational;
+// parent owns sort / selection / viewMode state.
+import { LibrarySortMenu } from './LibrarySortMenu'
+import type { LibrarySortKey } from '../../hooks/useLibrarySort'
+
+type ViewMode = 'list' | 'grid'
+
+export function LibraryToolbar({
+  sort,
+  onSortChange,
+  showSelectButton,
+  selectionActive,
+  onToggleSelection,
+  viewMode,
+  onViewModeChange,
+  t,
+}: {
+  sort: LibrarySortKey
+  onSortChange: (next: LibrarySortKey) => void
+  showSelectButton: boolean
+  selectionActive: boolean
+  onToggleSelection: () => void
+  viewMode: ViewMode
+  onViewModeChange: (mode: ViewMode) => void
+  t: (key: string) => string
+}) {
+  return (
+    <div className="library-toolbar">
+      <div className="library-toolbar__left">
+        <LibrarySortMenu value={sort} onChange={onSortChange} />
+        {showSelectButton && (
+          <button
+            type="button"
+            className={`library-select-btn ${selectionActive ? 'library-select-btn--active' : ''}`}
+            onClick={onToggleSelection}
+          >
+            {selectionActive ? t('library.bulk.cancel') : t('library.bulk.select')}
+          </button>
+        )}
+      </div>
+      <div className="library-toolbar__right">
+        <button
+          className={`library-view-btn ${viewMode === 'grid' ? 'library-view-btn--active' : ''}`}
+          onClick={() => onViewModeChange('grid')}
+          aria-label="Grid view"
+        >
+          <span className="material-icons-outlined">grid_view</span>
+        </button>
+        <button
+          className={`library-view-btn ${viewMode === 'list' ? 'library-view-btn--active' : ''}`}
+          onClick={() => onViewModeChange('list')}
+          aria-label="List view"
+        >
+          <span className="material-icons-outlined">format_list_bulleted</span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/library/SavedBookGridCard.tsx
+++ b/apps/web/src/components/library/SavedBookGridCard.tsx
@@ -1,0 +1,90 @@
+// Saved (catalog) book card in the library grid view. Extracted verbatim from
+// LibraryPage.tsx (R6 slice-1) — presentational; `key` stays at the call site.
+import { Link } from 'react-router-dom'
+import { getStorageUrl } from '../../api/client'
+import type { LibraryItem, ReadingProgressDto } from '../../api/auth'
+import { OfflineBadge } from '../OfflineBadge'
+import { BookActionMenu } from './BookActionMenu'
+import { stringToColor } from '../../utils/colors'
+
+export function SavedBookGridCard({
+  item,
+  progress,
+  t,
+  onRemove,
+  onMarkFinished,
+  onMarkUnfinished,
+}: {
+  item: LibraryItem
+  progress: ReadingProgressDto | undefined
+  t: (key: string) => string
+  onRemove: () => void
+  onMarkFinished: () => void
+  onMarkUnfinished: () => void
+}) {
+  const percent = progress?.percent ?? 0
+  const destination = progress?.chapterSlug
+    ? `/${item.language}/books/${item.slug}/${progress.chapterSlug}`
+    : `/${item.language}/books/${item.slug}`
+  return (
+    <div className="library-card">
+      <Link to={destination} className="library-card__cover" title={`Read ${item.title} online`}>
+        {item.coverPath ? (
+          <img src={getStorageUrl(item.coverPath)} alt={item.title} />
+        ) : (
+          <div
+            className="library-card__cover-placeholder"
+            style={{ backgroundColor: stringToColor(item.title) }}
+          >
+            {item.title?.[0] || '?'}
+          </div>
+        )}
+        {percent >= 1 && (
+          <div className="user-book-card__completed-badge">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            Read
+          </div>
+        )}
+        {percent > 0 && percent < 1 && (
+          <div className="library-card__progress-bar">
+            <div
+              className="library-card__progress-fill"
+              style={{ width: `${Math.round(percent * 100)}%` }}
+            />
+          </div>
+        )}
+      </Link>
+      <div className="library-card__info">
+        <div className="library-card__text">
+          <Link to={destination} className="library-card__title" title={item.title}>
+            {item.title}
+          </Link>
+          {item.author && (
+            <span className="user-book-card__author" title={item.author}>{item.author}</span>
+          )}
+          <div className="library-card__meta">
+            {percent >= 1 && (
+              <span className="user-book-card__progress-text user-book-card__progress-text--done">Read</span>
+            )}
+            {percent > 0 && percent < 1 && (
+              <span className="library-card__progress-text">
+                {Math.round(percent * 100)}% {t('library.read')}
+              </span>
+            )}
+            <OfflineBadge editionId={item.editionId} />
+          </div>
+        </div>
+        <BookActionMenu
+          type="saved"
+          book={item}
+          isFinished={percent >= 1}
+          onRemove={onRemove}
+          onMarkFinished={onMarkFinished}
+          onMarkUnfinished={onMarkUnfinished}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/library/SavedBookListItem.tsx
+++ b/apps/web/src/components/library/SavedBookListItem.tsx
@@ -1,0 +1,85 @@
+// Saved (catalog) book row in the library list view. Extracted verbatim from
+// LibraryPage.tsx (R6 slice-1) — presentational; `key` stays at the call site.
+import { Link } from 'react-router-dom'
+import { getStorageUrl } from '../../api/client'
+import type { LibraryItem, ReadingProgressDto } from '../../api/auth'
+import { OfflineBadge } from '../OfflineBadge'
+import { BookActionMenu } from './BookActionMenu'
+import { stringToColor } from '../../utils/colors'
+import { formatTimeAgo } from './timeAgo'
+
+export function SavedBookListItem({
+  item,
+  progress,
+  t,
+  onRemove,
+  onMarkFinished,
+  onMarkUnfinished,
+}: {
+  item: LibraryItem
+  progress: ReadingProgressDto | undefined
+  t: (key: string) => string
+  onRemove: () => void
+  onMarkFinished: () => void
+  onMarkUnfinished: () => void
+}) {
+  const percent = progress?.percent ?? 0
+  const destination = progress?.chapterSlug
+    ? `/${item.language}/books/${item.slug}/${progress.chapterSlug}`
+    : `/${item.language}/books/${item.slug}`
+  return (
+    <article className="library-list-item">
+      <Link to={destination} className="library-list-item__cover">
+        {item.coverPath ? (
+          <img src={getStorageUrl(item.coverPath)} alt={item.title} />
+        ) : (
+          <div
+            className="library-list-item__cover-placeholder"
+            style={{ backgroundColor: stringToColor(item.title) }}
+          >
+            {item.title?.[0] || '?'}
+          </div>
+        )}
+      </Link>
+      <div className="library-list-item__content">
+        <Link to={destination} className="library-list-item__title" title={item.title}>
+          {item.title}
+        </Link>
+        <div className="library-list-item__progress">
+          <div className="library-list-item__progress-header">
+            <span>{t('library.readingProgress')}</span>
+            <span className="library-list-item__progress-percent">{Math.round(percent * 100)}%</span>
+          </div>
+          <div className="library-list-item__progress-bar">
+            <div
+              className="library-list-item__progress-fill"
+              style={{ width: `${Math.round(percent * 100)}%` }}
+            />
+          </div>
+        </div>
+        <div className="library-list-item__info">
+          {item.author && (
+            <span className="library-list-item__info-item" title={item.author}>{item.author}</span>
+          )}
+          {progress?.updatedAt && (
+            <span className="library-list-item__info-item">
+              <span className="material-icons-outlined">schedule</span>
+              {t('library.lastRead')} {formatTimeAgo(progress.updatedAt, t)}
+            </span>
+          )}
+          <OfflineBadge editionId={item.editionId} />
+        </div>
+      </div>
+      <div className="library-list-item__actions">
+        <BookActionMenu
+          type="saved"
+          book={item}
+          isFinished={percent >= 1}
+          onRemove={onRemove}
+          onMarkFinished={onMarkFinished}
+          onMarkUnfinished={onMarkUnfinished}
+        />
+      </div>
+    </article>
+  )
+}

--- a/apps/web/src/components/library/UploadBookListItem.tsx
+++ b/apps/web/src/components/library/UploadBookListItem.tsx
@@ -1,0 +1,123 @@
+// Uploaded (user) book row in the library list view. Extracted verbatim from
+// LibraryPage.tsx (R6 slice-1) — presentational; `key` stays at the call site.
+import { Link } from 'react-router-dom'
+import { getUserBookCoverUrl, type UserBook } from '../../api/userBooks'
+import { BookActionMenu } from './BookActionMenu'
+import { stringToColor } from '../../utils/colors'
+import { formatTimeAgo } from './timeAgo'
+
+export function UploadBookListItem({
+  book,
+  language,
+  highlighted,
+  onChange,
+  t,
+}: {
+  book: UserBook
+  language: string
+  highlighted: boolean
+  onChange: () => void
+  t: (key: string) => string
+}) {
+  const isReady = book.status === 'Ready'
+  const percent = book.progressPercent ?? 0
+  const destination = isReady
+    ? (book.progressChapterSlug ? `/${language}/library/my/${book.id}/read/${book.progressChapterSlug}` : `/${language}/library/my/${book.id}`)
+    : '#'
+  const coverUrl = getUserBookCoverUrl(book.coverPath)
+  return (
+    <article data-book-id={book.id} className={`library-list-item${highlighted ? ' library-list-item--highlighted' : ''}`}>
+      {isReady ? (
+        <Link to={destination} className="library-list-item__cover">
+          {coverUrl ? (
+            <img
+              src={coverUrl}
+              alt={book.title}
+              onError={(e) => { e.currentTarget.style.display = 'none'; e.currentTarget.nextElementSibling?.classList.remove('hidden') }}
+            />
+          ) : null}
+          <div
+            className={`library-list-item__cover-placeholder ${coverUrl ? 'hidden' : ''}`}
+            style={{ backgroundColor: stringToColor(book.title) }}
+          >
+            {book.title?.[0] || '?'}
+          </div>
+        </Link>
+      ) : (
+        <div className="library-list-item__cover library-list-item__cover--disabled">
+          {coverUrl ? (
+            <img
+              src={coverUrl}
+              alt={book.title}
+              onError={(e) => { e.currentTarget.style.display = 'none'; e.currentTarget.nextElementSibling?.classList.remove('hidden') }}
+            />
+          ) : null}
+          <div
+            className={`library-list-item__cover-placeholder ${coverUrl ? 'hidden' : ''}`}
+            style={{ backgroundColor: stringToColor(book.title) }}
+          >
+            {book.title?.[0] || '?'}
+          </div>
+        </div>
+      )}
+      <div className="library-list-item__content">
+        {isReady ? (
+          <Link to={destination} className="library-list-item__title">
+            {book.title}
+          </Link>
+        ) : (
+          <span className="library-list-item__title">{book.title}</span>
+        )}
+        {isReady && book.completedAt && (
+          <div className="library-list-item__progress">
+            <div className="library-list-item__progress-header">
+              <span className="library-list-item__completed-text">Read</span>
+            </div>
+          </div>
+        )}
+        {isReady && !book.completedAt && (
+          <div className="library-list-item__progress">
+            <div className="library-list-item__progress-header">
+              <span>{t('library.readingProgress')}</span>
+              <span className="library-list-item__progress-percent">{Math.round(percent * 100)}%</span>
+            </div>
+            <div className="library-list-item__progress-bar">
+              <div
+                className="library-list-item__progress-fill"
+                style={{ width: `${Math.round(percent * 100)}%` }}
+              />
+            </div>
+          </div>
+        )}
+        <div className="library-list-item__info">
+          {book.chapterCount > 0 && (
+            <span className="library-list-item__info-item">
+              {book.chapterCount} {t('library.chapters')}
+            </span>
+          )}
+          {isReady && book.progressUpdatedAt && (
+            <span className="library-list-item__info-item">
+              <span className="material-icons-outlined">schedule</span>
+              {t('library.lastRead')} {formatTimeAgo(book.progressUpdatedAt, t)}
+            </span>
+          )}
+          {book.status === 'Processing' && (
+            <span className="library-list-item__info-item library-list-item__info-item--processing">
+              <span className="material-icons-outlined">sync</span>
+              {t('library.processing')}
+            </span>
+          )}
+          {book.status === 'Failed' && (
+            <span className="library-list-item__info-item library-list-item__info-item--error">
+              <span className="material-icons-outlined">error</span>
+              {t('library.failed')}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="library-list-item__actions">
+        <BookActionMenu type="userbook" book={book} onChange={onChange} />
+      </div>
+    </article>
+  )
+}

--- a/apps/web/src/components/library/timeAgo.ts
+++ b/apps/web/src/components/library/timeAgo.ts
@@ -1,0 +1,17 @@
+// Extracted verbatim from LibraryPage.tsx (R6 slice-1). Shared by the saved &
+// upload list-item cards. Behavior unchanged.
+export function formatTimeAgo(dateStr: string, t: (key: string) => string): string {
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMins / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffMins < 1) return t('library.timeJustNow')
+  if (diffMins < 60) return `${diffMins} ${t('library.timeMinAgo')}`
+  if (diffHours < 24) return `${diffHours} ${t('library.timeHoursAgo')}`
+  if (diffDays === 1) return t('library.timeYesterday')
+  if (diffDays < 7) return `${diffDays} ${t('library.timeDaysAgo')}`
+  return date.toLocaleDateString()
+}

--- a/apps/web/src/pages/LibraryPage.tsx
+++ b/apps/web/src/pages/LibraryPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { useHighlightedBook } from '../hooks/useHighlightedBook'
 import { useLibrary } from '../hooks/useLibrary'
@@ -7,14 +7,11 @@ import { useLanguage } from '../context/LanguageContext'
 import { useTranslation } from '../hooks/useTranslation'
 import { SeoHead } from '../components/SeoHead'
 import { Footer } from '../components/Footer'
-import { OfflineBadge } from '../components/OfflineBadge'
-import { BookActionMenu } from '../components/library/BookActionMenu'
 import { UploadDropZone } from '../components/library/UploadDropZone'
 import { LibraryShelves } from '../components/library/LibraryShelves'
 import { LibrarySidebar } from '../components/library/LibrarySidebar'
 import { useLibrarySource } from '../hooks/useLibrarySource'
 import { LibraryStatsHeader } from '../components/library/LibraryStatsHeader'
-import { LibrarySortMenu } from '../components/library/LibrarySortMenu'
 import { LibraryStatusTabs } from '../components/library/LibraryStatusTabs'
 import { LibrarySearch } from '../components/library/LibrarySearch'
 import { useLibrarySort } from '../hooks/useLibrarySort'
@@ -31,14 +28,18 @@ import { BulkActionBar } from '../components/library/BulkActionBar'
 import { useLibrarySelection } from '../hooks/useLibrarySelection'
 import { invalidateUserTagsCache } from '../hooks/useUserTags'
 import { EmptyState } from '../components/EmptyState'
-import { createApi, getStorageUrl } from '../api/client'
+import { createApi } from '../api/client'
 import {
-  getUserBooks, getUserBookCoverUrl, type UserBook,
+  getUserBooks, type UserBook,
   bulkDeleteUserBooks, bulkFinishUserBooks, bulkTagUserBooks, bulkAddToCollection,
   searchUserLibrary, type UserBookSearchHit,
 } from '../api/userBooks'
 import { ReadLaterShelf } from '../components/library/ReadLaterShelf'
-import { stringToColor } from '../utils/colors'
+import { LibraryShelfTabs } from '../components/library/LibraryShelfTabs'
+import { LibraryToolbar } from '../components/library/LibraryToolbar'
+import { SavedBookListItem } from '../components/library/SavedBookListItem'
+import { UploadBookListItem } from '../components/library/UploadBookListItem'
+import { SavedBookGridCard } from '../components/library/SavedBookGridCard'
 import { getAllProgress, ReadingProgressDto, markAsRead, markAsUnread } from '../api/auth'
 import { emitDataChanges, useDataChange } from '../lib/dataEvents'
 
@@ -483,26 +484,7 @@ export function LibraryPage() {
         <CollectionChips activeId={activeCollectionId} onSelect={onCollectionChange} />
 
         {/* Shelf tabs: Books (existing library) vs Read later (Send to TextStack clips) */}
-        <div className="library-shelf-tabs" role="tablist" aria-label={t('library.title')}>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={shelf === 'books'}
-            className={`library-shelf-tab${shelf === 'books' ? ' library-shelf-tab--active' : ''}`}
-            onClick={() => setShelf('books')}
-          >
-            {t('library.readLater.tabBooks')}
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={shelf === 'readlater'}
-            className={`library-shelf-tab${shelf === 'readlater' ? ' library-shelf-tab--active' : ''}`}
-            onClick={() => setShelf('readlater')}
-          >
-            {t('library.readLater.tab')}
-          </button>
-        </div>
+        <LibraryShelfTabs shelf={shelf} onSelect={setShelf} t={t} />
 
         {shelf === 'readlater' ? (
           <ReadLaterShelf
@@ -522,36 +504,16 @@ export function LibraryPage() {
           return (
             <div id="library-grid" style={{ scrollMarginTop: '90px' }}>
               {/* Toolbar (single, unified) */}
-              <div className="library-toolbar">
-                <div className="library-toolbar__left">
-                  <LibrarySortMenu value={sort} onChange={setSort} />
-                  {showUploadsBlock && userBooks.length > 0 && (
-                    <button
-                      type="button"
-                      className={`library-select-btn ${selection.active ? 'library-select-btn--active' : ''}`}
-                      onClick={() => selection.active ? selection.exit() : selection.enter()}
-                    >
-                      {selection.active ? t('library.bulk.cancel') : t('library.bulk.select')}
-                    </button>
-                  )}
-                </div>
-                <div className="library-toolbar__right">
-                  <button
-                    className={`library-view-btn ${viewMode === 'grid' ? 'library-view-btn--active' : ''}`}
-                    onClick={() => setViewMode('grid')}
-                    aria-label="Grid view"
-                  >
-                    <span className="material-icons-outlined">grid_view</span>
-                  </button>
-                  <button
-                    className={`library-view-btn ${viewMode === 'list' ? 'library-view-btn--active' : ''}`}
-                    onClick={() => setViewMode('list')}
-                    aria-label="List view"
-                  >
-                    <span className="material-icons-outlined">format_list_bulleted</span>
-                  </button>
-                </div>
-              </div>
+              <LibraryToolbar
+                sort={sort}
+                onSortChange={setSort}
+                showSelectButton={showUploadsBlock && userBooks.length > 0}
+                selectionActive={selection.active}
+                onToggleSelection={() => selection.active ? selection.exit() : selection.enter()}
+                viewMode={viewMode}
+                onViewModeChange={setViewMode}
+                t={t}
+              />
 
               {totalRaw > 0 && (
                 <>
@@ -589,245 +551,40 @@ export function LibraryPage() {
                 )
               ) : viewMode === 'list' ? (
                 <div className="library-list">
-                  {renderList.map((c) => c.kind === 'saved' ? (() => {
-                    const item = c.item
-                    const progress = progressMap[item.editionId]
-                    const percent = progress?.percent ?? 0
-                    const destination = progress?.chapterSlug
-                      ? `/${item.language}/books/${item.slug}/${progress.chapterSlug}`
-                      : `/${item.language}/books/${item.slug}`
-                    return (
-                      <article key={`saved-${item.editionId}`} className="library-list-item">
-                        <Link to={destination} className="library-list-item__cover">
-                          {item.coverPath ? (
-                            <img src={getStorageUrl(item.coverPath)} alt={item.title} />
-                          ) : (
-                            <div
-                              className="library-list-item__cover-placeholder"
-                              style={{ backgroundColor: stringToColor(item.title) }}
-                            >
-                              {item.title?.[0] || '?'}
-                            </div>
-                          )}
-                        </Link>
-                        <div className="library-list-item__content">
-                          <Link to={destination} className="library-list-item__title" title={item.title}>
-                            {item.title}
-                          </Link>
-                          <div className="library-list-item__progress">
-                            <div className="library-list-item__progress-header">
-                              <span>{t('library.readingProgress')}</span>
-                              <span className="library-list-item__progress-percent">{Math.round(percent * 100)}%</span>
-                            </div>
-                            <div className="library-list-item__progress-bar">
-                              <div
-                                className="library-list-item__progress-fill"
-                                style={{ width: `${Math.round(percent * 100)}%` }}
-                              />
-                            </div>
-                          </div>
-                          <div className="library-list-item__info">
-                            {item.author && (
-                              <span className="library-list-item__info-item" title={item.author}>{item.author}</span>
-                            )}
-                            {progress?.updatedAt && (
-                              <span className="library-list-item__info-item">
-                                <span className="material-icons-outlined">schedule</span>
-                                {t('library.lastRead')} {formatTimeAgo(progress.updatedAt, t)}
-                              </span>
-                            )}
-                            <OfflineBadge editionId={item.editionId} />
-                          </div>
-                        </div>
-                        <div className="library-list-item__actions">
-                          <BookActionMenu
-                            type="saved"
-                            book={item}
-                            isFinished={percent >= 1}
-                            onRemove={() => remove(item.editionId)}
-                            onMarkFinished={() => handleMarkRead(item.editionId, item.slug, item.language)}
-                            onMarkUnfinished={() => handleMarkUnread(item.editionId, item.slug, item.language)}
-                          />
-                        </div>
-                      </article>
-                    )
-                  })() : (() => {
-                    const book = c.book
-                    const isReady = book.status === 'Ready'
-                    const percent = book.progressPercent ?? 0
-                    const destination = isReady
-                      ? (book.progressChapterSlug ? `/${language}/library/my/${book.id}/read/${book.progressChapterSlug}` : `/${language}/library/my/${book.id}`)
-                      : '#'
-                    const coverUrl = getUserBookCoverUrl(book.coverPath)
-                    const isHighlighted = highlightedBookId === book.id
-                    return (
-                      <article key={`upload-${book.id}`} data-book-id={book.id} className={`library-list-item${isHighlighted ? ' library-list-item--highlighted' : ''}`}>
-                        {isReady ? (
-                          <Link to={destination} className="library-list-item__cover">
-                            {coverUrl ? (
-                              <img
-                                src={coverUrl}
-                                alt={book.title}
-                                onError={(e) => { e.currentTarget.style.display = 'none'; e.currentTarget.nextElementSibling?.classList.remove('hidden') }}
-                              />
-                            ) : null}
-                            <div
-                              className={`library-list-item__cover-placeholder ${coverUrl ? 'hidden' : ''}`}
-                              style={{ backgroundColor: stringToColor(book.title) }}
-                            >
-                              {book.title?.[0] || '?'}
-                            </div>
-                          </Link>
-                        ) : (
-                          <div className="library-list-item__cover library-list-item__cover--disabled">
-                            {coverUrl ? (
-                              <img
-                                src={coverUrl}
-                                alt={book.title}
-                                onError={(e) => { e.currentTarget.style.display = 'none'; e.currentTarget.nextElementSibling?.classList.remove('hidden') }}
-                              />
-                            ) : null}
-                            <div
-                              className={`library-list-item__cover-placeholder ${coverUrl ? 'hidden' : ''}`}
-                              style={{ backgroundColor: stringToColor(book.title) }}
-                            >
-                              {book.title?.[0] || '?'}
-                            </div>
-                          </div>
-                        )}
-                        <div className="library-list-item__content">
-                          {isReady ? (
-                            <Link to={destination} className="library-list-item__title">
-                              {book.title}
-                            </Link>
-                          ) : (
-                            <span className="library-list-item__title">{book.title}</span>
-                          )}
-                          {isReady && book.completedAt && (
-                            <div className="library-list-item__progress">
-                              <div className="library-list-item__progress-header">
-                                <span className="library-list-item__completed-text">Read</span>
-                              </div>
-                            </div>
-                          )}
-                          {isReady && !book.completedAt && (
-                            <div className="library-list-item__progress">
-                              <div className="library-list-item__progress-header">
-                                <span>{t('library.readingProgress')}</span>
-                                <span className="library-list-item__progress-percent">{Math.round(percent * 100)}%</span>
-                              </div>
-                              <div className="library-list-item__progress-bar">
-                                <div
-                                  className="library-list-item__progress-fill"
-                                  style={{ width: `${Math.round(percent * 100)}%` }}
-                                />
-                              </div>
-                            </div>
-                          )}
-                          <div className="library-list-item__info">
-                            {book.chapterCount > 0 && (
-                              <span className="library-list-item__info-item">
-                                {book.chapterCount} {t('library.chapters')}
-                              </span>
-                            )}
-                            {isReady && book.progressUpdatedAt && (
-                              <span className="library-list-item__info-item">
-                                <span className="material-icons-outlined">schedule</span>
-                                {t('library.lastRead')} {formatTimeAgo(book.progressUpdatedAt, t)}
-                              </span>
-                            )}
-                            {book.status === 'Processing' && (
-                              <span className="library-list-item__info-item library-list-item__info-item--processing">
-                                <span className="material-icons-outlined">sync</span>
-                                {t('library.processing')}
-                              </span>
-                            )}
-                            {book.status === 'Failed' && (
-                              <span className="library-list-item__info-item library-list-item__info-item--error">
-                                <span className="material-icons-outlined">error</span>
-                                {t('library.failed')}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                        <div className="library-list-item__actions">
-                          <BookActionMenu type="userbook" book={book} onChange={fetchUserBooks} />
-                        </div>
-                      </article>
-                    )
-                  })())}
+                  {renderList.map((c) => c.kind === 'saved' ? (
+                    <SavedBookListItem
+                      key={`saved-${c.item.editionId}`}
+                      item={c.item}
+                      progress={progressMap[c.item.editionId]}
+                      t={t}
+                      onRemove={() => remove(c.item.editionId)}
+                      onMarkFinished={() => handleMarkRead(c.item.editionId, c.item.slug, c.item.language)}
+                      onMarkUnfinished={() => handleMarkUnread(c.item.editionId, c.item.slug, c.item.language)}
+                    />
+                  ) : (
+                    <UploadBookListItem
+                      key={`upload-${c.book.id}`}
+                      book={c.book}
+                      language={language}
+                      highlighted={highlightedBookId === c.book.id}
+                      onChange={fetchUserBooks}
+                      t={t}
+                    />
+                  ))}
                 </div>
               ) : (
                 <div className="library-page__grid">
-                  {renderList.map((c) => c.kind === 'saved' ? (() => {
-                    const item = c.item
-                    const progress = progressMap[item.editionId]
-                    const percent = progress?.percent ?? 0
-                    const destination = progress?.chapterSlug
-                      ? `/${item.language}/books/${item.slug}/${progress.chapterSlug}`
-                      : `/${item.language}/books/${item.slug}`
-                    return (
-                      <div key={`saved-${item.editionId}`} className="library-card">
-                        <Link to={destination} className="library-card__cover" title={`Read ${item.title} online`}>
-                          {item.coverPath ? (
-                            <img src={getStorageUrl(item.coverPath)} alt={item.title} />
-                          ) : (
-                            <div
-                              className="library-card__cover-placeholder"
-                              style={{ backgroundColor: stringToColor(item.title) }}
-                            >
-                              {item.title?.[0] || '?'}
-                            </div>
-                          )}
-                          {percent >= 1 && (
-                            <div className="user-book-card__completed-badge">
-                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
-                                <polyline points="20 6 9 17 4 12" />
-                              </svg>
-                              Read
-                            </div>
-                          )}
-                          {percent > 0 && percent < 1 && (
-                            <div className="library-card__progress-bar">
-                              <div
-                                className="library-card__progress-fill"
-                                style={{ width: `${Math.round(percent * 100)}%` }}
-                              />
-                            </div>
-                          )}
-                        </Link>
-                        <div className="library-card__info">
-                          <div className="library-card__text">
-                            <Link to={destination} className="library-card__title" title={item.title}>
-                              {item.title}
-                            </Link>
-                            {item.author && (
-                              <span className="user-book-card__author" title={item.author}>{item.author}</span>
-                            )}
-                            <div className="library-card__meta">
-                              {percent >= 1 && (
-                                <span className="user-book-card__progress-text user-book-card__progress-text--done">Read</span>
-                              )}
-                              {percent > 0 && percent < 1 && (
-                                <span className="library-card__progress-text">
-                                  {Math.round(percent * 100)}% {t('library.read')}
-                                </span>
-                              )}
-                              <OfflineBadge editionId={item.editionId} />
-                            </div>
-                          </div>
-                          <BookActionMenu
-                            type="saved"
-                            book={item}
-                            isFinished={percent >= 1}
-                            onRemove={() => remove(item.editionId)}
-                            onMarkFinished={() => handleMarkRead(item.editionId, item.slug, item.language)}
-                            onMarkUnfinished={() => handleMarkUnread(item.editionId, item.slug, item.language)}
-                          />
-                        </div>
-                      </div>
-                    )
-                  })() : (() => {
+                  {renderList.map((c) => c.kind === 'saved' ? (
+                    <SavedBookGridCard
+                      key={`saved-${c.item.editionId}`}
+                      item={c.item}
+                      progress={progressMap[c.item.editionId]}
+                      t={t}
+                      onRemove={() => remove(c.item.editionId)}
+                      onMarkFinished={() => handleMarkRead(c.item.editionId, c.item.slug, c.item.language)}
+                      onMarkUnfinished={() => handleMarkUnread(c.item.editionId, c.item.slug, c.item.language)}
+                    />
+                  ) : (() => {
                     const book = c.book
                     const hit = excerptByBookId.get(book.id)
                     return (
@@ -883,20 +640,4 @@ export function LibraryPage() {
     <Footer />
     </>
   )
-}
-
-function formatTimeAgo(dateStr: string, t: (key: string) => string): string {
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMins / 60)
-  const diffDays = Math.floor(diffHours / 24)
-
-  if (diffMins < 1) return t('library.timeJustNow')
-  if (diffMins < 60) return `${diffMins} ${t('library.timeMinAgo')}`
-  if (diffHours < 24) return `${diffHours} ${t('library.timeHoursAgo')}`
-  if (diffDays === 1) return t('library.timeYesterday')
-  if (diffDays < 7) return `${diffDays} ${t('library.timeDaysAgo')}`
-  return date.toLocaleDateString()
 }


### PR DESCRIPTION
## What & why
First R6 slice — decompose the largest frontend god-file, `LibraryPage.tsx` (902 lines), into cohesive presentational components. Pure extraction, **zero behavior change**.

## Changes
- Extracted 5 components + a shared `timeAgo` helper into `apps/web/src/components/library/`: `LibraryShelfTabs`, `LibraryToolbar`, `SavedBookListItem`, `UploadBookListItem`, `SavedBookGridCard`.
- Parent `LibraryPage.tsx` **902 → 643 lines** — keeps every hook/effect/`useCallback`/`useMemo`, the merge-sort/FTS derived-state block, and the selection keyboard effect **verbatim**; only leaf JSX moved out.
- `Search.tsx` (830) intentionally left — already fully decomposed (no god-file smell).

## Verification
- Adversarial QA: each extracted subtree diffed against origin's inline JSX → **byte-identical** markup/classes/`aria-*`/`data-book-id`/i18n keys (incl. Processing/Failed branches + badge SVG); callbacks threaded with the same closures/args; React `key`s stay at the call-site (reconciliation unchanged); parent hooks region byte-identical.
- `tsc --noEmit` 0 errors; `vitest run` **595 passed**; extracted components are pure (no hooks/state).
- **Browser gate**: CI e2e runs the library specs (`reader-progress`, `bookmarks`, `upload-flow`) — selectors `.library-list-item`/`.library-card`/`*__title` preserved.

## Rollback
One revert. Pure UI reorganization — no logic, no API, no data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)