### PR TITLE
Ask for the native language once, on the way in

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -5,12 +5,14 @@ import {
 } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter } from 'expo-router'
-import { authApi } from '@textstack/shared'
+import { authApi, type UserDto } from '@textstack/shared'
 import { GoogleSignin } from '@react-native-google-signin/google-signin'
 import Constants from 'expo-constants'
 import { useAuth } from '../../src/context/AuthContext'
 import { useTheme } from '../../src/context/ThemeContext'
 import { fonts } from '../../src/theme/typography'
+import { useNativeLanguage } from '../../src/context/NativeLanguageContext'
+import { shouldAskForLanguage } from '../../src/lib/languageOnboarding'
 import { trackLogin, trackSignUp } from '../../src/lib/analytics'
 
 /** Mirror web heuristic: backend doesn't surface an isNew flag, so a fresh
@@ -52,6 +54,7 @@ export default function LoginScreen() {
   const { colors } = useTheme()
   const router = useRouter()
   const { signInWithTokens } = useAuth()
+  const { hasConfirmedLanguage } = useNativeLanguage()
   const [loading, setLoading] = useState(false)
   const [mode, setMode] = useState<Mode>('login')
   const [email, setEmail] = useState('')
@@ -86,12 +89,12 @@ export default function LoginScreen() {
         const result = await authApi.registerWithEmail(email.trim(), password, name.trim() || undefined)
         await signInWithTokens(result.accessToken, result.refreshToken, result.user)
         trackSignUp('email')
-        goToLibrary()
+        landAfterAuth(result.user)
       } else {
         const result = await authApi.loginWithEmail(email.trim(), password)
         await signInWithTokens(result.accessToken, result.refreshToken, result.user)
         trackLogin('email')
-        goToLibrary()
+        landAfterAuth(result.user)
       }
     } catch (e: any) {
       setError(e.message || 'Something went wrong.')
@@ -108,8 +111,26 @@ export default function LoginScreen() {
    * in" button lives. So signing in dropped the reader on a settings screen
    * instead of on their books. `replace` rather than `push` so Back does not
    * walk into the login form of an account you are already signed into.
+   *
+   * A brand-new account has no native language, and without one the reader's
+   * core feature translates English into English. So a new account is sent to
+   * the question first, and everyone else straight to their books.
+   *
+   * The decision is `shouldAskForLanguage`, the same function the root gate
+   * uses — two copies of this rule would drift, and the failure would be
+   * invisible: either a returning reader interrogated on every sign-in, or a
+   * new one never asked at all. The freshly returned `user` is passed rather
+   * than read from context because `signInWithTokens` has not propagated yet.
    */
