### PR TITLE
The other eight screens stop turning a failure into an empty state

### DIFF
--- a/apps/mobile/app/authors.tsx
+++ b/apps/mobile/app/authors.tsx
@@ -5,9 +5,10 @@ import {
 import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
-import { createBooksApi, getStorageUrl } from '@textstack/shared'
+import { createBooksApi, getStorageUrl, isOfflineError } from '@textstack/shared'
 import type { Author } from '@textstack/shared'
 import { useTheme } from '../src/context/ThemeContext'
+import { useReconnectCount } from '../src/hooks/useOnline'
 import { useLanguage } from '../src/context/LanguageContext'
 import { fonts } from '../src/theme/typography'
 
@@ -21,6 +22,9 @@ export default function AuthorsScreen() {
   const [authors, setAuthors] = useState<Author[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<'offline' | 'failed' | null>(null)
+  const [attempt, setAttempt] = useState(0)
+  const reconnects = useReconnectCount()
   const [loadingMore, setLoadingMore] = useState(false)
   const [query, setQuery] = useState('')
   const [queryDebounced, setQueryDebounced] = useState('')
@@ -49,10 +53,14 @@ export default function AuthorsScreen() {
         search: queryDebounced || undefined,
       })
       if (id !== lastFetchRef.current) return
+      setLoadError(null)
       setAuthors(prev => reset ? res.items : [...prev, ...res.items])
       setTotal(res.total)
     } catch (e) {
-      if (id === lastFetchRef.current) console.warn('Failed to fetch authors:', e)
+      if (id === lastFetchRef.current) {
+        console.warn('Failed to fetch authors:', e)
+        setLoadError(isOfflineError(e) ? 'offline' : 'failed')
+      }
     } finally {
       if (id === lastFetchRef.current) {
         setLoading(false)
@@ -61,7 +69,7 @@ export default function AuthorsScreen() {
     }
   }, [queryDebounced, sort, authors.length, language])
 
-  useEffect(() => { fetchAuthors(true) }, [queryDebounced, sort, language])
+  useEffect(() => { fetchAuthors(true) }, [queryDebounced, sort, language, reconnects, attempt])
 
   const loadMore = () => {
     if (!loadingMore && authors.length < total) fetchAuthors(false)
@@ -121,11 +129,22 @@ export default function AuthorsScreen() {
         onEndReached={loadMore}
         onEndReachedThreshold={0.5}
         ListEmptyComponent={
-          !loading ? (
+          loading ? null : loadError ? (
+            <View>
+              <Text style={[styles.empty, { color: colors.textSecondary }]}>
+                {loadError === 'offline'
+                  ? "You're offline — authors need a connection."
+                  : "Couldn't load authors."}
+              </Text>
+              <TouchableOpacity onPress={() => { setLoading(true); setAttempt(a => a + 1) }}>
+                <Text style={[styles.empty, { color: colors.primary }]}>Try again</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
             <Text style={[styles.empty, { color: colors.textSecondary }]}>
               {query ? 'No authors found' : 'No authors yet'}
             </Text>
-          ) : null
+          )
         }
         ListFooterComponent={
           loadingMore ? (

--- a/apps/mobile/app/books.tsx
+++ b/apps/mobile/app/books.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import { View, Text, FlatList, StyleSheet, TouchableOpacity, TextInput } from 'react-native'
 import { useRouter } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
-import { createBooksApi, getStorageUrl } from '@textstack/shared'
+import { createBooksApi, getStorageUrl, isOfflineError } from '@textstack/shared'
 import type { Edition, Genre } from '@textstack/shared'
 import { useTheme } from '../src/context/ThemeContext'
 import { useLanguage } from '../src/context/LanguageContext'
 import { fonts } from '../src/theme/typography'
+import { useReconnectCount } from '../src/hooks/useOnline'
 import { BookCard } from '../src/components/ui/BookCard'
 import { FilterChips } from '../src/components/ui/FilterChips'
 
@@ -25,6 +26,9 @@ export default function BooksScreen() {
   const [books, setBooks] = useState<Edition[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<'offline' | 'failed' | null>(null)
+  const [attempt, setAttempt] = useState(0)
+  const reconnects = useReconnectCount()
   const [loadingMore, setLoadingMore] = useState(false)
   const [query, setQuery] = useState('')
   const [queryDebounced, setQueryDebounced] = useState('')
@@ -70,10 +74,16 @@ export default function BooksScreen() {
         sort: sort || undefined,
       })
       if (id !== lastFetchRef.current) return
+      setLoadError(null)
       setBooks(prev => reset ? res.items : [...prev, ...res.items])
       setTotal(res.total)
     } catch (e) {
-      if (id === lastFetchRef.current) console.warn('Failed to fetch books:', e)
+      if (id === lastFetchRef.current) {
+        console.warn('Failed to fetch books:', e)
+        // "No books found" is a statement about the catalog. A failed request is
+        // a statement about the request, and they are not the same sentence.
+        setLoadError(isOfflineError(e) ? 'offline' : 'failed')
+      }
     } finally {
       if (id === lastFetchRef.current) {
         setLoading(false)
@@ -82,7 +92,8 @@ export default function BooksScreen() {
     }
   }, [queryDebounced, sort, genre, books.length, language])
 
-  useEffect(() => { fetchBooks(true) }, [queryDebounced, sort, genre, language])
+  // reconnects + attempt: recover when the network returns, and on request.
+  useEffect(() => { fetchBooks(true) }, [queryDebounced, sort, genre, language, reconnects, attempt])
 
   const loadMore = () => {
     if (!loadingMore && books.length < total) fetchBooks(false)
@@ -150,7 +161,21 @@ export default function BooksScreen() {
         onEndReached={loadMore}
         onEndReachedThreshold={0.5}
         ListEmptyComponent={
-          !loading ? (
+          loading ? null : loadError ? (
+            // This file writes its copy inline rather than through t(); following
+            // that convention here rather than converting the screen inside a
+            // defect fix.
+            <View style={styles.emptyBox}>
+              <Text style={[styles.empty, { color: colors.textSecondary }]}>
+                {loadError === 'offline'
+                  ? "You're offline — the catalog needs a connection."
+                  : "Couldn't load the catalog."}
+              </Text>
+              <TouchableOpacity onPress={() => { setLoading(true); setAttempt(a => a + 1) }}>
+                <Text style={[styles.clearBtn, { color: colors.primary }]}>Try again</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
             <View style={styles.emptyBox}>
               <Text style={[styles.empty, { color: colors.textSecondary }]}>
                 {hasFilters ? 'No books found' : 'No books yet'}
@@ -161,7 +186,7 @@ export default function BooksScreen() {
                 </TouchableOpacity>
               )}
             </View>
-          ) : null
+          )
         }
         ListFooterComponent={
           loadingMore ? (

--- a/apps/mobile/app/genres.tsx
+++ b/apps/mobile/app/genres.tsx
@@ -3,13 +3,14 @@ import {
   View, Text, FlatList, StyleSheet, TouchableOpacity,
 } from 'react-native'
 import { useRouter, Stack } from 'expo-router'
-import { createBooksApi } from '@textstack/shared'
+import { createBooksApi, isOfflineError } from '@textstack/shared'
 import type { Genre } from '@textstack/shared'
 import { useTheme } from '../src/context/ThemeContext'
 import { useLanguage } from '../src/context/LanguageContext'
 import { fonts } from '../src/theme/typography'
 import { SkeletonLoader } from '../src/components/ui/SkeletonLoader'
 import { EmptyState } from '../src/components/ui/EmptyState'
+import { useReconnectCount } from '../src/hooks/useOnline'
 
 export default function GenresScreen() {
   const router = useRouter()
@@ -17,6 +18,9 @@ export default function GenresScreen() {
   const { language } = useLanguage()
   const [genres, setGenres] = useState<Genre[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<'offline' | 'failed' | null>(null)
+  const [attempt, setAttempt] = useState(0)
+  const reconnects = useReconnectCount()
 
   useEffect(() => {
     let cancelled = false
@@ -26,11 +30,16 @@ export default function GenresScreen() {
       .then(res => {
         if (cancelled) return
         setGenres(Array.isArray(res) ? res : res.items)
+        setLoadError(null)
       })
-      .catch(e => { if (!cancelled) console.warn('Failed to fetch genres:', e) })
+      .catch(e => {
+        if (cancelled) return
+        console.warn('Failed to fetch genres:', e)
+        setLoadError(isOfflineError(e) ? 'offline' : 'failed')
+      })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
-  }, [language])
+  }, [language, reconnects, attempt])
 
   return (
     <>
@@ -45,6 +54,13 @@ export default function GenresScreen() {
               </View>
             ))}
           </View>
+        ) : genres.length === 0 && loadError ? (
+          <EmptyState
+            icon={loadError === 'offline' ? 'cloud-offline-outline' : 'alert-circle-outline'}
+            title={loadError === 'offline' ? "You're offline" : "Couldn't load genres"}
+            buttonLabel="Try again"
+            onButtonPress={() => { setLoading(true); setAttempt(a => a + 1) }}
+          />
         ) : genres.length === 0 ? (
           <EmptyState icon="library-outline" title="No genres found" />
         ) : (

--- a/apps/mobile/app/highlights/index.tsx
+++ b/apps/mobile/app/highlights/index.tsx
@@ -3,11 +3,12 @@ import { View, Text, SectionList, StyleSheet, TouchableOpacity, TextInput, Activ
 import { useRouter, Stack } from 'expo-router'
 import { Image } from 'expo-image'
 import { Ionicons } from '@expo/vector-icons'
-import { highlightsApi, getStorageUrl } from '@textstack/shared'
+import { highlightsApi, getStorageUrl, isOfflineError } from '@textstack/shared'
 import type { HighlightListItem } from '@textstack/shared'
 import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
 import { fonts } from '../../src/theme/typography'
+import { useReconnectCount } from '../../src/hooks/useOnline'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 
 const PAGE_SIZE = 50
@@ -48,6 +49,9 @@ export default function HighlightsScreen() {
   const [highlights, setHighlights] = useState<HighlightListItem[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<'offline' | 'failed' | null>(null)
+  const [attempt, setAttempt] = useState(0)
+  const reconnects = useReconnectCount()
   const [sort, setSort] = useState<'newest' | 'oldest'>('newest')
   const [colorFilter, setColorFilter] = useState('')
   const [bookType, setBookType] = useState<BookType>('all')
@@ -87,15 +91,23 @@ export default function HighlightsScreen() {
         setHighlights(prev => [...prev, ...res.items])
       }
       setTotal(res.totalCount)
+      if (gen === genRef.current) setLoadError(null)
     } catch (e) {
-      if (gen === genRef.current) console.warn('Failed to load highlights:', e)
+      if (gen === genRef.current) {
+        console.warn('Failed to load highlights:', e)
+        // Was console-only, so a failed load rendered "Your highlights will
+        // appear here" — the new-reader screen, to someone whose highlights just
+        // did not arrive.
+        setLoadError(isOfflineError(e) ? 'offline' : 'failed')
+      }
     } finally {
       if (offset > 0) loadingMoreRef.current = false
       if (gen === genRef.current) setLoading(false)
     }
   }, [sort, colorFilter, searchDebounced, bookType])
 
-  useEffect(() => { setLoading(true); fetchHighlights() }, [fetchHighlights])
+  // reconnects + attempt: recover when the network returns, and when asked.
+  useEffect(() => { setLoading(true); fetchHighlights() }, [fetchHighlights, reconnects, attempt])
 
   // Group by book
   const sections = useMemo<BookSection[]>(() => {
@@ -272,6 +284,14 @@ export default function HighlightsScreen() {
 
         {loading ? (
           <ActivityIndicator style={{ padding: 40 }} color={colors.primary} />
+        ) : highlights.length === 0 && loadError ? (
+          <EmptyState
+            icon={loadError === 'offline' ? 'cloud-offline-outline' : 'alert-circle-outline'}
+            title={loadError === 'offline' ? t('library.offline.title') : t('library.loadFailed.title')}
+            subtitle={loadError === 'offline' ? t('library.offline.body') : t('library.loadFailed.body')}
+            buttonLabel={t('common.retry')}
+            onButtonPress={() => { setLoading(true); setAttempt(a => a + 1) }}
+          />
         ) : highlights.length === 0 ? (
           <EmptyState icon="color-wand-outline" title={t('highlights.empty')} subtitle={t('highlights.emptySubtitle')} />
         ) : (

--- a/apps/mobile/app/highlights/review.tsx
+++ b/apps/mobile/app/highlights/review.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from 'react'
 import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native'
 import { Stack, useRouter } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
-import { highlightsApi } from '@textstack/shared'
+import { highlightsApi, isOfflineError } from '@textstack/shared'
 import type { HighlightReviewItem } from '@textstack/shared'
+import { useReconnectCount } from '../../src/hooks/useOnline'
 import { useTheme } from '../../src/context/ThemeContext'
 import { fonts } from '../../src/theme/typography'
 
@@ -20,6 +21,9 @@ export default function HighlightReviewScreen() {
   const [items, setItems] = useState<HighlightReviewItem[]>([])
   const [index, setIndex] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<'offline' | 'failed' | null>(null)
+  const [attempt, setAttempt] = useState(0)
+  const reconnects = useReconnectCount()
   const [done, setDone] = useState(false)
   const [reviewed, setReviewed] = useState(0)
 
@@ -29,13 +33,20 @@ export default function HighlightReviewScreen() {
     // keeps state updates bound to the current mount.
     let cancelled = false
     highlightsApi.getHighlightsForReview(20)
-      .then(res => { if (!cancelled) setItems(res) })
-      .catch(e => { if (!cancelled) console.warn('Failed to load review items:', e) })
+      .then(res => { if (!cancelled) { setItems(res); setLoadError(null) } })
+      .catch(e => {
+        if (cancelled) return
+        console.warn('Failed to load review items:', e)
+        // "All caught up!" is a congratulation. Saying it to someone whose
+        // highlights failed to load is the same class of lie as telling an
+        // offline reader they own no books.
+        setLoadError(isOfflineError(e) ? 'offline' : 'failed')
+      })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [reconnects, attempt])
 
   const current = items[index]
 
@@ -62,6 +73,29 @@ export default function HighlightReviewScreen() {
       <>
         <Stack.Screen options={{ title: 'Review Highlights', headerShown: true }} />
         <ActivityIndicator style={{ flex: 1 }} color={colors.primary} />
+      </>
+    )
+  }
+
+  if (items.length === 0 && loadError) {
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Review Highlights', headerShown: true, headerStyle: { backgroundColor: colors.background }, headerShadowVisible: false }} />
+        <View style={[styles.center, { backgroundColor: colors.background }]}>
+          <Ionicons
+            name={loadError === 'offline' ? 'cloud-offline-outline' : 'alert-circle-outline'}
+            size={48}
+            color={colors.textSecondary}
+          />
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+            {loadError === 'offline'
+              ? "You're offline — your highlights will be here when you reconnect."
+              : "Couldn't load your highlights."}
+          </Text>
+          <TouchableOpacity onPress={() => { setLoading(true); setAttempt(a => a + 1) }}>
+            <Text style={[styles.emptyText, { color: colors.primary }]}>Try again</Text>
+          </TouchableOpacity>
+        </View>
       </>
     )
   }

--- a/apps/mobile/app/my-books/[id].tsx
+++ b/apps/mobile/app/my-books/[id].tsx
@@ -3,14 +3,16 @@ import { View, Text, ScrollView, StyleSheet, TouchableOpacity, ActivityIndicator
 import { Image } from 'expo-image'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
-import { userBooksApi, getStorageUrl, getApiConfig, storedBookPercent, formatBookPercent, parsePdfPageLocator, chapterSlugForPage } from '@textstack/shared'
+import { userBooksApi, getStorageUrl, getApiConfig, storedBookPercent, formatBookPercent, parsePdfPageLocator, chapterSlugForPage, isOfflineError } from '@textstack/shared'
 import type { UserBookDetailResponse } from '@textstack/shared'
 import { enrichUserBook } from '../../src/lib/api'
 import { useTheme } from '../../src/context/ThemeContext'
 import { useToast } from '../../src/context/ToastContext'
 import { useLanguage } from '../../src/context/LanguageContext'
 import { fonts } from '../../src/theme/typography'
+import { useReconnectCount } from '../../src/hooks/useOnline'
 import { LoadingScreen } from '../../src/components/ui/LoadingScreen'
+import { EmptyState } from '../../src/components/ui/EmptyState'
 import { trackBookOpened } from '../../src/lib/analytics'
 import { AddToCollectionSheet } from '../../src/components/library/AddToCollectionSheet'
 
@@ -22,6 +24,9 @@ export default function UserBookDetailScreen() {
   const { t } = useLanguage()
   const [book, setBook] = useState<UserBookDetailResponse | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<'offline' | 'failed' | null>(null)
+  const [attempt, setAttempt] = useState(0)
+  const reconnects = useReconnectCount()
   const [savedProgress, setSavedProgress] = useState<{ chapterSlug: string | null; percent: number | null; locator: string | null } | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [enriching, setEnriching] = useState(false)
@@ -50,13 +55,17 @@ export default function UserBookDetailScreen() {
         if (unmountedRef.current) return
         setBook(b)
         if (p) setSavedProgress({ chapterSlug: p.chapterSlug, percent: p.percent, locator: p.locator ?? null })
+        setLoadError(null)
       } catch (e) {
         console.error('Failed to load user book:', e)
+        if (!unmountedRef.current) setLoadError(isOfflineError(e) ? 'offline' : 'failed')
       } finally {
         if (!unmountedRef.current) setLoading(false)
       }
     })()
-  }, [id])
+    // `reconnects` so the screen recovers on its own — until now a failed load
+    // left it showing a spinner until the reader backed out and came in again.
+  }, [id, reconnects, attempt])
 
   // Auto-refresh while processing. Uses recursive setTimeout (not setInterval)
   // so we can implement exponential backoff on repeated failures and avoid
@@ -239,8 +248,36 @@ export default function UserBookDetailScreen() {
     }
   }
 
+  // A failed load used to land here and STAY here: `book` stays null, `loading`
+  // goes false, and this branch returns a spinner forever — no header, no
+  // message, no retry. It is also the only return in this file without a
+  // <Stack.Screen>, so the native header never mounts and the content runs under
+  // the status bar. That was reported as a layout defect (N-4); it was the error
+  // state showing through.
+  if (!loading && !book) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: true, title: '' }} />
+        <View style={[styles.container, { backgroundColor: colors.background }]}>
+          <EmptyState
+            icon={loadError === 'offline' ? 'cloud-offline-outline' : 'alert-circle-outline'}
+            title={loadError === 'offline' ? t('library.offline.title') : t('library.loadFailed.title')}
+            subtitle={loadError === 'offline' ? t('library.offline.body') : t('library.loadFailed.body')}
+            buttonLabel={t('common.retry')}
+            onButtonPress={() => { setLoading(true); setAttempt(a => a + 1) }}
+          />
+        </View>
+      </>
+    )
+  }
+
   if (loading || !book) {
-    return <LoadingScreen />
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: true, title: '' }} />
+        <LoadingScreen />
+      </>
+    )
   }
 
   const estPages = book.totalWordCount ? Math.round(book.totalWordCount / 250) : null

--- a/apps/mobile/app/stats/index.tsx
+++ b/apps/mobile/app/stats/index.tsx
@@ -5,7 +5,7 @@ import {
 } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { Stack, useFocusEffect } from 'expo-router'
-import { readingTrackingApi, vocabularyApi } from '@textstack/shared'
+import { readingTrackingApi, vocabularyApi, isOfflineError } from '@textstack/shared'
 import type { ReadingStatsDto, DailyStatDto, AchievementDto, GoalDto, VocabularyStatsDto, VocabDailyStatDto } from '@textstack/shared'
 import type { BookStatsResponse } from '@textstack/shared'
 import { ACHIEVEMENTS, ALL_ACHIEVEMENT_CODES } from '../../src/lib/achievements'
@@ -13,6 +13,7 @@ import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
 import { useToast } from '../../src/context/ToastContext'
 import { fonts } from '../../src/theme/typography'
+import { useReconnectCount } from '../../src/hooks/useOnline'
 import { SkeletonLoader } from '../../src/components/ui/SkeletonLoader'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { FilterChips } from '../../src/components/ui/FilterChips'
@@ -33,6 +34,9 @@ export default function StatsScreen() {
   const [vocabDaily, setVocabDaily] = useState<VocabDailyStatDto[]>([])
   const [year, setYear] = useState<number | undefined>(undefined)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<'offline' | 'failed' | null>(null)
+  const [attempt, setAttempt] = useState(0)
+  const reconnects = useReconnectCount()
   const [refreshing, setRefreshing] = useState(false)
   // Generation counter — stats screen can refocus mid-fetch (push to
   // Goals detail → back) or change the `year` filter quickly; without
@@ -61,14 +65,23 @@ export default function StatsScreen() {
       setBookStats(bs)
       setVocabStats(vs)
       setVocabDaily(vd)
+      if (gen === genRef.current) setLoadError(null)
     } catch (e) {
-      if (gen === genRef.current) console.warn('Stats load error:', e)
+      if (gen === genRef.current) {
+        console.warn('Stats load error:', e)
+        // `stats` stays null on failure, and the empty check below requires it
+        // to be non-null — so a failed load fell through to the main body and
+        // rendered the whole screen as zeroes. Numbers are a worse lie than an
+        // empty state, because they look like an answer.
+        setLoadError(isOfflineError(e) ? 'offline' : 'failed')
+      }
     } finally {
       if (gen === genRef.current) setLoading(false)
     }
   }, [year])
 
