### PR TITLE
Make the mobile e2e suite able to fail

### DIFF
--- a/apps/mobile/e2e/README.md
+++ b/apps/mobile/e2e/README.md
@@ -1,0 +1,56 @@
+# Mobile e2e — what this lane is, and what it is not
+
+Playwright driving the **Expo web build** in a phone-sized viewport. It exercises
+routing, screen composition and empty states. It exercises **no native code**:
+not the reader WebView's gestures, not SQLite, not keep-awake, not offline mode.
+Anything that needs the device belongs in Lane B (Maestro) — see
+[`../../../docs/qa/MOBILE-TEST-PLAN.md`](../../../docs/qa/MOBILE-TEST-PLAN.md).
+
+## State
+
+**Not run by CI, and not yet worth running.** These specs need a live backend, so
+they cannot gate a pull request. Making them hermetic — request interception
+installed before navigation, fixtures per route — is Lane A of the test plan and
+has not been done.
+
+What *was* done, on 2026-08-27, is making them stop lying:
+
+| | before | after |
+|---|---|---|
+| tests | 22 | 17 |
+| assertions that cannot fail | 34 | 0 |
+
+Five tests were deleted. Three contained no `expect` at all — they clicked
+things and ended. Two hid their only assertion inside an `if`, so the case they
+existed to catch passed silently, and they could not be repaired here because the
+rows they check only exist for a signed-in reader. Six self-skips on conditions
+indistinguishable from a broken screen became one, for the only precondition this
+lane genuinely cannot control: a deployment whose catalog is empty.
+
+The shape to never write again:
+
+```ts
+// Cannot fail. The catch swallows the timeout, and the matcher then asserts a
+// boolean this line produced two expressions ago.
+expect(await page.locator('…').isVisible().catch(() => false)).toBeTruthy()
+```
+
+```ts
+// Can fail, and says why in the trace.
+await expect(page.locator('…')).toBeVisible()
+```
+
+This matters more than the count. A suite in this shape was green for the whole
+week the Library screen was unusable, and green again through the manual pass
+that found 24 defects. Fewer tests that can fail beat more that cannot.
+
+## Running
+
+```bash
+cd apps/mobile
+npx expo start --web          # or point PLAYWRIGHT_BASE_URL at a running build
+npx playwright test --config e2e/playwright.config.ts
+```
+
+Signed out by default. Assertions that would differ for a signed-in reader accept
+the sign-in branch explicitly rather than assuming one.

--- a/apps/mobile/e2e/tests/books.spec.ts
+++ b/apps/mobile/e2e/tests/books.spec.ts
@@ -1,42 +1,25 @@
 import { test, expect } from '@playwright/test'
 
