### PR TITLE
Stop re-resolving the same changelog conflict, and write down the __DEV__ trap

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Append-at-top logs. Every PR adds a line at the same place, so every PR after
+# the first in a batch conflicts on a file where both sides are always right.
+# One batch of six cost six rebases and six full CI reruns — docker and e2e
+# included — for a conflict that has never once been a real disagreement.
+#
+# `union` keeps both sides instead of asking. Ordering inside the block can come
+# out interleaved, which is worth a glance when a batch lands; that is a cheaper
+# review than resolving the same conflict six times.
+CHANGELOG.md merge=union
+docs/changelog-archive/*.md merge=union

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -18,6 +18,26 @@ When asked to run a QA scenario:
 2. Verify each expected result
 3. Document any deviations in "Actual Results"
 
+## Instrumenting a defect for the next run
+
+**Diagnostics meant for a device reproduction must not be behind `__DEV__`.**
+
+A tester runs the Play build plus an OTA. `__DEV__` is false there — only the
+`development` EAS profile sets `developmentClient`. A `console.log` added to
+"make the next run report a fact" prints nothing in the only configuration the
+next run will use.
+
+This is written down because it happened: the language-onboarding defect was
+reproduced three times, each time with logging in place that could not fire, so
+three reproductions produced no evidence and two fixes were built on guesses.
+
+Use `breadcrumb()` (`apps/mobile/src/lib/breadcrumb.ts`) instead — a Sentry
+breadcrumb rides along with whatever the session reports, costs nothing when no
+DSN is set, and is readable without a cable. Record the *inputs to the decision*
+and the answer, not the flow: a breadcrumb per step is a trail nobody reads.
+
+`__DEV__` stays right for warnings aimed at whoever is running the dev client.
+
 ## Scenario Format
 
 Each scenario includes:


### PR DESCRIPTION
Two one-line-shaped fixes for the two items from the last bug report that actually cost something.

## 1. `merge=union` on the append-at-top logs

Every PR adds a line at the top of `CHANGELOG.md`, so every PR after the first in a batch conflicts — on a file where **both sides are always right**. Today's batch of six cost six rebases and six full CI reruns, docker and e2e included, for a conflict that has never once been a real disagreement.

The repo had no `.gitattributes` at all. Verified on a scratch repo rather than assumed:

```
REBASE CLEAN
HEADER

- entry A
- entry B
- old entry
```

Ordering inside the block can interleave when a batch lands, which is worth a glance — a cheaper review than resolving the same conflict six times.

## 2. The `__DEV__` trap, written down

A tester runs the Play build plus an OTA, where `__DEV__` is false — only the `development` EAS profile sets `developmentClient`. So logging added to "make the next run report a fact" prints nothing in the only configuration the next run uses.

This is in the QA readme because it happened: the language-onboarding defect was reproduced **three times** with instrumentation in place that could not fire, so three reproductions produced no evidence and two fixes were built on guesses. It is my mistake, and the kind that repeats unless it is written where the next person looks.

Points at `breadcrumb()`, and says to record the inputs to a decision rather than the flow — a breadcrumb per step is a trail nobody reads. `__DEV__` stays right for warnings aimed at whoever is running the dev client.

## Not included

The other four items from that report are latent or not actionable: the toolbar-labels claim needs a device check (the code removes labels for no language), the web/mobile library-status duplication has identical thresholds today, reader settings being device-local is a product gap rather than a defect, and the tool-projection audit is still running — I will act on that one with facts rather than fold it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)