### PR TITLE
fix(backup): verify timeout 60s→120s + fix stale EAS command in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,8 +438,10 @@ Test naming convention: `{MethodName}_{Scenario}_{ExpectedResult}`
 
 ```bash
 cd apps/mobile
-eas build -p android --profile production --auto-submit
+eas build -p android --profile production --auto-submit-with-profile internal
 ```
+
+(`--auto-submit` alone FAILS — eas.json has no `submit.production` profile, only `internal`/`closed`; the profile must be named. For JS-only changes prefer an OTA: `npx eas-cli update --branch production --platform android -m "<msg>"`. CI path: the `mobile-release.yml` workflow_dispatch — requires the repo secret `EXPO_TOKEN`, which is NOT currently set.)
 
 That single command builds the AAB and pushes it to Internal Testing. Service account key is stored in EAS-managed credentials (uploaded via `eas credentials -p android` or the web dashboard), so `eas submit` works from any machine or CI without a local key file. Local mirror at `apps/mobile/google-service-account.json` (gitignored) is a convenience backup, not required. Service account email: `eas-submit-textstack@orbital-heaven-496518-t5.iam.gserviceaccount.com`. Permission granted: "Release apps to testing tracks" for the TextStack app.
 

--- a/infra/scripts/backup-verify.sh
+++ b/infra/scripts/backup-verify.sh
@@ -69,11 +69,11 @@ diagnose_startup_failure() {
 }
 
 echo "[verify] waiting for postgres to accept connections ..."
-for i in {1..60}; do
+for i in {1..120}; do
   if docker exec "$CONTAINER" pg_isready -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; then
     break
   fi
-  # Bail early if the container has already exited — no point waiting 60s.
+  # Bail early if the container has already exited — no point waiting 120s.
   if [[ -z "$(docker ps -q --filter "name=$CONTAINER" 2>/dev/null)" ]]; then
     echo "[verify] FAIL: verify container exited during startup" >&2
     diagnose_startup_failure
@@ -82,7 +82,7 @@ for i in {1..60}; do
   sleep 1
 done
 if ! docker exec "$CONTAINER" pg_isready -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; then
-  echo "[verify] FAIL: postgres did not become ready after 60s" >&2
+  echo "[verify] FAIL: postgres did not become ready after 120s" >&2
   diagnose_startup_failure
   exit 1
 fi


### PR DESCRIPTION
Two loose ends:
- **Backup verify near-miss**: 07-14 and 07-15 nightly backups failed — the throwaway verify postgres finished init *seconds* past the 60s readiness window when the schedule-drifted backup collided with a deploy on the same self-hosted box (the 07-14 log shows `PostgreSQL init process complete` inside the failure diagnostics). 120s absorbs the contention; dump+storage artifacts were always fine — only the verify gate flapped. (#417 raised 30→60; same knob, two more data points.)
- **CLAUDE.md**: documented release command `--auto-submit` fails (no `submit.production` profile) — now documents `--auto-submit-with-profile internal`, the OTA path, and the missing `EXPO_TOKEN` CI secret.

`bash -n` clean; doc-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)