### PR TITLE
Stop writing a scroll position over a PDF page, and start sending the unit again

### DIFF
--- a/apps/web/src/api/userBooks.ts
+++ b/apps/web/src/api/userBooks.ts
@@ -374,7 +374,18 @@ export async function saveUserBookProgress(
   bookId: string,
   // chapterSlug is nullable — a chapterless PDF read in Original layout sends
   // null with a "page:<N>" locator (ADR-012 S2).
-  data: { chapterSlug: string | null; locator?: string; percent?: number; updatedAt?: string }
+  // The type had stopped describing the request: it named neither percentUnit
+  // nor locatorKind, so a caller could omit one and the compiler said nothing.
+  // That is exactly how this client shipped without percentUnit and quietly
+  // stored no percentage at all.
+  data: {
+    chapterSlug: string | null
+    locator?: string
+    percent?: number
+    percentUnit?: string
+    locatorKind?: string
+    updatedAt?: string
+  }
 ): Promise<void> {
   await authFetch<void>(`/me/books/${bookId}/progress`, {
     method: 'PUT',

--- a/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
@@ -39,6 +39,7 @@ const baseProps: Props = {
   mode: 'public',
   chapterIdentifier: 'ch1',
   chapterLoaded: true,
+  originalActive: false,
   overallProgress: 0,
   effectiveProgress: null,
   effectiveLoading: false,
@@ -267,5 +268,35 @@ describe('useReaderScrollSync — save on chapter open', () => {
     const last = updateProgress.mock.calls[updateProgress.mock.calls.length - 1]
     expect(last[3]).toBe('ch1-id')
     expect(last[4]).toBe('ch1')
+  })
+})
+
+describe('useReaderScrollSync — Original-layout PDF', () => {
+  it('neither restores nor saves while the PDF viewer owns the position', () => {
+    // This hook writes scroll:<identifier>:<offset>. A PDF read in Original
+    // layout stores page:<n>, and they are different coordinate spaces — one
+    // written over the other loses the reader's place.
+    //
+    // It hides better here than on mobile: an uploaded PDF usually HAS reflow
+    // chapters, so the chapter fetch succeeds in Original layout, chapterLoaded
+    // is true, and the save-on-open fires while the reader is looking at pages.
+    const userProgress = { saveProgress: vi.fn(), flushSave: vi.fn() }
+    const publicProgress = { updateProgress: vi.fn(), flushSave: vi.fn() }
+
+    renderHook(() =>
+      useReaderScrollSync({
+        ...baseProps,
+        mode: 'userbook',
+        originalActive: true,
+        effectiveProgress: { locator: 'scroll:ch1:4200' },
+        userProgress,
+        publicProgress,
+      }),
+    )
+
+    expect(userProgress.saveProgress).not.toHaveBeenCalled()
+    expect(publicProgress.updateProgress).not.toHaveBeenCalled()
+    // And it must not drag the page to a scroll offset the PDF viewer did not ask for.
+    expect(window.scrollTo).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/hooks/useReaderScrollSync.ts
+++ b/apps/web/src/hooks/useReaderScrollSync.ts
@@ -26,6 +26,19 @@ interface Params {
   mode: ReaderMode
   chapterIdentifier: string | undefined
   chapterLoaded: boolean
+  /**
+   * True while the Original-layout PDF viewer owns the reading position.
+   *
+   * This hook writes `scroll:<identifier>:<offset>`. A PDF read in Original
+   * layout stores `page:<n>`, and the two are different coordinate spaces —
+   * writing one over the other loses the reader's place. The mobile app had the
+   * same gap and lost a reader twelve pages; here it is worse hidden, because an
+   * uploaded PDF usually HAS reflow chapters, so `chapterLoaded` is true and the
+   * save-on-open fires while the reader is looking at pages.
+   *
+   * See ADR-013.
+   */
+  originalActive: boolean
   overallProgress: number
   effectiveProgress: ProgressLocator | null
   effectiveLoading: boolean
@@ -41,6 +54,7 @@ export function useReaderScrollSync({
   mode,
   chapterIdentifier,
   chapterLoaded,
+  originalActive,
   overallProgress,
   effectiveProgress,
   effectiveLoading,
@@ -70,7 +84,7 @@ export function useReaderScrollSync({
   // this, hitting "Next" at the bottom of ch1 leaves you mid-/end-of ch2.
   useEffect(() => {
     if (scrollRestoredRef.current || effectiveLoading) return
-    if (!chapterLoaded) return
+    if (originalActive || !chapterLoaded) return
 
     const targetOffset = (() => {
       if (!effectiveProgress?.locator?.startsWith('scroll:')) return 0
@@ -87,7 +101,7 @@ export function useReaderScrollSync({
       scrollRestoredRef.current = true
       setRestoredFor(chapterIdentifier ?? null)
     })
-  }, [chapterLoaded, effectiveLoading, effectiveProgress, chapterIdentifier])
+  }, [originalActive, chapterLoaded, effectiveLoading, effectiveProgress, chapterIdentifier])
 
   // Save-on-chapter-open: the debounced scroll save is gated by user scrolling,
   // so chapter→chapter navigation (route param change; ReaderPage stays mounted)
@@ -96,7 +110,7 @@ export function useReaderScrollSync({
   // sequenced AFTER restore so the offset reflects the restored scroll, not a
   // transient 0. Uses the current chapter's id + book-level overallProgress.
   useEffect(() => {
-    if (!chapterLoaded || !chapterIdentifier) return
+    if (originalActive || !chapterLoaded || !chapterIdentifier) return
     // Wait until restore has run for THIS chapter (offset is settled).
     if (restoredFor !== chapterIdentifier) return
     if (savedOnOpenForRef.current === chapterIdentifier) return
@@ -121,11 +135,15 @@ export function useReaderScrollSync({
     // overallProgress intentionally excluded: we snapshot it on open only. The
     // scroll-debounced effect owns continuous updates as the user reads.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chapterIdentifier, chapterLoaded, mode, restoredFor, publicBookChapters, publicProgress, userProgress])
+  }, [originalActive, chapterIdentifier, chapterLoaded, mode, restoredFor, publicBookChapters, publicProgress, userProgress])
 
   // Flush pending save now: write locally + ask the underlying hook to ship
   // synchronously (keepalive fetch) so we don't lose the write on tab death.
   const flushSave = useCallback(() => {
+    // Same rule as the two effects above: a PDF viewer's position is not ours
+    // to write, and this one fires on tab close with keepalive — the write most
+    // likely to be the last one the server sees.
+    if (originalActive) return
     const pending = pendingSaveRef.current
     if (!pending) return
 
@@ -149,7 +167,7 @@ export function useReaderScrollSync({
     }
 
     pendingSaveRef.current = null
-  }, [mode, publicBookChapters, publicProgress, userProgress])
+  }, [originalActive, mode, publicBookChapters, publicProgress, userProgress])
 
   // Debounced save on scroll position change. The save effect keys off
   // overallProgress so it re-runs when chapter scroll moves.
@@ -185,7 +203,7 @@ export function useReaderScrollSync({
       pendingSaveRef.current = null
       saveTimerRef.current = null
     }, SAVE_DEBOUNCE_MS)
-  }, [mode, publicBookChapters, chapterIdentifier, overallProgress, publicProgress, userProgress])
+  }, [originalActive, mode, publicBookChapters, chapterIdentifier, overallProgress, publicProgress, userProgress])
 
   // Flush on visibility hidden / beforeunload / unmount.
   useEffect(() => {

--- a/apps/web/src/hooks/useUserBookProgress.ts
+++ b/apps/web/src/hooks/useUserBookProgress.ts
@@ -1,3 +1,4 @@
+import { PERCENT_UNIT_BOOK, LOCATOR_SPACE_SCROLL } from '@textstack/shared'
 import { useEffect, useCallback, useRef, useState } from 'react'
 import { getUserBookProgress, saveUserBookProgress } from '../api/userBooks'
 
@@ -108,6 +109,13 @@ export function useUserBookProgress(bookId: string) {
         chapterSlug: toSync.chapterSlug,
         locator: toSync.locator,
         percent: toSync.percent,
+        // Both declarations are required or the server ignores what they
+        // describe: without percentUnit the number is dropped (which is what
+        // this hook was doing since the unit contract shipped — web has stored
+        // NO percent for uploaded books since then), and without locatorKind a
+        // scroll write cannot replace a PDF page locator.
+        percentUnit: PERCENT_UNIT_BOOK,
+        locatorKind: LOCATOR_SPACE_SCROLL,
         updatedAt: new Date(toSync.updatedAt).toISOString(),
       })
         .then(() => {
@@ -136,6 +144,11 @@ export function useUserBookProgress(bookId: string) {
       chapterSlug: toSync.chapterSlug,
       locator: toSync.locator,
       percent: toSync.percent,
+      // Same two declarations as the debounced path above. This body is built
+      // by hand rather than by a shared builder, which is exactly how it came to
+      // be missing one of them.
+      percentUnit: PERCENT_UNIT_BOOK,
+      locatorKind: LOCATOR_SPACE_SCROLL,
       updatedAt: new Date(toSync.updatedAt).toISOString(),
     })
     const url = `/api/me/books/${bookId}/progress`

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -423,6 +423,10 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
     mode,
     chapterIdentifier,
     chapterLoaded: !!chapter,
+    // An uploaded PDF usually HAS reflow chapters, so the chapter fetch succeeds
+    // in Original layout too and the save-on-open would fire while the reader is
+    // looking at pages. Same defect the mobile reader had.
+    originalActive,
     overallProgress,
     effectiveProgress,
     effectiveLoading,


### PR DESCRIPTION
Two web defects, neither in the QA report — that pass is Android only, and both of these are web.

## 1. The same structural gap the mobile reader had

`useReaderScrollSync` writes `scroll:<identifier>:<offset>` and was passed no notion of Original layout — although `ReaderPage.tsx:203` has computed `originalActive` for other purposes all along.

**It hides better here than on mobile.** An uploaded PDF usually *has* reflow chapters, so the chapter fetch succeeds in Original layout too, `chapterLoaded` is true, and the save-on-open fires while the reader is looking at pages.

Guarded at all four entry points, including `flushSave` — which runs on tab close with `keepalive`, and is therefore the write most likely to be the last one the server sees.

The test asserts it neither saves *nor restores*: dragging the page to a scroll offset the PDF viewer never asked for is the same defect wearing the other hat. Verified failing with the guard removed.

## 2. A regression I introduced

`useUserBookProgress` builds its PUT body by hand and **never sent `percentUnit`**. Since the unit contract shipped, the server drops an undeclared number by design — so **the web client has stored no percentage at all for uploaded books** since that merge. The catalog path got the field; this one was missed.

Both bodies now declare `percentUnit` and `locatorKind`.

**The type is why it was possible.** The body parameter named neither field, so omitting one was not an error the compiler could see:

```ts
data: { chapterSlug: string | null; locator?: string; percent?: number; updatedAt?: string }
```

It compiled because every caller passes a builder's return value rather than an object literal. A type that does not describe the request cannot catch a missing field. Widened.

740 web tests, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
