### PR TITLE
A filter that hides ten books says so, and lets go

### DIFF
--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -34,6 +34,11 @@ import { fonts } from '../../src/theme/typography'
 
 const VIEW_MODE_KEY = 'textstack_library_view'
 
+// Module-level so the identity is stable — a fresh [] each render would
+// invalidate useContinueReadingList's memo on every keystroke.
+const EMPTY_LIBRARY: UserLibraryItem[] = []
+const EMPTY_UPLOADS: UserBookDto[] = []
+
 export default function LibraryScreen() {
   const { isAuthenticated } = useAuth()
   const { colors } = useTheme()
@@ -66,7 +71,15 @@ export default function LibraryScreen() {
   // Set to -1 on unmount so trailing resolutions are dropped (B-10).
   // Must sit above the early returns below — it is a hook, and `loading` /
   // `!isAuthenticated` both bail out before the render body.
-  const resumeList = useContinueReadingList(library, progressMap, userBooks)
+  // The resume card is a lens over the same books, so it obeys the same source
+  // filter. It used to be computed from the unfiltered data and rendered ABOVE
+  // the filter row, so switching to "My uploads" left a catalog book sitting on
+  // top of a list that had just excluded it — the screen contradicting itself.
+  const resumeList = useContinueReadingList(
+    source === 'uploads' ? EMPTY_LIBRARY : library,
+    progressMap,
+    source === 'catalog' ? EMPTY_UPLOADS : userBooks,
+  )
 
   const loadGenRef = useRef(0)
   useEffect(() => () => { loadGenRef.current = -1 }, [])
@@ -217,6 +230,17 @@ export default function LibraryScreen() {
   // Everything above the first book row. Three blocks: resume, search, filters.
   // It used to be thirteen — roughly 2.4 screens of chrome a reader scrolled
   // past to reach their own books.
+  // What "a filter is on" means, in one place. It was implicit before, and the
+  // Clear button only knew about two of the four things that can hide a book.
+  const sourceFiltered = source !== 'all' || activeCollectionId != null
+  const anyFilterActive = sourceFiltered || status !== 'all' || !!debouncedQuery
+  const clearAllFilters = () => {
+    setSource('all')
+    setActiveCollectionId(null)
+    setStatus('all')
+    clearQuery()
+  }
+
   const listHeader = (
     <>
       {resumeList.length > 0 && <ResumeHero pick={resumeList[0]} />}
@@ -233,9 +257,19 @@ export default function LibraryScreen() {
           hitSlop={10}
           style={styles.viewBtn}
           accessibilityRole="button"
-          accessibilityLabel={t('library.view.open')}
+          accessibilityLabel={sourceFiltered ? t('library.view.openFiltered') : t('library.view.open')}
         >
-          <Ionicons name="options-outline" size={20} color={colors.text} />
+          <Ionicons
+            name="options-outline"
+            size={20}
+            color={sourceFiltered ? colors.primary : colors.text}
+          />
+          {/* The only place the active source was ever shown was inside the
+              sheet — which is closed. Ten books vanishing with no visible cause
+              reads as data loss, not as a filter. */}
+          {sourceFiltered && (
+            <View style={[styles.filterDot, { backgroundColor: colors.primary, borderColor: colors.background }]} />
+          )}
         </TouchableOpacity>
       </View>
       {entries.length === 0 && (
@@ -243,12 +277,19 @@ export default function LibraryScreen() {
           <Text style={{ fontFamily: fonts.sans, fontSize: 14, color: colors.textSecondary, textAlign: 'center' }}>
             {debouncedQuery ? t('library.search.empty').replace('{query}', debouncedQuery) : t('library.filter.empty')}
           </Text>
+          {/* Was setStatus('all') and nothing else. With source = "My uploads"
+              and no uploads, the button that says "Clear filter" visibly did
+              nothing at all — a dead end whose only exit was reopening the
+              sheet the reader could not tell was involved. */}
           <TouchableOpacity
-            onPress={() => { if (debouncedQuery) clearQuery(); else setStatus('all') }}
+            onPress={clearAllFilters}
             style={[styles.filterEmptyBtn, { borderColor: colors.border }]}
+            accessibilityRole="button"
           >
             <Text style={{ fontFamily: fonts.sansMedium, fontSize: 13, color: colors.text }}>
-              {debouncedQuery ? t('library.search.clear') : t('library.filter.clear')}
+              {debouncedQuery && !sourceFiltered && status === 'all'
+                ? t('library.search.clear')
+                : t('library.filter.clear')}
             </Text>
           </TouchableOpacity>
         </View>

--- a/apps/mobile/src/components/library/BookList.tsx
+++ b/apps/mobile/src/components/library/BookList.tsx
@@ -236,7 +236,15 @@ export function BookList({
                 onPress={() => router.push(`/reader/${(e as { item: UserLibraryItem }).item.slug}/${continueSlug}`)}
               >
                 <Ionicons name="play" size={12} color="#fff" />
-                <Text style={styles.continueBtnText}>{t('library.resume.continue')}</Text>
+                {/* "Continue" promises to put the reader back where they stopped.
+                    A book at 0% has a chapterSlug the moment the reader opens it
+                    and scrolls nothing, so the promise was made with nowhere to
+                    return to. `library.resume.start` has existed in en.json since
+                    the beginning, unused — the switch was intended and never
+                    wired. */}
+                <Text style={styles.continueBtnText}>
+                  {pct > 0 ? t('library.resume.continue') : t('library.resume.start')}
+                </Text>
               </TouchableOpacity>
             ) : null}
           </View>

--- a/apps/mobile/src/components/library/LibraryStatusTabs.tsx
+++ b/apps/mobile/src/components/library/LibraryStatusTabs.tsx
@@ -68,25 +68,35 @@ export function LibraryStatusTabs({ value, onChange, counts }: Props) {
   )
 }
 
+// Metrics are tight on purpose. The four default tabs plus their counts did not
+// fit the ~367dp left beside the view button on a 411dp phone, so "Not started"
+// sat half off the edge with its counter invisible — and because the row hides
+// its scroll indicator, that reads as clipped rather than scrollable. The header
+// comment above records an earlier attempt to fix this by reordering, which moved
+// the clipping instead of removing it.
+//
+// Trailing padding matters too: a fifth tab appears when an upload fails, and
+// without it the last tab can never scroll clear of the edge.
 const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: 14,
+    gap: 2,
+    paddingLeft: 10,
+    paddingRight: 18,
   },
   tab: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 6,
-    paddingHorizontal: 10,
+    gap: 5,
+    paddingHorizontal: 6,
     paddingVertical: 12,
     borderBottomWidth: 2,
   },
   count: {
     fontFamily: fonts.sansBold,
     fontSize: 11,
-    paddingHorizontal: 6,
+    paddingHorizontal: 4,
     paddingVertical: 1,
     borderRadius: 8,
     overflow: 'hidden',

--- a/apps/mobile/src/components/library/ResumeHero.tsx
+++ b/apps/mobile/src/components/library/ResumeHero.tsx
@@ -59,7 +59,10 @@ export function ResumeHero({ pick }: { pick: ContinueReadingPick }) {
 
         <View style={[styles.cta, { backgroundColor: colors.primary }]}>
           <Ionicons name="play" size={15} color="#fff" />
-          <Text style={styles.ctaText}>{t('library.resume.continue')}</Text>
+          {/* Same promise, same condition — see BookList. */}
+          <Text style={styles.ctaText}>
+            {percent > 0 ? t('library.resume.continue') : t('library.resume.start')}
+          </Text>
         </View>
       </View>
     </PressableScale>

--- a/apps/mobile/src/components/library/shared.ts
+++ b/apps/mobile/src/components/library/shared.ts
@@ -19,6 +19,17 @@ export const styles = StyleSheet.create({
   // else behind the options button on the right.
   controlRow: { flexDirection: 'row', alignItems: 'center' },
   viewBtn: { paddingHorizontal: 12, paddingVertical: 10 },
+  // Small, and on the control that opens the sheet — the reader needs to know a
+  // filter is on, not what it is; the sheet answers that.
+  filterDot: {
+    position: 'absolute',
+    top: 6,
+    right: 8,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    borderWidth: 1.5,
+  },
   container: { flex: 1 },
   center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20, gap: 8 },
   emptyTitle: { fontFamily: fonts.serifBold, fontSize: 22, marginTop: 8 },

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -344,7 +344,8 @@
       "layout": "Layout",
       "grid": "Grid",
       "list": "List",
-      "done": "Done"
+      "done": "Done",
+      "openFiltered": "View options — a filter is active"
     },
     "storage": {
       "label": "Upload space",


### PR DESCRIPTION
Closes **P2-3**, **P2-4**, **P3-3** from `docs/qa/reports/2026-08-26-android-manual-pass.md`, plus one defect QA could not see.

## The report

> View → "My uploads" (0) → Done: the list is empty, the counters are zeroed, "No books match this filter". **What was filtered is not written anywhere. Ten books simply disappeared.** The filter survives switching tabs, and the resume card keeps showing a book the filter excluded — the screen contradicting itself.

## The dead end QA hit but could not diagnose

The way out did not work. `library.tsx:247` called `setStatus('all')` and nothing else — never `source`, never `activeCollectionId`. So in **exactly** the state the tester was in, the button labelled **Clear filter** visibly did nothing at all. The only exit was reopening a sheet they had no reason to associate with the missing books.

One place now knows what "filtered" means and how to undo all four things that can hide a book.

## The rest

**The active filter is visible.** A dot on the control that opens the sheet, and the icon takes the accent colour. The reader needs to know a filter is on; the sheet answers *which*.

**The resume card obeys the source filter.** It was computed from unfiltered data and rendered *above* the filter row. It is a lens over the same books, so it takes the same lens.

**"Continue" on a 0% book (P3-3).** A book gets a `chapterSlug` the moment it is opened, so `continueSlug` was truthy for books the reader had never scrolled — and the button promised to return them where they stopped, with nowhere to return to. `library.resume.start` ("Start reading") has sat in `en.json` unused since the beginning: the switch was intended and never wired.

**The status row did not fit (P2-4).** Four tabs plus counts exceeded the ~367dp left beside the view button on a 411dp phone, so "Not started" sat half off the edge with its counter invisible — and because the row hides its scroll indicator, that reads as *clipped* rather than *scrollable*.

The file's own header comment records an earlier attempt:

> "All" leads because it is the default — pinning it to the right meant the row clipped mid-word ("Not sta…")

That moved the clipping rather than removing it. Tightened metrics so the four default tabs fit, with trailing room so the fifth (failed uploads) can still scroll clear.

## Verify on device

View → My uploads with zero uploads → the dot is visible, **Clear filter** brings all books back. Switch source with a book in progress: the resume card follows the filter instead of contradicting it. A never-opened book reads **Start reading**. At 411dp all four status tabs and their counters are fully visible.

`tsc` clean; 124 mobile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)