### PR TITLE
Offline stops looking like an empty account

### DIFF
--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -4,7 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useRouter, useFocusEffect } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
 import {
-  libraryApi, readingProgressApi, userBooksApi,
+  libraryApi, readingProgressApi, userBooksApi, isOfflineError,
 } from '@textstack/shared'
 import {
   collectionsApi, buildLibraryEntries, filterEntries, countEntries, sortEntries, entryTitle, entryAuthor,
@@ -17,6 +17,8 @@ import { useToast } from '../../src/context/ToastContext'
 import { useCollectionsVersion } from '../../src/hooks/useCollections'
 import { SkeletonLoader } from '../../src/components/ui/SkeletonLoader'
 import { EmptyState } from '../../src/components/ui/EmptyState'
+import { OfflineBanner } from '../../src/components/ui/OfflineBanner'
+import { getAllCachedBooks } from '../../src/lib/offlineDb'
 import { FirstBookState } from '../../src/components/library/FirstBookState'
 import { LibraryViewSheet, type LibrarySource } from '../../src/components/library/LibraryViewSheet'
 import { LibrarySearch } from '../../src/components/library/LibrarySearch'
@@ -58,6 +60,11 @@ export default function LibraryScreen() {
   const [progressMap, setProgressMap] = useState<Record<string, ReadingProgressDto>>({})
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
+  // Why the list is empty, when it is. Without this the screen cannot tell
+  // "you have no books" from "I could not ask", and it showed the first-run
+  // welcome to an offline reader with twelve books — indistinguishable from
+  // having lost the account.
+  const [loadError, setLoadError] = useState<'offline' | 'failed' | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   // Generation counter guards against:
   //  1. Out-of-order resolution — pull-to-refresh racing a focus-effect
@@ -83,12 +90,35 @@ export default function LibraryScreen() {
       if (myGen !== loadGenRef.current) return // superseded or unmounted
       setLibrary(lib)
       setUserBooks(books)
+      setLoadError(null)
       const map: Record<string, ReadingProgressDto> = {}
       for (const p of progress) map[p.editionId] = p
       setProgressMap(map)
     } catch (e) {
       if (myGen !== loadGenRef.current) return
       console.error('Library load error:', e)
+      const offline = isOfflineError(e)
+      setLoadError(offline ? 'offline' : 'failed')
+      // Offline: fall back to what is genuinely on the device. Downloaded books
+      // carry title and cover in SQLite — the same rehydration app/book/[slug].tsx
+      // has always done. Uploads and saved-but-not-downloaded books are not
+      // cached at all, so the banner says the list is partial rather than
+      // pretending it is whole.
+      if (offline) {
+        try {
+          const cached = await getAllCachedBooks()
+          if (myGen !== loadGenRef.current) return
+          setLibrary(prev => (prev.length > 0 ? prev : cached.map(c => ({
+            editionId: c.editionId,
+            slug: c.slug,
+            title: c.title,
+            language: 'en',
+            coverPath: c.coverPath,
+            createdAt: new Date(c.cachedAt).toISOString(),
+            author: null,
+          }))))
+        } catch { /* cache unavailable — the banner still explains the empty list */ }
+      }
     } finally {
       if (myGen === loadGenRef.current) setLoading(false)
     }
@@ -185,6 +215,22 @@ export default function LibraryScreen() {
     )
   }
 
+  // Nothing to show AND a reason for it — never the welcome screen. `loadError`
+  // is what separates "no books" from "no answer"; conflating them was the bug.
+  if (library.length === 0 && userBooks.length === 0 && loadError) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <EmptyState
+          icon={loadError === 'offline' ? 'cloud-offline-outline' : 'alert-circle-outline'}
+          title={loadError === 'offline' ? t('library.offline.title') : t('library.loadFailed.title')}
+          subtitle={loadError === 'offline' ? t('library.offline.body') : t('library.loadFailed.body')}
+          buttonLabel={t('common.retry')}
+          onButtonPress={() => { setLoading(true); loadData() }}
+        />
+      </View>
+    )
+  }
+
   // Nothing anywhere: one screen, one action. Rendering the lists here would
   // give the user a search box, status tabs, a sort row and a grid toggle for
   // zero books — and a generic "browse the catalog" CTA, which is the wrong
