### PR TITLE
Vocabulary stops burying the words under the controls

### DIFF
--- a/apps/mobile/app/(tabs)/vocabulary.tsx
+++ b/apps/mobile/app/(tabs)/vocabulary.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import {
   View, Text, StyleSheet, FlatList, TouchableOpacity, TextInput,
-  RefreshControl,
-} from 'react-native'
+  RefreshControl, ScrollView } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter, useFocusEffect } from 'expo-router'
-import { vocabularyApi, getVocabLevel } from '@textstack/shared'
+import { vocabularyApi } from '@textstack/shared'
 import type { VocabularyWordDto, VocabularyStatsDto, PendingVocabWordDto, WordLookupDto } from '@textstack/shared'
 import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
@@ -13,12 +12,13 @@ import { useToast } from '../../src/context/ToastContext'
 import { fonts } from '../../src/theme/typography'
 import { SkeletonLoader } from '../../src/components/ui/SkeletonLoader'
 import { EmptyState } from '../../src/components/ui/EmptyState'
-import { PressableScale } from '../../src/components/ui/PressableScale'
 import { useTts } from '../../src/hooks/useTts'
 import type { ReviewMode } from '../../src/hooks/useVocabularyReview'
 import { ClusterBonusCard } from '../../src/components/vocabulary/ClusterBonusCard'
-import { WeeklyBudgetBar } from '../../src/components/vocabulary/WeeklyBudgetBar'
 import { VocabSettingsModal } from '../../src/components/vocabulary/VocabSettingsModal'
+import { VocabViewSheet } from '../../src/components/vocabulary/VocabViewSheet'
+import { VocabSummaryCard } from '../../src/components/vocabulary/VocabSummaryCard'
+import { buildContextSnippet } from '../../src/lib/contextSnippet'
 
 const STAGE_LABELS = ['New', 'Recognition', 'Recall', 'Context', 'Mastered']
 const STAGE_COLORS = ['#9CA3AF', '#3B82F6', '#F59E0B', '#8B5CF6', '#10B981']
@@ -63,6 +63,7 @@ export default function VocabularyScreen() {
   const [lookupItems, setLookupItems] = useState<WordLookupDto[] | null>(null)
   const [lookupBusyId, setLookupBusyId] = useState<string | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [viewSheetOpen, setViewSheetOpen] = useState(false)
 
   const activeFilter = TABS.find(t => t.key === tab)?.filter
 
@@ -231,25 +232,17 @@ export default function VocabularyScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.background }}>
-      {/* Anti-spiral F5: weekly budget replaces "Review Due: 847" panic number */}
-      {stats?.weeklyProgress && (
-        <>
-          <WeeklyBudgetBar progress={stats.weeklyProgress} />
-          <View style={styles.settingsRow}>
-            <TouchableOpacity
-              onPress={() => setSettingsOpen(true)}
-              style={[styles.settingsBtn, { backgroundColor: colors.surface, borderColor: colors.border }]}
-              accessibilityLabel={t('vocabulary.settings.title')}
-              hitSlop={8}
-            >
-              <Ionicons name="settings-outline" size={14} color={colors.textSecondary} />
-              <Text style={[styles.settingsText, { color: colors.textSecondary, fontFamily: fonts.sans }]}>
-                {t('vocabulary.settings.title')}
-              </Text>
-            </TouchableOpacity>
-          </View>
-        </>
-      )}
+      {/* Three blocks above the first word, not eight — the same treatment
+          Library got. What stays is what changes the next action: one card with
+          the due count and its button, search, and the filter. Everything that
+          only shapes the view is behind the gear. */}
+      <VocabSummaryCard
+        stats={stats}
+        dueCount={dueCount}
+        onPractice={() => router.push(`/vocabulary/review?reviewMode=${reviewMode}`)}
+        onSmartSession={() => router.push('/tutor')}
+        smartSessionLabel={t('tutor.entry.cta')}
+      />
 
       <VocabSettingsModal
         visible={settingsOpen}
