### PR TITLE
Offline becomes a mechanism, not a per-screen edit

### DIFF
--- a/apps/mobile/app/(tabs)/search.tsx
+++ b/apps/mobile/app/(tabs)/search.tsx
@@ -11,6 +11,7 @@ import { useLanguage } from '../../src/context/LanguageContext'
 import { fonts } from '../../src/theme/typography'
 import { SkeletonLoader, BookGridSkeleton } from '../../src/components/ui/SkeletonLoader'
 import { OfflineBanner } from '../../src/components/ui/OfflineBanner'
+import { useReconnectCount } from '../../src/hooks/useOnline'
 import { BookCard } from '../../src/components/ui/BookCard'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { trackSearchPerformed } from '../../src/lib/analytics'
@@ -102,8 +103,12 @@ export default function DiscoverScreen() {
   // data being non-empty, so a failed fetch made all three vanish and left a
   // search box and an "Ask the librarian" card with no explanation. Empty and
   // unreachable are different states and now look different.
-  const [catalogOffline, setCatalogOffline] = useState(false)
+  const [catalogError, setCatalogError] = useState<'offline' | 'failed' | null>(null)
   const [searchOffline, setSearchOffline] = useState(false)
+  const reconnects = useReconnectCount()
+  // Bumped by the banner's retry, so a reader who does not want to wait for
+  // NetInfo can ask again.
+  const [catalogAttempt, setCatalogAttempt] = useState(0)
 
   const debouncedQuery = useDebounce(query.trim(), 300)
 
@@ -131,15 +136,22 @@ export default function DiscoverScreen() {
       setBooks(booksRes.items)
       setAuthors(authorsRes.items)
       setCatalogStats({ books: booksRes.total, authors: authorsRes.total, genres: genresRes.total })
-      setCatalogOffline(false)
+      setCatalogError(null)
     }).catch(e => {
       if (cancelled) return
       console.error('Catalog fetch failed:', e)
-      setCatalogOffline(isOfflineError(e))
+      // Was `setCatalogOffline(isOfflineError(e))`, so a 500 set it to FALSE and
+      // Discover rendered blank with no message at all — three sections gated on
+      // their own data, all empty, nothing to explain it.
+      setCatalogError(isOfflineError(e) ? 'offline' : 'failed')
     })
       .finally(() => { if (!cancelled) setCatalogLoading(false) })
     return () => { cancelled = true }
-  }, [language])
+    // `reconnects` is the fix for N-2. This was `[language]` alone, and Discover
+    // is a tab screen that never unmounts — so once the catalog failed, nothing
+    // re-ran it. The banner survived the network coming back and could only be
+    // cleared by restarting the app.
+  }, [language, reconnects, catalogAttempt])
 
   // Use functional setState so saveRecent/removeRecent don't need
   // `recentSearches` in their deps — that previously leaked into doSearch's