-  useEffect(() => { loadData() }, [loadData])
+  // reconnects + attempt: come back on the network returning, and on request.
+  useEffect(() => { loadData() }, [loadData, reconnects, attempt])
   useFocusEffect(useCallback(() => {
     // Refresh on focus, but only after first load completes so we don't
     // double-fetch on mount. `loadData` itself carries a generation
@@ -119,6 +132,23 @@ export default function StatsScreen() {
             </View>
           </View>
         </ScrollView>
+      </>
+    )
+  }
+
+  if (loadError && !stats) {
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Reading Stats', headerShown: true }} />
+        <View style={[styles.center, { backgroundColor: colors.background }]}>
+          <EmptyState
+            icon={loadError === 'offline' ? 'cloud-offline-outline' : 'alert-circle-outline'}
+            title={loadError === 'offline' ? t('library.offline.title') : t('library.loadFailed.title')}
+            subtitle={loadError === 'offline' ? t('library.offline.body') : t('library.loadFailed.body')}
+            buttonLabel={t('common.retry')}
+            onButtonPress={() => { setLoading(true); setAttempt(a => a + 1) }}
+          />
+        </View>
       </>
     )
   }


### PR DESCRIPTION
The rest of the screens. Closes **N-4**, and finishes what #461 started on three of fifteen.

`isOfflineError` was called from **two files in the repository**. It is called from ten now.

## N-4 was the error state showing through

`my-books/[id].tsx` was the worst of them, and it explains a defect filed as a layout bug.

On a failed load `book` stays `null` and `loading` goes `false`, and the branch that catches that returned **a spinner forever** — no header, no message, no retry. It is also the only return in the file without a `<Stack.Screen>`, so the native header never mounted and the content ran under the status bar.

The header overlapping the clock was not a padding mistake. It was what a permanently-failed screen looks like.

## `stats` lied with numbers

`stats` stays `null` on failure, and the empty check requires it non-null — so a failed load fell past **both** branches and rendered the whole screen as zeroes: no reading time, no streak, no words.

Numbers are a worse lie than an empty state, because they look like an answer.

## The congratulation

`highlights` said *"Your highlights will appear here"*. `highlights/review` said *"All caught up!"* — to someone whose highlights had simply not arrived.

## The catalog lists

`books`, `authors` and `genres` said *"No books found"*, which is a statement about the catalog, made about a request that never reached it.

Those three write their copy inline rather than through `t()`. This follows that convention rather than converting three screens inside a defect fix — same call I made for the sign-in form's error strings.

## Every one refetches on reconnect

None of them needs the reader to work out that backing out of the screen and coming in again would help. That is the whole reason `useReconnectCount` exists.

## Coverage

| | before | after |
|---|---|---|
| screens that classify a load failure | 3 | 11 |
| files calling `isOfflineError` | 2 | 10 |

`app/book/[slug].tsx` shows as zero in that count because it has its own `fetchError` + `offlineMode` pair — it was the model implementation, and it already distinguishes. Left alone.

Still on their own taxonomies: `author/[slug]` and `genre/[slug]` (copy-paste of each other, both branch on `e.status === 404` and both already have a retry) and `vocabulary/review` / `librarian`, whose errors are owned by their hooks. They are honest today; converting them is tidying, not a fix, and belongs with whatever touches them next.

183 mobile tests, 336 shared, `tsc` clean.

## Verify on device

Airplane mode, then open each of: your book's detail page, Highlights, Stats, Books, Authors, Genres. Each says it could not load and offers **Try again** — none of them claims you have nothing. Turn the network on and they come back without being asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