@@ -219,6 +265,9 @@ export default function LibraryScreen() {
   // past to reach their own books.
   const listHeader = (
     <>
+      {/* Above everything, because it changes how the whole list should be read:
+          uploads and saved-but-undownloaded books are not cached at all. */}
+      {loadError === 'offline' && <OfflineBanner message={t('library.offline.partial')} />}
       {resumeList.length > 0 && <ResumeHero pick={resumeList[0]} />}
       {/* Silent until the store is nearly full, so it appears exactly when it
           changes what the reader would do next. The full figure is on Profile. */}

--- a/apps/mobile/app/(tabs)/search.tsx
+++ b/apps/mobile/app/(tabs)/search.tsx
@@ -4,12 +4,13 @@ import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { createBooksApi, getStorageUrl } from '@textstack/shared'
+import { createBooksApi, getStorageUrl, isOfflineError } from '@textstack/shared'
 import type { SearchResult, Edition, Author } from '@textstack/shared'
 import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
 import { fonts } from '../../src/theme/typography'
 import { SkeletonLoader, BookGridSkeleton } from '../../src/components/ui/SkeletonLoader'
+import { OfflineBanner } from '../../src/components/ui/OfflineBanner'
 import { BookCard } from '../../src/components/ui/BookCard'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { trackSearchPerformed } from '../../src/lib/analytics'
@@ -97,6 +98,12 @@ export default function DiscoverScreen() {
   const [authors, setAuthors] = useState<Author[]>([])
   const [catalogStats, setCatalogStats] = useState<{ books: number; authors: number; genres: number } | null>(null)
   const [catalogLoading, setCatalogLoading] = useState(true)
+  // The catalog, "Recently Added" and the author row are each gated on their own
+  // data being non-empty, so a failed fetch made all three vanish and left a
+  // search box and an "Ask the librarian" card with no explanation. Empty and
+  // unreachable are different states and now look different.
+  const [catalogOffline, setCatalogOffline] = useState(false)
+  const [searchOffline, setSearchOffline] = useState(false)
 
   const debouncedQuery = useDebounce(query.trim(), 300)
 
@@ -124,8 +131,11 @@ export default function DiscoverScreen() {
       setBooks(booksRes.items)
       setAuthors(authorsRes.items)
       setCatalogStats({ books: booksRes.total, authors: authorsRes.total, genres: genresRes.total })
+      setCatalogOffline(false)
     }).catch(e => {
-      if (!cancelled) console.error('Catalog fetch failed:', e)
+      if (cancelled) return
+      console.error('Catalog fetch failed:', e)
+      setCatalogOffline(isOfflineError(e))
     })
       .finally(() => { if (!cancelled) setCatalogLoading(false) })
     return () => { cancelled = true }
@@ -172,12 +182,17 @@ export default function DiscoverScreen() {
       // flight. Without this, a slow response for "har" would overwrite
       // the results for "harry" that arrived first.
       if (gen !== searchGenRef.current) return
+      setSearchOffline(false)
       setResults(items)
       saveRecent(q)
       trackSearchPerformed({ query: q, resultsCount: items.length })
     } catch (e) {
       if (gen !== searchGenRef.current) return
       console.error('Search failed:', e)
+      // A search that never reached the server rendered as "No results for
+      // harry" — which reads as a claim about the catalog, not about the
+      // connection, and sends the reader off to doubt their spelling.
+      setSearchOffline(isOfflineError(e))
     } finally {
       if (gen === searchGenRef.current) setLoading(false)
     }
@@ -326,10 +341,20 @@ export default function DiscoverScreen() {
           ))}
         </View>
       ) : results.length === 0 && searched ? (
-        <EmptyState
-          icon="search-outline"
-          title={`${t('search.noResults')} "${query}"`}
-        />
+        searchOffline ? (
+          <EmptyState
+            icon="cloud-offline-outline"
+            title={t('search.offline.title')}
+            subtitle={t('search.offline.body')}
+            buttonLabel={t('common.retry')}
+            onButtonPress={() => doSearch(query)}
+          />
+        ) : (
+          <EmptyState
+            icon="search-outline"
+            title={`${t('search.noResults')} "${query}"`}
+          />
+        )
       ) : searched ? (
         <FlatList
           data={paged}
@@ -369,6 +394,13 @@ export default function DiscoverScreen() {
                 </TouchableOpacity>
               ))}
             </View>
