### PR TITLE
fix(seo): SSG had been dead 5 weeks — fetch silently drops the Host header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### SEO — static-site generation had been dead for five weeks; a forbidden HTTP header killed it — backend — 2026-08-11
+
+Started from a Bing Webmaster Tools screenshot with four warnings and ended somewhere else entirely. The warnings ("limited crawl capacity", "too many pages with insufficient content") were symptoms; Google Search Console independently agreed (`Crawled – currently not indexed: 780`, `Discovered – not indexed: 311`, `Soft 404: 67` with a validation started 15 May that never passed). Chasing the soft-404 list led to real book and author pages — Pan Michael, The Wings of the Dove, Lew Wallace — not the junk URLs an initial guess predicted.
+
+**Root cause.** `ssg-worker.mjs` calls `http://api:8080/ssg/routes` and deliberately sets a `Host` header so `SiteContextMiddleware` can resolve the site — the file even carries a comment explaining that without it "fetch would otherwise default Host to the URL host (`api`) → 404 → silent job". That mitigation cannot work: **`Host` is a forbidden header name in the fetch spec**, so undici drops it. Verified inside the running container — `fetch` with an explicit `Host: textstack.app` still returns 404. The request arrives as `Host: api`, which is not in `site_domains`, so resolution returned null and the middleware answered `404 Site not found`. Every rebuild job failed. The worker stayed `healthy`, and the only evidence was a log line nobody was watching.
+
+The trigger was refactor R1b, which removed the legacy `?site=` override that had been papering over this.
+
+**Blast radius, measured.** Newest generated page: **3 July**. The sitemap is built live from the database and advertises **1153** book URLs; the generator had produced **764** pages. So roughly **389 published books returned a hard 404 to crawlers** while being actively advertised in the sitemap — which is precisely Google's `Not found (404): 153` and Bing's 140-of-1.3K index.
+
+**Fix.** `SiteResolver` now falls back to the single site (`ICurrentSite.Id`) when the host matches no registered domain, logging a warning naming the host. This is safe in exactly the way the removed `?site=` override was not: that override could name a *different* site, producing a `SiteContext` whose Id diverged from the process-wide `ICurrentSite.Id` that EF's global query filters key on — silently yielding zero rows. Resolving to `ICurrentSite.Id` itself makes divergence impossible, and which hosts can reach the middleware at all is already constrained by `AllowedHosts`. Fixing the resolver rather than the worker also closes the class: any future internal caller that cannot set `Host` (which is every `fetch` caller) now works.
+
+Covered by integration tests rather than unit tests, deliberately: `SiteResolver` depends on the concrete `AppDbContext`, whose model only builds on Npgsql, and the failure was inherently about a real request's host — something a mock cannot express. `SsgRouteResolutionTests` asserts `/ssg/routes` returns 200 for `Host: api`, still works for a known host, and returns a non-empty route list (an empty list would rebuild nothing while reporting success — the same silent-failure shape).
+
+**Two pieces of misleading infrastructure found on the way, worth knowing even though they are not the bug.** `X-SEO-Render` is set from `map $is_bot`, so it reports "you look like a bot", NOT "an SSG file was served" — it says `ssg` even when the fallback ran, which cost real debugging time here. And nginx's `location /ssg/ { internal; alias …/data/ssg/; }` points at a directory that does not exist; `try_files` resolves `$ssg_file` against `root` instead, so the real pages come from `apps/web/dist/ssg` and that block is dead code whose comment asserts it is required.
+
+**This fix alone does not restore the pages** — a full SSG rebuild has to run after deploy for those ~389 books to get generated.
+
+Not addressed here, and separate: the catch-all `location /` returns 200 to bots for any non-SSG path (the bot-404 guard exists only in `@spa`), and Cloudflare's managed `robots.txt` block sets `Content-Signal: ai-input` absent plus `Disallow: /` for ClaudeBot/GPTBot/Google-Extended and friends, which is why Bing reports the site cannot appear in Copilot and grounding results. The latter is a product decision, not a bug.
+
 ### Users — entitlement tiers replace two hardcoded storage constants — backend — 2026-08-09
 
 Triggered by a support case that turned out to be two unrelated ceilings wearing one error message. An upload failed with `Upload failed: 413` while the quota bar read 167.7 MB of 500 MB — plenty of room. **The 413 is Cloudflare's per-request body cap, not our quota**, verified against production by probing with increasing bodies: 10/50/90 MB reached the API (401 — the body got through), 110 MB returned `413 cloudflare`. nginx and Kestrel are both already configured at 500 MB and were never the constraint. That half is fixed separately by chunked upload; this entry is the other half.