-  const goToLibrary = () => router.replace('/(tabs)/library')
+  const landAfterAuth = (u: UserDto) => {
+    const ask = shouldAskForLanguage({
+      isAuthenticated: true,
+      isGuest: u.isGuest,
+      serverNativeLanguage: u.nativeLanguage,
+      hasConfirmedLanguage,
+    })
+    router.replace(ask ? '/onboarding/language' : '/(tabs)/library')
+  }
 
   const handleGoogleSignIn = async () => {
     setLoading(true)
@@ -123,7 +144,7 @@ export default function LoginScreen() {
       await signInWithTokens(result.accessToken, result.refreshToken, result.user)
       if (isFreshAccount(result.user.createdAt)) trackSignUp('google')
       else trackLogin('google')
-      goToLibrary()
+      landAfterAuth(result.user)
     } catch (e: any) {
       if (e?.code !== 'SIGN_IN_CANCELLED') {
         // Surface the underlying GoogleSignin error (DEVELOPER_ERROR,
@@ -171,7 +192,7 @@ export default function LoginScreen() {
       await signInWithTokens(result.accessToken, result.refreshToken, result.user)
       if (isFreshAccount(result.user.createdAt)) trackSignUp('apple')
       else trackLogin('apple')
-      goToLibrary()
+      landAfterAuth(result.user)
     } catch (e: any) {
       if (e.code !== 'ERR_REQUEST_CANCELED') {
         Alert.alert('Error', 'Apple sign-in failed')

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -12,7 +12,7 @@ import { useAuth } from '../../src/context/AuthContext'
 import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
 import { useOnline } from '../../src/hooks/useOnline'
-import { useNativeLanguage, TARGET_LANGUAGES } from '../../src/context/NativeLanguageContext'
+import { useNativeLanguage } from '../../src/context/NativeLanguageContext'
 import { getLanguage, getFlagEmoji } from '../../src/data/languages'
 import { LanguagePickerModal } from '../../src/components/LanguagePickerModal'
 import { VocabReminderSettingsRow } from '../../src/components/profile/VocabReminderSettingsRow'
@@ -32,7 +32,7 @@ export default function ProfileScreen() {
   const { user, isAuthenticated, signOut, updateUser, getAccessToken } = useAuth()
   const { colors, themeMode, setThemeMode } = useTheme()
   const { language, switchLanguage } = useLanguage()
-  const { nativeLanguage, targetLanguage, setNativeLanguage, setTargetLanguage } = useNativeLanguage()
+  const { nativeLanguage, setNativeLanguage } = useNativeLanguage()
   const router = useRouter()
   const [editing, setEditing] = useState(false)
   const [editName, setEditName] = useState('')
@@ -301,30 +301,13 @@ export default function ProfileScreen() {
           </View>
         </TouchableOpacity>
 
-        {/* I'm learning (target language) */}
-        <View style={[styles.menuItem, { borderBottomColor: colors.border }]}>
-          <Ionicons name="school-outline" size={20} color={colors.textSecondary} style={styles.menuIcon} />
-          <Text style={[styles.menuText, { color: colors.text }]}>Learning</Text>
-          <View style={{ flexDirection: 'row', gap: 4 }}>
-            {TARGET_LANGUAGES.map(lang => (
-              <TouchableOpacity
-                key={lang.code}
-                onPress={() => setTargetLanguage(lang.code)}
-                style={{
-                  paddingHorizontal: 12,
-                  paddingVertical: 4,
-                  borderRadius: 12,
-                  backgroundColor: targetLanguage === lang.code ? colors.primaryLight : 'transparent',
-                }}
-                activeOpacity={0.7}
-              >
-                <Text style={{ fontFamily: fonts.sansMedium, fontSize: 13, color: targetLanguage === lang.code ? colors.primary : colors.textSecondary }}>
-                  {lang.flag} {lang.label}
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
-        </View>
+        {/* "Learning" used to sit here: a row of chips built from TARGET_LANGUAGES,
+            which is NATIVE_LANGUAGES.filter(code === 'en') — one chip, permanently
+            selected, doing nothing. QA read it as a real setting and filed it twice:
+            once as a styling inconsistency next to "I know" (a chevron row vs a chip
+            row), and once as the reason a new account believed it was learning
+            English. A control with one option is not a control. It comes back when
+            the catalogue has a second language. */}
 
         {/* Theme switcher */}
         <View style={[styles.menuItem, { borderBottomColor: colors.border }]}>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -7,15 +7,16 @@ import * as SplashScreen from 'expo-splash-screen'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { setupApi } from '../src/lib/api'
 import { Sentry, initSentry } from '../src/lib/sentry'
-import { AuthProvider } from '../src/context/AuthContext'
+import { AuthProvider, useAuth } from '../src/context/AuthContext'
 import { DownloadProvider } from '../src/context/DownloadContext'
 import { ThemeProvider, useTheme } from '../src/context/ThemeContext'
 import { LanguageProvider } from '../src/context/LanguageContext'
-import { NativeLanguageProvider } from '../src/context/NativeLanguageContext'
+import { NativeLanguageProvider, useNativeLanguage } from '../src/context/NativeLanguageContext'
 import { ToastProvider } from '../src/context/ToastContext'
 import { ErrorBoundary } from '../src/components/ErrorBoundary'
 import { LegacyRuntimeBanner } from '../src/components/LegacyRuntimeBanner'
 import { useAppFonts } from '../src/theme/fonts'
+import { shouldAskForLanguage } from '../src/lib/languageOnboarding'
 
 SplashScreen.preventAutoHideAsync()
 
@@ -106,6 +107,41 @@ function ColdResetOnResume() {
   return null
 }
 
+/**
+ * Sends a signed-in reader whose native language nobody ever asked for to the
+ * one screen that asks. Null-rendering and isolated for the same reason as
+ * `ColdResetOnResume`: `usePathname()` re-renders its own scope, and that scope
+ * must not be the whole `<Stack>`.
+ *
+ * Registration routes here directly (see `app/(auth)/login.tsx`). This gate is
+ * for everyone else — accounts made before the screen existed, and the reinstall
+ * case where local storage is empty but the profile is years old. Both show up
+ * as `nativeLanguage: null` from the server.
+ */
+function LanguageOnboardingGate() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const { user, isAuthenticated } = useAuth()
+  const { hasConfirmedLanguage } = useNativeLanguage()
+
+  const ask = shouldAskForLanguage({
+    isAuthenticated,
+    isGuest: !!user?.isGuest,
+    serverNativeLanguage: user?.nativeLanguage,
+    hasConfirmedLanguage,
+    alreadyOnboarding: pathname.startsWith('/onboarding'),
+  })
+
+  useEffect(() => {
+    // Never over the auth modal: the user is mid-sign-in, and login.tsx routes
+    // here itself once it knows whether the account is new.
+    if (!ask || pathname.includes('login')) return
+    router.replace('/onboarding/language')
+  }, [ask, pathname, router])
+
+  return null
+}
+
 function AppContent() {
   const { isDark } = useTheme()
 
@@ -115,12 +151,16 @@ function AppContent() {
     // runtime except the frozen "1.0.0" one, so this costs an empty View.
     <View style={{ flex: 1 }}>
       <ColdResetOnResume />
+      <LanguageOnboardingGate />
       <StatusBar style={isDark ? 'light' : 'dark'} />
       <LegacyRuntimeBanner />
       <View style={{ flex: 1 }}>
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="(tabs)" />
           <Stack.Screen name="(auth)/login" options={{ presentation: 'modal' }} />
+          {/* Not a modal and not dismissible by gesture: it is a step, and the
+              value it collects is the one the reader cannot use the app without. */}
+          <Stack.Screen name="onboarding/language" options={{ animation: 'fade', gestureEnabled: false }} />
           <Stack.Screen name="book/[slug]" />
           <Stack.Screen name="reader/[bookSlug]/[chapterSlug]" options={{ animation: 'slide_from_bottom' }} />
           <Stack.Screen name="vocabulary/review" />

--- a/apps/mobile/app/onboarding/language.tsx
+++ b/apps/mobile/app/onboarding/language.tsx
@@ -1,0 +1,71 @@
+import { View, Text, StyleSheet } from 'react-native'
+import { useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { LanguageList } from '../../src/components/LanguageList'
+import { useNativeLanguage } from '../../src/context/NativeLanguageContext'
+import { useLanguage } from '../../src/context/LanguageContext'
+import { useTheme } from '../../src/context/ThemeContext'
+import { fonts } from '../../src/theme/typography'
+
+/**
+ * The one question the product cannot run without.
+ *
+ * TextStack translates the book's language into the reader's own. Without
+ * knowing the second half of that pair there is nothing to translate into, so
+ * the app guessed English — and then translated English into English for every
+ * new account, turning its core feature into a no-op. A manual QA pass caught it
+ * on a five-minute-old account: Profile read "I know: English / Learning:
+ * English" while the server had `nativeLanguage: null`.
+ *
+ * **One question, not two.** The QA report proposed asking what you know and
+ * what you are learning. There is only one answer to the second — `TARGET_LANGUAGES`
+ * is `NATIVE_LANGUAGES.filter(code === 'en')` — and a question with one possible
+ * answer is not a question, it is the dead "Learning: English" chip the same
+ * report filed separately as P3-4.
+ *
+ * **No skip button, deliberately.** Skipping would put the reader back in the
+ * exact state this screen exists to end: a guessed value that nothing can tell
+ * apart from a chosen one. There is no dead end either — the list is searchable,
+ * English sits at the top of Popular, and a reader who genuinely knows English
+ * best answers in one tap. The difference is that it is now an answer instead of
+ * a silence, which is the whole point.
+ */
+export default function LanguageOnboardingScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const { colors } = useTheme()
+  const { t } = useLanguage()
+  const { nativeLanguage, setNativeLanguage } = useNativeLanguage()
+
+  const handleSelect = (code: string) => {
+    // Marks the choice confirmed and pushes it to the profile — see
+    // NativeLanguageContext.setNativeLanguage.
+    setNativeLanguage(code)
+    // replace, not push: there is nothing to go back to, and Android's hardware
+    // Back must not return the reader to a question they have answered.
+    router.replace('/(tabs)/library')
+  }
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.background, paddingTop: insets.top + 24, paddingBottom: insets.bottom },
+      ]}
+    >
+      <Text style={[styles.title, { color: colors.text }]} accessibilityRole="header">
+        {t('onboarding.nativeLanguageTitle')}
+      </Text>
+      <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+        {t('onboarding.nativeLanguageSubtitle')}
+      </Text>
+      <LanguageList value={nativeLanguage} onSelect={handleSelect} />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingHorizontal: 16 },
+  title: { fontSize: 24, fontFamily: fonts.sansBold, marginBottom: 8 },
+  subtitle: { fontSize: 14, fontFamily: fonts.sans, lineHeight: 20, marginBottom: 20 },
+})

--- a/apps/mobile/src/components/ExplanationSheet.tsx
+++ b/apps/mobile/src/components/ExplanationSheet.tsx
@@ -17,7 +17,10 @@ interface ExplanationSheetProps {
 
 export function ExplanationSheet({ visible, word, sentence, bookId, fromLang: fromOverride, onClose }: ExplanationSheetProps) {
   const { colors } = useTheme()
-  const { toLang } = useTargetLanguage(fromOverride)
+  // Explanations are addressed to the reader, so this is readerLang and never
+  // null: explaining an English word in English is useful, unlike translating
+  // one into itself.
+  const { readerLang } = useTargetLanguage(fromOverride)
   const [explanation, setExplanation] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -31,7 +34,7 @@ export function ExplanationSheet({ visible, word, sentence, bookId, fromLang: fr
     setLoading(true)
     setError('')
     setExplanation('')
-    explainApi.explain({ word, sentence, bookId, targetLang: toLang }, ctrl.signal)
+    explainApi.explain({ word, sentence, bookId, targetLang: readerLang }, ctrl.signal)
       .then(res => { if (!ctrl.signal.aborted) setExplanation(res.explanation) })
       .catch(err => {
         if (ctrl.signal.aborted) return
@@ -40,7 +43,7 @@ export function ExplanationSheet({ visible, word, sentence, bookId, fromLang: fr
       })
       .finally(() => { if (!ctrl.signal.aborted) setLoading(false) })
     return () => { ctrl.abort() }
-  }, [visible, word, sentence, toLang, bookId])
+  }, [visible, word, sentence, readerLang, bookId])
 
   return (
     <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>

--- a/apps/mobile/src/components/LanguageList.tsx
+++ b/apps/mobile/src/components/LanguageList.tsx
@@ -1,0 +1,188 @@
+import { useState, useMemo, useImperativeHandle, forwardRef } from 'react'
+import { View, Text, StyleSheet, TouchableOpacity, FlatList, TextInput } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useTheme } from '../context/ThemeContext'
+import { fonts } from '../theme/typography'
+import {
+  LANGUAGES,
+  POPULAR_LANGUAGES,
+  OTHER_LANGUAGES,
+  getFlagEmoji,
+  type LanguageEntry,
+} from '../data/languages'
+
+/**
+ * The searchable language list, without any opinion about what contains it.
+ *
+ * It was born inside `LanguagePickerModal` and stayed there until onboarding
+ * needed the same list on a full screen. Copying it would have meant two lists
+ * drifting apart — the codebase has already paid for that with three text-anchor
+ * implementations and two percent conventions.
+ */
+
+interface Props {
+  value: string
+  onSelect: (code: string) => void
+  /** The modal autofocuses search; a first-run screen should not raise the
+   *  keyboard over the question it just asked. */
+  autoFocusSearch?: boolean
+}
+
+export interface LanguageListHandle {
+  /** Clear the query — the modal calls this when it closes. */
+  reset: () => void
+}
+
+type Row =
+  | { kind: 'section'; title: string }
+  | { kind: 'item'; lang: LanguageEntry }
+
+export const LanguageList = forwardRef<LanguageListHandle, Props>(function LanguageList(
+  { value, onSelect, autoFocusSearch = false },
+  ref,
+) {
+  const { colors } = useTheme()
+  const [query, setQuery] = useState('')
+
+  useImperativeHandle(ref, () => ({ reset: () => setQuery('') }), [])
+
+  const rows: Row[] = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) {
+      return [
+        { kind: 'section', title: 'Popular' },
+        ...POPULAR_LANGUAGES.map((lang) => ({ kind: 'item' as const, lang })),
+        { kind: 'section', title: 'All languages' },
+        ...OTHER_LANGUAGES.map((lang) => ({ kind: 'item' as const, lang })),
+      ]
+    }
+    const filtered = LANGUAGES.filter(
+      (l) =>
+        l.englishName.toLowerCase().includes(q) ||
+        l.nativeName.toLowerCase().includes(q) ||
+        l.code.toLowerCase().startsWith(q),
+    )
+    return filtered.map((lang) => ({ kind: 'item' as const, lang }))
+  }, [query])
+
+  return (
+    <>
+      <View style={[styles.searchRow, { borderColor: colors.border }]}>
+        <Ionicons name="search" size={18} color={colors.textSecondary} style={{ marginRight: 8 }} />
+        <TextInput
+          value={query}
+          onChangeText={setQuery}
+          placeholder="Search language..."
+          placeholderTextColor={colors.textSecondary}
+          style={[styles.searchInput, { color: colors.text, fontFamily: fonts.sans }]}
+          autoCorrect={false}
+          autoCapitalize="none"
+          autoFocus={autoFocusSearch}
+          accessibilityLabel="Search language"
+          returnKeyType="search"
+        />
+      </View>
+
+      {rows.length === 0 ? (
+        <Text style={[styles.empty, { color: colors.textSecondary }]}>
+          No results for "{query.trim()}"
+        </Text>
+      ) : (
+        <FlatList
+          data={rows}
+          keyExtractor={(item, i) =>
+            item.kind === 'section' ? `section-${item.title}` : `item-${item.lang.code}-${i}`
+          }
+          keyboardShouldPersistTaps="handled"
+          style={styles.list}
+          renderItem={({ item }) => {
+            if (item.kind === 'section') {
+              return (
+                <Text
+                  style={[styles.sectionLabel, { color: colors.textSecondary }]}
+                  accessibilityRole="header"
+                >
+                  {item.title}
+                </Text>
+              )
+            }
+            const lang = item.lang
+            const selected = lang.code === value
+            return (
+              <TouchableOpacity
+                style={[
+                  styles.row,
+                  { borderBottomColor: colors.border },
+                  selected && { backgroundColor: colors.primaryLight },
+                ]}
+                onPress={() => onSelect(lang.code)}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  lang.englishName === lang.nativeName
+                    ? lang.nativeName
+                    : `${lang.nativeName}, ${lang.englishName}`
+                }
+                accessibilityState={{ selected }}
+              >
+                <Text style={styles.flag}>{getFlagEmoji(lang.code)}</Text>
+                <View style={{ flex: 1 }}>
+                  <Text
+                    style={[
+                      styles.rowNative,
+                      { color: colors.text, fontFamily: fonts.sansMedium },
+                      selected && { color: colors.primary },
+                    ]}
+                  >
+                    {lang.nativeName}
+                  </Text>
+                  {lang.englishName !== lang.nativeName && (
+                    <Text style={[styles.rowEnglish, { color: colors.textSecondary, fontFamily: fonts.sans }]}>
+                      {lang.englishName}
+                    </Text>
+                  )}
+                </View>
+                {selected && <Ionicons name="checkmark" size={20} color={colors.primary} />}
+              </TouchableOpacity>
+            )
+          }}
+        />
+      )}
+    </>
+  )
+})
+
+const styles = StyleSheet.create({
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginBottom: 8,
+  },
+  searchInput: { flex: 1, fontSize: 15, padding: 0 },
+  list: { flex: 1 },
+  sectionLabel: {
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    fontFamily: fonts.sansMedium,
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 8,
+    borderBottomWidth: 1,
+    gap: 12,
+    borderRadius: 4,
+  },
+  flag: { fontSize: 22 },
+  rowNative: { fontSize: 15 },
+  rowEnglish: { fontSize: 12, marginTop: 2 },
+  empty: { textAlign: 'center', padding: 24, fontSize: 14 },
+})

--- a/apps/mobile/src/components/LanguagePickerModal.tsx
+++ b/apps/mobile/src/components/LanguagePickerModal.tsx
@@ -1,15 +1,9 @@
-import { useState, useMemo, useEffect } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity, Modal, Pressable, FlatList, TextInput } from 'react-native'
+import { useRef, useEffect } from 'react'
+import { View, Text, StyleSheet, TouchableOpacity, Modal, Pressable } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '../context/ThemeContext'
 import { fonts } from '../theme/typography'
-import {
-  LANGUAGES,
-  POPULAR_LANGUAGES,
-  OTHER_LANGUAGES,
-  getFlagEmoji,
-  type LanguageEntry,
-} from '../data/languages'
+import { LanguageList, type LanguageListHandle } from './LanguageList'
 
 interface Props {
   visible: boolean
@@ -18,36 +12,13 @@ interface Props {
   onChange: (code: string) => void
 }
 
-type Row =
-  | { kind: 'section'; title: string }
-  | { kind: 'item'; lang: LanguageEntry }
-
 export function LanguagePickerModal({ visible, onClose, value, onChange }: Props) {
   const { colors } = useTheme()
-  const [query, setQuery] = useState('')
+  const listRef = useRef<LanguageListHandle>(null)
 
   useEffect(() => {
-    if (!visible) setQuery('')
+    if (!visible) listRef.current?.reset()
   }, [visible])
-
-  const rows: Row[] = useMemo(() => {
-    const q = query.trim().toLowerCase()
-    if (!q) {
-      return [
-        { kind: 'section', title: 'Popular' },
-        ...POPULAR_LANGUAGES.map((lang) => ({ kind: 'item' as const, lang })),
-        { kind: 'section', title: 'All languages' },
-        ...OTHER_LANGUAGES.map((lang) => ({ kind: 'item' as const, lang })),
-      ]
-    }
-    const filtered = LANGUAGES.filter(
-      (l) =>
-        l.englishName.toLowerCase().includes(q) ||
-        l.nativeName.toLowerCase().includes(q) ||
-        l.code.toLowerCase().startsWith(q),
-    )
-    return filtered.map((lang) => ({ kind: 'item' as const, lang }))
-  }, [query])
 
   const handleSelect = (code: string) => {
     onChange(code)
@@ -79,87 +50,7 @@ export function LanguagePickerModal({ visible, onClose, value, onChange }: Props
             </TouchableOpacity>
           </View>
 
-          <View style={[styles.searchRow, { borderColor: colors.border }]}>
-            <Ionicons name="search" size={18} color={colors.textSecondary} style={{ marginRight: 8 }} />
-            <TextInput
-              value={query}
-              onChangeText={setQuery}
-              placeholder="Search language..."
-              placeholderTextColor={colors.textSecondary}
-              style={[styles.searchInput, { color: colors.text, fontFamily: fonts.sans }]}
-              autoCorrect={false}
-              autoCapitalize="none"
-              autoFocus
-              accessibilityLabel="Search language"
-              returnKeyType="search"
-            />
-          </View>
-
-          {rows.length === 0 ? (
-            <Text style={[styles.empty, { color: colors.textSecondary }]}>
-              No results for "{query.trim()}"
-            </Text>
-          ) : (
-            <FlatList
-              data={rows}
-              keyExtractor={(item, i) =>
-                item.kind === 'section' ? `section-${item.title}` : `item-${item.lang.code}-${i}`
-              }
-              keyboardShouldPersistTaps="handled"
-              style={styles.list}
-              renderItem={({ item }) => {
-                if (item.kind === 'section') {
-                  return (
-                    <Text
-                      style={[styles.sectionLabel, { color: colors.textSecondary }]}
-                      accessibilityRole="header"
-                    >
-                      {item.title}
-                    </Text>
-                  )
-                }
-                const lang = item.lang
-                const selected = lang.code === value
-                return (
-                  <TouchableOpacity
-                    style={[
-                      styles.row,
-                      { borderBottomColor: colors.border },
-                      selected && { backgroundColor: colors.primaryLight },
-                    ]}
-                    onPress={() => handleSelect(lang.code)}
-                    activeOpacity={0.7}
-                    accessibilityRole="button"
-                    accessibilityLabel={
-                      lang.englishName === lang.nativeName
-                        ? lang.nativeName
-                        : `${lang.nativeName}, ${lang.englishName}`
-                    }
-                    accessibilityState={{ selected }}
-                  >
-                    <Text style={styles.flag}>{getFlagEmoji(lang.code)}</Text>
-                    <View style={{ flex: 1 }}>
-                      <Text
-                        style={[
-                          styles.rowNative,
-                          { color: colors.text, fontFamily: fonts.sansMedium },
-                          selected && { color: colors.primary },
-                        ]}
-                      >
-                        {lang.nativeName}
-                      </Text>
-                      {lang.englishName !== lang.nativeName && (
-                        <Text style={[styles.rowEnglish, { color: colors.textSecondary, fontFamily: fonts.sans }]}>
-                          {lang.englishName}
-                        </Text>
-                      )}
-                    </View>
-                    {selected && <Ionicons name="checkmark" size={20} color={colors.primary} />}
-                  </TouchableOpacity>
-                )
-              }}
-            />
-          )}
+          <LanguageList ref={listRef} value={value} onSelect={handleSelect} autoFocusSearch />
         </Pressable>
       </Pressable>
     </Modal>
@@ -195,36 +86,4 @@ const styles = StyleSheet.create({
   },
   title: { fontSize: 17, fontFamily: fonts.sansBold },
   closeBtn: { padding: 4 },
-  searchRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderWidth: 1,
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    marginBottom: 8,
-  },
-  searchInput: { flex: 1, fontSize: 15, padding: 0 },
-  list: { flex: 1 },
-  sectionLabel: {
-    fontSize: 11,
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-    fontFamily: fonts.sansMedium,
-    paddingVertical: 8,
-    paddingHorizontal: 4,
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 12,
-    paddingHorizontal: 8,
-    borderBottomWidth: 1,
-    gap: 12,
-    borderRadius: 4,
-  },
-  flag: { fontSize: 22 },
-  rowNative: { fontSize: 15 },
-  rowEnglish: { fontSize: 12, marginTop: 2 },
-  empty: { textAlign: 'center', padding: 24, fontSize: 14 },
 })

--- a/apps/mobile/src/components/SelectionActionBar.tsx
+++ b/apps/mobile/src/components/SelectionActionBar.tsx
@@ -92,8 +92,10 @@ export function SelectionActionBar({
   onClose,
 }: SelectionActionBarProps) {
   const { colors } = useTheme()
-  const { fromLang, toLang } = useTargetLanguage(language)
-  const isSameLang = fromLang === toLang
+  const { fromLang, translationTarget } = useTargetLanguage(language)
+  // No target means the reader already knows this language — there is nothing
+  // to translate into, so the inline gloss is skipped rather than fetched.
+  const isSameLang = translationTarget == null
 
   // Inline translation for single-word taps. Fetched here (was in the
   // deleted WordCard). Cancellation guard avoids stale results when the
@@ -110,7 +112,7 @@ export function SelectionActionBar({
       return
     }
     // Instant render on a cache hit (re-tap of a seen word) — no spinner.
-    const cached = peekTranslation(selectedText, fromLang, toLang)
+    const cached = peekTranslation(selectedText, fromLang, translationTarget!)
     if (cached !== undefined) {
       setTranslation(cached.translation)
       setCategory(cached.category)
@@ -121,12 +123,12 @@ export function SelectionActionBar({
     setTranslation('')
     setCategory(undefined)
     setTranslating(true)
-    cachedTranslate(selectedText, fromLang, toLang)
+    cachedTranslate(selectedText, fromLang, translationTarget!)
       .then((r) => { if (!cancelled) { setTranslation(r.translation); setCategory(r.category) } })
       .catch(() => { if (!cancelled) setTranslation('') })
       .finally(() => { if (!cancelled) setTranslating(false) })
     return () => { cancelled = true }
-  }, [selectedText, isMultiWord, fromLang, toLang, isSameLang])
+  }, [selectedText, isMultiWord, fromLang, translationTarget, isSameLang])
 
   const handleCopy = () => {
     if (selectedText) Clipboard.setStringAsync(selectedText)

--- a/apps/mobile/src/components/TranslationSheet.tsx
+++ b/apps/mobile/src/components/TranslationSheet.tsx
@@ -22,29 +22,32 @@ interface TranslationSheetProps {
 
 export function TranslationSheet({ visible, text, onClose, onSpeak, fromLang: fromOverride }: TranslationSheetProps) {
   const { colors } = useTheme()
-  const { fromLang, toLang } = useTargetLanguage(fromOverride)
+  const { fromLang, translationTarget } = useTargetLanguage(fromOverride)
   // Human-readable native labels for the sheet header. Fall back to the
   // uppercased language code (e.g. "EN") when the code isn't in our
   // catalogue — no throw, no blank space.
-  const fromLabel = getLanguage(fromLang)?.nativeName ?? fromLang.toUpperCase()
-  const toLabel = getLanguage(toLang)?.nativeName ?? toLang.toUpperCase()
+  const label = (code: string) => getLanguage(code)?.nativeName ?? code.toUpperCase()
+  const fromLabel = label(fromLang)
+  const toLabel = translationTarget ? label(translationTarget) : null
   const [translated, setTranslated] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
   useEffect(() => {
-    if (!visible || !text) return
+    // Nothing to translate into: the reader knows this language. Don't spend a
+    // request proving that English means English — the sheet says so instead.
+    if (!visible || !text || !translationTarget) return
     setLoading(true)
     setError('')
     setTranslated('')
-    trackTranslationUsed({ fromLang, toLang, kind: text.includes(' ') ? 'selection' : 'word' })
-    translationApi.translate(text, fromLang, toLang)
+    trackTranslationUsed({ fromLang, toLang: translationTarget, kind: text.includes(' ') ? 'selection' : 'word' })
+    translationApi.translate(text, fromLang, translationTarget)
       .then((res: any) => {
         setTranslated(res.translatedText || res.translation || '')
       })
       .catch(() => setError('Translation failed'))
       .finally(() => setLoading(false))
-  }, [visible, text, fromLang, toLang])
+  }, [visible, text, fromLang, translationTarget])
 
   return (
     <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
@@ -81,10 +84,18 @@ export function TranslationSheet({ visible, text, onClose, onSpeak, fromLang: fr
             <View style={[styles.divider, { backgroundColor: colors.border }]} />
 
             <View style={styles.textBlock}>
-              <Text style={[styles.langLabel, { color: colors.primary }]}>{toLabel}</Text>
-              {loading && <ActivityIndicator color={colors.primary} style={{ marginTop: 8 }} accessibilityLabel="Translating" />}
-              {error ? <Text style={{ color: colors.error, marginTop: 8 }} accessibilityRole="alert">{error}</Text> : null}
-              {translated ? <Text style={[styles.translatedText, { color: colors.text }]}>{translated}</Text> : null}
+              {toLabel ? (
+                <>
+                  <Text style={[styles.langLabel, { color: colors.primary }]}>{`\u2192 ${toLabel}`}</Text>
+                  {loading && <ActivityIndicator color={colors.primary} style={{ marginTop: 8 }} accessibilityLabel="Translating" />}
+                  {error ? <Text style={{ color: colors.error, marginTop: 8 }} accessibilityRole="alert">{error}</Text> : null}
+                  {translated ? <Text style={[styles.translatedText, { color: colors.text }]}>{translated}</Text> : null}
+                </>
+              ) : (
+                <Text style={[styles.translatedText, { color: colors.textSecondary }]}>
+                  {`You read ${fromLabel} natively, so there is nothing to translate into. Pick a different language in Profile.`}
+                </Text>
+              )}
             </View>
           </View>
         </View>

--- a/apps/mobile/src/context/NativeLanguageContext.tsx
+++ b/apps/mobile/src/context/NativeLanguageContext.tsx
@@ -63,15 +63,12 @@ interface NativeLanguageContextValue {
    * null as false, or they will flash the prompt at every user on every launch.
    */
   hasConfirmedLanguage: boolean | null
-  /** Record that the choice was made without changing the language itself. */
-  markLanguageConfirmed: () => void
 }
 
 const NativeLanguageContext = createContext<NativeLanguageContextValue>({
   nativeLanguage: 'en',
   setNativeLanguage: () => {},
   hasConfirmedLanguage: null,
-  markLanguageConfirmed: () => {},
 })
 
 export function NativeLanguageProvider({ children }: { children: ReactNode }) {
@@ -179,11 +176,6 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.id, user?.nativeLanguage, user?.isGuest])
 
-  const markLanguageConfirmed = useCallback(() => {
-    setConfirmedState(true)
-    AsyncStorage.setItem(CONFIRMED_KEY, '1').catch(() => {})
-  }, [])
-
   const setNativeLanguage = useCallback((code: string) => {
     if (!isSupported(code)) return
     setNativeState(code)
@@ -207,7 +199,7 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
 
   return (
     <NativeLanguageContext.Provider value={{
-      nativeLanguage, setNativeLanguage, hasConfirmedLanguage, markLanguageConfirmed,
+      nativeLanguage, setNativeLanguage, hasConfirmedLanguage,
     }}>
       {children}
     </NativeLanguageContext.Provider>

--- a/apps/mobile/src/context/NativeLanguageContext.tsx
+++ b/apps/mobile/src/context/NativeLanguageContext.tsx
@@ -23,6 +23,8 @@ export const TARGET_LANGUAGES = NATIVE_LANGUAGES.filter((l) => l.code === 'en')
 
 const NATIVE_KEY = 'textstack_native_language'
 const TARGET_KEY = 'textstack_target_language'
+// Same key the web app uses, for the same reason — see `hasConfirmedLanguage`.
+const CONFIRMED_KEY = 'textstack_native_language_confirmed'
 
 function isSupported(code: string): boolean {
   return LANGUAGES.some((l) => l.code === code)
@@ -46,6 +48,22 @@ interface NativeLanguageContextValue {
   targetLanguage: string
   setNativeLanguage: (code: string) => void
   setTargetLanguage: (code: string) => void
+  /**
+   * Whether `nativeLanguage` is something the user actually chose, as opposed to
+   * something we guessed. `nativeLanguage` alone cannot answer this: it is never
+   * empty — it defaults to 'en' and only *maybe* becomes the device locale — so a
+   * reader who has never been asked is indistinguishable from one who genuinely
+   * reads English natively. That ambiguity is the whole bug: a QA account showed
+   * "I know: English / Learning: English" with `nativeLanguage: null` on the
+   * server, and translation quietly became English → English.
+   *
+   * Null while the answer is still being read from AsyncStorage. Callers that
+   * gate UI on "has not chosen yet" must wait for a boolean rather than treating
+   * null as false, or they will flash the prompt at every user on every launch.
+   */
+  hasConfirmedLanguage: boolean | null
+  /** Record that the choice was made without changing the language itself. */
+  markLanguageConfirmed: () => void
 }
 
 const NativeLanguageContext = createContext<NativeLanguageContextValue>({
@@ -53,11 +71,16 @@ const NativeLanguageContext = createContext<NativeLanguageContextValue>({
   targetLanguage: 'en',
   setNativeLanguage: () => {},
   setTargetLanguage: () => {},
+  hasConfirmedLanguage: null,
+  markLanguageConfirmed: () => {},
 })
 
 export function NativeLanguageProvider({ children }: { children: ReactNode }) {
   const [nativeLanguage, setNativeState] = useState('en')
   const [targetLanguage, setTargetState] = useState('en')
+  // null until AsyncStorage answers — see the interface docblock for why the
+  // tri-state matters to callers.
+  const [hasConfirmedLanguage, setConfirmedState] = useState<boolean | null>(null)
   const { user, getAccessToken, updateUser } = useAuth()
   const prevUserIdRef = useRef<string | undefined>(user?.id)
   // Set once the server→local mirror has applied an authoritative value, so the
@@ -69,7 +92,12 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
     Promise.all([
       AsyncStorage.getItem(NATIVE_KEY),
       AsyncStorage.getItem(TARGET_KEY),
-    ]).then(([native, target]) => {
+      AsyncStorage.getItem(CONFIRMED_KEY),
+    ]).then(([native, target, confirmed]) => {
+      // Resolve the tri-state first and unconditionally: a failed read must still
+      // land on `false` (below, in .catch) rather than leaving it null forever,
+      // or anything gated on it hangs.
+      setConfirmedState(confirmed === '1')
       // The signed-in user's server language wins — don't overwrite it with the
       // stale local value just because this async read happened to resolve last.
       if (!serverLangAppliedRef.current) {
@@ -83,7 +111,7 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
       if (target && TARGET_LANGUAGES.some((l) => l.code === target)) {
         setTargetState(target)
       }
-    }).catch(() => {})
+    }).catch(() => { setConfirmedState(false) })
   }, [])
 
   // Server → local: mirror the signed-in user's nativeLanguage into state +
@@ -104,6 +132,12 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
       if (switched) {
         const device = getDeviceLanguage()
         setNativeState(isSupported(device) ? device : 'en')
+        // The value just became a guess again, so the claim that someone chose it
+        // has to go with it — otherwise the next account inherits a confirmation
+        // it never gave and is never asked.
+        setConfirmedState(false)
+        serverLangAppliedRef.current = false
+        AsyncStorage.removeItem(CONFIRMED_KEY).catch(() => {})
       }
       return
     }
@@ -112,13 +146,55 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
     if (!serverLang || !isSupported(serverLang)) return
     serverLangAppliedRef.current = true
     setNativeState(serverLang)   // idempotent — React skips if unchanged
-    AsyncStorage.setItem(NATIVE_KEY, serverLang).catch(() => {})
+    // A value on the server is a choice the user made, on some device, at some
+    // point. Honour it as confirmed so a returning reader is never asked twice.
+    //
+    // Note what is deliberately NOT done here: web marks *any* signed-in user
+    // confirmed even when the server field is empty (apps/web
+    // NativeLanguageContext.tsx:108-114), because there it only silences a pulse
+    // on an icon. Copying that would silence the onboarding prompt for exactly
+    // the users it exists for — the ones the server has no answer for.
+    setConfirmedState(true)
+    AsyncStorage.multiSet([[NATIVE_KEY, serverLang], [CONFIRMED_KEY, '1']]).catch(() => {})
   }, [user?.id, user?.nativeLanguage, user?.isGuest])
+
+  // Local → server, when the server has no answer. Covers the guest who picks a
+  // language and then registers, and the account created before this screen
+  // existed. Reads AsyncStorage rather than state because on the register fast
+  // path `user.id` changes before a just-written state update has flushed.
+  useEffect(() => {
+    if (!user || user.isGuest || user.nativeLanguage) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const [confirmed, stored] = await Promise.all([
+          AsyncStorage.getItem(CONFIRMED_KEY),
+          AsyncStorage.getItem(NATIVE_KEY),
+        ])
+        if (cancelled || confirmed !== '1' || !stored || !isSupported(stored)) return
+        const token = await getAccessToken()
+        if (cancelled || !token) return
+        const res = await authApi.updateProfile(user.name ?? null, token, stored)
+        if (!cancelled && res?.user) await updateUser(res.user)
+      } catch {
+        // Local value stands; the next sign-in retries this same effect.
+      }
+    })()
+    return () => { cancelled = true }
+    // Fires on identity change, not on every local pick.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id, user?.nativeLanguage, user?.isGuest])
+
+  const markLanguageConfirmed = useCallback(() => {
+    setConfirmedState(true)
+    AsyncStorage.setItem(CONFIRMED_KEY, '1').catch(() => {})
+  }, [])
 
   const setNativeLanguage = useCallback((code: string) => {
     if (!isSupported(code)) return
     setNativeState(code)
-    AsyncStorage.setItem(NATIVE_KEY, code).catch(() => {})
+    setConfirmedState(true)
+    AsyncStorage.multiSet([[NATIVE_KEY, code], [CONFIRMED_KEY, '1']]).catch(() => {})
     // Local → server: persist for signed-in (non-guest) users so the pref
     // follows them across devices and matches the web.
     if (user && !user.isGuest) {
@@ -141,7 +217,10 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
   }, [])
 
   return (
-    <NativeLanguageContext.Provider value={{ nativeLanguage, targetLanguage, setNativeLanguage, setTargetLanguage }}>
+    <NativeLanguageContext.Provider value={{
+      nativeLanguage, targetLanguage, setNativeLanguage, setTargetLanguage,
+      hasConfirmedLanguage, markLanguageConfirmed,
+    }}>
       {children}
     </NativeLanguageContext.Provider>
   )

--- a/apps/mobile/src/context/NativeLanguageContext.tsx
+++ b/apps/mobile/src/context/NativeLanguageContext.tsx
@@ -18,11 +18,14 @@ export const NATIVE_LANGUAGES: NativeLang[] = POPULAR_LANGUAGES.map((l) => ({
   label: l.englishName,
 }))
 
-// Target languages = languages with book content
-export const TARGET_LANGUAGES = NATIVE_LANGUAGES.filter((l) => l.code === 'en')
+// There is no TARGET_LANGUAGES any more. It was NATIVE_LANGUAGES.filter(code ===
+// 'en') — one entry — and it backed a Profile row of chips with a single,
+// permanently-selected option. QA read that row as a real setting and concluded
+// the app thought they were learning English. The concept returns when the
+// catalogue has a second language; until then it was state nothing could change
+// and nothing read.
 
 const NATIVE_KEY = 'textstack_native_language'
-const TARGET_KEY = 'textstack_target_language'
 // Same key the web app uses, for the same reason — see `hasConfirmedLanguage`.
 const CONFIRMED_KEY = 'textstack_native_language_confirmed'
 
@@ -45,9 +48,7 @@ function getDeviceLanguage(): string {
 
 interface NativeLanguageContextValue {
   nativeLanguage: string
-  targetLanguage: string
   setNativeLanguage: (code: string) => void
-  setTargetLanguage: (code: string) => void
   /**
    * Whether `nativeLanguage` is something the user actually chose, as opposed to
    * something we guessed. `nativeLanguage` alone cannot answer this: it is never
@@ -68,16 +69,13 @@ interface NativeLanguageContextValue {
 
 const NativeLanguageContext = createContext<NativeLanguageContextValue>({
   nativeLanguage: 'en',
-  targetLanguage: 'en',
   setNativeLanguage: () => {},
-  setTargetLanguage: () => {},
   hasConfirmedLanguage: null,
   markLanguageConfirmed: () => {},
 })
 
 export function NativeLanguageProvider({ children }: { children: ReactNode }) {
   const [nativeLanguage, setNativeState] = useState('en')
-  const [targetLanguage, setTargetState] = useState('en')
   // null until AsyncStorage answers — see the interface docblock for why the
   // tri-state matters to callers.
   const [hasConfirmedLanguage, setConfirmedState] = useState<boolean | null>(null)
@@ -91,9 +89,8 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     Promise.all([
       AsyncStorage.getItem(NATIVE_KEY),
-      AsyncStorage.getItem(TARGET_KEY),
       AsyncStorage.getItem(CONFIRMED_KEY),
-    ]).then(([native, target, confirmed]) => {
+    ]).then(([native, confirmed]) => {
       // Resolve the tri-state first and unconditionally: a failed read must still
       // land on `false` (below, in .catch) rather than leaving it null forever,
       // or anything gated on it hangs.
@@ -107,9 +104,6 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
           const device = getDeviceLanguage()
           if (isSupported(device)) setNativeState(device)
         }
-      }
-      if (target && TARGET_LANGUAGES.some((l) => l.code === target)) {
-        setTargetState(target)
       }
     }).catch(() => { setConfirmedState(false) })
   }, [])
@@ -211,15 +205,9 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
     }
   }, [user, getAccessToken, updateUser])
 
-  const setTargetLanguage = useCallback((code: string) => {
-    setTargetState(code)
-    AsyncStorage.setItem(TARGET_KEY, code).catch(() => {})
-  }, [])
-
   return (
     <NativeLanguageContext.Provider value={{
-      nativeLanguage, targetLanguage, setNativeLanguage, setTargetLanguage,
-      hasConfirmedLanguage, markLanguageConfirmed,
+      nativeLanguage, setNativeLanguage, hasConfirmedLanguage, markLanguageConfirmed,
     }}>
       {children}
     </NativeLanguageContext.Provider>

--- a/apps/mobile/src/hooks/useTargetLanguage.ts
+++ b/apps/mobile/src/hooks/useTargetLanguage.ts
@@ -2,33 +2,43 @@ import { useLanguage } from '../context/LanguageContext'
 import { useNativeLanguage } from '../context/NativeLanguageContext'
 
 /**
- * Resolves the canonical "book language → user native language" pair for
- * translation lookups (and historically dictionary; mobile dropped the
- * dictionary path 2026-05-15, ReviewFeedback in vocabulary still uses it).
+ * The language pair behind every word the reader taps.
  *
- *   fromLang  — the language of the text being consumed (current book / UI
- *               reading language).
- *   toLang    — the language to translate into; user's native when it
- *               differs from the source, otherwise a sensible fallback so
- *               we never translate en → en (which would be a no-op).
+ * Two questions used to share one answer, and the conflation was the bug. They
+ * are not the same question:
  *
- * Centralising this prevents per-component drift — before this hook,
- * TranslationSheet / WordCard each derived the pair differently and some
- * hardcoded `en → uk`. (DictionarySheet was a third caller; removed 2026-05-15
- * when mobile dropped the Free Dictionary API.)
+ *   fromLang          — the language of the text in front of the reader.
+ *   readerLang        — the language to ADDRESS the reader in. Always a real
+ *                       language: an explanation of an English word for an
+ *                       English speaker is written in English, and that is
+ *                       useful.
+ *   translationTarget — the language to translate INTO, or `null` when there is
+ *                       nothing to translate into because the reader already
+ *                       knows the language they are reading.
+ *
+ * The old shape returned a single `toLang` that fell back to `'en'` when native
+ * matched the source. Its docblock claimed this was "a sensible fallback so we
+ * never translate en → en" — the fallback WAS 'en', so an English reader of an
+ * English book got exactly the en → en no-op the comment promised to prevent.
+ * QA found it as a Translation panel with two identical sections both labelled
+ * ENGLISH. `null` cannot be quietly passed to a translate call the way `'en'`
+ * could; that is the point of the change.
+ *
+ * Mirrors web's `resolveTargetLang` (apps/web ReaderHighlights.tsx).
  */
 export function useTargetLanguage(overrideFromLang?: string): {
   fromLang: string
-  toLang: string
+  readerLang: string
+  translationTarget: string | null
 } {
   const { language } = useLanguage()
   const { nativeLanguage } = useNativeLanguage()
 
   const fromLang = overrideFromLang || language
-  const toLang =
-    nativeLanguage !== fromLang
-      ? nativeLanguage
-      : 'en'
 
-  return { fromLang, toLang }
+  return {
+    fromLang,
+    readerLang: nativeLanguage,
+    translationTarget: nativeLanguage !== fromLang ? nativeLanguage : null,
+  }
 }

--- a/apps/mobile/src/lib/languageOnboarding.test.ts
+++ b/apps/mobile/src/lib/languageOnboarding.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { shouldAskForLanguage, type LanguageOnboardingState } from './languageOnboarding'
+
+const base: LanguageOnboardingState = {
+  isAuthenticated: true,
+  isGuest: false,
+  serverNativeLanguage: null,
+  hasConfirmedLanguage: false,
+}
+
+describe('shouldAskForLanguage', () => {
+  it('asks a signed-in user the server has no answer for', () => {
+    // The QA account exactly: registered, `nativeLanguage: null`, never asked.
+    expect(shouldAskForLanguage(base)).toBe(true)
+  })
+
+  it('does not ask a guest', () => {
+    // A guest has no profile row to save the answer into, and gets the prompt
+    // after registering instead.
+    expect(shouldAskForLanguage({ ...base, isGuest: true })).toBe(false)
+  })
+
+  it('does not ask a signed-out visitor', () => {
+    expect(shouldAskForLanguage({ ...base, isAuthenticated: false })).toBe(false)
+  })
+
+  it('does not ask while AsyncStorage has not answered yet', () => {
+    // This is the whole reason `hasConfirmedLanguage` is a tri-state. Reading it
+    // as a boolean shows the prompt for a frame on every cold start, to everyone.
+    expect(shouldAskForLanguage({ ...base, hasConfirmedLanguage: null })).toBe(false)
+  })
+
+  it('does not ask again once the choice was made locally', () => {
+    expect(shouldAskForLanguage({ ...base, hasConfirmedLanguage: true })).toBe(false)
+  })
+
+  it('does not ask when the server already holds an answer', () => {
+    // Chosen on the web, or on another device. Asking again would be a regression
+    // for every existing user.
+    expect(shouldAskForLanguage({ ...base, serverNativeLanguage: 'uk' })).toBe(false)
+  })
+
+  it('treats an empty or blank server value as no answer', () => {
+    // `authApi.updateProfile` documents '' as "clear this field", so an empty
+    // string reaches us as a real value and must not count as a choice.
+    expect(shouldAskForLanguage({ ...base, serverNativeLanguage: '' })).toBe(true)
+    expect(shouldAskForLanguage({ ...base, serverNativeLanguage: '   ' })).toBe(true)
+  })
+
+  it('does not redirect when the prompt is already on screen', () => {
+    // Without this the onboarding route re-triggers its own guard and loops.
+    expect(shouldAskForLanguage({ ...base, alreadyOnboarding: true })).toBe(false)
+  })
+
+  it('server answer wins over a missing local confirmation', () => {
+    // Reinstall: AsyncStorage is empty, the account is years old. Restoring the
+    // language from the server must not come with an interrogation.
+    expect(shouldAskForLanguage({
+      ...base, serverNativeLanguage: 'de', hasConfirmedLanguage: false,
+    })).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/languageOnboarding.ts
+++ b/apps/mobile/src/lib/languageOnboarding.ts
@@ -1,0 +1,43 @@
+/**
+ * One question: should this reader be asked what language they know?
+ *
+ * TextStack's thesis is that you learn a language by reading real books in it.
+ * The native language is the one input that thesis cannot run without — it is
+ * the target of every translation, every gloss, every vocabulary card. The app
+ * shipped without ever asking for it, defaulted to English, and so translated
+ * English into English for every new account. A manual QA pass put it plainly:
+ * "between a broken and an excellent product is one setting nobody asked about".
+ *
+ * The decision lives here rather than in the screen because it is the part that
+ * regresses: five inputs, four of which are asynchronous, and a wrong answer is
+ * either a prompt that nags returning users forever or one that never appears.
+ * `apps/mobile/vitest.config.ts` covers `src/lib/**` only, so a pure function is
+ * also the only shape of this logic that can have tests at all.
+ */
+export interface LanguageOnboardingState {
+  /** Signed in at all. Guests are never asked — they have nowhere to save it. */
+  isAuthenticated: boolean
+  isGuest: boolean
+  /** `user.nativeLanguage` from the server. Null/empty means it never answered. */
+  serverNativeLanguage: string | null | undefined
+  /**
+   * From `NativeLanguageContext`. **Null means "still reading AsyncStorage"** —
+   * not "no". Treating null as false is the flash bug: every launch would show
+   * the prompt for a frame before storage answers.
+   */
+  hasConfirmedLanguage: boolean | null
+  /** Already looking at the prompt. Guards against a re-entrant redirect. */
+  alreadyOnboarding?: boolean
+}
+
+export function shouldAskForLanguage(s: LanguageOnboardingState): boolean {
+  if (!s.isAuthenticated || s.isGuest) return false
+  if (s.alreadyOnboarding) return false
+  // Undecided, not undecided-in-the-negative. Wait for storage.
+  if (s.hasConfirmedLanguage === null) return false
+  if (s.hasConfirmedLanguage) return false
+  // A value on the server is an answer given on some device at some point.
+  // Whitespace is not an answer — the profile endpoint accepts '' as "clear".
+  if (s.serverNativeLanguage && s.serverNativeLanguage.trim() !== '') return false
+  return true
+}

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -118,6 +118,8 @@
   "onboarding": {
     "chooseLanguage": "Choose your language",
     "chooseLanguageSubtitle": "You can change this later in settings",
+    "nativeLanguageTitle": "What language do you know best?",
+    "nativeLanguageSubtitle": "We'll translate into it while you read. You can change it any time in Profile.",
     "learnByReading": "Learn by reading",
     "tapToTranslate": "Tap any word to see its translation",
     "saveWords": "Save words to build your vocabulary",


### PR DESCRIPTION
Closes **P0-2**, **P1-1**, **P3-4** from `docs/qa/reports/2026-08-26-android-manual-pass.md`. Four slices, one branch each.

## Why

A five-minute-old account showed **"I know: English / Learning: English"** while the server said `nativeLanguage: null`. Tapping a word in an English book returned a Translation panel with two identical sections, both labelled ENGLISH.

The tester's summary is the honest framing:

> Between a broken and an excellent product is one setting the app never asks about.

They proved it by setting Ukrainian by hand: the same toolbar that had shown five unlabelled icons then showed `goddess → богиня` inline, plus highlight colours and "+ to vocabulary".

## The four slices

**1. The app can tell a chosen language from a guessed one.** `nativeLanguage` is never empty — it defaults to `'en'` and only *sometimes* becomes the device locale — so a reader who has never been asked is indistinguishable from one who genuinely reads English. Adds `hasConfirmedLanguage`, tri-state because `null` means "AsyncStorage has not answered yet"; reading it as a boolean flashes the prompt at every user on every cold start.

Also adds the **local → server write-back mobile never had**. Web has it (`apps/web/src/context/NativeLanguageContext.tsx:129-139`); mobile hit the same branch and `return`ed.

Deliberately *not* copied from web: marking any signed-in user confirmed even when the server field is empty. There it silences a pulsing icon. Here it would silence the prompt for exactly the users it exists for.

**2. Ask, once, on the way in.** New `app/onboarding/language.tsx`.

- **One question, not two.** The report asked for both halves. `TARGET_LANGUAGES` is `NATIVE_LANGUAGES.filter(code === 'en')` — one entry. A question with one possible answer is not a question; it is the dead "Learning" chip the same report filed separately as P3-4.
- **No skip.** Skipping restores the exact state the screen exists to end. It is not a dead end either — English is one tap at the top of Popular. The difference is that it becomes an answer instead of a silence.
- **Two entry points, one rule.** Registration routes here; a root gate catches accounts made before the screen existed and reinstalls where storage is empty but the profile is old. Both call `shouldAskForLanguage`, because two copies would drift and both failure modes are invisible in review — a returning reader interrogated on every launch, or a new one never asked.

The list moves out of `LanguagePickerModal` into `LanguageList`, shared by the modal and the screen. Copying it would have been the fourth time this repo grew a second implementation of something it already had.

The strings were already there — `en.json` has carried an `onboarding` block with "Choose your language" since before any of this. Adds two keys that name the actual question.

**3. Stop translating a language into itself.** `useTargetLanguage` returned one `toLang` for two different questions. Explaining a word *to* the reader and translating a word *for* the reader are not the same job: the first always has an answer, the second has none when the reader already knows the language.

It fell back to `'en'` under a docblock promising *"a sensible fallback so we never translate en → en"*. The fallback **was** `'en'`.

Now `readerLang` (always real) and `translationTarget` (`null` when there is nothing to translate into). `null` cannot be quietly passed to a translate call the way `'en'` could — that is the point. The sheet says so in words instead of spending a request, and the target label carries an arrow so which side is which is readable.

**4. Delete the "Learning" row and the state behind it.** One permanently-selected chip with nothing to choose. Leaving the orphaned state is how this app grew 13 blocks of chrome above its first book. Git remembers it when the catalogue gets a second language.

## Tests

The decision is a pure function with 9 tests. It has five inputs, four of them asynchronous. `apps/mobile/vitest.config.ts` covers `src/lib/**` only — hooks and components need an RN test harness that does not exist yet — so this is both the highest-value shape and the only testable one.

`npx tsc --noEmit` clean; 133 mobile tests pass.

## Verify on device

New account → asked once → Profile shows the chosen language → tapping a word in an English book returns a real translation, not `ENGLISH / ENGLISH`. Existing account with `nativeLanguage: null` gets the same prompt on next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)