### PR TITLE
A percentage now travels with the unit it is measured in

### DIFF
--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,3 +1,5 @@
+import { PERCENT_UNIT_BOOK } from '@textstack/shared'
+
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080'
 
 export interface User {
@@ -214,7 +216,10 @@ export async function getAllProgress(): Promise<AllProgressResponse> {
 export async function upsertProgress(editionId: string, data: UpsertProgressRequest): Promise<ReadingProgressDto> {
   return authFetch<ReadingProgressDto>(`/me/progress/${editionId}`, {
     method: 'PUT',
-    body: JSON.stringify(data),
+    // Every web writer funnels through here, so the unit is declared once. The
+    // server stores a percentage only when it knows what it is a fraction of —
+    // see Application.ReadingTracking.ProgressUnit.
+    body: JSON.stringify({ ...data, percentUnit: PERCENT_UNIT_BOOK }),
   })
 }
 

--- a/backend/src/Api/Endpoints/UserDataEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserDataEndpoints.cs
@@ -3,6 +3,7 @@ using Api.Mapping;
 using Api.Sites;
 using Application.Auth;
 using Application.Common.Interfaces;
+using Application.ReadingTracking;
 using Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -227,16 +228,24 @@ public static class UserDataEndpoints
     {
         target.ChapterId = request.ChapterId;
         target.Locator = request.Locator;
-        target.Percent = request.Percent;
-        // Completion is recorded, not inferred later from a threshold. Same 0.99
-        // rule uploads use (UserBookService.UpsertProgressAsync), so both kinds of
-        // book answer "finished?" the same way. Re-reading a finished book does
-        // not un-finish it — only an explicit mark-as-unfinished clears this,
-        // which arrives as percent 0.
-        if (request.Percent is >= 0.99)
-            target.CompletedAt ??= DateTimeOffset.UtcNow;
-        else if (request.Percent is <= 0)
-            target.CompletedAt = null;
+
+        // The position is always the reader's, so it is always saved. The NUMBER is
+        // only saved when the caller says what it is a fraction of — an old client
+        // sending a chapter fraction cannot be told from a correct one by looking at
+        // it, and this column has already been wrong once that way.
+        if (ProgressUnit.IsTrusted(request.PercentUnit))
+        {
+            target.Percent = request.Percent;
+            // Completion is recorded, not inferred later from a threshold. Same 0.99
+            // rule uploads use (UserBookService.UpsertProgressAsync), so both kinds of
+            // book answer "finished?" the same way. Re-reading a finished book does
+            // not un-finish it — only an explicit mark-as-unfinished clears this,
+            // which arrives as percent 0.
+            if (request.Percent is >= 0.99)
+                target.CompletedAt ??= DateTimeOffset.UtcNow;
+            else if (request.Percent is <= 0)
+                target.CompletedAt = null;
+        }
         // High-water mark for the RAG spoiler gate — monotonic, never decreases. NULL means
         // "never recorded" (distinct from ordinal 0, a real 0-based first chapter), so the first
         // write seeds it rather than max-ing against an implied 0.
@@ -547,7 +556,12 @@ public record UpsertProgressRequest(
     Guid ChapterId,
     string Locator,
     double? Percent,
-    DateTimeOffset? UpdatedAt
+    DateTimeOffset? UpdatedAt,
+    /// <summary>What <paramref name="Percent"/> is a fraction OF. Only "book" is
+    /// stored — see <see cref="Application.ReadingTracking.ProgressUnit"/>.
+    /// Absent from clients that predate the contract, whose percentages are of
+    /// unknown scale and are therefore left unstored.</summary>
+    string? PercentUnit = null
 );
 
 public record BookmarkDto(

--- a/backend/src/Application/ReadingTracking/ProgressUnit.cs
+++ b/backend/src/Application/ReadingTracking/ProgressUnit.cs
@@ -1,0 +1,34 @@
+namespace Application.ReadingTracking;
+
+/// <summary>
+/// Whether a reading percentage a client sent means what this server thinks it means.
+///
+/// <para>
+/// <c>ReadingProgress.Percent</c> and <c>UserBook.ProgressPercent</c> are BOOK-wide
+/// fractions. For a long time nothing said so: mobile wrote the fraction of the
+/// current chapter, web wrote the fraction of the book, and both landed in the same
+/// column. A reader saw 10% on the resume card and 32% on the row below it, for the
+/// same book, without scrolling.
+/// </para>
+/// <para>
+/// The clients were fixed. The problem is that old ones keep running — an Android
+/// build already installed goes on writing chapter fractions until its owner updates,
+/// and there is no way to tell those writes apart from correct ones by looking at
+/// the number. So the unit travels with the value: a client that knows the unit says
+/// so, and a percentage that arrives without one is not trusted enough to store.
+/// </para>
+/// <para>
+/// Untrusted writes are not rejected. The locator, the chapter and the timestamp are
+/// still the reader's real position and are saved as usual — only the number is left
+/// as it was. A stale client keeps working; it just stops corrupting the column.
+/// </para>
+/// </summary>
+public static class ProgressUnit
+{
+    /// <summary>Fraction of the whole book, 0..1. The only unit this server stores.</summary>
+    public const string Book = "book";
+
+    /// <summary>True when the caller declared the unit this server stores.</summary>
+    public static bool IsTrusted(string? percentUnit) =>
+        string.Equals(percentUnit, Book, StringComparison.OrdinalIgnoreCase);
+}

--- a/backend/src/Application/UserBooks/UserBookService.cs
+++ b/backend/src/Application/UserBooks/UserBookService.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using Application.ReadingTracking;
 using System.Text.Json;
 using Application.Common.Interfaces;
 using Application.Entitlements;
@@ -548,11 +549,16 @@ public class UserBookService(IAppDbContext db, IFileStorageService storage, IEnt
         // and the first saves of a cold open). Keep the last known good percent
         // rather than nulling the column, and never let the client substitute a
         // chapter fraction, which reaches 1.0 at the bottom of every chapter.
-        if (request.Percent.HasValue)
+        //
+        // And only when the caller declared what the number is a fraction of. An
+        // older build sending a chapter fraction is indistinguishable from a
+        // correct write by inspection, so an undeclared unit means the position is
+        // saved and the number is left alone. See ProgressUnit.
+        if (request.Percent.HasValue && ProgressUnit.IsTrusted(request.PercentUnit))
             book.ProgressPercent = request.Percent;
         book.ProgressUpdatedAt = request.UpdatedAt ?? DateTimeOffset.UtcNow;
 
-        if (request.Percent is >= 0.99)
+        if (request.Percent is >= 0.99 && ProgressUnit.IsTrusted(request.PercentUnit))
         {
             book.CompletedAt ??= DateTimeOffset.UtcNow;
             // Auto-mark clips read once finished so they leave the Unread shelf.

--- a/backend/src/Contracts/UserBooks/UserBookDtos.cs
+++ b/backend/src/Contracts/UserBooks/UserBookDtos.cs
@@ -124,7 +124,10 @@ public record UpsertUserBookProgressRequest(
     string? ChapterSlug,
     string? Locator,
     double? Percent,
-    DateTimeOffset? UpdatedAt
+    DateTimeOffset? UpdatedAt,
+    /// <summary>What Percent is a fraction OF. Only "book" is stored; a percentage
+    /// without a declared unit is left unsaved. See Application.ReadingTracking.ProgressUnit.</summary>
+    string? PercentUnit = null
 );
 
 // ChapterId/ChapterSlug are nullable: PDFs opened in "Original layout" (ADR-012) are

--- a/packages/shared/src/api/readingProgress.ts
+++ b/packages/shared/src/api/readingProgress.ts
@@ -1,5 +1,6 @@
 import { authFetch, jsonBody } from './client'
 import type { ReadingProgressDto } from '../types/api'
+import { PERCENT_UNIT_BOOK } from '../reader/progressPayload'
 
 export function getProgress(editionId: string) {
   return authFetch<ReadingProgressDto>(`/me/progress/${editionId}`)
@@ -29,6 +30,9 @@ export function updateProgress(
     chapterId: data.chapterId,
     locator: `scroll:${data.chapterSlug}:${offset}`,
     percent: data.progress,
+    // Book-wide, and says so. Without the declaration the server keeps whatever
+    // it already had — see Application.ReadingTracking.ProgressUnit.
+    percentUnit: PERCENT_UNIT_BOOK,
     // Client timestamp for LWW merge on server (UserDataEndpoints.cs:134) and on restore in web.
     // Skips stale overwrites if a newer record already exists on the server.
     updatedAt: new Date().toISOString(),

--- a/packages/shared/src/reader/pdfProgress.ts
+++ b/packages/shared/src/reader/pdfProgress.ts
@@ -8,6 +8,8 @@
 // Kept free of DOM/pdfjs so the payload builder + locator parse are unit-tested
 // in isolation.
 
+import { PERCENT_UNIT_BOOK } from './progressPayload'
+
 export function clamp01(n: number): number {
   if (!Number.isFinite(n)) return 0
   if (n < 0) return 0
@@ -22,6 +24,9 @@ export interface PdfProgressPayload {
   locator: string
   /** currentPage / numPages, clamped to [0,1]. */
   percent: number
+  /** Declares what `percent` is a fraction of; the server stores it only when
+   *  this says "book". */
+  percentUnit: string
   updatedAt: string
 }
 
@@ -41,6 +46,9 @@ export function buildPdfProgressPayload(
     chapterSlug: null,
     locator: `page:${page}`,
     percent,
+    // A page fraction IS a book fraction for a chapterless PDF, so this is a
+    // genuine book-wide value and says so.
+    percentUnit: PERCENT_UNIT_BOOK,
     updatedAt: new Date(now).toISOString(),
   }
 }

--- a/packages/shared/src/reader/progressPayload.test.ts
+++ b/packages/shared/src/reader/progressPayload.test.ts
@@ -213,9 +213,34 @@ describe('buildUserBookProgressPayload — full payload shape', () => {
     })
     expect(p).toEqual({
       percent: 0.73,
+      percentUnit: 'book',
       chapterSlug: 'ch5',
       locator: 'scroll:ch5:4200',
     })
+  })
+
+  it('declares the unit whenever it sends a percent, and never without one', () => {
+    // The server stores a percentage only when it knows what it is a fraction of,
+    // so a payload carrying a number without its unit would silently stop being
+    // saved — and a unit without a number would be a claim about nothing.
+    const withPercent = buildUserBookProgressPayload({
+      currentChapterSlug: 'ch5',
+      fallbackChapterSlug: null,
+      chapterProgress: 0.5,
+      chapters: [{ slug: 'ch5', wordCount: 1000 }],
+    })
+    expect(withPercent?.percent).toBeDefined()
+    expect(withPercent?.percentUnit).toBe('book')
+
+    // No chapter list — the book fraction cannot be computed, so neither travels
+    // and the server keeps its last known good value.
+    const withoutPercent = buildUserBookProgressPayload({
+      currentChapterSlug: 'ch5',
+      fallbackChapterSlug: null,
+      chapterProgress: 0.5,
+    })
+    expect(withoutPercent?.percent).toBeUndefined()
+    expect(withoutPercent?.percentUnit).toBeUndefined()
   })
 })
 

--- a/packages/shared/src/reader/progressPayload.ts
+++ b/packages/shared/src/reader/progressPayload.ts
@@ -1,4 +1,15 @@
 /**
+ * The unit every percentage in this codebase is measured in, declared on the wire.
+ *
+ * The server stores a book-wide fraction, and for a long time nothing said so —
+ * mobile wrote chapter fractions, web wrote book fractions, and both landed in the
+ * same column. The clients agree now, but old builds keep running and their writes
+ * cannot be told apart by looking at the number. So the number travels with its
+ * unit, and the server declines to store one that arrives without it.
+ */
+export const PERCENT_UNIT_BOOK = 'book'
+
+/**
  * Pure builders for the reading-progress wire payloads.
  *
  * Why pure functions and not inline in the hooks: hooks combine refs +
@@ -29,6 +40,9 @@ export interface UserBookProgressPayload {
    *  bottom of every chapter, which is the confusion this column was
    *  canonicalised to end. */
   percent?: number
+  /** Declares what `percent` is a fraction of. Sent whenever `percent` is, and
+   *  never without it — the server stores the number only when it is present. */
+  percentUnit?: string
   chapterSlug: string
   locator: string
 }
@@ -92,7 +106,10 @@ export function buildUserBookProgressPayload(input: UserBookProgressInputs): Use
     chapterSlug: slug,
     locator: `scroll:${slug}:${safeOffset}`,
   }
-  if (bookPct != null) payload.percent = clampUnit(bookPct)
+  if (bookPct != null) {
+    payload.percent = clampUnit(bookPct)
+    payload.percentUnit = PERCENT_UNIT_BOOK
+  }
   return payload
 }
 

--- a/tests/TextStack.UnitTests/ProgressUnitTests.cs
+++ b/tests/TextStack.UnitTests/ProgressUnitTests.cs
@@ -1,0 +1,47 @@
+using Application.ReadingTracking;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// The percent column has been wrong once already — mobile wrote chapter
+/// fractions, web wrote book fractions, and a reader saw 10% and 32% for the same
+/// book on one screen. The clients agree now, but old builds keep running and
+/// their writes cannot be told apart by inspecting the number.
+/// </summary>
+public class ProgressUnitTests
+{
+    [Fact]
+    public void IsTrusted_BookUnit_True()
+    {
+        Assert.True(ProgressUnit.IsTrusted(ProgressUnit.Book));
+    }
+
+    [Fact]
+    public void IsTrusted_MissingUnit_False()
+    {
+        // The whole point: a client that predates the contract sends no unit, and
+        // its percentage is of unknown scale.
+        Assert.False(ProgressUnit.IsTrusted(null));
+        Assert.False(ProgressUnit.IsTrusted(""));
+        Assert.False(ProgressUnit.IsTrusted("   "));
+    }
+
+    [Fact]
+    public void IsTrusted_ChapterUnit_False()
+    {
+        // Nothing sends this today. It is here so that if a chapter-scale unit is
+        // ever introduced deliberately, it fails this test rather than being
+        // silently stored in a column that means something else.
+        Assert.False(ProgressUnit.IsTrusted("chapter"));
+    }
+
+    [Theory]
+    [InlineData("Book")]
+    [InlineData("BOOK")]
+    public void IsTrusted_IsCaseInsensitive(string unit)
+    {
+        // A client that capitalises differently is still a client that knows the
+        // unit; rejecting it would drop a correct write for a cosmetic reason.
+        Assert.True(ProgressUnit.IsTrusted(unit));
+    }
+}

--- a/tests/TextStack.UnitTests/UpsertProgressTests.cs
+++ b/tests/TextStack.UnitTests/UpsertProgressTests.cs
@@ -1,4 +1,5 @@
 using Api.Endpoints;
+using Application.ReadingTracking;
 using Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
@@ -39,7 +40,12 @@ public class UpsertProgressTests
         UpdatedAt = updatedAt ?? DateTimeOffset.UnixEpoch,
     };
 
