### PR TITLE
Three small lies on the way in

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -78,6 +78,14 @@ export default function LoginScreen() {
     if (loading) return
     setError('')
     if (!email.trim()) { setError('Email is required.'); return }
+    // Checked here so the server's answer stays truthful. Sending "notanemail"
+    // came back as "Invalid email or password" — a statement about a credential
+    // pair, to someone who has not entered an address. Deliberately permissive:
+    // it rejects what cannot be an address, not what does not look like one.
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email.trim())) {
+      setError('That does not look like an email address.')
+      return
+    }
     if (mode !== 'forgot' && password.length < 8) { setError('Password must be at least 8 characters.'); return }
 
     setLoading(true)

--- a/apps/mobile/app/(tabs)/search.tsx
+++ b/apps/mobile/app/(tabs)/search.tsx
@@ -405,24 +405,29 @@ export default function DiscoverScreen() {
 
           {/* Catalog Stats Bar */}
           {catalogStats && (
+            /* Three links that read as a caption. They are the same shade as
+               body text with no chevron and no underline, while "View all books →"
+               sits a few rows below styled correctly — the contrast is inside one
+               screen. Tinting them and adding the chevron says they go somewhere. */
             <View style={[styles.statsBar, { borderColor: colors.border }]}>
-              <TouchableOpacity onPress={() => router.push('/books')}>
-                <Text style={[styles.statItem, { color: colors.textSecondary }]}>
-                  {catalogStats.books} books
-                </Text>
-              </TouchableOpacity>
-              <Text style={[styles.statDot, { color: colors.border }]}>&middot;</Text>
-              <TouchableOpacity onPress={() => router.push('/authors')}>
-                <Text style={[styles.statItem, { color: colors.textSecondary }]}>
-                  {catalogStats.authors} authors
-                </Text>
-              </TouchableOpacity>
-              <Text style={[styles.statDot, { color: colors.border }]}>&middot;</Text>
-              <TouchableOpacity onPress={() => router.push('/genres')}>
-                <Text style={[styles.statItem, { color: colors.textSecondary }]}>
-                  {catalogStats.genres} genres
-                </Text>
-              </TouchableOpacity>
+              {([
+                { label: `${catalogStats.books} books`, to: '/books' as const },
+                { label: `${catalogStats.authors} authors`, to: '/authors' as const },
+                { label: `${catalogStats.genres} genres`, to: '/genres' as const },
+              ]).map((item, i) => (
+                <View key={item.to} style={styles.statGroup}>
+                  {i > 0 && <Text style={[styles.statDot, { color: colors.border }]}>&middot;</Text>}
+                  <TouchableOpacity
+                    onPress={() => router.push(item.to)}
+                    style={styles.statLink}
+                    accessibilityRole="link"
+                    accessibilityLabel={item.label}
+                  >
+                    <Text style={[styles.statItem, { color: colors.primary }]}>{item.label}</Text>
+                    <Ionicons name="chevron-forward" size={12} color={colors.primary} />
+                  </TouchableOpacity>
+                </View>
+              ))}
             </View>
           )}
 
@@ -579,6 +584,8 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   statItem: { fontFamily: fonts.sansMedium, fontSize: 13 },
+  statGroup: { flexDirection: 'row', alignItems: 'center' },
+  statLink: { flexDirection: 'row', alignItems: 'center', gap: 1 },
   statDot: { fontSize: 16 },
 
   // Sections

--- a/apps/mobile/src/components/library/AddMenuBottomSheet.tsx
+++ b/apps/mobile/src/components/library/AddMenuBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Animated, Modal, Pressable, StyleSheet, Text, TouchableOpacity, View, Linking } from 'react-native'
+import { Animated, Modal, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter } from 'expo-router'
 import { useTheme } from '../../context/ThemeContext'
@@ -16,7 +16,6 @@ interface Item {
   key: string
   icon: keyof typeof Ionicons.glyphMap
   labelKey: string
-  comingSoon?: boolean
   onPress?: () => void
 }
 
@@ -41,18 +40,21 @@ export function AddMenuBottomSheet({ visible, onClose, onUpload }: Props) {
     cb?.()
   }
 
