### PR TITLE
refactor(web): reader adopts shared computeBookProgress (R6 slice-2, final)

### DIFF
--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -36,6 +36,7 @@ import { useGuestLimits } from '../context/GuestLimitsContext'
 import { WordHint } from '../components/reader/WordHint'
 import { SaveProgressPrompt } from '../components/reader/SaveProgressPrompt'
 import { getUserBooks } from '../api/userBooks'
+import { computeBookProgress } from '@textstack/shared'
 import { sourceDomain } from '../components/library/ReadLaterShelf'
 import '../styles/micro-practice.css'
 
@@ -212,24 +213,12 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
   // Overall book progress = words-read / total-words across chapters,
   // driven by URL chapter + intra-chapter scroll.
   const calculatedProgress = useMemo(() => {
-    if (!chapterList) return 0
-    const currentId = chapterIdentifier || ''
-    if (!currentId) return 0
-    const currentChapterIndex = chapterList.findIndex(c => c.identifier === currentId)
-    if (currentChapterIndex === -1) return 0
-
-    const totalWords = chapterList.reduce((sum, c) => sum + (c.wordCount || 0), 0)
-    if (totalWords === 0) {
-      return (currentChapterIndex + overlayScrollProgress) / chapterList.length
-    }
-
-    const wordsBeforeCurrent = chapterList
-      .slice(0, currentChapterIndex)
-      .reduce((sum, c) => sum + (c.wordCount || 0), 0)
-    const currentChapterWords = chapterList[currentChapterIndex].wordCount || 0
-    const wordsRead = wordsBeforeCurrent + currentChapterWords * overlayScrollProgress
-
-    return wordsRead / totalWords
+    const chapters = chapterList?.map(c => ({ slug: c.identifier, wordCount: c.wordCount })) ?? []
+    // overlayScrollProgress is already clamped 0..1. Don't pass totalWordCount:
+    // the legacy inline formula used the chapter-list word sum as denominator,
+    // which is exactly computeBookProgress's fallback — passing a canonical
+    // total would diverge from that number.
+    return computeBookProgress(chapters, chapterIdentifier, overlayScrollProgress) ?? 0
   }, [chapterList, chapterIdentifier, overlayScrollProgress])
 
   // Force 100% when book is completed

--- a/packages/shared/src/reader/bookProgress.test.ts
+++ b/packages/shared/src/reader/bookProgress.test.ts
@@ -159,6 +159,76 @@ describe('computeBookProgress — single-chapter book', () => {
   })
 })
 
