### PR TITLE
The Android invite works on the live site, where chapter URLs end in a slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Beta** — the Android invite works on the live site, where chapter URLs end in a slash — web · [details](docs/changelog-archive/2026-H2.md#2026-08-31-beta-the-android-invite-works-on-the-live-site)
 - **Beta** — the site invites Android readers into the closed test, but only ones who have opened a book — web · [details](docs/changelog-archive/2026-H2.md#2026-08-31-beta-the-site-invites-android-readers)
 - **Resume** — the locator decides on every screen that offers to continue, not just one — mobile · [details](docs/changelog-archive/2026-H2.md#2026-08-29-resume-the-locator-decides-on-every-screen)
 - **Progress** — a row stops being able to contradict itself — mobile · [details](docs/changelog-archive/2026-H2.md#2026-08-29-progress-a-row-stops-being-able-to-contradict-itself)

--- a/apps/web/src/components/AndroidTesterBanner.tsx
+++ b/apps/web/src/components/AndroidTesterBanner.tsx
@@ -9,8 +9,12 @@ const COOKIE_KEY = 'cookieConsent'
 
 export const OPT_IN_URL = 'https://play.google.com/apps/testing/app.textstack.mobile'
 
-/** Reader routes: /:lang/books/:book/:chapter and /:lang/library/my/:id/read[/:chapter]. */
-const READER_PATH = /\/books\/[^/]+\/[^/]+$|\/library\/my\/[^/]+\/read/
+/**
+ * Reader routes: /:lang/books/:book/:chapter and /:lang/library/my/:id/read[/:chapter].
+ * The trailing slash is not optional in production — nginx 301s chapter URLs to it — so a
+ * pattern anchored on the bare segment matches locally and never matches on the live site.
+ */
+const READER_PATH = /\/books\/[^/]+\/[^/]+\/?$|\/library\/my\/[^/]+\/read/
 
 function isAndroid() {
   return /Android/i.test(navigator.userAgent)

--- a/apps/web/src/components/__tests__/AndroidTesterBanner.test.tsx
+++ b/apps/web/src/components/__tests__/AndroidTesterBanner.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AndroidTesterBanner } from '../AndroidTesterBanner'
+
+vi.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+const ANDROID = 'Mozilla/5.0 (Linux; Android 16; Pixel 7 Pro) AppleWebKit/537.36 Chrome/140 Mobile Safari/537.36'
+const DESKTOP = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/140 Safari/537.36'
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(window.navigator, 'userAgent', { value: ua, configurable: true })
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AndroidTesterBanner />
+    </MemoryRouter>,
+  )
+}
+
+const shown = () => screen.queryByText('androidBeta.title') !== null
+
+describe('AndroidTesterBanner', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setUserAgent(ANDROID)
+    // The two preconditions a returning Android reader would already have.
+    localStorage.setItem('cookieConsent', 'accepted')
+    localStorage.setItem('androidTesterBanner.hasRead', '1')
+  })
+
+  it('shows for an Android reader who has read and answered the cookie banner', () => {
+    renderAt('/en')
+    expect(shown()).toBe(true)
+  })
+
+  it('stays hidden on desktop', () => {
+    setUserAgent(DESKTOP)
+    renderAt('/en')
+    expect(shown()).toBe(false)
+  })
+
+  it('stays hidden until the cookie banner has been answered', () => {
+    localStorage.removeItem('cookieConsent')
+    renderAt('/en')
+    expect(shown()).toBe(false)
+  })
+
+  it('stays hidden for someone who has not opened a book', () => {
+    localStorage.removeItem('androidTesterBanner.hasRead')
+    renderAt('/en')
+    expect(shown()).toBe(false)
+  })
+
+  it('stays hidden once dismissed', () => {
+    localStorage.setItem('androidTesterBanner', 'dismissed')
+    renderAt('/en')
+    expect(shown()).toBe(false)
+  })
+
+  // Production 301s chapter URLs to a trailing slash. A pattern anchored on the bare
+  // segment matches under `vite preview` and never matches on the live site.
+  it.each([
+    '/en/books/twelfth-night/2-act-i',
+    '/en/books/twelfth-night/2-act-i/',
+    '/en/library/my/abc/read',
+    '/en/library/my/abc/read/ch-1/',
+  ])('never interrupts the reader at %s', (path) => {
+    renderAt(path)
+    expect(shown()).toBe(false)
+  })
+
+  it.each(['/en/books/twelfth-night', '/en/books/twelfth-night/'])(
+    'still shows on the book page %s, which is not the reader',
+    (path) => {
+      renderAt(path)
+      expect(shown()).toBe(true)
+    },
+  )
+
+  it('records the read flag when the reader is visited', () => {
+    localStorage.removeItem('androidTesterBanner.hasRead')
+    renderAt('/en/books/twelfth-night/2-act-i/')
+    expect(localStorage.getItem('androidTesterBanner.hasRead')).toBe('1')
+  })
+})

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,18 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-08-31-beta-the-android-invite-works-on-the-live-site"></a>
+
+## Beta — the Android invite works on the live site, where chapter URLs end in a slash — web — 2026-08-31
+
+The banner shipped an hour earlier was inert in production, and the way it failed is the useful part.
+
+Its one interesting rule — wait until the visitor has opened a book, never interrupt them while they are in one — is decided by a single pattern matched against the pathname, anchored on the chapter segment: `/books/[^/]+/[^/]+$`. Under `vite preview`, where it was verified, `/en/books/twelfth-night/2-act-i` is exactly what the router sees and the pattern matches. On textstack.app nginx 301s that URL to `/en/books/twelfth-night/2-act-i/`, and an anchored `[^/]+$` cannot match a path ending in a slash. So the read flag was never recorded, the banner never appeared for anyone, and — the half that would have been worse had the first half worked — it would not have hidden itself inside the reader either.
+
+Both failures are the same missing character. The pattern now allows an optional trailing slash, and the negative case that keeps it honest is `/en/books/twelfth-night/` — the book page, also slash-terminated, which must still show the banner because it is not the reader.
+
+A test now pins all of it: platform, the two preconditions, dismissal, and the reader paths in both slash forms. The bug was reachable only through a production URL shape that the local preview does not produce, which is the argument for the test rather than another manual pass.
+
 <a id="2026-08-31-beta-the-site-invites-android-readers"></a>
 
 ## Beta — the site invites Android readers into the closed test, but only ones who have opened a book — web — 2026-08-31


### PR DESCRIPTION
The banner merged in #502 is inert in production.

Its rule — wait until the visitor has opened a book, never interrupt them while they are in one — is decided by a pattern anchored on the chapter segment: `/books/[^/]+/[^/]+$`. Under `vite preview`, where I verified it, the router sees exactly `/en/books/twelfth-night/2-act-i` and it matches. On textstack.app nginx 301s that to `/en/books/twelfth-night/2-act-i/`, and an anchored `[^/]+$` cannot match a path ending in a slash.

So the read flag is never recorded and the banner never appears for anyone. The same missing character means it would not have hidden itself inside the reader either, had the first half worked.

The pattern now allows an optional trailing slash. The negative case that keeps it honest is `/en/books/twelfth-night/` — the book page, also slash-terminated, which must still show the banner because it is not the reader.

## Test

12 cases pin platform, both preconditions, dismissal, the reader paths in both slash forms, and the book page in both slash forms. Verified the old pattern fails the trailing-slash case, so the test has teeth.

Found by checking the deployed site on an Android emulator rather than the local preview — the URL shape that breaks it does not exist locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M1aebchbna44Ro65ZnVXT