+/**
+ * The catalog list screen.
+ *
+ * A third test lived here — "sort chips are clickable" — which clicked two
+ * chips if they happened to be visible and asserted nothing at all. It could
+ * not fail, and it could not pass either; it only ran. Deleted rather than
+ * repaired, because asserting that a sort actually reorders the list needs
+ * fixture data this lane does not have yet (see MOBILE-TEST-PLAN.md, Lane A).
+ */
 test.describe('Books', () => {
-  test('books page loads with search and sort', async ({ page }) => {
+  test('renders a search field and the sort row', async ({ page }) => {
     await page.goto('/books')
     await page.waitForLoadState('networkidle')
-
-    // Search bar visible
-    const hasSearch = await page.locator('input[placeholder*="Search"]').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasSearch).toBeTruthy()
-
-    // Sort chips visible
-    const hasSort = await page.locator('text=Recent').first().isVisible({ timeout: 5000 }).catch(() => false)
-    expect(hasSort).toBeTruthy()
+    await expect(page.locator('input[placeholder*="Search" i]').first()).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('text=Recent').first()).toBeVisible({ timeout: 10000 })
   })
 
-  test('sort chips are clickable', async ({ page }) => {
+  test('shows either books or an empty state, never nothing', async ({ page }) => {
     await page.goto('/books')
     await page.waitForLoadState('networkidle')
-
-    // Click Title sort
-    const titleChip = page.locator('text=Title').first()
-    if (await titleChip.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await titleChip.click({ force: true })
-    }
-
-    // Click Oldest sort
-    const oldestChip = page.locator('text=Oldest').first()
-    if (await oldestChip.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await oldestChip.click({ force: true })
-    }
-  })
-
-  test('genre chips or books visible', async ({ page }) => {
-    await page.goto('/books')
-    await page.waitForLoadState('networkidle')
-
-    // Either genre chips or book cards or empty state
-    const hasContent = await page.locator('text=/All|No books/').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasContent).toBeTruthy()
+    await expect(page.locator('text=/All|No books/').first()).toBeVisible({ timeout: 15000 })
   })
 })

--- a/apps/mobile/e2e/tests/highlights.spec.ts
+++ b/apps/mobile/e2e/tests/highlights.spec.ts
@@ -1,53 +1,41 @@
 import { test, expect } from '@playwright/test'
 
+/**
+ * Highlights — the screen and its review route.
+ *
+ * Two tests were deleted: "book type tabs visible" and "sort and color filters
+ * visible". Both hid their only assertion inside an `if`, so the case they
+ * existed to catch — the row missing — passed silently. They are not converted
+ * here because signed out this screen renders a sign-in prompt and those rows do
+ * not exist to be asserted; making the claim needs an authenticated fixture,
+ * which is Lane A's job (MOBILE-TEST-PLAN.md).
+ *
+ * Every expectation below accepts the sign-in branch explicitly, rather than
+ * assuming a session this lane does not establish.
+ */
 test.describe('Highlights', () => {
-  test('highlights page loads', async ({ page }) => {
+  test('renders the screen or asks the reader to sign in', async ({ page }) => {
     await page.goto('/highlights')
     await page.waitForLoadState('networkidle')
-
-    // Should show Highlights header or empty state
-    const hasHighlights = await page.locator('text=Highlights').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasHighlights).toBeTruthy()
+    await expect(
+      page.locator('text=/Highlights|Sign in/i').first(),
+    ).toBeVisible({ timeout: 15000 })
   })
 
-  test('book type tabs visible', async ({ page }) => {
+  test('renders its search field or the sign-in prompt', async ({ page }) => {
     await page.goto('/highlights')
     await page.waitForLoadState('networkidle')
-
-    // Should show All/Library/Uploads tabs
-    const hasAll = await page.locator('text=All').first().isVisible({ timeout: 10000 }).catch(() => false)
-    if (hasAll) {
-      const hasLibrary = await page.locator('text=Library').first().isVisible({ timeout: 3000 }).catch(() => false)
-      const hasUploads = await page.locator('text=Uploads').first().isVisible({ timeout: 3000 }).catch(() => false)
-      expect(hasLibrary || hasUploads).toBeTruthy()
-    }
+    await expect(
+      page.locator('input[placeholder*="Search" i]').first()
+        .or(page.locator('text=/Sign in/i').first()),
+    ).toBeVisible({ timeout: 15000 })
   })
 
-  test('sort and color filters visible', async ({ page }) => {
-    await page.goto('/highlights')
-    await page.waitForLoadState('networkidle')
-
-    // Should show Newest/Oldest sort options
-    const hasSort = await page.locator('text=Newest').first().isVisible({ timeout: 10000 }).catch(() => false)
-    if (hasSort) {
-      const hasOldest = await page.locator('text=Oldest').first().isVisible({ timeout: 3000 }).catch(() => false)
-      expect(hasOldest).toBeTruthy()
-    }
-  })
-
-  test('search input visible', async ({ page }) => {
-    await page.goto('/highlights')
-    await page.waitForLoadState('networkidle')
-
-    const hasSearch = await page.locator('input[placeholder*="Search"]').or(page.locator('text=/Search highlights/i')).first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasSearch).toBeTruthy()
-  })
-
-  test('highlight review page loads', async ({ page }) => {
+  test('the review route renders', async ({ page }) => {
     await page.goto('/highlights/review')
     await page.waitForLoadState('networkidle')
-
-    const hasContent = await page.locator('text=/Review|caught up|No highlights/i').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasContent).toBeTruthy()
+    await expect(
+      page.locator('text=/Review|caught up|No highlights|Sign in/i').first(),
+    ).toBeVisible({ timeout: 15000 })
   })
 })

--- a/apps/mobile/e2e/tests/navigation.spec.ts
+++ b/apps/mobile/e2e/tests/navigation.spec.ts
@@ -1,30 +1,43 @@
 import { test, expect } from '@playwright/test'
 
+/**
+ * Route reachability. Every assertion here can fail.
+ *
+ * The previous version could not. Three of its four tests used
+ * `expect(await …isVisible().catch(() => false)).toBeTruthy()` — the catch
+ * swallows the timeout and the matcher then asserts a boolean the test itself
+ * produced, so a blank page passes. That shape was green throughout the week the
+ * Library screen was unusable, and its Library assertion matched the word
+ * "Saved", which was a tab name deleted in #452.
+ */
 test.describe('Navigation', () => {
-  test('home tab loads with books', async ({ page }) => {
+  test('/ redirects rather than rendering a screen of its own', async ({ page }) => {
+    // Home was deleted in #453 — `app/(tabs)/index.tsx` is now an auth-aware
+    // redirect: Library when signed in, Discover otherwise. These specs run
+    // signed out. `ColdResetOnResume` and `+not-found` both navigate here, so
+    // the redirect existing is load-bearing.
     await page.goto('/')
     await page.waitForLoadState('networkidle')
-    await expect(page.locator('text=TextStack').first()).toBeVisible({ timeout: 15000 })
+    await expect(page).toHaveURL(/\/(search|library)/)
   })
 
-  test('search page loads', async ({ page }) => {
+  test('Discover renders its search field', async ({ page }) => {
     await page.goto('/search')
     await page.waitForLoadState('networkidle')
-    const hasSearch = await page.locator('text=/Search across all books|Search books/').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasSearch).toBeTruthy()
+    await expect(page.locator('input[placeholder*="Search" i]').first()).toBeVisible({ timeout: 15000 })
   })
 
-  test('library page loads', async ({ page }) => {
+  test('Library signed out offers a way in', async ({ page }) => {
     await page.goto('/library')
     await page.waitForLoadState('networkidle')
-    const hasContent = await page.locator('text=/Saved|My Library|Sign In/').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasContent).toBeTruthy()
+    // Signed out, Library renders an EmptyState with a Sign In action. It must
+    // never be blank: this route is the app's front door since #453.
+    await expect(page.locator('text=/Sign in/i').first()).toBeVisible({ timeout: 15000 })
   })
 
-  test('profile page loads', async ({ page }) => {
+  test('Profile renders', async ({ page }) => {
     await page.goto('/profile')
     await page.waitForLoadState('networkidle')
-    const hasContent = await page.locator('text=/Sign In|Reading Stats|Browse/').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasContent).toBeTruthy()
+    await expect(page.locator('text=/Sign in|Appearance|Language/i').first()).toBeVisible({ timeout: 15000 })
   })
 })

--- a/apps/mobile/e2e/tests/reader-smoke.spec.ts
+++ b/apps/mobile/e2e/tests/reader-smoke.spec.ts
@@ -1,101 +1,74 @@
 import { test, expect } from '@playwright/test'
 
 /**
- * Reader smoke tests.
+ * Reader smoke.
  *
- * The reader renders its chapter content inside a WebView. Playwright can
- * see the shell (top bar, footer, settings drawer) but can't drive the
- * tap/selection gestures that actually live inside the embedded document.
- * So these tests check only the things that would fail catastrophically
- * if any of the reader hooks crashed on mount:
- *  - reader route resolves
- *  - top chrome / progress chrome render
- *  - settings drawer opens
+ * The reader renders its chapter inside a WebView. Playwright sees the shell —
+ * top bar, footer, sheets — but cannot drive the tap and selection gestures that
+ * live inside the embedded document, so this file checks only what would fail
+ * catastrophically if a reader hook crashed on mount. The gestures are covered
+ * by unit tests over the pure decisions (`pdfPersistGate`, `readerChrome`,
+ * `pdfViewerChrome`) and by a device pass.
  *
- * Real verification of the tap-to-WordCard, scroll-restore, and vocab
- * underline behaviors lives in the manual checklist on a physical device.
+ * **On skipping.** The previous version skipped itself six ways: no book card,
+ * no start button, no TOC button. Every one of those is also what a broken
+ * reader looks like, so the suite went green in exactly the cases it existed to
+ * catch. Only one precondition is genuinely environmental — whether this
+ * deployment's catalog has any books at all — and it is now the single skip,
+ * with a message that says so. Everything downstream of it fails.
  */
+
+/** Navigate from the catalog to an open reader. Fails loudly at every step. */
+async function openFirstBook(page: import('@playwright/test').Page) {
+  // `/` is an auth-aware redirect since #453; signed out it lands on Discover,
+  // which lists recently added books.
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  const bookCard = page.locator('[data-testid="book-card"]').or(page.locator('img')).first()
+  const catalogHasBooks = await bookCard.isVisible({ timeout: 15000 }).catch(() => false)
+  test.skip(!catalogHasBooks, 'This deployment has an empty catalog — nothing to open.')
+
+  await bookCard.click()
+  await page.waitForLoadState('networkidle')
+
+  // A book that opened must offer a way in. If this is missing the detail
+  // screen is broken, which is a failure, not a reason to stop looking.
+  const startBtn = page.locator('text=/Start Reading|Continue Reading|Start reading/').first()
+  await expect(startBtn).toBeVisible({ timeout: 15000 })
+  await startBtn.click()
+  await page.waitForLoadState('networkidle')
+
+  await expect(page).toHaveURL(/\/reader\//, { timeout: 15000 })
+}
+
 test.describe('Reader (smoke)', () => {
-  test('reader route mounts without crash', async ({ page }) => {
-    // Get a real book slug from the home feed so we don't pin to a single
-    // book that might rotate out of the library.
-    await page.goto('/')
-    await page.waitForLoadState('networkidle')
-
-    const bookCard = page.locator('[data-testid="book-card"]').or(page.locator('img').first())
-    if (!(await bookCard.first().isVisible({ timeout: 10000 }).catch(() => false))) {
-      test.skip(true, 'No books in home feed — skipping reader smoke')
-    }
-    await bookCard.first().click()
-    await page.waitForLoadState('networkidle')
-    await page.waitForTimeout(1500)
-
-    const startBtn = page.locator('text=/Start Reading|Continue Reading/').first()
-    if (!(await startBtn.isVisible({ timeout: 10000 }).catch(() => false))) {
-      test.skip(true, 'No start-reading button on book detail — skipping')
-    }
-    await startBtn.click()
-    await page.waitForLoadState('networkidle')
-    await page.waitForTimeout(3000)
-
-    // Reader URL pattern: /reader/<bookSlug>/<chapterSlug>. If the screen
-    // crashed we'd land on a NotFound or get routed back home.
-    await expect(page).toHaveURL(/\/reader\//)
+  test('a catalog book opens into the reader', async ({ page }) => {
+    await openFirstBook(page)
   })
 
-  /**
-   * TOC sheet — bug-sweep regression guard (ADR-011).
-   * Bug was: chapters array missing → TocSheet rendered with only header
-   * (collapsed to 0 height) and no visible empty state. Fix: minHeight +
-   * loading/empty states.
-   *
-   * Verifiable in Playwright: sheet opens and shows EITHER chapter rows OR
-   * the empty/loading copy. Anything other than those two cases (e.g.
-   * blank sheet) means the fix regressed.
-   */
-  test('TOC sheet opens and shows chapters OR loading/empty state', async ({ page }) => {
-    await page.goto('/')
-    await page.waitForLoadState('networkidle')
+  test('the table of contents opens and is never an empty sheet', async ({ page }) => {
+    // ADR-011 regression guard. The bug was a missing chapters array rendering
+    // the sheet collapsed to zero height with no empty state — a sheet that
+    // opens onto nothing at all.
+    await openFirstBook(page)
 
-    const bookCard = page.locator('[data-testid="book-card"]').or(page.locator('img').first())
-    if (!(await bookCard.first().isVisible({ timeout: 10000 }).catch(() => false))) {
-      test.skip(true, 'No books in home feed — skipping TOC test')
-    }
-    await bookCard.first().click()
-    await page.waitForLoadState('networkidle')
-    const startBtn = page.locator('text=/Start Reading|Continue Reading/').first()
-    if (!(await startBtn.isVisible({ timeout: 10000 }).catch(() => false))) {
-      test.skip(true, 'No start-reading button — skipping')
-    }
-    await startBtn.click()
-    await page.waitForLoadState('networkidle')
-    await page.waitForTimeout(3000)
-    await expect(page).toHaveURL(/\/reader\//)
-
-    // Reveal chrome (bars auto-hide on chapter load).
+    // Bars auto-hide three seconds after load; a tap brings them back. Since
+    // #463 a tap anywhere does this, including on a word.
     await page.locator('body').click({ position: { x: 200, y: 400 } })
-    await page.waitForTimeout(500)
 
-    // Locate TOC button via accessibilityLabel. In react-native-web Ionicons
-    // round-trip aria-label as the wrapping TouchableOpacity's accessibilityLabel.
-    // Tolerate slight wording variation across builds (ReaderTopBar may
-    // localize the label).
     const tocBtn = page.locator('[aria-label*="contents" i], [aria-label*="table of contents" i]').first()
-    if (!(await tocBtn.isVisible({ timeout: 3000 }).catch(() => false))) {
-      test.skip(true, 'TOC button not addressable in this build — skipping')
-    }
+    await expect(tocBtn).toBeVisible({ timeout: 10000 })
     await tocBtn.click()
 
-    // Sheet header always renders "Contents".
-    await expect(page.locator('text=Contents').first()).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('text=Contents').first()).toBeVisible({ timeout: 10000 })
 
-    // Body MUST show one of: chapter rows, loading spinner, or empty copy.
-    // If none visible, sheet is broken (the original bug).
-    const hasLoading = await page.locator('text=Loading chapters').isVisible({ timeout: 2000 }).catch(() => false)
-    const hasEmpty = await page.locator('text=No chapters available').isVisible({ timeout: 2000 }).catch(() => false)
-    // Chapter rows render as "<chapterNum>" followed by title — number-only
-    // strings are reliably distinguishable from chrome.
-    const hasChapter = await page.locator('text=/^\\s*1\\s*$/').first().isVisible({ timeout: 2000 }).catch(() => false)
-    expect(hasChapter || hasLoading || hasEmpty).toBe(true)
+    // The body must say one of three things. Anything else — most importantly
+    // nothing — is the bug this test exists for.
+    await expect(
+      page.locator('text=Loading chapters').first()
+        .or(page.locator('text=No chapters available').first())
+        .or(page.locator('text=/^\\s*1\\s*$/').first()),
+    ).toBeVisible({ timeout: 10000 })
   })
 })

--- a/apps/mobile/e2e/tests/search.spec.ts
+++ b/apps/mobile/e2e/tests/search.spec.ts
@@ -1,53 +1,36 @@
 import { test, expect } from '@playwright/test'
 
+/**
+ * Discover — search and the catalog it sits on.
+ *
+ * Two tests were deleted rather than repaired. "search results are grouped by
+ * book" and "clear button resets search" each performed some clicks and then
+ * ended, with no `expect` at all — they reported green on every run including
+ * ones where the feature was broken, because they never made a claim. A test
+ * that cannot fail is worse than no test: it occupies the place where a real
+ * one would go.
+ */
 test.describe('Search', () => {
-  test('search page shows empty state', async ({ page }) => {
+  test('opens on its empty state', async ({ page }) => {
     await page.goto('/search')
     await page.waitForLoadState('networkidle')
-
-    const hasPlaceholder = await page.locator('text=Search across all books').isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasPlaceholder).toBeTruthy()
+    await expect(page.locator('text=Search across all books').first()).toBeVisible({ timeout: 15000 })
   })
 
-  test('search input accepts text and returns results', async ({ page }) => {
+  test('a query resolves to results or to a stated absence of them', async ({ page }) => {
+    // The point of the alternation: an offline or failed search used to render
+    // as "No results for …" — a claim about the catalog rather than the
+    // connection. Both branches are legitimate answers; a blank screen is not.
     await page.goto('/search')
     await page.waitForLoadState('networkidle')
 
-    const input = page.locator('input[placeholder*="Search"]')
+    const input = page.locator('input[placeholder*="Search" i]').first()
     await input.fill('the')
     await input.press('Enter')
-    await page.waitForTimeout(2000)
 
-    // Should show results or no results
-    const hasResults = await page.locator('text=/\\d+ books?/').first().isVisible({ timeout: 10000 }).catch(() => false)
-    const hasNoResults = await page.locator('text=No results').first().isVisible({ timeout: 3000 }).catch(() => false)
-    expect(hasResults || hasNoResults).toBeTruthy()
-  })
-
-  test('search results are grouped by book', async ({ page }) => {
-    await page.goto('/search')
-    await page.waitForLoadState('networkidle')
-
-    const input = page.locator('input[placeholder*="Search"]')
-    await input.fill('the')
-    await input.press('Enter')
-    await page.waitForTimeout(2000)
-
-    // If results, should show "N books · M matches" summary
-    const hasSummary = await page.locator('text=/\\d+ books?.*\\d+ match/').first().isVisible({ timeout: 5000 }).catch(() => false)
-    // Summary may or may not show depending on results
-  })
-
-  test('clear button resets search', async ({ page }) => {
-    await page.goto('/search')
-    await page.waitForLoadState('networkidle')
-
-    const input = page.locator('input[placeholder*="Search"]')
-    await input.fill('test')
-
-    // Clear button should appear
-    await page.waitForTimeout(500)
-    const clearBtn = page.locator('[aria-label="close-circle"]').or(page.locator('svg').last())
-    // Clicking clear returns to empty state
+    await expect(
+      page.locator('text=/\\d+ books?/').first()
+        .or(page.locator('text=/No results|offline/i').first()),
+    ).toBeVisible({ timeout: 15000 })
   })
 })

--- a/apps/mobile/e2e/tests/vocabulary.spec.ts
+++ b/apps/mobile/e2e/tests/vocabulary.spec.ts
@@ -1,44 +1,48 @@
 import { test, expect } from '@playwright/test'
 
+/**
+ * Vocabulary — the screen and its two review routes.
+ *
+ * "filter tabs visible" used to wrap its only assertion in `if (hasAll)`, so
+ * when the tabs were missing — the case it existed to catch — it asserted
+ * nothing and passed. The condition is now the assertion.
+ *
+ * Note the chrome here changed in #464: eight blocks above the first word
+ * became three, and review style and sort moved into a view sheet. These tests
+ * assert the three that stayed.
+ */
 test.describe('Vocabulary', () => {
-  test('vocabulary page loads', async ({ page }) => {
+  test('renders the screen or asks the reader to sign in', async ({ page }) => {
     await page.goto('/vocabulary')
     await page.waitForLoadState('networkidle')
-
-    // Should show vocabulary header or empty state
-    const hasVocab = await page.locator('text=/Vocabulary|No words yet|Sign in/i').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasVocab).toBeTruthy()
+    await expect(
+      page.locator('text=/Vocabulary|No words yet|Sign in/i').first(),
+    ).toBeVisible({ timeout: 15000 })
   })
 
-  test('filter tabs visible', async ({ page }) => {
+  test('the filter row is present and is a row of filters', async ({ page }) => {
     await page.goto('/vocabulary')
     await page.waitForLoadState('networkidle')
-
-    // Filter tabs: All, New, Learning, Mastered
-    const hasAll = await page.locator('text=All').first().isVisible({ timeout: 10000 }).catch(() => false)
-    if (hasAll) {
-      const hasNew = await page.locator('text=New').first().isVisible({ timeout: 3000 }).catch(() => false)
-      const hasLearning = await page.locator('text=Learning').first().isVisible({ timeout: 3000 }).catch(() => false)
-      expect(hasNew || hasLearning).toBeTruthy()
-    }
+    // Six filters since #464 — All, New, Learning, Mastered, Pending, Lookups.
+    // Asserting two of them distinguishes "the row rendered" from "some element
+    // somewhere happens to say All".
+    await expect(page.locator('text=All').first()).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('text=/New|Learning/').first()).toBeVisible({ timeout: 10000 })
   })
 
-  test('review page accessible', async ({ page }) => {
+  test('the review route renders', async ({ page }) => {
     await page.goto('/vocabulary/review')
     await page.waitForLoadState('networkidle')
-
-    // Should show review UI or empty state
-    const hasReview = await page.locator('text=/Review|No words|nothing to review/i').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasReview).toBeTruthy()
+    await expect(
+      page.locator('text=/Review|No words|nothing to review|Sign in/i').first(),
+    ).toBeVisible({ timeout: 15000 })
   })
 
-  test('practice mode route loads', async ({ page }) => {
+  test('the practice route renders', async ({ page }) => {
     await page.goto('/vocabulary/review?practice=1')
     await page.waitForLoadState('networkidle')
-
-    // Practice route is reachable — backend returns weeklyProgress=null so
-    // the bar is hidden; just verify the page itself renders without crashing.
-    const hasPage = await page.locator('text=/Practice|Review|No words|nothing to review/i').first().isVisible({ timeout: 10000 }).catch(() => false)
-    expect(hasPage).toBeTruthy()
+    await expect(
+      page.locator('text=/Practice|Review|No words|nothing to review|Sign in/i').first(),
+    ).toBeVisible({ timeout: 15000 })
   })
 })


### PR DESCRIPTION
Option 1 from the three offered: delete what tests removed UI or asserts nothing, fix the shape in the rest, leave full Lane A as the tester's brief.

## The measurement

| | before | after |
|---|---|---|
| tests | 22 | 17 |
| assertions that cannot fail | **34** | **0** |

The shape, which appeared 34 times:

```ts
expect(await page.locator('…').isVisible().catch(() => false)).toBeTruthy()
```

The `catch` swallows the timeout, and the matcher then asserts a boolean the same line produced two expressions ago. A blank page passes.

This is not theoretical. A suite in this shape was green for the whole week the Library screen was unusable, and green again through the manual pass that found 24 defects.

## Five deleted

**Three contained no `expect` at all** — `sort chips are clickable`, `search results are grouped by book`, `clear button resets search`. They clicked things and ended. They could not fail, and could not pass either; they only ran, occupying the place a real test would go.

**Two hid their only assertion inside an `if`** (`book type tabs visible`, `sort and color filters visible`), so the case they existed to catch passed silently. Not repaired here: signed out, the Highlights screen renders a sign-in prompt and those rows do not exist to be asserted. Making that claim needs an authenticated fixture, which is Lane A.

## Six self-skips became one

`reader-smoke.spec.ts` skipped on "no book card", "no start button", "no TOC button" — every one of which is *also what a broken reader looks like*. The suite stopped looking in exactly the cases it existed to catch.

One precondition is genuinely environmental — whether a deployment's catalog has any books — and it keeps its skip, with a message that says so. Everything downstream of it now fails.

## Two specs asserted UI that no longer exists

`navigation.spec.ts` matched the word **"Saved"** — a tab deleted in #452 — and treated `/` as a screen rather than the auth-aware redirect it became in #453. It now asserts the redirect, which is load-bearing: `ColdResetOnResume` and `+not-found` both navigate there.

`vocabulary.spec.ts` now asserts the three blocks that survived #464 rather than the eight that did not.

## Still not in CI

Deliberately. These need a live backend, so they cannot gate a PR — making them hermetic is Lane A of `MOBILE-TEST-PLAN.md` and remains undone. The new `apps/mobile/e2e/README.md` says that plainly, along with what this lane can and cannot see, so the next person does not mistake it for coverage.

Every fix in this week's sweep shipped with pure unit tests instead — around sixty. Fewer tests that can fail beat more that cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)