+    /// <summary>A write from a current client, which declares its percent unit.</summary>
     private static UpsertProgressRequest Request(Guid chapterId, double percent = 0.5) =>
+        new(chapterId, "epubcfi(/6/4!/4/2)", percent, null, ProgressUnit.Book);
+
+    /// <summary>A write from a build that predates the unit contract.</summary>
+    private static UpsertProgressRequest LegacyRequest(Guid chapterId, double percent = 0.5) =>
         new(chapterId, "epubcfi(/6/4!/4/2)", percent, null);
 
     [Fact]
@@ -186,5 +192,41 @@ public class UpsertProgressTests
         var ex = new DbUpdateException("save failed", new InvalidOperationException("boom"));
 
         Assert.False(UserDataEndpoints.IsUniqueViolation(ex));
+    }
+
+    [Fact]
+    public void ApplyProgressUpdate_UndeclaredUnit_KeepsStoredPercentButMovesPosition()
+    {
+        // An Android build installed before the unit contract goes on writing
+        // chapter fractions until its owner updates, and a chapter fraction is
+        // indistinguishable from a book fraction by inspection — that is how the
+        // same book came to show 10% on the resume card and 32% on the row below.
+        //
+        // Its position is still the reader's real position, so the locator and the
+        // chapter move. Only the number stays as it was.
+        var chapter = ChapterAt(3);
+        var target = Progress(maxChapter: 1);
+        target.Percent = 0.42;
+        target.Locator = "old-locator";
+
+        UserDataEndpoints.ApplyProgressUpdate(target, LegacyRequest(chapter.Id, percent: 0.99), chapter);
+
+        Assert.Equal(0.42, target.Percent);
+        Assert.Equal("epubcfi(/6/4!/4/2)", target.Locator);
+        Assert.Equal(chapter.Id, target.ChapterId);
+    }
+
+    [Fact]
+    public void ApplyProgressUpdate_UndeclaredUnit_CannotFinishABook()
+    {
+        // Completion is derived from the percent, so an untrusted number must not
+        // be able to mark a book read — a stale client hitting the bottom of a
+        // chapter would otherwise finish the whole book.
+        var chapter = ChapterAt(3);
+        var target = Progress(maxChapter: 1);
+
+        UserDataEndpoints.ApplyProgressUpdate(target, LegacyRequest(chapter.Id, percent: 1.0), chapter);
+
+        Assert.Null(target.CompletedAt);
     }
 }

