### PR TITLE
Fill in the real signing fingerprints

### DIFF
--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "app.textstack.mobile",
       "sha256_cert_fingerprints": [
-        "REPLACE_WITH_PLAY_APP_SIGNING_SHA256"
+        "4B:46:2F:65:F2:F0:0F:34:38:BB:A0:FE:93:84:E2:90:A2:27:AC:D7:C8:3C:AF:F6:16:49:C6:FF:71:29:05:21",
+        "9B:CC:0E:FF:68:26:AE:3C:23:FA:95:12:AC:4F:43:BD:CD:29:8D:60:CC:F7:C3:EC:28:A3:38:4C:42:9A:E1:D2"
       ]
     }
   }

--- a/docs/03-ops/android-app-links.md
+++ b/docs/03-ops/android-app-links.md
@@ -42,7 +42,12 @@ npx eas-cli credentials -p android      # Android → production → shows the f
 Or Play Console → your app → **Test and release → Setup → App integrity → App signing**.
 
 Copy the **App signing key certificate** SHA-256 (32 colon-separated hex bytes) into
-`sha256_cert_fingerprints`, replacing `REPLACE_WITH_PLAY_APP_SIGNING_SHA256`.
+`sha256_cert_fingerprints`.
+
+Easiest route: the same page has a **Digital Asset Links JSON** section at the bottom where Google
+generates the snippet with the app signing fingerprint already filled in — take it from there rather
+than transcribing hex by hand. The upload key's fingerprints are listed separately, under
+**Upload key certificate**, further up the page.
 
 **List both keys.** Play re-signs uploads with the app signing key, but a build installed straight
 from an `.aab`/`.apk` you built yourself carries the **upload** key. Listing both means the same file

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -78,11 +78,6 @@ someone's memory.
 - **`t()` takes no parameters, so plurals cannot be translated.** `plural()` in `packages/shared` handles
   English one-vs-many in code; strings living in `en.json` (`"{count} highlights"`, `"{count} chapters"`)
   stay hard-plural until the i18n layer accepts a count.
-- **App Links wait on one fingerprint.** `apps/web/public/.well-known/assetlinks.json` is in place and
-  deploys with the site, but its `sha256_cert_fingerprints` still holds a placeholder — the SHA-256 is
-  held by Play App Signing, not by this repo. Until an owner pastes it (steps:
-  [`docs/03-ops/android-app-links.md`](03-ops/android-app-links.md)), `https://textstack.app/en/books/…`
-  and the password-reset email open a browser instead of the installed app.
 - **iOS Universal Links were never configured.** No `associatedDomains` in `app.json`, empty
   entitlements — the iOS half of this work does not exist yet, on either side.
 - **Soft-404s to crawlers.** The catch-all nginx `location /` returns 200 for non-SSG paths; the bot-404


### PR DESCRIPTION
Completes #481. The mechanism shipped and works — `/.well-known/assetlinks.json` is served as `application/json` in production — but it still held `REPLACE_WITH_PLAY_APP_SIGNING_SHA256`, so Android kept failing verification.

Play Console corroborated the defect on its own, before I touched anything: a notification dated Aug 16 reads *"2 deep links may be failing because your web domains aren't associated with your app."*

## Both keys, in the order that matters

1. **App signing key** — what every Play-installed build carries. This is the one real users need.
2. **Upload key** — what a locally built `.aab`/`.apk` carries, so a sideloaded test build verifies too.

Taken from **App integrity → App signing**. The app signing value is the one Google generates in that page's own *Digital Asset Links JSON* block; the runbook now points there rather than at transcribing hex by hand, since a single wrong byte fails verification silently.

## The test turned itself on

`assetlinks.test.ts` went from 3 passing + 1 skipped to **4 passing** with no edit — the format check was gated on the placeholder being present, exactly so nobody had to remember a second commit.

## After deploy

```
adb shell pm verify-app-links --re-verify app.textstack.mobile
adb shell pm get-app-links app.textstack.mobile
#   expect: textstack.app: verified      (currently: 1024)
```

Verification runs at install time, so an already-installed build needs that `--re-verify` (or a reinstall). No app change, no OTA, no new build.

Still open and unchanged: iOS declares no `associatedDomains` at all, so Universal Links there were never configured on either side. Recorded in STATUS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)