### PR TITLE
An uploaded EPUB opens on the book, not on its own index

### DIFF
--- a/apps/mobile/src/components/reader/PdfReaderChrome.tsx
+++ b/apps/mobile/src/components/reader/PdfReaderChrome.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { View, Text, TextInput, TouchableOpacity, StyleSheet, Animated, Keyboard } from 'react-native'
+import { useRef, useState } from 'react'
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, Animated, Keyboard, PanResponder } from 'react-native'
 import { fonts } from '../../theme/typography'
 
 interface Props {
@@ -31,15 +31,65 @@ export function PdfReaderChrome({
   bottomInset, currentPage, numPages, onJumpToPage,
 }: Props) {
   const [pageInput, setPageInput] = useState('')
+  const [typing, setTyping] = useState(false)
+  // Page under the finger while dragging. Null when not dragging, so the counter
+  // falls back to where the viewer actually is.
+  const [scrubPage, setScrubPage] = useState<number | null>(null)
+  const trackWidthRef = useRef(0)
+  // Where the drag started, in track coordinates. PanResponder's moveX is a
+  // SCREEN coordinate while locationX is relative to the view, so mixing them
+  // offsets every drag by the track's position on screen.
+  const grantXRef = useRef(0)
+  // The side effect on release reads this, not the state setter — running an
+  // effect inside a state updater fires twice under StrictMode.
+  const scrubPageRef = useRef<number | null>(null)
 
   const submit = () => {
     const n = parseInt(pageInput, 10)
     if (Number.isFinite(n) && n >= 1) onJumpToPage(n) // viewer clamps overflow
     setPageInput('')
+    setTyping(false)
     Keyboard.dismiss()
   }
 
-  const fraction = numPages >= 1 ? Math.min(1, currentPage / numPages) : 0
+  const pageAt = (x: number) => {
+    const w = trackWidthRef.current
+    if (!w || numPages < 1) return 1
+    const f = Math.max(0, Math.min(1, x / w))
+    return Math.max(1, Math.min(numPages, Math.round(f * (numPages - 1)) + 1))
+  }
+
+  // Drag the bar to move through the book. The bar was already there, drawn as a
+  // read-only fill; it just could not be touched. What could be touched was a
+  // 56px-wide numeric field showing "1 /" clipped, plus a Go button — a desktop
+  // control on a phone, and QA said so.
+  const pan = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => numPages > 1,
+      onMoveShouldSetPanResponder: () => numPages > 1,
+      onPanResponderGrant: e => {
+        grantXRef.current = e.nativeEvent.locationX
+        const p = pageAt(grantXRef.current)
+        scrubPageRef.current = p
+        setScrubPage(p)
+      },
+      onPanResponderMove: (_e, g) => {
+        const p = pageAt(grantXRef.current + g.dx)
+        scrubPageRef.current = p
+        setScrubPage(p)
+      },
+      onPanResponderRelease: () => {
+        const p = scrubPageRef.current
+        scrubPageRef.current = null
+        setScrubPage(null)
+        if (p != null) onJumpToPage(p)
+      },
+      onPanResponderTerminate: () => { scrubPageRef.current = null; setScrubPage(null) },
+    }),
+  ).current
+
+  const shownPage = scrubPage ?? currentPage
+  const fraction = numPages >= 1 ? Math.min(1, shownPage / numPages) : 0
 
   return (
     <Animated.View
@@ -49,36 +99,73 @@ export function PdfReaderChrome({
       ]}
       pointerEvents={barsVisible ? 'auto' : 'none'}
     >
-      <View style={[styles.progressBar, { backgroundColor: borderColor }]}>
-        <View style={[styles.progressFill, { width: `${Math.round(fraction * 100)}%`, backgroundColor: barText + '40' }]} />
+      <View
+        style={styles.trackHit}
+        onLayout={e => { trackWidthRef.current = e.nativeEvent.layout.width }}
+        accessibilityRole="adjustable"
+        accessibilityLabel="Scrub through pages"
+        accessibilityValue={{ min: 1, max: Math.max(1, numPages), now: shownPage }}
+        {...pan.panHandlers}
+      >
+        <View style={[styles.progressBar, { backgroundColor: borderColor }]}>
+          <View style={[styles.progressFill, { width: `${Math.round(fraction * 100)}%`, backgroundColor: barText + (scrubPage != null ? '99' : '40') }]} />
+        </View>
+        {numPages > 1 && (
+          <View
+            style={[
+              styles.knob,
+              {
+                left: `${Math.round(fraction * 100)}%`,
+                backgroundColor: barText,
+                transform: [{ scale: scrubPage != null ? 1.4 : 1 }],
+              },
+            ]}
+            pointerEvents="none"
+          />
+        )}
       </View>
       <View style={styles.row}>
-        <View style={styles.jumpWrap}>
-          <TextInput
-            style={[styles.input, { color: barText, borderColor: barText + '30' }]}
-            value={pageInput}
-            onChangeText={t => setPageInput(t.replace(/\D/g, ''))}
-            onSubmitEditing={submit}
-            placeholder={String(currentPage)}
-            placeholderTextColor={barText + '66'}
-            keyboardType="number-pad"
-            returnKeyType="go"
-            inputMode="numeric"
-            maxLength={6}
-            accessibilityLabel="Go to page"
-          />
-          <TouchableOpacity
-            onPress={submit}
-            style={[styles.goBtn, { borderColor: barText + '30' }]}
-            accessibilityRole="button"
-            accessibilityLabel="Go to page"
-          >
-            <Text style={[styles.goText, { color: barText + 'CC' }]}>Go</Text>
-          </TouchableOpacity>
-        </View>
-        <Text style={[styles.counter, { color: barText + '99' }]} accessibilityLabel={`Page ${currentPage} of ${numPages || '…'}`}>
-          {currentPage} / {numPages || '…'}
-        </Text>
+        {typing ? (
+          <View style={styles.jumpWrap}>
+            <TextInput
+              style={[styles.input, { color: barText, borderColor: barText + '30' }]}
+              value={pageInput}
+              onChangeText={t => setPageInput(t.replace(/\D/g, ''))}
+              onSubmitEditing={submit}
+              onBlur={() => { setTyping(false); setPageInput('') }}
+              placeholder={String(currentPage)}
+              placeholderTextColor={barText + '66'}
+              keyboardType="number-pad"
+              returnKeyType="go"
+              inputMode="numeric"
+              maxLength={6}
+              autoFocus
+              accessibilityLabel="Go to page"
+            />
+            <TouchableOpacity
+              onPress={submit}
+              style={[styles.goBtn, { borderColor: barText + '30' }]}
+              accessibilityRole="button"
+              accessibilityLabel="Go to page"
+            >
+              <Text style={[styles.goText, { color: barText + 'CC' }]}>Go</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <View style={styles.jumpWrap} />
+        )}
+        {/* Tapping the counter is the way to a precise page. Dragging 500 pages
+            to reach 87 is not navigation, but neither is a permanent input box. */}
+        <TouchableOpacity
+          onPress={() => { if (!typing) setTyping(true) }}
+          hitSlop={10}
+          accessibilityRole="button"
+          accessibilityLabel={`Page ${shownPage} of ${numPages || 'unknown'}. Tap to enter a page number.`}
+        >
+          <Text style={[styles.counter, { color: barText + (scrubPage != null ? 'EE' : '99') }]}>
+            {shownPage} / {numPages || '…'}
+          </Text>
+        </TouchableOpacity>
       </View>
     </Animated.View>
   )