--- a/tests/TextStack.UnitTests/UserBookProgressServiceTests.cs
+++ b/tests/TextStack.UnitTests/UserBookProgressServiceTests.cs
@@ -1,4 +1,5 @@
 using Application.Common.Interfaces;
+using Application.ReadingTracking;
 using Application.UserBooks;
 using Contracts.UserBooks;
 using Domain.Entities;
@@ -71,7 +72,7 @@ public class UserBookProgressServiceTests
         var book = h.SeedBook(userId);
 
         var req = new UpsertUserBookProgressRequest(
-            ChapterSlug: null, Locator: "page:17", Percent: 0.16, UpdatedAt: null);
+            ChapterSlug: null, Locator: "page:17", Percent: 0.16, UpdatedAt: null, PercentUnit: ProgressUnit.Book);
 
         var (success, error) = await h.Service.UpsertProgressAsync(userId, book.Id, req, CancellationToken.None);
 
@@ -99,7 +100,7 @@ public class UserBookProgressServiceTests
         var book = h.SeedBook(userId);
 
         var req = new UpsertUserBookProgressRequest(
-            ChapterSlug: "chapter-3", Locator: "word:42", Percent: 0.5, UpdatedAt: null);
+            ChapterSlug: "chapter-3", Locator: "word:42", Percent: 0.5, UpdatedAt: null, PercentUnit: ProgressUnit.Book);
 
         var (success, _) = await h.Service.UpsertProgressAsync(userId, book.Id, req, CancellationToken.None);
 
