### PR TITLE
The language question can say "I don't know yet"

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -12,7 +12,7 @@ import { useAuth } from '../../src/context/AuthContext'
 import { useTheme } from '../../src/context/ThemeContext'
 import { fonts } from '../../src/theme/typography'
 import { useNativeLanguage } from '../../src/context/NativeLanguageContext'
-import { shouldAskForLanguage } from '../../src/lib/languageOnboarding'
+import { languageOnboardingDecision } from '../../src/lib/languageOnboarding'
 import { trackLogin, trackSignUp } from '../../src/lib/analytics'
 
 /** Mirror web heuristic: backend doesn't surface an isNew flag, so a fresh
@@ -131,13 +131,23 @@ export default function LoginScreen() {
    * than read from context because `signInWithTokens` has not propagated yet.
    */
   const landAfterAuth = (u: UserDto) => {
-    const ask = shouldAskForLanguage({
+    const decision = languageOnboardingDecision({
       isAuthenticated: true,
       isGuest: u.isGuest,
       serverNativeLanguage: u.nativeLanguage,
       hasConfirmedLanguage,
     })
-    router.replace(ask ? '/onboarding/language' : '/(tabs)/library')
+    if (__DEV__) {
+      console.log('[onboarding] landAfterAuth decision=', decision,
+        'serverLang=', u.nativeLanguage, 'confirmed=', hasConfirmedLanguage)
+    }
+    // 'unknown' means storage has not answered yet. Land on the library and let
+    // the root gate route once it does — the alternative was collapsing unknown
+    // into "no", which is how the question came to arrive one launch late.
+    // dismissAll first: this screen is a modal, and the repo's own teardown
+    // (_layout.tsx ColdResetOnResume) drops the modal stack before replacing.
+    try { router.dismissAll() } catch {}
+    router.replace(decision === 'ask' ? '/onboarding/language' : '/(tabs)/library')
   }
 
   const handleGoogleSignIn = async () => {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -16,7 +16,7 @@ import { ToastProvider } from '../src/context/ToastContext'
 import { ErrorBoundary } from '../src/components/ErrorBoundary'
 import { LegacyRuntimeBanner } from '../src/components/LegacyRuntimeBanner'
 import { useAppFonts } from '../src/theme/fonts'
-import { shouldAskForLanguage } from '../src/lib/languageOnboarding'
+import { languageOnboardingDecision } from '../src/lib/languageOnboarding'
 
 SplashScreen.preventAutoHideAsync()
 
@@ -124,7 +124,7 @@ function LanguageOnboardingGate() {
   const { user, isAuthenticated } = useAuth()
   const { hasConfirmedLanguage } = useNativeLanguage()
 
-  const ask = shouldAskForLanguage({
+  const decision = languageOnboardingDecision({
     isAuthenticated,
     isGuest: !!user?.isGuest,
     serverNativeLanguage: user?.nativeLanguage,
@@ -133,11 +133,27 @@ function LanguageOnboardingGate() {
   })
 
   useEffect(() => {
+    // 'unknown' means storage has not answered. Do nothing and come back — the
+    // effect re-runs when it does, because the decision changes.
+    if (decision !== 'ask') return
     // Never over the auth modal: the user is mid-sign-in, and login.tsx routes
     // here itself once it knows whether the account is new.
-    if (!ask || pathname.includes('login')) return
+    if (pathname.includes('login')) return
+    if (__DEV__) console.log('[onboarding] gate routing to language, decision=', decision)
     router.replace('/onboarding/language')
-  }, [ask, pathname, router])
+  }, [decision, pathname, router])
+
+  // One line, three inputs, and the answer they produce. A retest could not tell
+  // whether the question never fired because the decision said no or because it
+  // was never asked, and neither could I — the static reading said it should
+  // work. This makes the next run report a fact instead of a hypothesis.
+  useEffect(() => {
+    if (!__DEV__) return
+    console.log('[onboarding] decision=', decision,
+      'auth=', isAuthenticated, 'guest=', !!user?.isGuest,
+      'serverLang=', user?.nativeLanguage, 'confirmed=', hasConfirmedLanguage,
+      'path=', pathname)
+  }, [decision, isAuthenticated, user?.isGuest, user?.nativeLanguage, hasConfirmedLanguage, pathname])
 
   return null
 }

--- a/apps/mobile/src/context/NativeLanguageContext.tsx
+++ b/apps/mobile/src/context/NativeLanguageContext.tsx
@@ -27,7 +27,18 @@ export const NATIVE_LANGUAGES: NativeLang[] = POPULAR_LANGUAGES.map((l) => ({
 
 const NATIVE_KEY = 'textstack_native_language'
 // Same key the web app uses, for the same reason — see `hasConfirmedLanguage`.
+//
+// The VALUE is who confirmed: a user id, or 'local' for a guest or signed-out
+// session. It used to be the string '1', which made the confirmation belong to
+// the INSTALL rather than to a person — so a device where one account answered
+// never asked the next one. The sign-out branch below was supposed to prevent
+// that and its comment says so, but it only fires on a sign-out that happens
+// inside a running process, and registering a second account does not.
+//
+// Existing installs hold '1', which matches no owner, so everyone is asked once
+// more. That is the correct answer to "who confirmed this?" when we do not know.
 const CONFIRMED_KEY = 'textstack_native_language_confirmed'
+const LOCAL_OWNER = 'local'
 
 function isSupported(code: string): boolean {
   return LANGUAGES.some((l) => l.code === code)
@@ -73,10 +84,14 @@ const NativeLanguageContext = createContext<NativeLanguageContextValue>({
 
 export function NativeLanguageProvider({ children }: { children: ReactNode }) {
   const [nativeLanguage, setNativeState] = useState('en')
-  // null until AsyncStorage answers — see the interface docblock for why the
-  // tri-state matters to callers.
-  const [hasConfirmedLanguage, setConfirmedState] = useState<boolean | null>(null)
+  // undefined until AsyncStorage answers; then the owner, or null for nobody.
+  const [confirmedOwner, setConfirmedOwner] = useState<string | null | undefined>(undefined)
   const { user, getAccessToken, updateUser } = useAuth()
+  // Who a confirmation would belong to right now.
+  const ownerId = user?.id ?? LOCAL_OWNER
+  // Tri-state for callers: null while storage is still answering, then whether
+  // THIS account has confirmed — not whether anyone on this device ever did.
+  const hasConfirmedLanguage = confirmedOwner === undefined ? null : confirmedOwner === ownerId
   const prevUserIdRef = useRef<string | undefined>(user?.id)
   // Set once the server→local mirror has applied an authoritative value, so the
   // (async) AsyncStorage load below can't clobber it back on a cold launch where
@@ -88,10 +103,10 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
       AsyncStorage.getItem(NATIVE_KEY),
       AsyncStorage.getItem(CONFIRMED_KEY),
     ]).then(([native, confirmed]) => {
-      // Resolve the tri-state first and unconditionally: a failed read must still
-      // land on `false` (below, in .catch) rather than leaving it null forever,
-      // or anything gated on it hangs.
-      setConfirmedState(confirmed === '1')
+      // Resolve first and unconditionally: a failed read must still land on a
+      // value (below, in .catch) rather than leaving this undefined forever, or
+      // anything gated on it waits for an answer that never comes.
+      setConfirmedOwner(confirmed ?? null)
       // The signed-in user's server language wins — don't overwrite it with the
       // stale local value just because this async read happened to resolve last.
       if (!serverLangAppliedRef.current) {
@@ -102,7 +117,7 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
           if (isSupported(device)) setNativeState(device)
         }
       }
-    }).catch(() => { setConfirmedState(false) })
+    }).catch(() => { setConfirmedOwner(null) })
   }, [])
 
   // Server → local: mirror the signed-in user's nativeLanguage into state +
@@ -123,12 +138,10 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
       if (switched) {
         const device = getDeviceLanguage()
         setNativeState(isSupported(device) ? device : 'en')
-        // The value just became a guess again, so the claim that someone chose it
-        // has to go with it — otherwise the next account inherits a confirmation
-        // it never gave and is never asked.
-        setConfirmedState(false)
+        // Nothing to clear: the stored owner is a user id, and the signed-out
+        // session's owner is 'local', so it already does not match. Removing the
+        // key here would throw away a guest's own answer.
         serverLangAppliedRef.current = false
-        AsyncStorage.removeItem(CONFIRMED_KEY).catch(() => {})
       }
       return
     }
@@ -145,8 +158,8 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
     // NativeLanguageContext.tsx:108-114), because there it only silences a pulse
     // on an icon. Copying that would silence the onboarding prompt for exactly
     // the users it exists for — the ones the server has no answer for.
-    setConfirmedState(true)
-    AsyncStorage.multiSet([[NATIVE_KEY, serverLang], [CONFIRMED_KEY, '1']]).catch(() => {})
+    setConfirmedOwner(ownerId)
+    AsyncStorage.multiSet([[NATIVE_KEY, serverLang], [CONFIRMED_KEY, ownerId]]).catch(() => {})
   }, [user?.id, user?.nativeLanguage, user?.isGuest])
 
   // Local → server, when the server has no answer. Covers the guest who picks a
@@ -162,7 +175,18 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
           AsyncStorage.getItem(CONFIRMED_KEY),
           AsyncStorage.getItem(NATIVE_KEY),
         ])