@@ -98,6 +185,10 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 2,
   },
+  // A touch target around the 4px bar. The bar itself stays thin — the finger
+  // needs the room, the eye does not.
+  trackHit: { height: 22, justifyContent: 'center' },
+  knob: { position: 'absolute', width: 10, height: 10, borderRadius: 5, marginLeft: -5 },
   progressBar: { height: 4 },
   progressFill: { height: 4 },
   row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 12, paddingVertical: 8, minHeight: 48 },

--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -116,7 +116,22 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
     }
     h1, h2, h3, h4, h5, h6 { margin: 1em 0 0.5em; }
     p { margin: 0.5em 0; }
-    a { color: #2563EB; }
+    /* Links belong to the page, not to a browser. This was a bare colour and
+       nothing else, so the UA's default underline came through and an uploaded
+       EPUB's internal cross-references rendered as web-blue underlined text over
+       warm serif prose. Keeping them tinted but underlined only on the ink colour
+       keeps them findable without shouting. */
+    a { color: inherit; text-decoration: underline; text-decoration-thickness: 1px;
+        text-underline-offset: 2px; text-decoration-color: currentColor; opacity: 0.85; }
+    /* No list rules existed at all, which is why a book's own numbered lists lost
+       their numbering and its bulleted lists lost their indent. */
+    ul, ol { margin: 0.6em 0; padding-left: 1.6em; }
+    ul { list-style: disc; }
+    ol { list-style: decimal; }
+    li { margin: 0.25em 0; }
+    li > p { margin: 0.2em 0; }
+    blockquote { margin: 0.8em 0 0.8em 1em; padding-left: 0.8em;
+                 border-left: 2px solid currentColor; opacity: 0.85; }
     .chapter-separator {
       text-align: center;
       padding: 40px 16px;

--- a/backend/src/Extraction/TextStack.Extraction/Extractors/EpubTextExtractor.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Extractors/EpubTextExtractor.cs
@@ -90,6 +90,25 @@ public sealed class EpubTextExtractor : ITextExtractor
             }
         }
 
