### PR TITLE
One way to read a book's progress, and a dash when it is unknown

### DIFF
--- a/apps/mobile/app/my-books/[id].tsx
+++ b/apps/mobile/app/my-books/[id].tsx
@@ -3,7 +3,7 @@ import { View, Text, ScrollView, StyleSheet, TouchableOpacity, ActivityIndicator
 import { Image } from 'expo-image'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
-import { userBooksApi, getStorageUrl, getApiConfig, computeBookProgress, parsePdfPageLocator, chapterSlugForPage } from '@textstack/shared'
+import { userBooksApi, getStorageUrl, getApiConfig, storedBookPercent, formatBookPercent, parsePdfPageLocator, chapterSlugForPage } from '@textstack/shared'
 import type { UserBookDetailResponse } from '@textstack/shared'
 import { enrichUserBook } from '../../src/lib/api'
 import { useTheme } from '../../src/context/ThemeContext'
@@ -244,17 +244,16 @@ export default function UserBookDetailScreen() {
   }
 
   const estPages = book.totalWordCount ? Math.round(book.totalWordCount / 250) : null
-  // Book-wide percent (not chapter-scroll percent) — mirror the reader/library
-  // so the detail page doesn't show "85%" while the user is on chapter 2. Slug
-  // fallback matches the reader's `slug || chapter-{n}` synthesis.
-  const bookPct = savedProgress?.chapterSlug
-    ? computeBookProgress(
-        (book.chapters ?? []).map(c => ({ slug: c.slug || `chapter-${c.chapterNumber}`, wordCount: c.wordCount })),
-        savedProgress.chapterSlug,
-        savedProgress.percent ?? 0,
-        book.totalWordCount ?? undefined,
-      )
-    : null
+  // Read the stored number; do not derive it again.
+  //
+  // This used to call computeBookProgress with `savedProgress.percent` — already
+  // a BOOK fraction — in the `chapterProgress` slot, which takes a CHAPTER
+  // fraction. It re-scaled an already-scaled number, so it was wrong for every
+  // EPUB too, just plausibly wrong. And it derived only when a chapter slug
+  // existed, which a PDF read in Original layout deliberately has none of: the
+  // list said 14%, this screen said 0%, and the two agreed only after the
+  // locator had been corrupted into chapter space.
+  const bookPct = storedBookPercent(savedProgress)
   const progressPct = bookPct != null ? Math.round(bookPct * 100) : 0
 
   return (
@@ -351,10 +350,17 @@ export default function UserBookDetailScreen() {
           <View style={styles.progressSection}>
             <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 6 }}>
               <Text style={{ fontSize: 13, color: colors.textSecondary, fontFamily: fonts.sans }}>Reading progress</Text>
-              <Text style={{ fontSize: 13, color: colors.primary, fontFamily: fonts.sansMedium }}>{progressPct}%</Text>
+              <Text style={{ fontSize: 13, color: colors.primary, fontFamily: fonts.sansMedium }}>
+                {formatBookPercent(bookPct)}
+              </Text>
             </View>
             <View style={[styles.progressTrack, { backgroundColor: colors.border }]}>
-              <View style={[styles.progressFill, { width: `${progressPct}%`, backgroundColor: colors.primary }]} />
+              {/* Empty and muted when unknown — a full-width track next to "—"
+                  reads as 0%, which is the claim we just stopped making. */}
+              <View style={[
+                styles.progressFill,
+                { width: `${progressPct}%`, backgroundColor: bookPct == null ? colors.border : colors.primary },
+              ]} />
             </View>
           </View>
         )}

--- a/packages/shared/src/library/entries.ts
+++ b/packages/shared/src/library/entries.ts
@@ -14,6 +14,7 @@
  * Pure and I/O-free. The mobile hooks own persistence; this owns the semantics.
  */
 
+import { storedBookPercent } from '../reader/bookProgress'
 import type { UserLibraryItem, UserBookDto, ReadingProgressDto } from '../types/api'
 
 export type LibraryEntry =
@@ -69,13 +70,34 @@ export function entryCreatedAt(e: LibraryEntry): string {
   return e.kind === 'saved' ? e.item.createdAt : e.book.createdAt
 }
 
-/** 0..1. Catalog progress lives in a separate map; upload progress is inline. */
+/**
+ * The stored percentage, or null when the book has none.
+ *
+ * Catalog progress lives in a separate map; upload progress is inline. Both go
+ * through `storedBookPercent`, so there is one reader of this number in the
+ * codebase rather than one per screen — which is how the detail page came to
+ * show 0% for a book this row showed at 14%.
+ */
+export function entryProgressOrNull(
+  e: LibraryEntry,
+  progressMap: Record<string, ReadingProgressDto>,
+): number | null {
+  return storedBookPercent(e.kind === 'saved' ? progressMap[e.item.editionId] : { percent: e.book.progressPercent })
+}
+
+/**
+ * 0..1, with unknown collapsed to 0.
+ *
+ * Sorting and filtering need a number — `null` cannot be compared or bucketed —
+ * so the collapse happens here, once, explicitly. UI that can say "—" should use
+ * `entryProgressOrNull` instead; this one deliberately cannot tell the two apart
+ * and must not be used to render a percentage.
+ */
 export function entryProgress(
   e: LibraryEntry,
   progressMap: Record<string, ReadingProgressDto>,
 ): number {
-  if (e.kind === 'saved') return progressMap[e.item.editionId]?.percent ?? 0
-  return e.book.progressPercent ?? 0
+  return entryProgressOrNull(e, progressMap) ?? 0
 }
 
 /** Last activity, falling back to when the book entered the library so a

--- a/packages/shared/src/reader/bookProgress.ts
+++ b/packages/shared/src/reader/bookProgress.ts
@@ -22,6 +22,45 @@
  * 0%.
  */
 