@@ -121,7 +122,7 @@ public class UserBookProgressServiceTests
         var book = h.SeedBook(userId);
 
         var req = new UpsertUserBookProgressRequest(
-            ChapterSlug: null, Locator: "page:200", Percent: 0.99, UpdatedAt: null);
+            ChapterSlug: null, Locator: "page:200", Percent: 0.99, UpdatedAt: null, PercentUnit: ProgressUnit.Book);
 
         await h.Service.UpsertProgressAsync(userId, book.Id, req, CancellationToken.None);
 
@@ -144,11 +145,11 @@ public class UserBookProgressServiceTests
         var book = h.SeedBook(userId);
 
         await h.Service.UpsertProgressAsync(userId, book.Id, new UpsertUserBookProgressRequest(
-            ChapterSlug: "ch-3", Locator: "scroll:ch-3:1200", Percent: 0.42, UpdatedAt: null),
+            ChapterSlug: "ch-3", Locator: "scroll:ch-3:1200", Percent: 0.42, UpdatedAt: null, PercentUnit: ProgressUnit.Book),
             CancellationToken.None);
 
         await h.Service.UpsertProgressAsync(userId, book.Id, new UpsertUserBookProgressRequest(
-            ChapterSlug: "ch-4", Locator: "scroll:ch-4:300", Percent: null, UpdatedAt: null),
+            ChapterSlug: "ch-4", Locator: "scroll:ch-4:300", Percent: null, UpdatedAt: null, PercentUnit: ProgressUnit.Book),
             CancellationToken.None);
 
         Assert.Equal(0.42, book.ProgressPercent);