+        // Files that exist to BE navigation, not to be read. Publishers routinely
+        // put the EPUB 3 nav document in the spine, so it arrived as chapter one:
+        // DetectFrontMatterType titled it "Contents", and the reader opened a
+        // user's book on a list of default-blue underlined links over the serif
+        // page. The app builds its own table of contents from TocGenerator, so
+        // this document has no reader left.
+        //
+        // Matched by file path from the EPUB schema, not by looking for the words
+        // "table of contents" in the text — a real chapter is allowed to mention
+        // them, and DetectFrontMatterType's fuzzy match is why the nav document
+        // looked like legitimate front matter in the first place.
+        var navigationPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var navDocPath = book.Schema.Epub3NavDocument?.FilePath;
+        if (!string.IsNullOrWhiteSpace(navDocPath))
+            navigationPaths.Add(navDocPath);
+        var ncxPath = book.Schema.Epub2Ncx?.FilePath;
+        if (!string.IsNullOrWhiteSpace(ncxPath))
+            navigationPaths.Add(ncxPath);
+
         foreach (var textContent in book.ReadingOrder)
         {
             if (ct.IsCancellationRequested)
@@ -97,6 +116,14 @@ public sealed class EpubTextExtractor : ITextExtractor
 
             try
             {
+                if (!string.IsNullOrEmpty(textContent.FilePath) && navigationPaths.Contains(textContent.FilePath))
+                {
+                    warnings.Add(new ExtractionWarning(
+                        ExtractionWarningCode.ContentFiltered,
+                        "Skipped the navigation document listed in the spine"));
+                    continue;
+                }
+
                 var html = textContent.Content;
                 if (string.IsNullOrWhiteSpace(html))
                     continue;

--- a/backend/src/Worker/Services/UserIngestionService.cs
+++ b/backend/src/Worker/Services/UserIngestionService.cs
@@ -189,10 +189,15 @@ public class UserIngestionService
             db.UserChapters.RemoveRange(existingChapters);
 
             // Create chapters. Number saved chapters densely 1..N by their position
-            // in THIS loop, not by unit.OrderIndex — the original list has gaps after
-            // TOC/front-matter units are filtered out, which made the reader's Contents
-            // start at "2". The running counter feeds both ChapterNumber and the slug's
-            // order arg so slugs stay consistent with numbering.
+            // in THIS loop, not by unit.OrderIndex — the extractor skips units
+            // (empty content, piracy watermarks, the spine's navigation document),
+            // so OrderIndex has gaps. The running counter feeds both ChapterNumber
+            // and the slug's order arg so slugs stay consistent with numbering.
+            //
+            // This comment used to claim TOC and front matter were "filtered out".
+            // Only the navigation document is, and only since the extractor learned
+            // to recognise it — before that a user's uploaded EPUB opened on its
+            // own table of contents.
             var qualityScores = new List<int>();
             var savedChapterIndex = 0;
             foreach (var unit in result.Units)

--- a/tests/TextStack.Extraction.Tests/EpubNavigationDocumentTests.cs
+++ b/tests/TextStack.Extraction.Tests/EpubNavigationDocumentTests.cs
@@ -1,0 +1,135 @@
+using System.IO.Compression;
+using System.Text;
+using TextStack.Extraction.Contracts;
+using TextStack.Extraction.Extractors;
+
+namespace TextStack.Extraction.Tests;
+
+/// <summary>
+/// Publishers routinely list the EPUB 3 navigation document in the spine. Nothing
+/// skipped it, so it arrived as unit zero, <c>DetectFrontMatterType</c> titled it
+/// "Contents", and a reader opening their own uploaded book landed on a page of
+/// default-blue underlined links over the serif layout — with the title repeated
+/// three times and the numbering broken.
+///
+/// The fixture is built here rather than checked in because the defect is about a
+/// specific structural choice (nav present AND in the spine) that the existing
+/// fixtures do not make, and a binary fixture would hide that choice from anyone
+/// reading the test.
+/// </summary>
+public class EpubNavigationDocumentTests
+{
+    [Fact]
+    public async Task ExtractAsync_NavDocumentInSpine_IsNotAChapter()
+    {
+        await using var epub = BuildEpubWithNavInSpine();
+        var result = await new EpubTextExtractor().ExtractAsync(
+            new ExtractionRequest { Content = epub, FileName = "nav-in-spine.epub" });
+
+        Assert.Single(result.Units);
+        Assert.Equal("Chapter One", result.Units[0].Title);
+        // The nav document's own text must not appear anywhere in the book.
+        Assert.DoesNotContain(result.Units, u => (u.PlainText ?? string.Empty).Contains("Table of Contents"));
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NavDocumentInSpine_RecordsWhyItWasDropped()
+    {
+        // Silent filtering is how a parser loses a real chapter and nobody notices.
+        await using var epub = BuildEpubWithNavInSpine();
+        var result = await new EpubTextExtractor().ExtractAsync(
+            new ExtractionRequest { Content = epub, FileName = "nav-in-spine.epub" });
+
+        Assert.Contains(result.Diagnostics.Warnings, w => w.Message.Contains("navigation document"));
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ChapterMentioningContents_IsKept()
+    {
+        // The guard is a file-path match, not a text match, precisely so that a
+        // real chapter discussing a table of contents survives. The old fuzzy
+        // detection is what made the nav document look like legitimate front
+        // matter to begin with.
+        await using var epub = BuildEpubWithNavInSpine(
+            chapterBody: "<h1>Chapter One</h1><p>He studied the table of contents for a long while.</p>");
+        var result = await new EpubTextExtractor().ExtractAsync(
+            new ExtractionRequest { Content = epub, FileName = "nav-in-spine.epub" });
+
+        Assert.Single(result.Units);
+        Assert.Contains("table of contents", result.Units[0].PlainText ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Stream BuildEpubWithNavInSpine(string? chapterBody = null)
+    {
+        const string container = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+              <rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles>
+            </container>
+            """;
+
+        const string opf = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+              <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <dc:identifier id="uid">urn:uuid:nav-in-spine</dc:identifier>
+                <dc:title>Nav In Spine</dc:title>
+                <dc:language>en</dc:language>
+                <dc:creator>Test Author</dc:creator>
+              </metadata>
+              <manifest>
+                <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+                <item id="ch1" href="ch1.xhtml" media-type="application/xhtml+xml"/>
+              </manifest>
+              <spine>
+                <itemref idref="nav"/>
+                <itemref idref="ch1"/>
+              </spine>
+            </package>
+            """;
+
+        const string nav = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+              <head><title>Nav In Spine</title></head>
+              <body>
+                <nav epub:type="toc" id="toc">
+                  <h1>Table of Contents</h1>
+                  <ol><li><a href="ch1.xhtml">Chapter One</a></li></ol>
+                </nav>
+              </body>
+            </html>
+            """;
+
+        var body = chapterBody ?? "<h1>Chapter One</h1><p>" + string.Join(" ",
+            Enumerable.Repeat("The first real words of the book.", 12)) + "</p>";
+        var chapter = $"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <html xmlns="http://www.w3.org/1999/xhtml">
+              <head><title>Chapter One</title></head>
+              <body>{body}</body>
+            </html>
+            """;
+
+        var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            // mimetype must be first and stored uncompressed.
+            var mime = zip.CreateEntry("mimetype", CompressionLevel.NoCompression);
+            using (var w = new StreamWriter(mime.Open(), Encoding.ASCII)) w.Write("application/epub+zip");
+
+            Add(zip, "META-INF/container.xml", container);
+            Add(zip, "OEBPS/content.opf", opf);
+            Add(zip, "OEBPS/nav.xhtml", nav);
+            Add(zip, "OEBPS/ch1.xhtml", chapter);
+        }
+        ms.Position = 0;
+        return ms;
+
+        static void Add(ZipArchive zip, string path, string content)
+        {
+            using var w = new StreamWriter(zip.CreateEntry(path).Open(), new UTF8Encoding(false));
+            w.Write(content);
+        }
+    }
+}


### PR DESCRIPTION
Closes **P2-7** and **P2-8** from `docs/qa/reports/2026-08-26-android-manual-pass.md`.

## The report

Uploading a book is called out as **the best scenario in the app** — file to finished book with author, genre and description in under a minute, no "processing…" screen. Then:

> **The first screen of an uploaded EPUB is an unstyled web page.** The table of contents rendered in default blue underlined links over the warm serif layout; the title repeated three times; the numbering broken (two items both numbered "1").

## Why

Publishers routinely list the EPUB 3 navigation document in the spine, and `EpubTextExtractor` walked the whole `ReadingOrder` with no filter — so the nav document became unit zero, and `DetectFrontMatterType` politely titled it **"Contents"**.

Meanwhile `UserIngestionService.cs:191` said:

> *"the original list has gaps after TOC/front-matter units are filtered out"*

No such filter existed on this path. The comment is now true of the navigation document specifically, and says which.

**Matched by file path from the EPUB schema**, not by searching the text for "table of contents". A real chapter is allowed to discuss one — and that fuzzy text match is precisely why the nav document passed for legitimate front matter in the first place. There is a test for the chapter that mentions it.

The fixture is built inside the test rather than checked in: the defect is a structural choice (nav present **and** in the spine) that a binary fixture would hide from anyone reading the test. Verified by neutralising the filter — all three fail, then pass again when it returns.

## Reader styling, same screen

```css
a { color: #2563EB; }
```

Colour and nothing else, so the UA's default underline came through as web-blue over serif prose. And there were **no `ol`/`ul`/`li` rules at all**, which is why a book's own numbered lists lost their numbering — the "two items both numbered 1" in the report. Blockquotes get a rule too, having had none.

## PDF page navigation (P2-8)

> A narrow input (clipped — you can see "1 /") and a Go button. On a phone you expect a slider.

The progress bar was already drawn; it just could not be touched. Now it can: drag to move, with the page under the finger previewed in the counter and the knob growing while you hold it. Tapping the counter opens the numeric field for a precise page — dragging 500 pages to reach 87 is not navigation, but neither is a permanent input box.

No slider dependency added; it is a `PanResponder` over the bar that was already there.

## Existing uploads

Books already ingested keep their old chapters until re-parsed. The retry action on a book already does exactly this, so there is no backfill job — say the word if you want the QA account's EPUB retried.

## Tests

278 extraction + 1383 unit tests pass; `tsc` clean; 133 mobile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