--- a/backend/src/Api/Sites/SiteResolver.cs
+++ b/backend/src/Api/Sites/SiteResolver.cs
@@ -1,3 +1,4 @@
+using Application.Common.Interfaces;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -8,13 +9,21 @@ public class SiteResolver : ISiteResolver
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IMemoryCache _cache;
+    private readonly ICurrentSite _currentSite;
+    private readonly ILogger<SiteResolver> _logger;
     private readonly TimeSpan _cacheDuration = TimeSpan.FromMinutes(10);
     private const string CachePrefix = "site:";
 
-    public SiteResolver(IServiceScopeFactory scopeFactory, IMemoryCache cache)
+    public SiteResolver(
+        IServiceScopeFactory scopeFactory,
+        IMemoryCache cache,
+        ICurrentSite currentSite,
+        ILogger<SiteResolver> logger)
     {
         _scopeFactory = scopeFactory;
         _cache = cache;
+        _currentSite = currentSite;
+        _logger = logger;
     }
 
     public async Task<SiteContext?> ResolveAsync(string host, CancellationToken ct = default)
@@ -58,6 +67,37 @@ public class SiteResolver : ISiteResolver
                 s.FeaturesJson
             ))
             .FirstOrDefaultAsync(ct);
+
+        // Last resort (ADR-007, single site permanent): an unmatched host resolves to THE site.
+        //
+        // This exists because it silently decapitated SSG for five weeks. The ssg-worker calls
+        // `http://api:8080/ssg/routes` and carefully sets a `Host` header so this resolver can find
+        // the site — but `Host` is a forbidden header name in the fetch spec, so undici drops it and
+        // the request arrives as `Host: api`. `api` is not in site_domains, resolution returned
+        // null, the middleware answered 404 "Site not found", and every rebuild job failed with a
+        // log line nobody was watching. The sitemap kept advertising books from the database while
+        // ~389 of them had no generated page and returned a hard 404 to crawlers.
+        //
+        // Falling back is safe in exactly the way R1b's removed `?site=` override was not: that
+        // override could name a DIFFERENT site, producing a SiteContext whose Id diverged from the
+        // process-wide ICurrentSite.Id that EF's global query filters key on — silently yielding
+        // zero rows. This resolves to ICurrentSite.Id itself, so divergence is impossible.
+        // Which hosts can even get here is already constrained by AllowedHosts.
+        if (site is null)
+        {
+            site = await db.Sites
+                .Where(s => s.Id == _currentSite.Id)
+                .Select(s => new SiteContext(
+                    s.Id, s.Code, s.PrimaryDomain, s.DefaultLanguage, s.Theme,
+                    s.AdsEnabled, s.IndexingEnabled, s.SitemapEnabled, s.FeaturesJson))
+                .FirstOrDefaultAsync(ct);
+
+            if (site is not null)
+                _logger.LogWarning(
+                    "Host '{Host}' is not a registered site domain; resolved to the default site. "
+                    + "Expected for internal callers (ssg-worker), unexpected for public traffic.",
+                    host);
+        }
 
         if (site is not null)
         {

--- a/tests/TextStack.IntegrationTests/SsgRouteResolutionTests.cs
+++ b/tests/TextStack.IntegrationTests/SsgRouteResolutionTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Regression for the bug that silently killed static-site generation for five weeks.
+///
+/// `ssg-worker.mjs` calls `http://api:8080/ssg/routes` and sets a `Host` header so the site can be
+/// resolved. But `Host` is a forbidden header name in the fetch spec — undici drops it — so the
+/// request actually arrives as `Host: api`, which is not a registered site domain. Site resolution
+/// returned null, the middleware answered 404, every rebuild job failed into a log nobody watched,
+/// and the sitemap kept advertising books whose pages had never been generated: ~389 published
+/// books returned a hard 404 to crawlers.
+///
+/// A unit test cannot cover this — `SiteResolver` depends on the concrete `AppDbContext`, whose
+/// model only builds on Npgsql. The failure was also inherently about a real HTTP request's host,
+/// which is exactly what an integration test can assert and a mock cannot.
+/// </summary>
+public class SsgRouteResolutionTests : IClassFixture<LiveApiFixture>
+{
+    private readonly LiveApiFixture _fixture;
+
+    public SsgRouteResolutionTests(LiveApiFixture fixture) => _fixture = fixture;
+
+    /// <summary>The exact shape of the ssg-worker's call: a host that is not a site domain.</summary>
+    [Theory]
+    [InlineData("api")]
+    [InlineData("api:8080")]
+    public async Task SsgRoutes_HostIsNotASiteDomain_StillResolves(string host)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ssg/routes");
+        request.Headers.Host = host;
+
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(
+            response.StatusCode == HttpStatusCode.InternalServerError, "endpoint unavailable (500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SsgRoutes_KnownHost_StillWorks()
+    {
+        var request = _fixture.CreateRequest(HttpMethod.Get, "/ssg/routes");
+
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The routes payload is what the generator iterates. An empty list would rebuild nothing while
+    /// reporting success — the silent-failure shape this whole fix is about.
+    /// </summary>
+    [Fact]
+    public async Task SsgRoutes_ReturnsANonEmptyRouteList()
+    {
+        var request = _fixture.CreateRequest(HttpMethod.Get, "/ssg/routes");
+        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response), "endpoint unavailable (404/500)");
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("/en/", body);
+    }
+}


### PR DESCRIPTION
## Summary

Started from a Bing Webmaster Tools screenshot with four warnings, ended somewhere else entirely.

`ssg-worker.mjs` calls `http://api:8080/ssg/routes` and deliberately sets a `Host` header so `SiteContextMiddleware` can resolve the site. The file even carries a comment explaining why:

> Sends an explicit Host header so SiteContextMiddleware can resolve the site. fetch would otherwise default Host to the URL host (`api`) → 404 → silent job

**That mitigation cannot work.** `Host` is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) in the fetch spec — undici drops it. Verified inside the running container:

```
fetch('http://api:8080/ssg/routes')                            -> 404
fetch(..., { headers: { Host: 'localhost' } })                 -> 404
fetch(..., { headers: { Host: 'textstack.app' } })             -> 404
```

The request arrives as `Host: api`, which is not in `site_domains` → resolution returns null → middleware answers `404 Site not found`. Every rebuild job failed. The worker stayed `healthy` and the only evidence was a log line nobody was watching.

The trigger was refactor **R1b**, which removed the legacy `?site=` override that had been papering over it.

## Blast radius, measured

| | |
|---|---|
| Newest generated page | **3 July** (5 weeks stale) |
| Book URLs advertised in sitemap (built live from DB) | **1153** |
| Book pages actually generated | **764** |
| **Published books returning a hard 404 to crawlers** | **~389** |

That is precisely Google's `Not found (404): 153` and Bing's 140-of-1.3K index. Google Search Console corroborates independently: `Crawled – currently not indexed: 780`, `Discovered – not indexed: 311`, `Soft 404: 67` with a validation started 15 May that never passed.

## Fix

`SiteResolver` falls back to the single site (`ICurrentSite.Id`) when the host matches no registered domain, logging a warning that names the host.

**Why this is safe when the removed `?site=` override was not** — that override could name a *different* site, producing a `SiteContext` whose Id diverged from the process-wide `ICurrentSite.Id` that EF's global query filters key on, silently yielding zero rows. Resolving to `ICurrentSite.Id` *itself* makes divergence impossible by construction. Which hosts can reach the middleware at all is already constrained by `AllowedHosts`.

Fixing the resolver rather than the worker closes the whole class: **every** `fetch`-based internal caller has this problem, not just this one.

## Tests

Integration, not unit — deliberately. `SiteResolver` depends on the concrete `AppDbContext`, whose model only builds on Npgsql, and the failure is inherently about a real request's host, which a mock cannot express. `SsgRouteResolutionTests` asserts:

- `/ssg/routes` returns 200 for `Host: api` and `Host: api:8080` (the exact broken shape)
- a known host still works
- the route list is **non-empty** — an empty list would rebuild nothing while reporting success, the same silent-failure shape this whole PR is about

1379 unit tests green; build + `dotnet format --verify-no-changes` clean.

## ⚠️ This fix alone does not restore the pages

A **full SSG rebuild must run after deploy** for those ~389 books to be generated. I'll trigger it once this is live and verify a previously-404ing book (`/en/books/ajax/`) starts serving.

## Rollback plan

`git revert`. Behaviour returns to strict host matching — i.e. back to SSG being broken, so rollback is only appropriate if the fallback causes an unforeseen problem. No migration, no data change.

## Two pieces of misleading infrastructure found on the way

Not part of this fix, but they cost real debugging time and someone should know:

- **`X-SEO-Render` lies.** It is set from `map $is_bot`, so it reports "you look like a bot", **not** "an SSG file was served" — it says `ssg` even when the SPA fallback ran.
- **`location /ssg/ { internal; alias …/data/ssg/; }` points at a directory that does not exist.** `try_files` resolves `$ssg_file` against `root` instead, so the real pages come from `apps/web/dist/ssg`. The block is dead code whose comment asserts it is required.

## Also found, deliberately not in this PR

- The catch-all `location /` returns **200 to bots** for any non-SSG path — the bot-404 guard exists only in `@spa`. Separate fix.
- Cloudflare's managed `robots.txt` omits `Content-Signal: ai-input` and adds `Disallow: /` for ClaudeBot / GPTBot / Google-Extended / CCBot / meta-externalagent. That is why Bing reports the site cannot appear in Copilot and grounding results. A product decision, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)