### PR TITLE
fix(backup): reap orphaned pgdata volumes (prod disk 100%)

### DIFF
--- a/infra/scripts/backup-verify.sh
+++ b/infra/scripts/backup-verify.sh
@@ -20,18 +20,28 @@ PG_USER="verify"
 PG_DB="verify"
 PG_PASS="verify"
 
+# -v removes the container's ANONYMOUS volume too. postgres declares an
+# anonymous VOLUME at /var/lib/postgresql/data, so every run that reaches
+# `docker rm -f` (a killed/timed-out run where --rm never fired) otherwise
+# leaks a full pgdata volume. 34 days of daily backups leaked 156 GB of these
+# and filled the docker data-root — which then broke the very backup that
+# creates them. `docker rm -fv` reaps the volume with the container.
 cleanup() {
-  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  docker rm -fv "$CONTAINER" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
-# Reap leaked verify containers from prior killed/timed-out runs — they hold
-# ports + memory and can starve a fresh postgres into never becoming ready.
+# Reap leaked verify containers (and their orphaned pgdata volumes) from prior
+# killed/timed-out runs — they hold ports + memory + disk and can starve a
+# fresh postgres into never becoming ready.
 LEAKED=$(docker ps -aq --filter "name=textstack_backup_verify_" 2>/dev/null || true)
 if [[ -n "$LEAKED" ]]; then
   echo "[verify] removing $(echo "$LEAKED" | wc -l | tr -d ' ') leaked verify container(s) ..." >&2
-  docker rm -f $LEAKED >/dev/null 2>&1 || true
+  docker rm -fv $LEAKED >/dev/null 2>&1 || true
 fi
+# Belt-and-suspenders: drop any dangling anonymous volumes orphaned before this
+# fix (or by an OOM-killed `docker rm`). Named volumes are untouched by prune.
+docker volume prune -f >/dev/null 2>&1 || true
 
 echo "[verify] starting postgres on :$PORT ..."
 docker run -d --rm \


### PR DESCRIPTION
## Problem
Prod `/mnt/data` (docker data-root) hit **100% / 0 bytes free** — 183G used, **156G of it dangling anonymous volumes** (57 orphaned pgdata volumes). This broke the nightly backup (the throwaway verify-postgres couldn't `initdb` with no space) and any container writes to the docker root.

## Root cause
`backup-verify.sh` spins up a throwaway `pgvector` postgres each run. postgres declares an anonymous `VOLUME /var/lib/postgresql/data`. On a killed/timed-out run, `--rm` never fires and `cleanup()`/reap did `docker rm -f` **without `-v`** → the anonymous pgdata volume leaked. 34 days × daily = ~156G → full disk → the backup that creates them fails. Self-reinforcing.

## Fix
- `docker rm -f` → **`docker rm -fv`** in both the EXIT trap and the leaked-container reap — the anonymous volume dies with its container.
- Added `docker volume prune -f` as a catch-all for SIGKILL'd runs the trap can't cover (named volumes are untouched by prune).

## Prod already remediated
Ran `docker volume prune -f` on the server: **reclaimed 163.4G**, `/mnt/data` **100% → 17%** (153G free). The 2 named `marker-*` volumes (3.4G) were intentionally kept. This PR stops the leak from recurring.

Discovered while investigating why the nightly backup had been failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)