@@ -164,7 +165,7 @@ public class UserBookProgressServiceTests
         var book = h.SeedBook(userId);
 
         await h.Service.UpsertProgressAsync(userId, book.Id, new UpsertUserBookProgressRequest(
-            ChapterSlug: "ch-1", Locator: "scroll:ch-1:10", Percent: null, UpdatedAt: null),
+            ChapterSlug: "ch-1", Locator: "scroll:ch-1:10", Percent: null, UpdatedAt: null, PercentUnit: ProgressUnit.Book),
             CancellationToken.None);
 
         Assert.Null(book.CompletedAt);
@@ -182,5 +183,28 @@ public class UserBookProgressServiceTests
         var got = await h.Service.GetProgressAsync(userId, book.Id, CancellationToken.None);
 
         Assert.Null(got);
+    }
+
+    [Fact]
+    public async Task UpsertProgressAsync_UndeclaredUnit_KeepsStoredPercentButMovesPosition()
+    {
+        // Same rule as catalog books: an old build's percentage is of unknown
+        // scale, so the position it reports is honoured and the number is not.
+        var h = new Harness();
+        var userId = Guid.NewGuid();
+        var book = h.SeedBook(userId);
+
+        await h.Service.UpsertProgressAsync(userId, book.Id, new UpsertUserBookProgressRequest(
+            ChapterSlug: "ch-1", Locator: "scroll:ch-1:10", Percent: 0.30, UpdatedAt: null, PercentUnit: ProgressUnit.Book),
+            CancellationToken.None);
+
+        await h.Service.UpsertProgressAsync(userId, book.Id, new UpsertUserBookProgressRequest(
+            ChapterSlug: "ch-9", Locator: "scroll:ch-9:640", Percent: 0.98, UpdatedAt: null),
+            CancellationToken.None);
+
+        Assert.Equal(0.30, book.ProgressPercent);
+        Assert.Equal("ch-9", book.ProgressChapterSlug);
+        Assert.Equal("scroll:ch-9:640", book.ProgressLocator);
+        Assert.Null(book.CompletedAt);
     }
 }