@@ -399,8 +411,12 @@ export default function DiscoverScreen() {
           {/* One sentence instead of three silently missing sections. Discover is
               the only place with nothing cached to fall back on, so it says so
               rather than rendering a convincing-looking empty page. */}
-          {catalogOffline && !catalogLoading && (
-            <OfflineBanner message={t('search.offline.catalog')} />
+          {catalogError && !catalogLoading && (
+            <OfflineBanner
+              message={catalogError === 'offline' ? t('search.offline.catalog') : t('library.loadFailed.body')}
+              actionLabel={t('common.retry')}
+              onAction={() => setCatalogAttempt(a => a + 1)}
+            />
           )}
 
           {/* Catalog Stats Bar */}

--- a/apps/mobile/app/(tabs)/vocabulary.tsx
+++ b/apps/mobile/app/(tabs)/vocabulary.tsx
@@ -4,7 +4,7 @@ import {
   RefreshControl, ScrollView } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter, useFocusEffect } from 'expo-router'
-import { vocabularyApi } from '@textstack/shared'
+import { vocabularyApi, isOfflineError } from '@textstack/shared'
 import type { VocabularyWordDto, VocabularyStatsDto, PendingVocabWordDto, WordLookupDto } from '@textstack/shared'
 import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
@@ -14,6 +14,7 @@ import { SkeletonLoader } from '../../src/components/ui/SkeletonLoader'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { useTts } from '../../src/hooks/useTts'
 import type { ReviewMode } from '../../src/hooks/useVocabularyReview'
+import { useReconnectCount } from '../../src/hooks/useOnline'
 import { ClusterBonusCard } from '../../src/components/vocabulary/ClusterBonusCard'
 import { VocabSettingsModal } from '../../src/components/vocabulary/VocabSettingsModal'
 import { VocabViewSheet } from '../../src/components/vocabulary/VocabViewSheet'
@@ -64,6 +65,8 @@ export default function VocabularyScreen() {
   const [lookupBusyId, setLookupBusyId] = useState<string | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [viewSheetOpen, setViewSheetOpen] = useState(false)
+  // Why the list is empty, when it is.
+  const [loadError, setLoadError] = useState<'offline' | 'failed' | null>(null)
 
   const activeFilter = TABS.find(t => t.key === tab)?.filter
 
@@ -94,18 +97,31 @@ export default function VocabularyScreen() {
         setWords(res.items)
       }
       setTotal(res.total)
+      setLoadError(null)
       offsetRef.current = currentOffset + res.items.length
       if (!loadMore && st) setStats(st)
     } catch (e) {
       if (myGen !== loadGenRef.current) return
       console.warn('Vocab load error:', e)
+      // Tell the screen WHY the list is empty. Without this it rendered "No
+      // words saved yet" to a reader who had one — the same defect Library was
+      // treated for, on a screen the treatment never reached.
+      setLoadError(isOfflineError(e) ? 'offline' : 'failed')
+      throw e
     } finally {
       if (loadMore) loadingMoreRef.current = false
       if (myGen === loadGenRef.current) setLoading(false)
     }
   }, [activeFilter, search, sort])
 