+describe('computeBookProgress — web ReaderPage inline-formula parity (R6)', () => {
+  // Frozen copy of the ORIGINAL inline `calculatedProgress` from
+  // apps/web/src/pages/ReaderPage.tsx (pre-R6-slice2), proving the shared
+  // function returns the byte-identical number the web reader used to compute
+  // locally. If this drifts, the reader progress bar / resume % would shift.
+  function legacyInline(
+    chapterList: Array<{ identifier: string; wordCount?: number | null }> | null,
+    chapterIdentifier: string | null | undefined,
+    overlayScrollProgress: number,
+  ): number {
+    if (!chapterList) return 0
+    const currentId = chapterIdentifier || ''
+    if (!currentId) return 0
+    const currentChapterIndex = chapterList.findIndex(c => c.identifier === currentId)
+    if (currentChapterIndex === -1) return 0
+
+    const totalWords = chapterList.reduce((sum, c) => sum + (c.wordCount || 0), 0)
+    if (totalWords === 0) {
+      return (currentChapterIndex + overlayScrollProgress) / chapterList.length
+    }
+    const wordsBeforeCurrent = chapterList
+      .slice(0, currentChapterIndex)
+      .reduce((sum, c) => sum + (c.wordCount || 0), 0)
+    const currentChapterWords = chapterList[currentChapterIndex].wordCount || 0
+    const wordsRead = wordsBeforeCurrent + currentChapterWords * overlayScrollProgress
+    return wordsRead / totalWords
+  }
+
+  // How ReaderPage now feeds the shared fn (overlayScrollProgress already 0..1).
+  function viaShared(
+    chapterList: Array<{ identifier: string; wordCount?: number | null }> | null,
+    chapterIdentifier: string | null | undefined,
+    overlayScrollProgress: number,
+  ): number {
+    const chapters = chapterList?.map(c => ({ slug: c.identifier, wordCount: c.wordCount })) ?? []
+    return computeBookProgress(chapters, chapterIdentifier, overlayScrollProgress) ?? 0
+  }
+
+  const weighted = [
+    { identifier: 'ch1', wordCount: 100 },
+    { identifier: 'ch2', wordCount: 200 },
+    { identifier: 'ch3', wordCount: 700 },
+  ]
+  const noWords = [
+    { identifier: 'a', wordCount: 0 },
+    { identifier: 'b', wordCount: null },
+    { identifier: 'c' },
+  ]
+  const single = [{ identifier: 'only', wordCount: 500 }]
+
+  const cases: Array<[string, typeof weighted | null, string | null | undefined, number]> = [
+    ['mid-chapter weighted', weighted, 'ch2', 0.5],
+    ['first chapter start', weighted, 'ch1', 0],
+    ['last chapter full', weighted, 'ch3', 1],
+    ['no-wordCount fallback mid', noWords, 'b', 0.5],
+    ['no-wordCount fallback last', noWords, 'c', 1],
+    ['single chapter half', single, 'only', 0.5],
+    ['null chapterList', null, 'ch1', 0.5],
+    ['empty chapterId', weighted, '', 0.5],
+    ['unknown chapterId', weighted, 'nope', 0.5],
+    ['undefined chapterId', weighted, undefined, 0.5],
+  ]
+
+  for (const [name, list, id, prog] of cases) {
+    it(`matches legacy inline: ${name}`, () => {
+      expect(viaShared(list, id, prog)).toBeCloseTo(legacyInline(list, id, prog), 12)
+    })
+  }
+})
+
 describe('computeBookProgress — monotonicity invariant', () => {
   it('moving forward through chapters never decreases book progress', () => {
     const chapters: ChapterWithCount[] = [


### PR DESCRIPTION
## What & why
Final R6 slice. A reader-hooks investigation found the '3 progress hooks' are mostly **false positives** (distinct responsibilities — facade / public writer / userbook writer / restore reader — not worth merging). The one genuine, safe dedup: web `ReaderPage.tsx` `calculatedProgress` is a line-for-line copy of shared `computeBookProgress` — a formula-drift liability our project memory explicitly flags.

## Change (display-only, 2 edits)
- Import `computeBookProgress` from `@textstack/shared`; replace the inline memo body (18→7 lines).
- **Omits `totalWordCount` on purpose** — the old denominator was the chapter-list word sum, which is exactly the shared fallback denominator; passing canonical `book.totalWordCount` could shift the number (the exact drift). Documented in code.
- `maxProgressRef` monotonic clamp, `rawProgress`/`overallProgress`, and the scroll-restore/save paths are **untouched**.

## Verification
- Adversarial QA: `legacyInline` parity fixture is a **string-for-string copy of origin's formula** (not tautological); denominator match confirmed; `?? 0` covers all degenerate cases; clamps proven **no-op** (`overlayScrollProgress` provably 0..1) → **byte-identical arithmetic**. Diff scoped to the memo + test only.
- 5 required parity cases match; frozen `legacyInline` vs `viaShared` test (10 fixtures) added to `bookProgress.test.ts`.
- `tsc --noEmit` 0; **40 shared** (30+10) + **595 web** tests pass.
- Browser gate: CI e2e `reader-progress.spec.ts` (incl. "overall book % not chapter %").

## Not touched
`useReaderScrollSync` (race zone), writer hooks, locator parse, restore-guard — all out of scope (investigation deemed them false positives / high-risk-low-reward).

## Rollback
One revert. Pure calc swap, no behavior/data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)