### PR DESCRIPTION
Not from the QA report — this is the defence the report proved we need.

## The evidence

`ReadingProgress.Percent` and `UserBook.ProgressPercent` are book-wide fractions. For a long time nothing said so: mobile wrote the fraction of the *current chapter*, web wrote the fraction of the *book*, and both landed in the same column. The tester found the result on one screen without scrolling:

> Resume card: "The Aeneid — **10% complete**". The same book's row below: "**32%**".
> `GET /me/progress/{editionId}` → `percent: 0.31724`, `chapterSlug: "2-book-ii"` — the server's number is the fraction read *inside Book II*.

#454 fixed the clients. **That did not end it.** The column had been reset by migration, and build 21 — still running the old JS — filled it back in with a chapter fraction. An Android build already on someone's phone keeps writing the old unit until its owner updates, and nothing about the number itself distinguishes the two.

## The change

The unit travels with the value. A client that knows what it is measuring says `percentUnit: "book"`. A percentage that arrives without a declared unit is not stored.

**Untrusted writes are not rejected.** The locator, the chapter and the timestamp are the reader's real position and are saved exactly as before — only the number is left alone, and completion (which is derived from the number) cannot be triggered by one. A stale build keeps working and keeps its place; it just stops corrupting the column.

Applied at both write paths — `UserDataEndpoints.ApplyProgressUpdate` for catalog books, `UserBookService.UpsertProgressAsync` for uploads — because both had the same hole.

Declared by every writer, each in one place: the shared mobile client, the two shared payload builders, and web's `upsertProgress`, which every web writer funnels through.

## On the tests

Seven existing tests failed the moment the guard landed. They were not wrong — they encoded the old contract, in which any number was storable. Each was updated to declare its unit rather than deleted, because each represents a *current* client, and a test that no longer compiles against the contract is a test that has something to say about it.

Three new tests cover what they used to cover by accident:
- an undeclared percent moves the position and leaves the number
- an undeclared percent cannot finish a book
- the same, for uploads

Plus five on the predicate itself, including a `"chapter"` unit that must never be trusted — nothing sends it today, but if a chapter-scale unit is ever introduced deliberately it will fail a test rather than be silently stored in a column that means something else.

## Verification

1391 backend unit tests, 318 shared, 737 web, 170 mobile. `tsc` clean on web and mobile; solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