@@ -257,74 +250,39 @@ export default function VocabularyScreen() {
         onSaved={() => { offsetRef.current = 0; loadData() }}
       />
 
+      <VocabViewSheet
+        visible={viewSheetOpen}
+        reviewMode={reviewMode}
+        sort={sort}
+        sortOptions={SORT_OPTIONS}
+        stats={stats}
+        onSelectReviewMode={m => setReviewMode(m as ReviewMode)}
+        onSelectSort={k => setSort(k as SortKey)}
+        onOpenSettings={() => setSettingsOpen(true)}
+        onClose={() => setViewSheetOpen(false)}
+      />
+
       {/* Cluster bonus card — only when an active, non-dismissed cluster exists */}
       {stats && (stats.clusterCount ?? 0) > 0 && (
         <ClusterBonusCard onChange={() => { offsetRef.current = 0; loadData() }} />
       )}
 
-      {/* Stats bar */}
-      {stats && (
-        <View style={[styles.statsBar, { borderBottomColor: colors.border }]}>
-          <StatBox label="Total" value={stats.totalWords} />
-          <StatBox label="Due" value={dueCount} color={dueCount > 0 ? colors.primary : undefined} />
-          <StatBox label="Mastered" value={stats.byStage.mastered || 0} color="#10B981" />
-          <StatBox label="Streak" value={stats.streak || 0} color={stats.streak > 0 ? '#F59E0B' : undefined} />
-          {getVocabLevel(stats.byStage.mastered).level > 0 && (
-            <StatBox label="Level" value={getVocabLevel(stats.byStage.mastered).label} color="#8B5CF6" />
-          )}
-          {stats.practicedToday > 0 && <StatBox label="Practiced" value={stats.practicedToday} color={colors.primary} />}
-        </View>
-      )}
+      {/* Search sits above the filter, like Library's. */}
+      <View style={styles.searchSortRow}>
+        <TextInput
+          style={[styles.searchInput, { backgroundColor: colors.surface, borderColor: colors.border, color: colors.text, fontFamily: fonts.sans }]}
+          placeholder="Search words..."
+          placeholderTextColor={colors.textSecondary}
+          value={search}
+          onChangeText={setSearch}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+      </View>
 
-      {/* Mode selector + Review/Practice buttons */}
-      {stats && stats.totalWords > 0 && (
-        <>
-          <View style={[styles.modeToggle, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-            {(['blitz', 'classic'] as ReviewMode[]).map(m => (
-              <PressableScale
-                key={m}
-                onPress={() => setReviewMode(m)}
-                style={[styles.modeToggleItem, reviewMode === m && { backgroundColor: colors.primary }]}
-              >
-                <Ionicons
-                  name={m === 'blitz' ? 'flash' : 'layers'}
-                  size={14}
-                  color={reviewMode === m ? '#fff' : colors.textSecondary}
-                />
-                <Text style={[styles.modeToggleText, { color: reviewMode === m ? '#fff' : colors.textSecondary }]}>
-                  {m === 'blitz' ? 'Blitz' : 'Flashcards'}
-                </Text>
-              </PressableScale>
-            ))}
-          </View>
-          <View style={styles.reviewRow}>
-            {dueCount > 0 && (
-              <TouchableOpacity
-                style={[styles.reviewBtn, { backgroundColor: colors.primary, flex: 1 }]}
-                onPress={() => router.push(`/vocabulary/review?reviewMode=${reviewMode}`)}
-              >
-                <Ionicons name="school-outline" size={18} color="#fff" style={{ marginRight: 6 }} />
-                <Text style={[styles.reviewBtnText, { fontFamily: fonts.sansMedium }]}>Practice ({dueCount})</Text>
-              </TouchableOpacity>
-            )}
-            {/* Smart session — AI tutor plans what to study and explains why (signed-in only; vocab tab is) */}
-            <TouchableOpacity
-              style={[styles.reviewBtn, { backgroundColor: colors.surface, borderColor: colors.primary, borderWidth: 1, flex: 1 }]}
-              onPress={() => router.push('/tutor')}
-              accessibilityRole="button"
-              accessibilityLabel={t('tutor.entry.cta')}
-            >
-              <Ionicons name="sparkles-outline" size={18} color={colors.primary} style={{ marginRight: 6 }} />
-              <Text style={[styles.reviewBtnText, { color: colors.primary, fontFamily: fonts.sansMedium }]}>
-                {t('tutor.entry.cta')}
-              </Text>
-            </TouchableOpacity>
-          </View>
-        </>
-      )}
-
-      {/* Filter tabs */}
-      <View style={styles.tabs}>
+      {/* Filter tabs + the one entry to everything else */}
+      <View style={styles.tabsRow}>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.tabs}>
         {TABS.map(t => (
           <TouchableOpacity
             key={t.key}
@@ -336,32 +294,16 @@ export default function VocabularyScreen() {
             </Text>
           </TouchableOpacity>
         ))}
-      </View>
-
-      {/* Search + Sort row */}
-      <View style={styles.searchSortRow}>
-        <TextInput
-          style={[styles.searchInput, { backgroundColor: colors.surface, borderColor: colors.border, color: colors.text, fontFamily: fonts.sans }]}
-          placeholder="Search words..."
-          placeholderTextColor={colors.textSecondary}
-          value={search}
-          onChangeText={setSearch}
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-        <View style={styles.sortRow}>
-          {SORT_OPTIONS.map(s => (
-            <TouchableOpacity
-              key={s.key}
-              onPress={() => setSort(s.key)}
-              style={[styles.sortChip, sort === s.key && { backgroundColor: colors.primaryLight }]}
-            >
-              <Text style={[styles.sortText, { color: sort === s.key ? colors.primary : colors.textSecondary, fontFamily: fonts.sans }]}>
-                {s.label}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+      </ScrollView>
+        <TouchableOpacity
+          onPress={() => setViewSheetOpen(true)}
+          hitSlop={10}
+          style={styles.viewBtn}
+          accessibilityRole="button"
+          accessibilityLabel="View options"
+        >
+          <Ionicons name="options-outline" size={20} color={colors.text} />
+        </TouchableOpacity>
       </View>
 
       {tab === 'lookups' ? (
@@ -512,32 +454,19 @@ export default function VocabularyScreen() {
   )
 }
 
-function StatBox({ label, value, color }: { label: string; value: number | string; color?: string }) {
-  const { colors } = useTheme()
-  return (
-    <View style={styles.statBox}>
-      <Text style={[styles.statValue, { color: color || colors.text, fontFamily: fonts.serifBold }]}>{value}</Text>
-      <Text style={[styles.statLabel, { color: colors.textSecondary, fontFamily: fonts.sans }]}>{label}</Text>
-    </View>
-  )
-}
 
 function ContextSnippet({ sentence, word }: { sentence: string; word: string }) {
   const { colors } = useTheme()
-  const lower = sentence.toLowerCase()
-  const idx = lower.indexOf(word.toLowerCase())
-  if (idx === -1) {
-    return <Text style={[styles.contextText, { color: colors.textSecondary }]} numberOfLines={1}>{sentence}</Text>
-  }
-  const before = sentence.slice(0, idx)
-  const match = sentence.slice(idx, idx + word.length)
-  const after = sentence.slice(idx + word.length)
-  // Trim to ~35 chars each side
-  const trimBefore = before.length > 35 ? '...' + before.slice(-35) : before
-  const trimAfter = after.length > 35 ? after.slice(0, 35) + '...' : after
+  const snippet = buildContextSnippet(sentence, word)
+  // No snippet means the word is not in the stored text. Printing the paragraph
+  // head anyway — which is what this did — shows a quote that does not contain
+  // the word it belongs to. The caller shows the translation instead.
+  if (!snippet) return null
   return (
     <Text style={[styles.contextText, { color: colors.textSecondary }]} numberOfLines={1}>
-      {trimBefore}<Text style={{ fontFamily: fonts.sansBold, color: colors.text }}>{match}</Text>{trimAfter}
+      {snippet.before}
+      <Text style={{ fontFamily: fonts.sansBold, color: colors.text }}>{snippet.match}</Text>
+      {snippet.after}
     </Text>
   )
 }
@@ -589,11 +518,16 @@ function WordRow({
         </TouchableOpacity>
         <View style={{ flex: 1 }}>
           <Text style={[styles.wordText, { color: colors.text, fontFamily: fonts.sansMedium }]}>{word.word}</Text>
-          {word.sentence && !expanded ? (
-            <ContextSnippet sentence={word.sentence} word={word.word} />
-          ) : word.translation && !editField ? (
+          {/* Both, not either. This was an either/or, so a word with a stored
+              sentence never showed its translation in the collapsed row — the
+              translation is the reason the word was saved, and it was the one
+              thing missing. The quote comes second because it is context. */}
+          {word.translation && !editField && (
             <Text style={[styles.wordTranslation, { color: colors.textSecondary, fontFamily: fonts.sans }]} numberOfLines={1}>{word.translation}</Text>
-          ) : null}
+          )}
+          {word.sentence && !expanded && (
+            <ContextSnippet sentence={word.sentence} word={word.word} />
+          )}
         </View>
         {!expanded && (
           <View style={[styles.stageBadge, { backgroundColor: stageColor + '20' }]}>
@@ -689,39 +623,15 @@ const styles = StyleSheet.create({
   emptyText: { fontSize: 16, textAlign: 'center' },
   emptySubtext: { fontSize: 13, marginTop: 4, textAlign: 'center' },
 
-  settingsRow: { flexDirection: 'row', justifyContent: 'flex-end', paddingHorizontal: 16, marginTop: 6 },
-  settingsBtn: {
-    flexDirection: 'row', alignItems: 'center', gap: 6,
-    paddingHorizontal: 10, paddingVertical: 6,
-    borderRadius: 14, borderWidth: 1,
-  },
-  settingsText: { fontSize: 11 },
 
   // Stats
-  statsBar: {
-    flexDirection: 'row',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    gap: 12,
-    borderBottomWidth: 1,
-  },
-  statBox: { flex: 1, alignItems: 'center' },
   statValue: { fontSize: 20 },
   statLabel: { fontSize: 11, marginTop: 2 },
 
   // Mode toggle
-  modeToggle: { flexDirection: 'row', marginHorizontal: 16, marginTop: 12, borderRadius: 10, borderWidth: 1, overflow: 'hidden' },
-  modeToggleItem: { flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6, paddingVertical: 10, borderRadius: 9 },
-  modeToggleText: { fontSize: 14, fontFamily: 'Inter-Medium' },
   // Context snippet
   contextText: { fontSize: 12, fontFamily: 'Inter-Regular', marginTop: 2 },
   // Review buttons
-  reviewRow: {
-    flexDirection: 'row',
-    paddingHorizontal: 16,
-    marginTop: 8,
-    gap: 8,
-  },
   reviewBtn: {
     paddingVertical: 12,
     borderRadius: 8,
@@ -732,6 +642,8 @@ const styles = StyleSheet.create({
   reviewBtnText: { color: '#fff', fontSize: 15 },
 
   // Tabs
+  tabsRow: { flexDirection: 'row', alignItems: 'center' },
+  viewBtn: { paddingHorizontal: 12, paddingVertical: 10 },
   tabs: {
     flexDirection: 'row',
     paddingHorizontal: 16,
@@ -756,9 +668,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     fontSize: 14,
   },
-  sortRow: { flexDirection: 'row', gap: 6, marginTop: 8 },
-  sortChip: { paddingHorizontal: 10, paddingVertical: 4, borderRadius: 12 },
-  sortText: { fontSize: 12 },
 
   // List
   listContent: { paddingBottom: 20 },

--- a/apps/mobile/src/components/vocabulary/VocabSummaryCard.tsx
+++ b/apps/mobile/src/components/vocabulary/VocabSummaryCard.tsx
@@ -1,0 +1,103 @@
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useTheme } from '../../context/ThemeContext'
+import { fonts } from '../../theme/typography'
+import { getVocabLevel } from '@textstack/shared'
+import type { VocabularyStatsDto } from '@textstack/shared'
+
+/**
+ * One card that says what to do next, replacing four blocks that said how
+ * things are going.
+ *
+ * It stands in for the stats tiles (Total / Due / Mastered / Streak / Level /
+ * Practiced), the two large buttons, and the weekly budget bar — roughly half
+ * the chrome QA counted above the first word. The tiles were not wrong, they
+ * were just answering a question nobody had asked yet: a reader opening this
+ * screen wants to review, and only then wants to know how it is going.
+ *
+ * So the count of due words is the headline, practising them is the button, and
+ * the rest is one quiet line underneath. Numbers that do not change the next
+ * action do not get a tile.
+ */
+
+interface Props {
+  stats: VocabularyStatsDto | null
+  dueCount: number
+  onPractice: () => void
+  onSmartSession: () => void
+  smartSessionLabel: string
+}
+
+export function VocabSummaryCard({ stats, dueCount, onPractice, onSmartSession, smartSessionLabel }: Props) {
+  const { colors } = useTheme()
+  if (!stats || stats.totalWords === 0) return null
+
+  const mastered = stats.byStage.mastered || 0
+  const level = getVocabLevel(mastered)
+
+  // Only what a reader would act on. A streak of zero is not an achievement to
+  // report, and a level of zero is not a level.
+  const facts = [
+    `${stats.totalWords} saved`,
+    mastered > 0 ? `${mastered} mastered` : null,
+    stats.streak > 0 ? `${stats.streak}-day streak` : null,
+    level.level > 0 ? level.label : null,
+  ].filter(Boolean).join(' · ')
+
+  return (
+    <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+      <Text style={[styles.headline, { color: colors.text }]}>
+        {dueCount > 0 ? `${dueCount} ${dueCount === 1 ? 'word' : 'words'} to review` : 'Nothing due right now'}
+      </Text>
+      <Text style={[styles.facts, { color: colors.textSecondary }]} numberOfLines={1}>{facts}</Text>
+
+      <View style={styles.actions}>
+        {dueCount > 0 && (
+          <TouchableOpacity
+            style={[styles.primary, { backgroundColor: colors.primary }]}
+            onPress={onPractice}
+            accessibilityRole="button"
+          >
+            <Ionicons name="school-outline" size={17} color="#fff" />
+            <Text style={styles.primaryText}>Practice</Text>
+          </TouchableOpacity>
+        )}
+        <TouchableOpacity
+          style={[styles.secondary, { borderColor: colors.primary }]}
+          onPress={onSmartSession}
+          accessibilityRole="button"
+          accessibilityLabel={smartSessionLabel}
+        >
+          <Ionicons name="sparkles-outline" size={16} color={colors.primary} />
+          <Text style={[styles.secondaryText, { color: colors.primary }]} numberOfLines={1}>
+            {smartSessionLabel}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginHorizontal: 14,
+    marginTop: 10,
+    marginBottom: 4,
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  headline: { fontFamily: fonts.serifBold, fontSize: 19 },
+  facts: { fontFamily: fonts.sans, fontSize: 12, marginTop: 3 },
+  actions: { flexDirection: 'row', gap: 8, marginTop: 12 },
+  primary: {
+    flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
+    gap: 6, paddingVertical: 11, borderRadius: 8,
+  },
+  primaryText: { fontFamily: fonts.sansMedium, fontSize: 15, color: '#fff' },
+  secondary: {
+    flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
+    gap: 6, paddingVertical: 11, borderRadius: 8, borderWidth: 1,
+  },
+  secondaryText: { fontFamily: fonts.sansMedium, fontSize: 14 },
+})

--- a/apps/mobile/src/components/vocabulary/VocabViewSheet.tsx
+++ b/apps/mobile/src/components/vocabulary/VocabViewSheet.tsx
@@ -1,0 +1,164 @@
+import { Modal, Pressable, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useTheme } from '../../context/ThemeContext'
+import { fonts } from '../../theme/typography'
+import type { VocabularyStatsDto } from '@textstack/shared'
+import { WeeklyBudgetBar } from './WeeklyBudgetBar'
+
+/**
+ * Every control that shapes the word list, behind one entry.
+ *
+ * The screen used to put eight blocks between the reader and their first word:
+ * a weekly budget bar, a settings chip, four to six stat tiles, an unlabelled
+ * two-colour segment (it was a review-mode switch), two large buttons, six
+ * filter chips, a search box and four sort chips — with "Mastered" wrapping to
+ * a second line. QA counted them and pointed out this is the same illness
+ * Library was treated for.
+ *
+ * Same treatment, then. What stays on the screen is what changes the next
+ * action: one primary CTA, search, and the filter. Everything that only shapes
+ * the view moves in here, and `LibraryViewSheet` is the model — down to the
+ * grabber, the Done affordance and the checkmark on the active row.
+ */
+
+export type ReviewModeKey = 'blitz' | 'classic'
+
+interface Props {
+  visible: boolean
+  reviewMode: ReviewModeKey
+  sort: string
+  sortOptions: readonly { key: string; label: string }[]
+  stats: VocabularyStatsDto | null
+  onSelectReviewMode: (next: ReviewModeKey) => void
+  onSelectSort: (next: string) => void
+  onOpenSettings: () => void
+  onClose: () => void
+}
+
+function SectionHeading({ children }: { children: string }) {
+  const { colors } = useTheme()
+  return <Text style={[styles.heading, { color: colors.textSecondary }]}>{children.toUpperCase()}</Text>
+}
+
+function Row({
+  icon, label, hint, active, onPress,
+}: {
+  icon: keyof typeof Ionicons.glyphMap
+  label: string
+  hint?: string
+  active?: boolean
+  onPress: () => void
+}) {
+  const { colors } = useTheme()
+  return (
+    <TouchableOpacity
+      style={[styles.row, active && { backgroundColor: colors.primaryLight }]}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityState={{ selected: !!active }}
+    >
+      <Ionicons name={icon} size={18} color={active ? colors.primary : colors.textSecondary} />
+      <View style={{ flex: 1 }}>
+        <Text style={[styles.label, { color: active ? colors.primary : colors.text }]} numberOfLines={1}>
+          {label}
+        </Text>
+        {hint && (
+          <Text style={[styles.hint, { color: colors.textSecondary }]} numberOfLines={1}>{hint}</Text>
+        )}
+      </View>
+      {active && <Ionicons name="checkmark" size={18} color={colors.primary} />}
+    </TouchableOpacity>
+  )
+}
+
+export function VocabViewSheet({
+  visible, reviewMode, sort, sortOptions, stats,
+  onSelectReviewMode, onSelectSort, onOpenSettings, onClose,
+}: Props) {
+  const { colors } = useTheme()
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose} accessibilityLabel="Close view options" />
+      <View style={[styles.sheet, { backgroundColor: colors.background }]}>
+        <View style={[styles.grabber, { backgroundColor: colors.border }]} />
+        <View style={styles.header}>
+          <Text style={[styles.title, { color: colors.text }]}>View</Text>
+          <TouchableOpacity onPress={onClose} hitSlop={10} accessibilityRole="button" accessibilityLabel="Done">
+            <Text style={[styles.done, { color: colors.primary }]}>Done</Text>
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 32 }}>
+          <SectionHeading>Review style</SectionHeading>
+          {/* The old segment showed two icons and two words in a filled bar with
+              no heading, which QA read as "an unnamed orange strip". Naming what
+              it chooses between costs one line. */}
+          <Row
+            icon="flash"
+            label="Blitz"
+            hint="Multiple choice, fast"
+            active={reviewMode === 'blitz'}
+            onPress={() => onSelectReviewMode('blitz')}
+          />
+          <Row
+            icon="layers"
+            label="Flashcards"
+            hint="Recall, then grade yourself"
+            active={reviewMode === 'classic'}
+            onPress={() => onSelectReviewMode('classic')}
+          />
+
+          <SectionHeading>Sort</SectionHeading>
+          {sortOptions.map(s => (
+            <Row
+              key={s.key}
+              icon="swap-vertical-outline"
+              label={s.label}
+              active={sort === s.key}
+              onPress={() => onSelectSort(s.key)}
+            />
+          ))}
+
+          {stats?.weeklyProgress && (
+            <>
+              <SectionHeading>This week</SectionHeading>
+              <View style={styles.budgetWrap}>
+                <WeeklyBudgetBar progress={stats.weeklyProgress} />
+              </View>
+            </>
+          )}
+
+          <SectionHeading>Settings</SectionHeading>
+          <Row
+            icon="settings-outline"
+            label="Daily cap and reminders"
+            onPress={() => { onClose(); onOpenSettings() }}
+          />
+        </ScrollView>
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  backdrop: { ...StyleSheet.absoluteFillObject, backgroundColor: 'rgba(0,0,0,0.4)' },
+  sheet: {
+    position: 'absolute', left: 0, right: 0, bottom: 0,
+    maxHeight: '80%',
+    borderTopLeftRadius: 20, borderTopRightRadius: 20,
+    paddingHorizontal: 12, paddingTop: 10,
+  },
+  grabber: { width: 36, height: 4, borderRadius: 2, alignSelf: 'center', marginBottom: 10 },
+  header: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: 8, paddingBottom: 8,
+  },
+  title: { fontFamily: fonts.serifBold, fontSize: 20 },
+  done: { fontFamily: fonts.sansMedium, fontSize: 15 },
+  heading: { fontFamily: fonts.sansMedium, fontSize: 11, letterSpacing: 0.6, paddingHorizontal: 12, paddingTop: 14, paddingBottom: 6 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 11, paddingHorizontal: 12, borderRadius: 8 },
+  label: { fontFamily: fonts.sansMedium, fontSize: 15 },
+  hint: { fontFamily: fonts.sans, fontSize: 12, marginTop: 1 },
+  budgetWrap: { paddingHorizontal: 4 },
+})

--- a/apps/mobile/src/lib/contextSnippet.test.ts
+++ b/apps/mobile/src/lib/contextSnippet.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { buildContextSnippet, SNIPPET_PREFIX_CHARS } from './contextSnippet'
+
+// The paragraph QA actually saved from — Dryden's Aeneid, stored as a block of
+// prose because extractSentence takes 500 characters of the block ancestor
+// rather than a sentence.
+const PARAGRAPH =
+  "O Muse! the causes and the crimes relate; What goddess was provok'd, and whence her hate; " +
+  "For what offense the Queen of Heav'n began To persecute so brave, so just a man."
+
+describe('buildContextSnippet', () => {
+  it('keeps the word visible when it sits deep in a paragraph', () => {
+    // The reported bug: the row showed "…d the crimes relate;…" and no goddess.
+    const s = buildContextSnippet(PARAGRAPH, 'goddess')
+    expect(s).not.toBeNull()
+    expect(s!.match).toBe('goddess')
+    expect(s!.before.length).toBeLessThanOrEqual(SNIPPET_PREFIX_CHARS + 1) // +1 for the ellipsis
+  })
+
+  it('spends its budget forward, not backward', () => {
+    // Reading continues to the right, so that is where the useful context is.
+    const s = buildContextSnippet(PARAGRAPH, 'goddess')!
+    expect(s.after.length).toBeGreaterThan(s.before.length)
+    expect(s.after).toContain('provok')
+  })
+
+  it('returns null rather than quoting a fragment without the word', () => {
+    // The old code printed the head of the paragraph, so the row showed a quote
+    // that did not contain the word it belonged to. Null lets the caller fall
+    // back to the translation, which is always true.
+    expect(buildContextSnippet(PARAGRAPH, 'aeneas')).toBeNull()
+  })
+
+  it('matches regardless of case', () => {
+    expect(buildContextSnippet('The Queen of Heaven began', 'queen')!.match).toBe('Queen')
+  })
+
+  it('does not trim a sentence that already fits', () => {
+    const s = buildContextSnippet('A short line with goddess in it', 'goddess')!
+    expect(s.before).not.toContain('…')
+    expect(s.after).not.toContain('…')
+  })
+
+  it('handles a word at the very start', () => {
+    const s = buildContextSnippet('Goddess of the dawn, and other matters entirely', 'goddess')!
+    expect(s.before).toBe('')
+    expect(s.match).toBe('Goddess')
+  })
+
+  it('handles missing input without throwing', () => {
+    expect(buildContextSnippet(null, 'x')).toBeNull()
+    expect(buildContextSnippet('x', null)).toBeNull()
+    expect(buildContextSnippet('', '')).toBeNull()
+  })
+})

--- a/apps/mobile/src/lib/contextSnippet.ts
+++ b/apps/mobile/src/lib/contextSnippet.ts
@@ -1,0 +1,75 @@
+/**
+ * The one-line quote shown under a saved word.
+ *
+ * QA saved "goddess" from *"What goddess was provok'd…"* and the list showed
+ * `goddess / …d the crimes relate;…` — a fragment from elsewhere in the
+ * paragraph, not containing the word, with no translation. Two arithmetic bugs
+ * and one either/or:
+ *
+ * 1. The old code allotted **35 characters on each side** of the match. At 12px
+ *    on a phone row with `numberOfLines={1}`, thirty-five characters of prefix
+ *    plus an ellipsis already fill the line — so the word itself, bolded and
+ *    supposedly the point of the quote, was pushed off the right edge before it
+ *    could render. The prefix has to be short enough that the match survives.
+ *
+ * 2. The stored "sentence" is not a sentence. `extractSentence` in readerBridge
+ *    returns the first 500 characters of the block ancestor, so it is usually a
+ *    whole paragraph, and a word saved from its third sentence sat far outside
+ *    any 35-character window.
+ *
+ * 3. When the match could not be found at all the old code printed the raw
+ *    paragraph head — a quote that does not contain the word it belongs to.
+ *    Returning null lets the caller show the translation instead, which is
+ *    always true.
+ */
+
+export interface ContextSnippet {
+  before: string
+  match: string
+  after: string
+}
+
+/** Characters of lead-in. Short on purpose — see (1). */
+export const SNIPPET_PREFIX_CHARS = 14
+/** Total characters of context around the match. */
+export const SNIPPET_TOTAL_CHARS = 56
+
+export function buildContextSnippet(
+  sentence: string | null | undefined,
+  word: string | null | undefined,
+  opts: { prefixChars?: number; totalChars?: number } = {},
+): ContextSnippet | null {
+  if (!sentence || !word) return null
+  const prefixChars = opts.prefixChars ?? SNIPPET_PREFIX_CHARS
+  const totalChars = opts.totalChars ?? SNIPPET_TOTAL_CHARS
+
+  const idx = sentence.toLowerCase().indexOf(word.toLowerCase())
+  if (idx === -1) return null
+
+  const match = sentence.slice(idx, idx + word.length)
+  const rawBefore = sentence.slice(0, idx)
+  const rawAfter = sentence.slice(idx + word.length)
+
+  // Fits whole — trimming here would add ellipses to a line that never needed
+  // them, which is noise pretending to be information.
+  if (sentence.length <= totalChars) return { before: rawBefore, match, after: rawAfter }
+
+  let before = rawBefore
+  if (before.length > prefixChars) {
+    // Cut at a word boundary where one is close, so the quote does not start
+    // mid-syllable.
+    const cut = before.length - prefixChars
+    const space = before.indexOf(' ', cut)
+    before = '…' + before.slice(space !== -1 && space - cut <= 6 ? space + 1 : cut)
+  }
+
+  // Whatever the match and the lead-in did not use goes forward — reading
+  // continues to the right, so that is where the useful context is.
+  const afterBudget = Math.max(0, totalChars - before.length - match.length)
+  let after = rawAfter
+  if (after.length > afterBudget) {
+    after = after.slice(0, afterBudget).replace(/\s+\S*$/, '') + '…'
+  }
+
+  return { before, match, after }
+}


### PR DESCRIPTION
Closes **P2-9** and **P2-10** from `docs/qa/reports/2026-08-26-android-manual-pass.md`.

## The report

> **Vocabulary: eight blocks of chrome above one word.** A weekly budget, a settings chip, four stat tiles, an unnamed orange strip, two large buttons, six filter chips, search, four sort chips — and only then the single word. The "Mastered" chip wraps to two lines. **This is exactly the illness Library was treated for.**

They were right, including about the treatment.

## Three blocks, not eight

What stays is what changes the next action:

1. **A card that says what to do** — the due count as the headline, Practice as the button, Smart session beside it.
2. **Search.**
3. **The filter**, with a gear for everything else.

Review style, sort, the weekly budget and settings move into a `VocabViewSheet` built from `LibraryViewSheet` — same grabber, same Done, same checkmark on the active row.

The "unnamed orange strip" was the Blitz/Flashcards switch: two icons and two words in a filled bar with no heading. In the sheet it is two rows under **Review style**, each with a line saying what it does. Naming what a control chooses between costs one line.

The stat tiles were not *wrong*, they were answering a question nobody had asked yet. Someone opening this screen wants to review; how it is going comes second. Total, mastered, streak and level are one quiet line under the headline now, and only when non-zero — a streak of zero is not an achievement to report.

## The word row (P2-10)

> Saved "goddess" / "богиня" from *"What goddess was provok'd…"*. The list shows: `goddess / …d the crimes relate;…` — the wrong fragment, the word is not in it, no translation.

Three separate faults:

**The prefix ate the line.** 35 characters were allotted each side of the match. At 12px with `numberOfLines={1}` on a phone row, thirty-five characters plus an ellipsis already fill it — so the bolded word, the entire point of the quote, was pushed off the right edge before it could render.

**The "sentence" is a paragraph.** `extractSentence` returns the first 500 characters of the block ancestor, so a word saved from the third sentence sat far outside any 35-character window.

**No match meant printing the paragraph head** — a quote that does not contain the word it belongs to. It now returns null and the caller falls back to the translation, which is always true.

**And the translation was never shown.** The row was an either/or: any word *with* a sentence never displayed its translation. The translation is the reason the word was saved. Now both.

The snippet is a pure function with 7 tests, using the actual paragraph from the report.

## Also

Removes what the collapse orphaned: one component, three imports, eleven styles. −164/+73 in the screen itself. Leaving them behind is how the screen grew eight blocks in the first place.

## Verify on device

Vocabulary with one saved word: the word is visible without scrolling, under a card, a search box and the filter row. The row shows the translation and a quote that contains the word. The gear opens Review style / Sort / This week / Settings.

`tsc` clean; 161 mobile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