+/**
+ * The stored book-wide percentage — the ONE way to read a book's progress
+ * outside the reader.
+ *
+ * `computeBookProgress` above exists to PRODUCE this number, from a chapter slug
+ * and a scroll fraction, inside the reader that has both. Once written it is
+ * canonical (that is what the percentUnit contract is for), and anything else
+ * that wants it should read it, not derive it again.
+ *
+ * The book detail screen derived it, and got two things wrong at once. It passed
+ * `savedProgress.percent` — already a BOOK fraction — into `computeBookProgress`
+ * as the `chapterProgress` argument, which is a CHAPTER fraction, re-scaling an
+ * already-scaled number; wrong for every EPUB, just plausibly wrong. And it
+ * derived only when a chapter slug was present, which a PDF read in Original
+ * layout deliberately has none of — so a book the list showed at 14% read 0%
+ * there, and the same screen started agreeing only once the locator had been
+ * corrupted into chapter space.
+ */
+export function storedBookPercent(
+  progress: { percent?: number | null } | null | undefined,
+): number | null {
+  const p = progress?.percent
+  return typeof p === 'number' && Number.isFinite(p) ? p : null
+}
+
+/**
+ * How an unknown percentage is rendered.
+ *
+ * `null` is '—', never '0%'. The docblock above has always said so; the detail
+ * screen mapped null to 0 anyway, which claims the reader opened the book and
+ * read none of it — a different and wrong statement.
+ *
+ * `0` really is '0%': a book opened at the top is not a book never opened.
+ */
+export function formatBookPercent(pct: number | null): string {
+  if (pct == null) return '—'
+  return `${Math.round(pct * 100)}%`
+}
+
 export interface ChapterWithCount {
   slug: string
   wordCount?: number | null

--- a/packages/shared/src/reader/bookProgressStored.test.ts
+++ b/packages/shared/src/reader/bookProgressStored.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { storedBookPercent, formatBookPercent } from './bookProgress'
+
+describe('storedBookPercent', () => {
+  it('reads the stored number through, untouched', () => {
+    expect(storedBookPercent({ percent: 0.139 })).toBe(0.139)
+  })
+
+  it('is null when there is no progress row', () => {
+    expect(storedBookPercent(null)).toBeNull()
+    expect(storedBookPercent(undefined)).toBeNull()
+  })
+
+  it('is null — not zero — when the row carries no percent', () => {
+    // The distinction the detail screen collapsed. A chapterless PDF stores a
+    // real percent and a null chapterSlug; deriving from the slug produced 0%
+    // for a book the list correctly showed at 14%.
+    expect(storedBookPercent({ percent: null })).toBeNull()
+    expect(storedBookPercent({})).toBeNull()
+  })
+
+  it('rejects a value that is not a finite number', () => {
+    expect(storedBookPercent({ percent: NaN })).toBeNull()
+    expect(storedBookPercent({ percent: Infinity })).toBeNull()
+  })
+
+  it('keeps a genuine zero', () => {
+    expect(storedBookPercent({ percent: 0 })).toBe(0)
+  })
+})
+
+describe('formatBookPercent', () => {
+  it('renders an unknown percentage as a dash, never as zero', () => {
+    // "I don't know how far you are" and "you have read none of it" are
+    // different statements, and only one of them is true.
+    expect(formatBookPercent(null)).toBe('—')
+  })
+
+  it('renders a real zero as zero', () => {
+    // A book opened at the top is not a book never opened.
+    expect(formatBookPercent(0)).toBe('0%')
+  })
+
+  it('rounds the way the library row does', () => {
+    expect(formatBookPercent(0.139)).toBe('14%')
+    expect(formatBookPercent(1)).toBe('100%')
+  })
+})


### PR DESCRIPTION
Closes **N-3** from `docs/qa/reports/2026-08-27-android-retest.md`.

> The book screen shows **0%** while a page locator is stored, though the list and the server both say 14%.

The tester added the observation that stung:

> *The irony is that the fix is called "a percentage now travels with the unit it is measured in": the unit travels with the number, and a third screen still does not read it.*

## It was worse than reported

`my-books/[id].tsx` did not merely fail to understand a page locator. It passed `savedProgress.percent` — **already a book fraction** — into `computeBookProgress` as the `chapterProgress` argument, which takes a **chapter fraction**. It re-scaled an already-scaled number.

So it had been wrong for **every EPUB** as well, just plausibly wrong enough that nobody looked. The PDF case is only where the error became loud, because a chapterless book took the `null` branch and mapped to `0`.

## So the fix is deletion, not a better formula

`computeBookProgress` exists to *produce* this number, inside the reader, which has the chapter slug and the scroll fraction. Once written it is canonical — that is what the `percentUnit` contract was for. Anything else that wants it should **read** it.

- `storedBookPercent()` — the one reader outside the reader.
- `entryProgress()` is expressed through it, so the library row and the detail screen cannot disagree by construction.
- `entryProgressOrNull()` for anything that can render the difference. `entryProgress` keeps collapsing `null` to `0` because sorting and filtering need a number, but the collapse now happens in one place and says why.

## `—` is not `0%`

`null` renders as a dash. The docblock on `computeBookProgress` has said so since it was written:

> *Returns `null` in degenerate cases … callers should render a placeholder like '—' rather than a misleading 0%.*

The screen mapped `null` to `0` anyway, which claims the reader opened the book and read none of it — a different statement, and a false one.

A genuine `0` still renders `0%`: a book opened at the top is not a book never opened. The progress track goes muted and empty alongside a dash, because a full-width bar next to `—` reads as zero regardless of the text.

326 shared tests, 177 mobile, `tsc` clean on both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