+          )}
+
+          {/* One sentence instead of three silently missing sections. Discover is
+              the only place with nothing cached to fall back on, so it says so
+              rather than rendering a convincing-looking empty page. */}
+          {catalogOffline && !catalogLoading && (
+            <OfflineBanner message={t('search.offline.catalog')} />
           )}
 
           {/* Catalog Stats Bar */}

--- a/apps/mobile/app/book/[slug].tsx
+++ b/apps/mobile/app/book/[slug].tsx
@@ -18,6 +18,7 @@ import {
 } from '../../src/lib/offlineDb'
 import { getLocalProgress } from '../../src/lib/progressStorage'
 import { fonts } from '../../src/theme/typography'
+import { OfflineBanner } from '../../src/components/ui/OfflineBanner'
 import { SkeletonLoader } from '../../src/components/ui/SkeletonLoader'
 
 export default function BookDetailScreen() {
@@ -235,14 +236,7 @@ export default function BookDetailScreen() {
           </View>
         </View>
 
-        {offlineMode && (
-          <View style={[styles.offlineBanner, { backgroundColor: colors.primaryLight, borderColor: colors.primary }]}>
-            <Ionicons name="cloud-offline-outline" size={16} color={colors.primary} />
-            <Text style={[styles.offlineBannerText, { color: colors.primary }]}>
-              You're offline — showing downloaded content only.
-            </Text>
-          </View>
-        )}
+        {offlineMode && <OfflineBanner message="You're offline — showing downloaded content only." />}
 
         {book.description && (
           <Text style={[styles.description, { color: colors.text }]}>{book.description}</Text>
@@ -542,20 +536,4 @@ const styles = StyleSheet.create({
   },
   errorTitle: { fontFamily: fonts.serifBold, fontSize: 20, marginTop: 16, textAlign: 'center' },
   errorBody: { fontFamily: fonts.sans, fontSize: 14, textAlign: 'center', marginTop: 4, maxWidth: 320 },
-  offlineBanner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginHorizontal: 16,
-    marginBottom: 12,
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-    borderRadius: 8,
-    borderWidth: 1,
-  },
-  offlineBannerText: {
-    fontFamily: fonts.sansMedium,
-    fontSize: 13,
-    flex: 1,
-  },
 })

--- a/apps/mobile/src/components/ui/OfflineBanner.tsx
+++ b/apps/mobile/src/components/ui/OfflineBanner.tsx
@@ -1,0 +1,50 @@
+import { View, Text, StyleSheet } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useTheme } from '../../context/ThemeContext'
+import { fonts } from '../../theme/typography'
+
+/**
+ * Says the app is offline and what that means for what is on screen.
+ *
+ * Lifted verbatim out of `app/book/[slug].tsx`, which was the only screen doing
+ * this correctly. Library and Discover both had the information — `safeFetch`
+ * sets `isNetworkError` on every failed request — and both threw it away in a
+ * `console.error`, leaving their lists empty. An offline reader with twelve
+ * books was shown the welcome screen written for someone with none, which is
+ * indistinguishable from having lost the account.
+ *
+ * The message is a prop because the honest sentence differs per screen: the book
+ * screen is showing downloaded content, the library may be showing a subset, and
+ * Discover has nothing to show at all.
+ */
+export function OfflineBanner({ message }: { message: string }) {
+  const { colors } = useTheme()
+  return (
+    <View
+      style={[styles.banner, { backgroundColor: colors.primaryLight, borderColor: colors.primary }]}
+      accessibilityRole="alert"
+    >
+      <Ionicons name="cloud-offline-outline" size={16} color={colors.primary} />
+      <Text style={[styles.text, { color: colors.primary }]}>{message}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  text: {
+    fontFamily: fonts.sansMedium,
+    fontSize: 13,
+    flex: 1,
+  },
+})

--- a/packages/shared/src/api/client.ts
+++ b/packages/shared/src/api/client.ts
@@ -38,6 +38,24 @@ async function safeFetch(input: string, init?: RequestInit): Promise<Response> {
   }
 }
 
