### PR TITLE
Editions get a completion field

### DIFF
--- a/apps/mobile/src/hooks/useBookActions.ts
+++ b/apps/mobile/src/hooks/useBookActions.ts
@@ -3,6 +3,7 @@ import { Alert } from 'react-native'
 import {
   libraryApi, readingProgressApi, userBooksApi, createBooksApi,
   type UserLibraryItem, type UserBookDto, type ReadingProgressDto,
+  FINISHED_THRESHOLD,
 } from '@textstack/shared'
 import { useLanguage } from '../context/LanguageContext'
 import { useToast } from '../context/ToastContext'
@@ -27,7 +28,10 @@ export function useBookActions() {
 
   const showSavedActions = useCallback((item: UserLibraryItem, ctx: SavedCtx) => {
     const progress = ctx.progressMap[item.editionId]
-    const isFinished = progress?.percent === 1
+    // The recorded answer, not a threshold guess. `percent === 1` was one of four
+    // different rules across the codebase for "is this finished?"; the fallback
+    // covers rows written before editions had a completion field.
+    const isFinished = progress?.completedAt != null || (progress?.percent ?? 0) >= FINISHED_THRESHOLD
     const buttons: { text: string; style?: 'cancel' | 'destructive'; onPress?: () => void }[] = []
 
     buttons.push({
@@ -49,6 +53,7 @@ export function useBookActions() {
               ...prev[item.editionId],
               editionId: item.editionId,
               percent: isFinished ? 0 : 1,
+              completedAt: isFinished ? null : new Date().toISOString(),
               chapterSlug: ch.slug,
               updatedAt: new Date().toISOString(),
             },

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -182,6 +182,9 @@ export interface ReadingProgressDto {
   locator: string
   percent: number | null
   updatedAt: string
+  /** Non-null once the book is finished. Read this instead of comparing
+   *  `percent` against a threshold of your own. */
+  completedAt?: string | null
 }
 
 export interface UpsertProgressRequest {

--- a/apps/web/src/components/library/SavedBookGridCard.tsx
+++ b/apps/web/src/components/library/SavedBookGridCard.tsx
@@ -23,6 +23,9 @@ export function SavedBookGridCard({
   onMarkUnfinished: () => void
 }) {
   const percent = progress?.percent ?? 0
+  // Recorded completion beats a threshold guess. `percent >= 1` was one of four
+  // different answers to "is this finished?" before editions had the field.
+  const isFinished = progress?.completedAt != null || percent >= 1
   const destination = progress?.chapterSlug
     ? `/${item.language}/books/${item.slug}/${progress.chapterSlug}`
     : `/${item.language}/books/${item.slug}`
@@ -39,7 +42,7 @@ export function SavedBookGridCard({
             {item.title?.[0] || '?'}
           </div>
         )}
-        {percent >= 1 && (
+        {isFinished && (
           <div className="user-book-card__completed-badge">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
               <polyline points="20 6 9 17 4 12" />
@@ -47,7 +50,7 @@ export function SavedBookGridCard({
             Read
           </div>
         )}
-        {percent > 0 && percent < 1 && (
+        {percent > 0 && !isFinished && (
           <div className="library-card__progress-bar">
             <div
               className="library-card__progress-fill"
@@ -65,10 +68,10 @@ export function SavedBookGridCard({
             <span className="user-book-card__author" title={item.author}>{item.author}</span>
           )}
           <div className="library-card__meta">
-            {percent >= 1 && (
+            {isFinished && (
               <span className="user-book-card__progress-text user-book-card__progress-text--done">Read</span>
             )}
-            {percent > 0 && percent < 1 && (
+            {percent > 0 && !isFinished && (
               <span className="library-card__progress-text">
                 {Math.round(percent * 100)}% {t('library.read')}
               </span>
@@ -79,7 +82,7 @@ export function SavedBookGridCard({
         <BookActionMenu
           type="saved"
           book={item}
-          isFinished={percent >= 1}
+          isFinished={isFinished}
           onRemove={onRemove}
           onMarkFinished={onMarkFinished}
           onMarkUnfinished={onMarkUnfinished}

--- a/apps/web/src/components/library/SavedBookListItem.tsx
+++ b/apps/web/src/components/library/SavedBookListItem.tsx
@@ -24,6 +24,9 @@ export function SavedBookListItem({
   onMarkUnfinished: () => void
 }) {
   const percent = progress?.percent ?? 0
+  // Recorded completion beats a threshold guess. `percent >= 1` was one of four
+  // different answers to "is this finished?" before editions had the field.
+  const isFinished = progress?.completedAt != null || percent >= 1
   const destination = progress?.chapterSlug
     ? `/${item.language}/books/${item.slug}/${progress.chapterSlug}`
     : `/${item.language}/books/${item.slug}`
@@ -74,7 +77,7 @@ export function SavedBookListItem({
         <BookActionMenu
           type="saved"
           book={item}
-          isFinished={percent >= 1}
+          isFinished={isFinished}
           onRemove={onRemove}
           onMarkFinished={onMarkFinished}
           onMarkUnfinished={onMarkUnfinished}

--- a/apps/web/src/hooks/useLibraryFilter.ts
+++ b/apps/web/src/hooks/useLibraryFilter.ts
@@ -55,6 +55,13 @@ function progressOf(item: LibraryItem, progressMap: Record<string, ReadingProgre
   return progressMap[item.editionId]?.percent ?? 0
 }
 
+/** The recorded completion, falling back to the threshold for rows written
+ *  before editions had a `completedAt`. Uploads already answer it this way. */
+function isFinishedItem(item: LibraryItem, progressMap: Record<string, ReadingProgressDto>): boolean {
+  const p = progressMap[item.editionId]
+  return p?.completedAt != null || (p?.percent ?? 0) >= FINISHED_THRESHOLD
+}
+
 export function filterLibraryItems(
   items: LibraryItem[],
   filter: LibraryFilterKey,
@@ -62,11 +69,11 @@ export function filterLibraryItems(
 ): LibraryItem[] {
   switch (filter) {
     case 'reading':
-      return items.filter(i => { const p = progressOf(i, progressMap); return p > 0 && p < FINISHED_THRESHOLD })
+      return items.filter(i => !isFinishedItem(i, progressMap) && progressOf(i, progressMap) > 0)
     case 'finished':
-      return items.filter(i => progressOf(i, progressMap) >= FINISHED_THRESHOLD)
+      return items.filter(i => isFinishedItem(i, progressMap))
     case 'notStarted':
-      return items.filter(i => progressOf(i, progressMap) === 0)
+      return items.filter(i => !isFinishedItem(i, progressMap) && progressOf(i, progressMap) === 0)
     case 'failed':
       return []
     case 'all':

--- a/backend/src/Api/Endpoints/UserDataEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserDataEndpoints.cs
@@ -63,7 +63,8 @@ public static class UserDataEndpoints
                 x.c.Slug,
                 x.p.Locator,
                 x.p.Percent,
-                x.p.UpdatedAt
+                x.p.UpdatedAt,
+                x.p.CompletedAt
             ))
             .ToListAsync(ct);
 
@@ -90,7 +91,8 @@ public static class UserDataEndpoints
                 x.c.Slug,
                 x.p.Locator,
                 x.p.Percent,
-                x.p.UpdatedAt
+                x.p.UpdatedAt,
+                x.p.CompletedAt
             ))
             .FirstOrDefaultAsync(ct);
 
@@ -143,7 +145,8 @@ public static class UserDataEndpoints
                     existingChapter?.Slug,
                     existing.Locator,
                     existing.Percent,
-                    existing.UpdatedAt
+                    existing.UpdatedAt,
+                    existing.CompletedAt
                 ));
             }
 
@@ -210,7 +213,8 @@ public static class UserDataEndpoints
             chapter.Slug,
             existing.Locator,
             existing.Percent,
-            existing.UpdatedAt
+            existing.UpdatedAt,
+            existing.CompletedAt
         ));
     }
 
@@ -224,6 +228,15 @@ public static class UserDataEndpoints
         target.ChapterId = request.ChapterId;
         target.Locator = request.Locator;
         target.Percent = request.Percent;
+        // Completion is recorded, not inferred later from a threshold. Same 0.99
+        // rule uploads use (UserBookService.UpsertProgressAsync), so both kinds of
+        // book answer "finished?" the same way. Re-reading a finished book does
+        // not un-finish it — only an explicit mark-as-unfinished clears this,
+        // which arrives as percent 0.
+        if (request.Percent is >= 0.99)
+            target.CompletedAt ??= DateTimeOffset.UtcNow;
+        else if (request.Percent is <= 0)
+            target.CompletedAt = null;
         // High-water mark for the RAG spoiler gate — monotonic, never decreases. NULL means
         // "never recorded" (distinct from ordinal 0, a real 0-based first chapter), so the first
         // write seeds it rather than max-ing against an implied 0.
@@ -524,7 +537,10 @@ public record ReadingProgressDto(
     string? ChapterSlug,
     string Locator,
     double? Percent,
-    DateTimeOffset UpdatedAt
+    DateTimeOffset UpdatedAt,
+    /// <summary>Non-null once the book is finished. Clients read this instead of
+    /// comparing <paramref name="Percent"/> against a threshold of their own.</summary>
+    DateTimeOffset? CompletedAt
 );
 
 public record UpsertProgressRequest(

--- a/backend/src/Application/Library/LibraryShelvesService.cs
+++ b/backend/src/Application/Library/LibraryShelvesService.cs
@@ -82,12 +82,13 @@ public class LibraryShelvesService(IAppDbContext db)
             let latestProgress = db.ReadingProgresses
                 .Where(p => p.UserId == userId && p.EditionId == e.Id)
                 .OrderByDescending(p => p.UpdatedAt)
-                .Select(p => new { p.Percent, p.UpdatedAt, p.ChapterId, p.Locator })
+                .Select(p => new { p.Percent, p.UpdatedAt, p.ChapterId, p.Locator, p.CompletedAt })
                 .FirstOrDefault()
             where latestProgress != null
                 && latestProgress.Percent != null
                 && latestProgress.Percent > InProgressMinPercent
                 && latestProgress.Percent < InProgressMaxPercent
+                && latestProgress.CompletedAt == null
             orderby latestProgress.UpdatedAt descending
             select new
             {
@@ -340,13 +341,12 @@ public class LibraryShelvesService(IAppDbContext db)
             let latest = db.ReadingProgresses
                 .Where(p => p.UserId == userId && p.EditionId == e.Id)
                 .OrderByDescending(p => p.UpdatedAt)
-                .Select(p => new { p.Percent, p.UpdatedAt })
+                .Select(p => new { p.Percent, p.UpdatedAt, p.CompletedAt })
                 .FirstOrDefault()
             where latest != null
-                && latest.Percent != null
-                && latest.Percent >= InProgressMaxPercent
-                && latest.UpdatedAt >= monthStart
-            orderby latest.UpdatedAt descending
+                && latest.CompletedAt != null
+                && latest.CompletedAt >= monthStart
+            orderby latest.CompletedAt descending
             select new
             {
                 e.Id,

--- a/backend/src/Domain/Entities/ReadingProgress.cs
+++ b/backend/src/Domain/Entities/ReadingProgress.cs
@@ -38,6 +38,21 @@ public class ReadingProgress : ISiteScoped
     /// </summary>
     public int? MaxChapterNumber { get; set; }
 
+    /// <summary>
+    /// Set once <see cref="Percent"/> crosses <c>0.99</c>, or by an explicit
+    /// mark-as-finished; cleared by mark-as-unfinished. The presence of this is
+    /// the answer to "is it finished?".
+    /// <para>
+    /// Editions had no completion field at all, so four different places each
+    /// answered the question with their own inequality against a percentage —
+    /// 0.95 in the shelf service, 0.95 in the web library filter, 1.0 on the web
+    /// cards, 1.0 in the mobile action sheet — and "mark as read" had to fake it
+    /// by writing a percent of exactly 1. Mirrors
+    /// <see cref="UserBook.CompletedAt"/>, which uploads have always had.
+    /// </para>
+    /// </summary>
+    public DateTimeOffset? CompletedAt { get; set; }
+
     public DateTimeOffset UpdatedAt { get; set; }
 
     public User User { get; set; } = null!;

--- a/backend/src/Infrastructure/Migrations/20260826183324_AddReadingProgressCompletedAt.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260826183324_AddReadingProgressCompletedAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260826183324_AddReadingProgressCompletedAt")]
+    partial class AddReadingProgressCompletedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260826183324_AddReadingProgressCompletedAt.cs
+++ b/backend/src/Infrastructure/Migrations/20260826183324_AddReadingProgressCompletedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReadingProgressCompletedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "completed_at",
+                table: "reading_progresses",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "completed_at",
+                table: "reading_progresses");
+        }
+    }
+}

--- a/packages/shared/src/library/entries.ts
+++ b/packages/shared/src/library/entries.ts
@@ -135,10 +135,13 @@ export function matchesStatus(
   // A catalog book cannot fail — nothing about it is processed for this user.
   if (status === 'failed') return false
   const p = entryProgress(e, progressMap)
+  // `completedAt` is the recorded answer; the threshold is the fallback for rows
+  // written before editions had a completion field.
+  const finished = progressMap[e.item.editionId]?.completedAt != null || p >= FINISHED_THRESHOLD
   switch (status) {
-    case 'reading': return p > 0 && p < FINISHED_THRESHOLD
-    case 'finished': return p >= FINISHED_THRESHOLD
-    case 'notStarted': return p === 0
+    case 'reading': return !finished && p > 0
+    case 'finished': return finished
+    case 'notStarted': return !finished && p === 0
   }
   return false
 }

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -145,6 +145,10 @@ export interface ReadingProgressDto {
   locator: string
   percent: number | null
   updatedAt: string
+  /** Non-null once the book is finished. Read this instead of comparing
+   *  `percent` against a threshold — editions used to have no completion field,
+   *  so four places each picked their own (0.95, 0.95, 1.0, 1.0). */
+  completedAt?: string | null
 }
 
 // Bookmarks

--- a/tests/TextStack.UnitTests/UpsertProgressTests.cs
+++ b/tests/TextStack.UnitTests/UpsertProgressTests.cs
@@ -56,6 +56,61 @@ public class UpsertProgressTests
     }
 
     /// <summary>
+    /// Editions had no completion field, so four places each answered "is this finished?" with
+    /// their own inequality — 0.95 in the shelf service, 0.95 in the web filter, 1.0 on the web
+    /// cards, 1.0 in the mobile action sheet — and "mark as read" faked it by writing a percent of
+    /// exactly 1. These lock the recorded answer.
+    /// </summary>
+    [Fact]
+    public void ApplyProgressUpdate_PercentAtLeast099_RecordsCompletion()
+    {
+        var chapter = ChapterAt(40);
+        var target = Progress(maxChapter: 39);
+
+        UserDataEndpoints.ApplyProgressUpdate(target, Request(chapter.Id, 0.99), chapter);
+
+        Assert.NotNull(target.CompletedAt);
+    }
+
+    [Fact]
+    public void ApplyProgressUpdate_RereadingAFinishedBook_DoesNotUnfinishIt()
+    {
+        var chapter = ChapterAt(1);
+        var target = Progress(maxChapter: 40);
+        var finishedAt = DateTimeOffset.UtcNow.AddDays(-3);
+        target.CompletedAt = finishedAt;
+
+        // Opening chapter 1 again reports a low percent; that is a re-read, not an un-finish.
+        UserDataEndpoints.ApplyProgressUpdate(target, Request(chapter.Id, 0.02), chapter);
+
+        Assert.Equal(finishedAt, target.CompletedAt);
+    }
+
+    [Fact]
+    public void ApplyProgressUpdate_PercentZero_ClearsCompletion()
+    {
+        var chapter = ChapterAt(1);
+        var target = Progress(maxChapter: 40);
+        target.CompletedAt = DateTimeOffset.UtcNow.AddDays(-3);
+
+        // Percent 0 is what mark-as-unfinished sends.
+        UserDataEndpoints.ApplyProgressUpdate(target, Request(chapter.Id, 0), chapter);
+
+        Assert.Null(target.CompletedAt);
+    }
+
+    [Fact]
+    public void ApplyProgressUpdate_MidBook_LeavesCompletionUnset()
+    {
+        var chapter = ChapterAt(5);
+        var target = Progress(maxChapter: 4);
+
+        UserDataEndpoints.ApplyProgressUpdate(target, Request(chapter.Id, 0.5), chapter);
+
+        Assert.Null(target.CompletedAt);
+    }
+
+    /// <summary>
     /// The high-water mark feeds the RAG spoiler gate, so it must never move backwards — a reader
     /// flipping back to chapter 1 must not re-expose chapter 30 as unread.
     /// </summary>


### PR DESCRIPTION
Uploaded books have always had `CompletedAt`. Catalog editions had **nothing**, so *"is this book finished?"* was answered four separate times, each with its own inequality:

| Where | Rule |
|---|---|
| `LibraryShelvesService` | `percent >= 0.95` |
| web `useLibraryFilter` | `percent >= 0.95` |
| web `SavedBook*` cards | `percent >= 1` |
| mobile action sheet | `percent === 1` |

They disagree by construction — a book at 97% was finished on two surfaces and still in progress on the other two.

And **"mark as read" had no way to say so.** It faked completion by writing a percent of exactly `1` — which is also what a reader scrolling to the end of the last chapter produces. The two were indistinguishable.

## What changed

`ReadingProgress.CompletedAt` records the answer. The upsert sets it on the same `>= 0.99` rule uploads use, so both kinds of book agree; percent `0` — what mark-as-unfinished sends — clears it.

**Re-reading a finished book does not un-finish it.** Only an explicit unfinish does. A threshold could never express that.

Every reader switches to the field, keeping the threshold as a fallback for rows written before the column existed. The shelf's *"finished this month"* now orders by when the book was **actually finished** rather than when its progress row was last touched — previously, opening a finished book to re-read a page moved it back to the top of that shelf.

## Verification

- **1383** backend (4 new on the `ApplyProgressUpdate` seam: record / re-read / unfinish / mid-book), **285** shared, **118** mobile, **737** web
- Migration applied against a real Postgres container and the column verified
- Android bundle exports

## Rollback

Schema migration only, with a working `Down` — unlike the reset that preceded it, nothing here is destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)