+  // Only what works.
+  //
+  // This menu had five items and two of them were labelled COMING IN A FUTURE
+  // UPDATE, taking exactly as much room as the one that opens a file picker. QA
+  // filed that. A third was worse: "Browser extension" looked like a working
+  // item and opened the Chrome Web Store HOME PAGE, because the extension lives
+  // in extension/ at 0.1.0 and its own README says publishing it is an
+  // unfinished owner-only step. A link to a store with nothing to find is not a
+  // feature preview, it is a dead end wearing a working item's clothes.
+  //
+  // Restore each of them on the day it does something: paste-a-URL and
+  // email-a-book when the endpoints exist, the extension when the listing does.
   const items: Array<Item | { divider: true; key: string }> = [
     { key: 'upload', icon: 'cloud-upload-outline', labelKey: 'addMenu.uploadFile', onPress: onUpload },
-    { key: 'url', icon: 'link-outline', labelKey: 'addMenu.pasteUrl', comingSoon: true },
-    { key: 'email', icon: 'mail-outline', labelKey: 'addMenu.emailBook', comingSoon: true },
     { key: 'd1', divider: true },
-    {
-      key: 'extension',
-      icon: 'extension-puzzle-outline',
-      labelKey: 'addMenu.browserExtension',
-      onPress: () => Linking.openURL('https://chromewebstore.google.com').catch(() => {}),
-    },
-    { key: 'd2', divider: true },
     {
       key: 'browse',
       icon: 'book-outline',
@@ -85,39 +87,16 @@ export function AddMenuBottomSheet({ visible, onClose, onUpload }: Props) {
           if ('divider' in entry) {
             return <View key={entry.key} style={[styles.divider, { backgroundColor: colors.border }]} />
           }
-          const disabled = !!entry.comingSoon
           return (
             <TouchableOpacity
               key={entry.key}
               style={styles.item}
-              disabled={disabled}
               onPress={handle(entry.onPress)}
               activeOpacity={0.7}
               accessibilityRole="menuitem"
-              accessibilityState={{ disabled }}
             >
-              <Ionicons
-                name={entry.icon}
-                size={22}
-                color={disabled ? colors.textSecondary : colors.text}
-                style={{ opacity: disabled ? 0.55 : 1 }}
-              />
-              <Text
-                style={[
-                  styles.label,
-                  {
-                    color: disabled ? colors.textSecondary : colors.text,
-                    fontStyle: disabled ? 'italic' : 'normal',
-                  },
-                ]}
-              >
-                {t(entry.labelKey)}
-              </Text>
-              {disabled && (
-                <Text style={[styles.badge, { backgroundColor: colors.surface, color: colors.textSecondary }]}>
-                  {t('addMenu.comingSoon')}
-                </Text>
-              )}
+              <Ionicons name={entry.icon} size={22} color={colors.text} />
+              <Text style={[styles.label, { color: colors.text }]}>{t(entry.labelKey)}</Text>
             </TouchableOpacity>
           )
         })}
@@ -164,14 +143,4 @@ const styles = StyleSheet.create({
   },
   label: { flex: 1, fontFamily: fonts.sansMedium, fontSize: 15 },
   divider: { height: 1, marginVertical: 4, marginHorizontal: 18 },
-  badge: {
-    fontFamily: fonts.sansMedium,
-    fontSize: 10,
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: 4,
-    overflow: 'hidden',
-    textTransform: 'uppercase',
-    letterSpacing: 0.4,
-  },
 })


### PR DESCRIPTION
Closes **P3-1**, **P3-2**, **P3-5** from `docs/qa/reports/2026-08-26-android-manual-pass.md`. (P3-3 and P3-4 landed in #462 and #459; P3-6 in #460.)

## P3-2 — the sign-in form blames the wrong thing

> "notanemail" goes to the server and comes back **"Invalid email or password"** — the user is told the login/password pair did not match, though they never entered an address.

`login.tsx:77` checked only for emptiness. The format is now checked before the request, so the server's answer stays truthful. Deliberately permissive — it rejects what *cannot* be an address, not what does not look like one.

## P3-1 — three links dressed as a caption

> "1304 books · 185 authors · 23 genres" looks like a subtitle, but it is three links. Next to it "View all books →" is styled correctly — the contrast is inside one screen.

They were `textSecondary`, no chevron, no underline. Now tinted with a chevron.

## P3-5 — two of five menu items were placeholders

> "Paste URL" and "Email a book" with a COMING IN A FUTURE UPDATE badge take up as much room as the working items.

And a third was worse than a placeholder. **"Browser extension" looked like it worked** — no badge, full opacity — and opened `https://chromewebstore.google.com`, the store's *home page*. The extension lives in `extension/` at version 0.1.0 and its own README says:

> *Web Store submission — packaging + listing is owner-only.*

So it is not published. A link to a store with nothing to find is not a feature preview; it is a dead end wearing a working item's clothes.

The menu now holds what works: upload a file, browse the catalog. The coming-soon rendering machinery goes with them — its only purpose was to draw items that do nothing, which is precisely what is being removed. Each item comes back the day it does something; the comment says so and names the condition.

`tsc` clean; 133 mobile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