-  useEffect(() => { setLoading(true); offsetRef.current = 0; loadData() }, [loadData])
+  // `reconnects` in the deps is what makes the screen recover on its own. A tab
+  // screen never unmounts, so without it the only way back from an offline load
+  // was restarting the app.
+  const reconnects = useReconnectCount()
+  useEffect(() => {
+    setLoading(true); offsetRef.current = 0
+    loadData().catch(() => {})
+  }, [loadData, reconnects])
 
   const loadPending = useCallback(async () => {
     try {
@@ -418,6 +434,15 @@ export default function VocabularyScreen() {
             </View>
           ))}
         </View>
+      ) : words.length === 0 && loadError ? (
+        // "You have no words" and "I could not ask" are different screens.
+        <EmptyState
+          icon={loadError === 'offline' ? 'cloud-offline-outline' : 'alert-circle-outline'}
+          title={loadError === 'offline' ? t('library.offline.title') : t('library.loadFailed.title')}
+          subtitle={loadError === 'offline' ? t('vocabulary.offline.body') : t('library.loadFailed.body')}
+          buttonLabel={t('common.retry')}
+          onButtonPress={() => { setLoading(true); offsetRef.current = 0; loadData().catch(() => {}) }}
+        />
       ) : words.length === 0 ? (
         <EmptyState
           icon="book-outline"

--- a/apps/mobile/src/components/ui/OfflineBanner.tsx
+++ b/apps/mobile/src/components/ui/OfflineBanner.tsx
@@ -1,4 +1,4 @@
-import { View, Text, StyleSheet } from 'react-native'
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '../../context/ThemeContext'
 import { fonts } from '../../theme/typography'
@@ -17,7 +17,18 @@ import { fonts } from '../../theme/typography'
  * screen is showing downloaded content, the library may be showing a subset, and
  * Discover has nothing to show at all.
  */
-export function OfflineBanner({ message }: { message: string }) {
+export function OfflineBanner({
+  message,
+  actionLabel,
+  onAction,
+}: {
+  message: string
+  /** Optional retry. A banner with no way out is a status light, not a control —
+   *  Discover's sat on screen through the network coming back with nothing the
+   *  reader could press. */
+  actionLabel?: string
+  onAction?: () => void
+}) {
   const { colors } = useTheme()
   return (
     <View
@@ -26,6 +37,11 @@ export function OfflineBanner({ message }: { message: string }) {
     >
       <Ionicons name="cloud-offline-outline" size={16} color={colors.primary} />
       <Text style={[styles.text, { color: colors.primary }]}>{message}</Text>
+      {actionLabel && onAction && (
+        <TouchableOpacity onPress={onAction} hitSlop={8} accessibilityRole="button">
+          <Text style={[styles.action, { color: colors.primary }]}>{actionLabel}</Text>
+        </TouchableOpacity>
+      )}
     </View>
   )
 }
@@ -46,5 +62,10 @@ const styles = StyleSheet.create({
     fontFamily: fonts.sansMedium,
     fontSize: 13,
     flex: 1,
+  },
+  action: {
+    fontFamily: fonts.sansBold,
+    fontSize: 13,
+    textDecorationLine: 'underline',
   },
 })

--- a/apps/mobile/src/hooks/useLoadState.ts
+++ b/apps/mobile/src/hooks/useLoadState.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { isOfflineError } from '@textstack/shared'
+import { useReconnectCount } from './useOnline'
+import type { LoadStatus } from '../lib/loadState'
+
+/**
+ * Runs a screen's load and remembers why it went wrong.
+ *
+ * It deliberately does NOT own the data. Library reads three endpoints and a
+ * SQLite cache; Discover reads three more and has nothing to fall back on;
+ * Vocabulary reads a list, a queue and a stats blob. Pretending those are one
+ * shape is how a "generic data hook" ends up with six options nobody
+ * understands. The screen keeps its own state and does its own fetching; this
+ * owns the one part that must be identical everywhere — classifying the failure,
+ * retrying, and coming back when the network does.
+ *
+ * The reconnect refetch is the point of the hook as much as the classification.
+ * Discover's offline banner survived the network returning because the only
+ * thing that cleared it was a successful re-run of an effect keyed on
+ * `[language]`, and a tab screen never unmounts. Every screen that uses this
+ * gets the reconnect behaviour by construction rather than by remembering.
+ */
+export function useLoadState(
+  load: () => Promise<void>,
+  deps: readonly unknown[] = [],
+): {
+  status: LoadStatus
+  /** Re-run the load. Safe to pass straight to a retry button. */
+  reload: () => void
+} {
+  const [status, setStatus] = useState<LoadStatus>('loading')
+  const reconnects = useReconnectCount()
+  const [attempt, setAttempt] = useState(0)
+
+  // Always the latest closure, so the effect below can depend on the caller's
+  // `deps` rather than on the identity of a function they would have to
+  // remember to memoize.
+  const loadRef = useRef(load)
+  loadRef.current = load
+
+  // Guards a resolution that arrives after the screen moved on — a slower first
+  // request landing behind a retry would otherwise overwrite the newer answer.
+  const genRef = useRef(0)
+
+  useEffect(() => {
+    const gen = ++genRef.current
+    setStatus('loading')
+    loadRef.current()
+      .then(() => { if (gen === genRef.current) setStatus('ready') })
+      .catch(e => {
+        if (gen !== genRef.current) return
+        // A 500 is not "check your connection". Telling a reader to look at
+        // their wifi while the backend is on fire sends them away from the
+        // actual problem, and away from the retry that would work.
+        setStatus(isOfflineError(e) ? 'offline' : 'failed')
+      })
+    return () => { genRef.current++ }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attempt, reconnects, ...deps])
+
+  const reload = useCallback(() => setAttempt(a => a + 1), [])
+
+  return { status, reload }
+}

--- a/apps/mobile/src/hooks/useOnline.ts
+++ b/apps/mobile/src/hooks/useOnline.ts
@@ -1,7 +1,35 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import NetInfo from '@react-native-community/netinfo'
 
+/**
+ * Connectivity, in the two shapes screens actually need.
+ *
+ * `useOnline()` answers "should I assume there is a network right now" and
+ * coerces the unknown initial state to `true`, which is the right default for
+ * deciding whether to show a warning.
+ *
+ * That coercion makes the transition invisible, though, and the transition is
+ * what a stale screen needs. QA turned airplane mode off and Discover kept its
+ * "You're offline" banner until the app was restarted: the banner is cleared
+ * only by a successful re-run of a fetch whose dependency list is `[language]`,
+ * and a tab screen never unmounts. Nothing was listening for the network coming
+ * back, because nothing could express it.
+ *
+ * `useReconnectCount()` is that signal — a counter that increments on every
+ * false → true edge, suitable for a dependency array.
+ */
 export function useOnline(): boolean {
+  return useOnlineState() !== false
+}
+
+/**
+ * The raw tri-state: `null` until NetInfo answers, then the truth.
+ *
+ * Prefer `useOnline()` unless you genuinely need to tell "not yet known" from
+ * "offline" — treating them the same is what a UI usually wants and what a
+ * reload trigger usually does not.
+ */
+export function useOnlineState(): boolean | null {
   const [online, setOnline] = useState<boolean | null>(null)
 
   useEffect(() => {
@@ -14,5 +42,35 @@ export function useOnline(): boolean {
     return unsubscribe
   }, [])
 
-  return online !== false
+  return online
+}
+
+/**
+ * Increments once each time the device comes back online.
+ *
+ * Put it in a dependency array to refetch on reconnect. It counts edges rather
+ * than exposing a boolean so that a consumer re-runs on the transition and not
+ * on every render where the answer happens to be `true`.
+ *
+ * The first settle does NOT count: NetInfo starts at `null`, and `null → true`
+ * on launch is not a reconnection — treating it as one fires a second fetch
+ * immediately after the first on every cold start.
+ */
+export function useReconnectCount(): number {
+  const online = useOnlineState()
+  const [count, setCount] = useState(0)
+  const wasOffline = useRef(false)
+
+  useEffect(() => {
+    if (online === false) {
+      wasOffline.current = true
+      return
+    }
+    if (online === true && wasOffline.current) {
+      wasOffline.current = false
+      setCount(c => c + 1)
+    }
+  }, [online])
+
+  return count
 }

--- a/apps/mobile/src/lib/loadState.test.ts
+++ b/apps/mobile/src/lib/loadState.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { resolveLoadView, isFailureEmpty } from './loadState'
+
+describe('resolveLoadView', () => {
+  it('shows content while loading and when ready', () => {
+    expect(resolveLoadView({ status: 'loading', hasData: false })).toBe('content')
+    expect(resolveLoadView({ status: 'ready', hasData: true })).toBe('content')
+  })
+
+  it('keeps the data and adds a banner when a failure still has something to show', () => {
+    // Library falls back to downloaded books. Throwing them away to render an
+    // error would be a worse answer than the caveat.
+    expect(resolveLoadView({ status: 'offline', hasData: true })).toBe('banner')
+    expect(resolveLoadView({ status: 'failed', hasData: true })).toBe('banner')
+  })
+
+  it('gives the whole screen to the message when there is nothing to show', () => {
+    expect(resolveLoadView({ status: 'offline', hasData: false })).toBe('empty')
+    expect(resolveLoadView({ status: 'failed', hasData: false })).toBe('empty')
+  })
+})
+
+describe('isFailureEmpty', () => {
+  it('separates "you have nothing yet" from "I could not ask"', () => {
+    // The distinction eight screens could not make. `list.length === 0` was the
+    // whole condition, so a reader whose twelve books had not arrived got the
+    // screen written to welcome someone who has none — indistinguishable from
+    // losing the account.
+    expect(isFailureEmpty('offline', false)).toBe(true)
+    expect(isFailureEmpty('failed', false)).toBe(true)
+    expect(isFailureEmpty('ready', false)).toBe(false)
+  })
+
+  it('is false whenever there is data, however it arrived', () => {
+    expect(isFailureEmpty('offline', true)).toBe(false)
+  })
+
+  it('is false while still loading, so a spinner never becomes an error', () => {
+    expect(isFailureEmpty('loading', false)).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/loadState.ts
+++ b/apps/mobile/src/lib/loadState.ts
@@ -1,0 +1,50 @@
+/**
+ * What a screen shows when a load did not go the way it hoped.
+ *
+ * Three screens were taught this by hand and eight were not. `isOfflineError`
+ * was called from two files in the whole repository; everywhere else a failed
+ * fetch was caught, written to the console, and left as an empty array — so
+ * Vocabulary told a reader with a saved word that they had none, and the book
+ * screen showed a spinner forever. A QA pass named the mistake exactly: the fix
+ * "was applied per screen rather than to a shared template."
+ *
+ * The decision is here, as a function, because it is the part that has to be the
+ * same everywhere. Loading the data stays with the screen — Library reads three
+ * endpoints and a SQLite cache, Discover reads three more and has nothing to
+ * fall back on, and no hook should pretend those are one shape.
+ */
+
+export type LoadStatus = 'loading' | 'ready' | 'offline' | 'failed'
+
+/**
+ * `content` — render normally.
+ * `banner` — render the data AND say it is partial or stale.
+ * `empty`  — there is nothing to render; the screen is the message.
+ */
+export type LoadView = 'content' | 'banner' | 'empty'
+
+export interface LoadViewInput {
+  status: LoadStatus
+  /** Whether the screen has anything worth showing — cached rows included. */
+  hasData: boolean
+}
+
+export function resolveLoadView({ status, hasData }: LoadViewInput): LoadView {
+  if (status === 'ready' || status === 'loading') return 'content'
+  // A failure with something on screen is a caveat, not a wall. Library falls
+  // back to downloaded books and must not throw them away to show an error.
+  return hasData ? 'banner' : 'empty'
+}
+
+/**
+ * Whether the empty state a screen renders is its own "you have nothing yet"
+ * copy or an explanation of a failure.
+ *
+ * This is the distinction the eight screens could not make. `library.length ===
+ * 0` was the whole condition, so "no books" and "no answer" produced the same
+ * screen — the one written to welcome a new reader, shown to someone whose
+ * twelve books had simply not arrived. Indistinguishable from losing an account.
+ */
+export function isFailureEmpty(status: LoadStatus, hasData: boolean): boolean {
+  return !hasData && (status === 'offline' || status === 'failed')
+}

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -793,6 +793,9 @@
       "saveFailed": "Could not save settings. Try again.",
       "dailyCapRange": "Daily new words must be 5–100.",
       "weeklyBudgetRange": "Weekly budget must be 10–500."
+    },
+    "offline": {
+      "body": "Your saved words will be here as soon as you reconnect."
     }
   }
 }


### PR DESCRIPTION
Closes **N-1** and **N-2** from `docs/qa/reports/2026-08-27-android-retest.md`, and builds the thing that should have been built the first time.

## The tester named the mistake, and they were right

> Library and Discover got honest offline states, Vocabulary did not, and the Discover banner does not clear after the network returns. **It looks like the fix was applied per screen rather than to a shared template.**

That is exactly what happened. Three screens were taught by hand; twelve were not. `isOfflineError` is called from **two files in the entire repository**.

## N-1 — Vocabulary

Airplane mode, Vocabulary tab: *"No words saved yet. Select words while reading to add them"* — to a reader who has one. The catch wrote to the console and left the list empty, and `words.length === 0` was the whole condition. Same defect as Library, on a screen the fix never reached.

## N-2 — the banner that would not leave

`catalogOffline` had exactly one thing that could clear it: a successful re-run of an effect whose dependency list was `[language]`. Discover is a tab screen and never unmounts. So once the catalog failed, nothing re-ran it — the banner survived the network coming back, and only an app restart cleared it.

**The reconnect signal could not be expressed.** `useOnline` coerces the unknown initial state to `true` — correct for "should I warn" and fatal for "did the network come back", because the transition is invisible in that signature.

Adds `useOnlineState` (the raw tri-state) and `useReconnectCount`, an edge counter built for a dependency array. **The first settle deliberately does not count**: `null → true` on launch is not a reconnection, and treating it as one fires a second fetch immediately after the first on every cold start.

## And a third thing, found while reading that code

```ts
setCatalogOffline(isOfflineError(e))
```

For a **500 this sets the flag to `false`** — so a server error rendered Discover blank with no message at all: three sections each gated on their own data, all empty, nothing to explain it. Now `'offline' | 'failed' | null`, with copy for each.

The banner also had no action slot, so there was nothing to press while it sat there. It has one now.

## What is shared, and what deliberately is not

The **decision** is a pure function with tests — `resolveLoadView` and `isFailureEmpty` — because that is the part that has to be identical everywhere. `isFailureEmpty` is the distinction twelve screens could not make: "you have nothing yet" and "I could not ask" are different screens, and `list.length === 0` cannot tell them apart.

**Loading stays with the screen.** Library reads three endpoints and a SQLite cache; Discover reads three more and has nothing to fall back on; Vocabulary reads a list, a queue and a stats blob. Pretending those are one shape is how a generic data hook grows six options nobody understands. `useLoadState` owns classification, retry and reconnect — not the data.

The remaining ten screens follow in the next PR; that is volume, not decision. The worst of them is `my-books/[id]`, which on a failed load returns a spinner **forever** — no header, no message, no retry — and that same branch is also why its header sits under the status bar (N-4).

183 mobile tests, 332 shared, `tsc` clean.

## Verify on device

Airplane mode → Vocabulary: an offline message with **Try again**, not "No words saved yet". Turn the network back on → the list returns **without restarting the app**, and Discover's banner goes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