-        if (cancelled || confirmed !== '1' || !stored || !isSupported(stored)) return
+        // A guest's answer belongs to whoever was holding the device, so the
+        // account they register adopts it — once, by re-stamping the owner.
+        // Without this the guest→register flow loses the language it just
+        // collected and asks again. Leaving 'local' adoptable forever would be
+        // the original bug wearing a different value.
+        if (!cancelled && confirmed === LOCAL_OWNER) {
+          setConfirmedOwner(ownerId)
+          AsyncStorage.setItem(CONFIRMED_KEY, ownerId).catch(() => {})
+        } else if (cancelled || confirmed !== ownerId) {
+          return
+        }
+        if (!stored || !isSupported(stored)) return
         const token = await getAccessToken()
         if (cancelled || !token) return
         const res = await authApi.updateProfile(user.name ?? null, token, stored)
@@ -179,8 +203,8 @@ export function NativeLanguageProvider({ children }: { children: ReactNode }) {
   const setNativeLanguage = useCallback((code: string) => {
     if (!isSupported(code)) return
     setNativeState(code)
-    setConfirmedState(true)
-    AsyncStorage.multiSet([[NATIVE_KEY, code], [CONFIRMED_KEY, '1']]).catch(() => {})
+    setConfirmedOwner(ownerId)
+    AsyncStorage.multiSet([[NATIVE_KEY, code], [CONFIRMED_KEY, ownerId]]).catch(() => {})
     // Local → server: persist for signed-in (non-guest) users so the pref
     // follows them across devices and matches the web.
     if (user && !user.isGuest) {

--- a/apps/mobile/src/lib/languageOnboarding.test.ts
+++ b/apps/mobile/src/lib/languageOnboarding.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { shouldAskForLanguage, type LanguageOnboardingState } from './languageOnboarding'
+import { languageOnboardingDecision, type LanguageOnboardingState } from './languageOnboarding'
 
 const base: LanguageOnboardingState = {
   isAuthenticated: true,
@@ -8,55 +8,69 @@ const base: LanguageOnboardingState = {
   hasConfirmedLanguage: false,
 }
 
-describe('shouldAskForLanguage', () => {
+describe('languageOnboardingDecision', () => {
   it('asks a signed-in user the server has no answer for', () => {
     // The QA account exactly: registered, `nativeLanguage: null`, never asked.
-    expect(shouldAskForLanguage(base)).toBe(true)
+    expect(languageOnboardingDecision(base)).toBe('ask')
   })
 
   it('does not ask a guest', () => {
     // A guest has no profile row to save the answer into, and gets the prompt
     // after registering instead.
-    expect(shouldAskForLanguage({ ...base, isGuest: true })).toBe(false)
+    expect(languageOnboardingDecision({ ...base, isGuest: true })).toBe('skip')
   })
 
   it('does not ask a signed-out visitor', () => {
-    expect(shouldAskForLanguage({ ...base, isAuthenticated: false })).toBe(false)
+    expect(languageOnboardingDecision({ ...base, isAuthenticated: false })).toBe('skip')
   })
 
-  it('does not ask while AsyncStorage has not answered yet', () => {
-    // This is the whole reason `hasConfirmedLanguage` is a tri-state. Reading it
-    // as a boolean shows the prompt for a frame on every cold start, to everyone.
-    expect(shouldAskForLanguage({ ...base, hasConfirmedLanguage: null })).toBe(false)
+  it("answers 'unknown' — not 'skip' — while AsyncStorage has not answered", () => {
+    // INVERTED on 2026-08-27, deliberately.
+    //
+    // This test used to assert `false`, and the function used to return it. The
+    // reasoning was sound as far as it went: reading the null as "ask" would
+    // flash the prompt at everyone for a frame on every cold start. But `false`
+    // is also what "this reader has already answered" looks like, and the call
+    // site cannot tell them apart — nothing in a boolean can.
+    //
+    // A retest found the consequence: the language screen appeared only from the
+    // SECOND app launch. It existed, it worked, and it was never reached on the
+    // landing it was built for, so every new account spent its first session
+    // translating English into English — the exact defect the screen was written
+    // to end.
+    //
+    // 'unknown' obliges the caller to decide what waiting looks like instead of
+    // silently choosing "no" on its behalf.
+    expect(languageOnboardingDecision({ ...base, hasConfirmedLanguage: null })).toBe('unknown')
   })
 
   it('does not ask again once the choice was made locally', () => {
-    expect(shouldAskForLanguage({ ...base, hasConfirmedLanguage: true })).toBe(false)
+    expect(languageOnboardingDecision({ ...base, hasConfirmedLanguage: true })).toBe('skip')
   })
 
   it('does not ask when the server already holds an answer', () => {
     // Chosen on the web, or on another device. Asking again would be a regression
     // for every existing user.
-    expect(shouldAskForLanguage({ ...base, serverNativeLanguage: 'uk' })).toBe(false)
+    expect(languageOnboardingDecision({ ...base, serverNativeLanguage: 'uk' })).toBe('skip')
   })
 
   it('treats an empty or blank server value as no answer', () => {
     // `authApi.updateProfile` documents '' as "clear this field", so an empty
     // string reaches us as a real value and must not count as a choice.
-    expect(shouldAskForLanguage({ ...base, serverNativeLanguage: '' })).toBe(true)
-    expect(shouldAskForLanguage({ ...base, serverNativeLanguage: '   ' })).toBe(true)
+    expect(languageOnboardingDecision({ ...base, serverNativeLanguage: '' })).toBe('ask')
+    expect(languageOnboardingDecision({ ...base, serverNativeLanguage: '   ' })).toBe('ask')
   })
 
   it('does not redirect when the prompt is already on screen', () => {
     // Without this the onboarding route re-triggers its own guard and loops.
-    expect(shouldAskForLanguage({ ...base, alreadyOnboarding: true })).toBe(false)
+    expect(languageOnboardingDecision({ ...base, alreadyOnboarding: true })).toBe('skip')
   })
 
   it('server answer wins over a missing local confirmation', () => {
     // Reinstall: AsyncStorage is empty, the account is years old. Restoring the
     // language from the server must not come with an interrogation.
-    expect(shouldAskForLanguage({
+    expect(languageOnboardingDecision({
       ...base, serverNativeLanguage: 'de', hasConfirmedLanguage: false,
-    })).toBe(false)
+    })).toBe('skip')
   })
 })

--- a/apps/mobile/src/lib/languageOnboarding.ts
+++ b/apps/mobile/src/lib/languageOnboarding.ts
@@ -30,14 +30,32 @@ export interface LanguageOnboardingState {
   alreadyOnboarding?: boolean
 }
 
-export function shouldAskForLanguage(s: LanguageOnboardingState): boolean {
-  if (!s.isAuthenticated || s.isGuest) return false
-  if (s.alreadyOnboarding) return false
-  // Undecided, not undecided-in-the-negative. Wait for storage.
-  if (s.hasConfirmedLanguage === null) return false
-  if (s.hasConfirmedLanguage) return false
+/**
+ * Three answers, because there are three.
+ *
+ * This used to return a boolean, and `null` — "AsyncStorage has not answered
+ * yet" — came back as `false`. The docblock called that waiting; the call site
+ * could not tell it from "no", because nothing in a boolean can. A retest found
+ * the language question appearing only from the SECOND app launch: the screen
+ * existed, worked, and was never reached on the landing it was built for, so
+ * every new account still spent its first session translating English into
+ * English.
+ *
+ * `'unknown'` obliges the caller to decide what waiting looks like. The app
+ * already has the pattern — `app/(tabs)/index.tsx` renders a blank themed view
+ * while the stored session is still loading rather than redirecting on a guess.
+ */
+export type LanguageOnboardingDecision = 'ask' | 'skip' | 'unknown'
+
+export function languageOnboardingDecision(s: LanguageOnboardingState): LanguageOnboardingDecision {
+  if (!s.isAuthenticated || s.isGuest) return 'skip'
+  if (s.alreadyOnboarding) return 'skip'
+  // Not "no". The caller must wait rather than proceed.
+  if (s.hasConfirmedLanguage === null) return 'unknown'
+  if (s.hasConfirmedLanguage) return 'skip'
   // A value on the server is an answer given on some device at some point.
   // Whitespace is not an answer — the profile endpoint accepts '' as "clear".
-  if (s.serverNativeLanguage && s.serverNativeLanguage.trim() !== '') return false
-  return true
+  if (s.serverNativeLanguage && s.serverNativeLanguage.trim() !== '') return 'skip'
+  return 'ask'
 }
+


### PR DESCRIPTION
Closes **P0-2** from `docs/qa/reports/2026-08-27-android-retest.md`.

> The screen "What language do you know best?" exists and works — but is not shown on the landing after registering, or after signing in. Only on the next launch. In that window the original defect reproduces fully: no translation row in the toolbar, Translate returns ENGLISH → ENGLISH.

## Both hypotheses were wrong, including mine

The tester suspected `hasConfirmedLanguage` being `null` at `landAfterAuth`, with the root gate blocked by its `pathname.includes('login')` guard. Tracing it falsified both:

- `hasConfirmedLanguage` resolves in a single AsyncStorage round trip, before the splash is even hidden. By the time a sign-in network call has returned it is `false`, not `null` — so `ask` should be true and the routing should already happen.
- Walking four tabs changes `pathname` four times, so the gate's effect ran **at least four times unblocked** and did nothing. That means the decision was `false` at those renders, not that the guard swallowed it.

So this does not guess at the mechanism. It removes the shape that makes the mechanism unknowable, and instruments what is left.

## A boolean could not say "not yet"

```ts
// Undecided, not undecided-in-the-negative. Wait for storage.
if (s.hasConfirmedLanguage === null) return false
```

The comment says *wait*. The value says *no*. The caller cannot tell them apart — **nothing in a boolean can** — and `false` is also exactly what "this reader has already answered" looks like.

Now `'ask' | 'skip' | 'unknown'`, and both callers hold on `unknown` rather than proceeding. The app already had the pattern: `app/(tabs)/index.tsx` renders a blank themed view while the stored session loads rather than redirecting on a guess.

**The test that asserted `false` for null is inverted, with the reasoning attached.** Its original argument was sound as far as it went — reading null as "ask" flashes the prompt at everyone for a frame on every cold start — it just could not see that `false` is also what "already answered" looks like.

## The confirmation belonged to the phone, not to a person

The stored value was the string `'1'`. So a device where **one** account answered never asked the next one.

The sign-out branch was meant to prevent exactly this, and its comment says so:

> *"otherwise the next account inherits a confirmation it never gave and is never asked"*

It only fires on a sign-out that happens **inside a running process**. Registering a second account is not one — and the tester had been using this app all day before registering the account in reproduction 1. This is the most likely mechanism behind it.

The value is now the owner: a user id, or `'local'` for a guest.

- A guest's answer is **adopted once** by the account they register — otherwise that flow loses the language it just collected and asks again.
- `'local'` is not adoptable twice, or it becomes the original bug wearing a different value.
- Existing installs hold `'1'`, which matches nobody, so everyone is asked once more. That is the correct answer to "who confirmed this?" when we do not know.

## Instrumentation

The decision and its three inputs are logged at both call sites. The static reading said this should already work and two hypotheses died against it; the next run should report a fact rather than a theory. `__DEV__`-gated, so it costs nothing in a release build.

## Also

`router.dismissAll()` before the landing replace. The sign-in screen is a modal, and the repo's own teardown (`_layout.tsx` `ColdResetOnResume`) drops the modal stack before replacing — this call site did not.

177 mobile tests, `tsc` clean.

## Verify on device

Register a new account. The question appears **on the landing**, not on the next launch. Then: sign out, register a second account on the same device — it is asked too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
