### PR TITLE
fix(reader): hide the top-bar % in Original PDF (it's word-based → always 0)

### DIFF
--- a/apps/web/src/components/reader/ReaderTopBar.tsx
+++ b/apps/web/src/components/reader/ReaderTopBar.tsx
@@ -13,6 +13,7 @@ interface Props {
   useLocalizedLink?: boolean // true for public books (uses LocalizedLink), false for user books (uses Link)
   showAsk?: boolean // catalog editions only — user uploads aren't chunked for RAG
   showSearch?: boolean // hidden in Original-layout PDF (no page-aware search yet)
+  showProgress?: boolean // hidden in Original-layout PDF — word-based % reads 0; the page indicator (N/total) is the real progress
   onAskClick?: () => void
   onSearchClick: () => void
   onTocClick: () => void
@@ -32,6 +33,7 @@ export function ReaderTopBar({
   useLocalizedLink = true,
   showAsk = false,
   showSearch = true,
+  showProgress = true,
   onAskClick,
   onSearchClick,
   onTocClick,
@@ -79,7 +81,7 @@ export function ReaderTopBar({
       </div>
 
       <div className="reader-top-bar__right">
-        <span className="reader-top-bar__progress">{Math.round(progress * 100)}%</span>
+        {showProgress && <span className="reader-top-bar__progress">{Math.round(progress * 100)}%</span>}
         {showSearch && (
           <button onClick={onSearchClick} className="reader-top-bar__btn" title="Search in chapter">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/apps/web/src/components/reader/__tests__/ReaderTopBar.test.tsx
+++ b/apps/web/src/components/reader/__tests__/ReaderTopBar.test.tsx
@@ -51,6 +51,15 @@ describe('ReaderTopBar — Original-layout PDF adaptations', () => {
     expect(container.querySelectorAll('.reader-top-bar__btn').length).toBe(3)
   })
 
+  it('shows the % by default but hides it when showProgress is false (Original PDF)', () => {
+    // Default: word-based % renders.
+    const shown = renderBar()
+    expect(shown.container.querySelector('.reader-top-bar__progress')?.textContent).toBe('50%')
+    // Original PDF (time-only session → 0%): hidden; the footer page indicator is the real progress.
+    const hidden = renderBar({ showProgress: false })
+    expect(hidden.container.querySelector('.reader-top-bar__progress')).toBeNull()
+  })
+
   it('stays visible (translateY(0)) when visible is pinned true in Original', () => {
     const { container } = renderBar({ visible: true })
     const header = container.querySelector('.reader-top-bar') as HTMLElement

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -645,6 +645,9 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
         // In-chapter search is reflow-DOM based; the PDF canvas has no page-aware
         // search yet, so hide the button rather than open a no-op (follow-up).
         showSearch={!originalActive}
+        // Original PDF has no word-based progress (session is time-only → 0%);
+        // the footer page indicator (N / total) is the real progress. Hide the % here.
+        showProgress={!originalActive}
         onAskClick={() => setAskOpen(true)}
         onSearchClick={() => setSearchOpen(true)}
         onTocClick={() => setTocOpen(true)}


### PR DESCRIPTION
The top-bar progress % is word-based (`overallProgress`). In Original PDF mode the reading session is **time-only** (`wordsRead=0`), so it renders **0%** even on page 24/106 — actively misleading. The footer **page indicator (N / total)** is the real, honest progress for a PDF.

Fix: `ReaderTopBar` gains a `showProgress` prop (default true); `ReaderPage` passes `showProgress={!originalActive}` so the % is hidden only for Original PDFs. Reflow/EPUB/catalog keep the word-based %. Unit test covers show-by-default + hide-when-false.

tsc + web build clean; ReaderTopBar tests 6/6. (Local browser-check impractical — no user-book PDF in local DB + arm64 ingest SIGILL; visual confirms on prod post-deploy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)