+/**
+ * True when a caught error means "the request never reached the server".
+ *
+ * `ApiError.isNetworkError` has been set correctly on every request since it was
+ * added, and its docblock says UIs "can show 'check your connection' instead of
+ * a generic server error". None did. Library, Discover and the book detail
+ * screen all caught, logged to the console, and left their state at `[]` — so an
+ * offline reader with twelve books was shown the empty state written for someone
+ * who has never added one.
+ *
+ * **Check your own abort signal first.** A deliberate cancellation also fails
+ * before reaching the server and is reported here as offline; only the caller
+ * knows it aborted on purpose.
+ */
+export function isOfflineError(e: unknown): boolean {
+  return e instanceof ApiError && e.isNetworkError
+}
+
 export function getStorageUrl(path: string | null | undefined): string | undefined {
   if (!path) return undefined
   // baseUrl is like "https://textstack.app/api" — storage is at origin, not under /api

--- a/packages/shared/src/api/index.ts
+++ b/packages/shared/src/api/index.ts
@@ -1,4 +1,4 @@
-export { initApi, getApiConfig, getStorageUrl, authFetch, publicFetch, ApiError, buildQuery, jsonBody } from './client'
+export { initApi, getApiConfig, getStorageUrl, authFetch, publicFetch, ApiError, isOfflineError, buildQuery, jsonBody } from './client'
 export type { ApiConfig } from './client'
 
 export { createBooksApi } from './books'

--- a/packages/shared/src/api/isOfflineError.test.ts
+++ b/packages/shared/src/api/isOfflineError.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { ApiError, isOfflineError } from './client'
+
+describe('isOfflineError', () => {
+  it('is true for a request that never reached the server', () => {
+    const e = new ApiError(0, 'Network request failed')
+    e.isNetworkError = true
+    expect(isOfflineError(e)).toBe(true)
+  })
+
+  it('is false for a server that answered badly', () => {
+    // 500 means the request arrived. Showing "you're offline" here would send
+    // the reader to check their wifi while the backend is the thing on fire.
+    expect(isOfflineError(new ApiError(500, 'Internal Server Error'))).toBe(false)
+    expect(isOfflineError(new ApiError(404, 'Not Found'))).toBe(false)
+  })
+
+  it('is false for anything that is not an ApiError', () => {
+    expect(isOfflineError(new TypeError('boom'))).toBe(false)
+    expect(isOfflineError('offline')).toBe(false)
+    expect(isOfflineError(null)).toBe(false)
+    expect(isOfflineError(undefined)).toBe(false)
+  })
+})

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -100,7 +100,8 @@
     "save": "Save",
     "saving": "Saving…",
     "cancel": "Cancel",
-    "close": "Close"
+    "close": "Close",
+    "retry": "Try again"
   },
   "nav": {
     "catalog": "Catalog",
@@ -349,6 +350,15 @@
     "storage": {
       "label": "Upload space",
       "nearlyFull": "Almost full — delete a book to free up space"
+    },
+    "offline": {
+      "title": "You're offline",
+      "body": "Your library will be here as soon as you reconnect.",
+      "partial": "You're offline — showing downloaded books only."
+    },
+    "loadFailed": {
+      "title": "Couldn't load your library",
+      "body": "Something went wrong on our side. Your books are safe."
     }
   },
   "addMenu": {
@@ -456,7 +466,12 @@
     "recentSearches": "Recent searches",
     "clearAll": "Clear all",
     "searchPlaceholder": "Search books...",
-    "foundEditions": "Found {total} books"
+    "foundEditions": "Found {total} books",
+    "offline": {
+      "catalog": "You're offline — the catalog needs a connection. Your downloaded books are in Library.",
+      "title": "You're offline",
+      "body": "Search needs a connection. Your downloaded books are in Library."
+    }
   },
   "privacy": {
     "seoTitle": "Privacy Policy — TextStack",


### PR DESCRIPTION
Closes **P0-5** and **P1-3** from `docs/qa/reports/2026-08-26-android-manual-pass.md`.

## The report

> Airplane mode → force-stop → launch → Library. Instead of a list or a cache, `FirstBookState`: *"Your reader is ready. Add a book you already want to finish"* and an "Upload a book" button. The same screen someone sees a minute after registering.
>
> No "you're offline" banner, no retry, no hint that the data simply did not arrive. **Indistinguishable from having lost the account.**

Twelve books in that account.

## The information was already in the app

`safeFetch` has set `isNetworkError` on every failed request since it was added, and the flag's own docblock says UIs "can show 'check your connection' instead of a generic server error". None did — the only mobile file reading it used it to suppress an abort.

The tester even quoted it back from `adb logcat`:

```
E/ReactNativeJS: 'Library load error:', { [ApiError: Network request failed]
                 status: 0, isNetworkError: true, name: 'ApiError' }
```

`library.tsx` caught that, wrote it to the console, and left `library` at `[]` — which falls straight into the `library.length === 0 && userBooks.length === 0` branch. The screen could not tell *no books* from *no answer*, and that conflation is the whole bug.

## What changed

**`isOfflineError` in `packages/shared`**, with a docblock that tells callers to check their own abort signal first — a deliberate cancellation also fails before reaching the server and is reported the same way. Three tests, including a 500: a server that answered badly is not offline, and telling that reader to check their wifi sends them away from the actual problem.

**The banner becomes a component.** `app/book/[slug].tsx` was the one screen doing this correctly — it rehydrates a `BookDetail` from SQLite and says *"You're offline — showing downloaded content only."* Lifted verbatim.

**Library** now distinguishes the two states, and when offline falls back to downloaded books via `getAllCachedBooks()` — the same rehydration the book screen has always done. The banner says **"downloaded books only"** rather than implying the list is complete: uploads and saved-but-undownloaded books are not cached at all, and a convincing-looking partial list is worse than an honest one.

**Discover** has nothing cached to fall back on, so it says so in one sentence instead of dropping three independently-gated sections (catalog, Recently Added, authors) and leaving a search box and an "Ask the librarian" card with no explanation.

**Offline search** rendered as *"No results for harry"* — a claim about the catalog rather than the connection, which sends the reader off to doubt their spelling. Now offline, with a retry.

## Honest limits

Uploads and saved-but-undownloaded books have **no offline representation at all** — nothing persists them. This PR does not add a snapshot cache for them; it makes the banner tell the truth about what is missing. A snapshot of the last successful response would show more and could show stale nonsense, which is a product call worth making deliberately rather than as a side effect of a bug fix.

## Verify on device

Airplane mode → force-stop → launch → Library: downloaded books plus a banner, or a clear offline state with **Try again** — never `FirstBookState`. Discover: one sentence, not three missing sections. Restore the network and pull to refresh: the full library returns.

`tsc` clean; 124 mobile, 306 shared, 737 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)