### PR TITLE
Stop promoting an SSG rebuild that lost its files, and stop calling that a success

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -278,10 +278,17 @@ jobs:
           SSG_DIR=$PROJECT_DIR/apps/web/dist/ssg
           [ -d "$SSG_DIR" ] || { echo "No SSG dir yet — skipping wait"; exit 0; }
 
-          DEADLINE=$(( $(date +%s) + 600 ))  # 10 min max
+          # A full rebuild renders ~2000 routes and has taken ~25 min; the old 10-minute
+          # deadline expired on every honest rebuild and then `exit 0`, so "SSG never
+          # refreshed" and "SSG refreshed fine" produced the same green deploy. Both halves
+          # were wrong: the budget is now 40 min, and running out of it fails the step.
+          DEADLINE=$(( $(date +%s) + 2400 ))
           SENTINEL="$SSG_DIR/en/books/dracula/index.html"
-          until [ -f "$SENTINEL" ] && [ "$(find "$SENTINEL" -mmin -15)" ]; do
-            [ "$(date +%s)" -ge "$DEADLINE" ] && { echo "Timeout waiting for SSG rebuild"; exit 0; }
+          until [ -f "$SENTINEL" ] && [ "$(find "$SENTINEL" -mmin -45)" ]; do
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "FAIL: SSG rebuild did not finish within 40 min — crawlers may be served a stale or partial tree"
+              exit 1
+            fi
             echo "Waiting for SSG rebuild… ($(date))"
             sleep 30
           done
@@ -296,6 +303,24 @@ jobs:
 
           TOTAL=$(find "$SSG_DIR" -name index.html | wc -l)
           [ "$TOTAL" -eq 0 ] && { echo "No SSG files yet (rebuild pending) — skip"; exit 0; }
+
+          # Quality was checked; quantity was not. On 2026-08-31 the tree held 104 author
+          # pages, 23 genres and zero books — every surviving file had a valid <h1>, so this
+          # step passed while the entire catalogue was 404 to crawlers. Compare against the
+          # route list the rebuild was given.
+          EXPECTED=$(curl -sf http://localhost:8080/ssg/routes | grep -o '"/[^"]*"' | wc -l)
+          if [ "$EXPECTED" -gt 0 ]; then
+            FLOOR=$(( EXPECTED * 9 / 10 ))
+            if [ "$TOTAL" -lt "$FLOOR" ]; then
+              echo "FAIL: SSG holds $TOTAL pages, expected at least $FLOOR of $EXPECTED routes."
+              echo "Whole sections are missing — a concurrent rebuild or a wiped dist, not a few bad renders."
+              find "$SSG_DIR" -mindepth 2 -maxdepth 2 -type d | sed 's/^/  section: /'
+              exit 1
+            fi
+            echo "SSG coverage: $TOTAL pages against $EXPECTED routes (floor $FLOOR)"
+          else
+            echo "Could not read route list — skipping coverage check"
+          fi
 
           BAD=0
           SAMPLES=""

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -38,3 +38,24 @@ jobs:
         run: |
           body=$(curl -sf $CURL_RETRY "https://textstack.app/api/search?q=the&lang=en&limit=1")
           echo "$body" | grep -q '"' || { echo "search endpoint returned empty body"; echo "$body"; exit 1; }
+
+      # An author page that 404s to crawlers while working for people is invisible to Google
+      # and invisible to us — it happened in May 2026 and again in August, both times because
+      # `authors.indexable` was false on rows that have a published book, so SSG never
+      # prerendered them and nginx served bots a hard 404. Sampled from the books API because
+      # every public listing is generated from the same filtered query the bug lives in;
+      # a book's author is the one place a missing author still shows up.
+      - name: Smoke — author pages are crawlable
+        run: |
+          BOT='Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+          OFFSET=$(( RANDOM % 1300 ))
+          slugs=$(curl -sf $CURL_RETRY "https://textstack.app/api/books?lang=en&limit=10&offset=$OFFSET" \
+            | python3 -c "import sys,json;d=json.load(sys.stdin);print('\n'.join(sorted({a['slug'] for b in (d['items'] if isinstance(d,dict) else d) for a in b.get('authors',[])})))")
+          [ -n "$slugs" ] || { echo "no author slugs returned at offset $OFFSET"; exit 1; }
+          bad=0
+          for s in $slugs; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' -A "$BOT" "https://textstack.app/en/authors/$s/" </dev/null)
+            [ "$code" = "200" ] || { echo "::error::author page $s returns $code to crawlers but works for people"; bad=$((bad+1)); }
+          done
+          echo "checked $(echo "$slugs" | wc -l | tr -d ' ') author pages from books at offset $OFFSET; $bad not crawlable"
+          [ "$bad" -eq 0 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **SEO** — 425 author pages stopped returning 404 to Google while working for people, and a check now asks a crawler's question — infra · [incident](docs/incidents/2026-08-31-authors-404-to-crawlers-only.md)
 - **Beta** — the Android invite works on the live site, where chapter URLs end in a slash — web · [details](docs/changelog-archive/2026-H2.md#2026-08-31-beta-the-android-invite-works-on-the-live-site)
 - **Beta** — the site invites Android readers into the closed test, but only ones who have opened a book — web · [details](docs/changelog-archive/2026-H2.md#2026-08-31-beta-the-site-invites-android-readers)
 - **Resume** — the locator decides on every screen that offers to continue, not just one — mobile · [details](docs/changelog-archive/2026-H2.md#2026-08-29-resume-the-locator-decides-on-every-screen)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **SSG** — a rebuild that lost its files stops promoting the remains over a working site, and the deploy stops calling that success — infra · [incident](docs/incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md)
 - **SEO** — 425 author pages stopped returning 404 to Google while working for people, and a check now asks a crawler's question — infra · [incident](docs/incidents/2026-08-31-authors-404-to-crawlers-only.md)
 - **Beta** — the Android invite works on the live site, where chapter URLs end in a slash — web · [details](docs/changelog-archive/2026-H2.md#2026-08-31-beta-the-android-invite-works-on-the-live-site)
 - **Beta** — the site invites Android readers into the closed test, but only ones who have opened a book — web · [details](docs/changelog-archive/2026-H2.md#2026-08-31-beta-the-site-invites-android-readers)

--- a/apps/web/scripts/ssg-worker.mjs
+++ b/apps/web/scripts/ssg-worker.mjs
@@ -14,7 +14,7 @@
 
 import pg from 'pg';
 import { spawn } from 'child_process';
-import { writeFileSync, unlinkSync, existsSync } from 'fs';
+import { writeFileSync, unlinkSync, existsSync, readdirSync } from 'fs';
 import { rename, rm } from 'fs/promises';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -203,6 +203,14 @@ async function processJob(job) {
 
     // 8. Update job status based on exit code
     if (exitCode === 0) {
+      // A clean exit says the renders succeeded, not that they survived. Deploy wipes
+      // apps/web/dist to rebuild the frontend and only snapshots dist/ssg — a rebuild
+      // running at that moment has its dist/ssg-new emptied underneath it, then promotes
+      // the remains over the good tree the deploy just restored. That is how the whole
+      // site went 404-to-crawlers on 2026-08-31. Count what is actually on disk before
+      // trusting it; throwing lands in the catch, which keeps dist/ssg untouched.
+      assertBuildSurvived(routes.length);
+
       // Atomic swap: ssg-new → ssg
       await atomicSwap();
 
@@ -255,6 +263,48 @@ async function submitToIndexNow(host, routes) {
       // Don't fail SSG if IndexNow fails
     }
   }
+}
+
+/** Pages actually written under `dir`, counted as index.html files. */
+function countRenderedPages(dir) {
+  let n = 0;
+  const walk = (d) => {
+    let entries;
+    try {
+      entries = readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) walk(join(d, e.name));
+      else if (e.name === 'index.html') n++;
+    }
+  };
+  walk(dir);
+  return n;
+}
+
+/**
+ * Refuse to promote a build that lost most of itself between rendering and swapping.
+ *
+ * The floor is deliberately loose: routes legitimately go unwritten when a page renders
+ * noindex (a draft book, a not-found), so a healthy build lands a little short of its
+ * route count. It is not trying to catch a handful of missing pages — it is there for the
+ * case where the directory is gone, which is not subtle: on 2026-08-31 a build reported
+ * 1990 of 1992 rendered and had 127 files left on disk.
+ */
+function assertBuildSurvived(expectedRoutes) {
+  const MIN_RATIO = 0.9;
+  const found = countRenderedPages(SSG_NEW_DIR);
+  const floor = Math.floor(expectedRoutes * MIN_RATIO);
+  if (found < floor) {
+    throw new Error(
+      `Refusing atomic swap: ${SSG_NEW_DIR} holds ${found} pages, expected at least ${floor} ` +
+      `of ${expectedRoutes} routes. Something removed the build while it ran (a concurrent ` +
+      `deploy wipes apps/web/dist). Keeping the current SSG tree.`
+    );
+  }
+  console.log(`Build survived: ${found} pages on disk (floor ${floor} of ${expectedRoutes})`);
 }
 
 /**

--- a/docs/incidents/2026-08-31-authors-404-to-crawlers-only.md
+++ b/docs/incidents/2026-08-31-authors-404-to-crawlers-only.md
@@ -1,0 +1,123 @@
+# 425 author pages returned 404 to Google while working perfectly for people
+
+**Date:** 2026-08-31
+**Status:** Resolved
+
+## Impact
+
+425 of 716 authors — every one of them with at least one published, indexable book — had
+`authors.indexable = false`. SSG prerenders only authors that pass that flag, and nginx routes
+crawlers to SSG output rather than the SPA. So `/en/authors/<slug>/` returned **404 to Googlebot and
+200 to a browser**, for the same URL, at the same moment:
+
+```
+/en/authors/george-grey/    human=200   Googlebot=404
+/en/authors/lew-wallace/    human=200   Googlebot=404
+/en/books/dracula/          human=200   Googlebot=200
+```
+
+Sampled 40 authors drawn from the database rather than from any public listing: 12 were in the
+public index and all 12 answered 200 to a crawler; 28 were not and all 28 answered 404. No
+exceptions in either direction.
+
+Duration is not precisely bounded. The `false` rows were created between 2026-01-01 and 2026-03-16;
+a partial backfill on 2026-05-19 brought 189 authors back but left 527 behind. The Ahrefs crawl of
+2026-08-25 recorded 356 of them as 404, 348 of those newly seen. Search Console at the time of this
+write-up: 644 pages indexed, 2,846 not indexed, **7 total search clicks in three months**.
+
+## Root cause
+
+Migration `20251225233053_AddAuthorsGenresSeoFields` added `authors.indexable` without
+`defaultValue: true`. Every row that already existed got `false`. The entity default in
+`Domain.Entities.Author` is `true`, so authors created through the application are fine — which is
+why the pool refilled with correct rows after May and the problem looked closed.
+
+The flag is read by the SSG route builder in `SsgEndpoints.cs`:
+
+```csharp
+var authors = await db.Authors
+    .Where(a => a.Indexable)
+    .Where(a => a.EditionAuthors.Any(ea =>
+        ea.Edition.Status == EditionStatus.Published && ea.Edition.Indexable))
+```
+
+Nothing here is wrong. `Indexable` means "an admin chose to hide this author", and honouring it is
+correct. The defect is that 425 rows were carrying a value nobody chose — a migration artefact
+wearing the costume of a deliberate decision.
+
+What turned a data blemish into an SEO outage is the split-serving in nginx: bots get SSG, humans get
+the SPA fallback. A page missing from SSG is a hard 404 for a crawler and a perfectly good page for a
+person. The two audiences cannot see each other's failures.
+
+## Fix
+
+Data, not code. A backfill of the 425 rows that have a published indexable edition, taken under a
+full `pg_dump` with the affected ids saved separately so a rollback is 425 rows rather than a restore:
+
+```sql
+UPDATE authors a SET indexable = true
+WHERE NOT a.indexable
+  AND EXISTS (SELECT 1 FROM edition_authors ea JOIN editions e ON e.id = ea.edition_id
+              WHERE ea.author_id = a.id AND e.status = 1 AND e.indexable);
+```
+
+`indexable = true` went from 189 to 614; authors with a published book and `false` went to zero; 102
+remain false and should, having no published book. The SSG route list grew from 185 authors to 610,
+and a full rebuild was queued.
+
+This closes the **instance**. It does not close the class, and the May backfill proves it: the same
+statement was run on 2026-05-19, fixed part of the pool, left the rest, and nobody knew for three
+months. The class is closed — as far as it can be — by the detection below.
+
+## Lesson
+
+**When crawlers and people are served different responses for the same URL, every human check is
+blind by construction.** Opening the page, clicking the link, asking a colleague to look — all of it
+confirms the half that works. The site had been visibly fine to everyone who visited it while half
+its author pages were 404 to the only visitor that mattered for growth.
+
+The corollary is about the flag itself. A column that means "someone decided to hide this" must never
+be able to acquire that meaning by accident. A migration that adds such a column without a default
+does not create a missing value; it creates 527 false decisions that are indistinguishable from real
+ones. If the code comment left after May had been a `defaultValue: true` instead, there would have
+been nothing to find today.
+
+## Detection
+
+Found by accident, three months in, and that is the important sentence.
+
+The owner sent an Ahrefs site-audit link for an unrelated reason — we were discussing Play Store
+testers. The audit had been sitting there since 2026-08-25 with `404 page: 356` on its front screen.
+Nothing alerted; the number was visible to anyone who opened the tab and nobody had.
+
+No alarm existed that could have caught it. `health-check.yml` ran every five minutes and checked the
+API, both frontends, book listing and search — all with a default user agent, so all served the SPA,
+so all green throughout. The check that would have caught this on day one is the one that asks a
+crawler's question, and it now exists: a step samples books from the public API, follows each book's
+author to `/en/authors/<slug>/` with a Googlebot user agent, and fails on anything but 200. Sampling
+from the books API is deliberate — every public listing of authors is generated by the same filtered
+query the bug lives in, so a missing author is invisible there. A book's author is the one public
+place a missing author still appears.
+
+Verified the probe fails before it passes: run against production mid-rebuild it reported four of
+seven sampled authors uncrawlable and exited non-zero.
+
+---
+
+## Full write-up
+
+The first hypothesis was wrong and worth recording. The 404s were all author pages, so the obvious
+guess was slug encoding: the first row in the audit was `hjalmar-söderberg`, non-ASCII, exactly the
+shape of a slug-generation mismatch. It was a coincidence of alphabetical sorting. Percent-encoding
+the slug and refetching returned the same 404 as the plain ASCII ones.
+
+The second wrong turn was mine and cost more time. A sweep of all 185 authors from the public API
+reported zero failures while a direct check of `george-grey` returned 404 seconds later. The sweep
+was not wrong about the authors it tested — `george-grey` was never in the list it was testing, which
+was the finding, not the error. But the sweep also had a real bug: `curl` inside `while read` consumes
+stdin, so the loop count could not be trusted either. Two defects with the same symptom, one of them
+the answer.
+
+The thing that resolved it was refusing to sample from the API listing and going to the database
+instead. 716 authors in `authors`, 185 in the public list — a gap that no public endpoint could have
+revealed, because every public endpoint is downstream of the filter.

--- a/docs/incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md
+++ b/docs/incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md
@@ -1,0 +1,107 @@
+# A deploy wiped the SSG build that was running, and the build promoted the remains over the good tree
+
+**Date:** 2026-08-31
+**Status:** Resolved
+
+## Impact
+
+Every page on textstack.app returned **404 to crawlers** for roughly 50 minutes — not one section,
+the whole site including the homepage:
+
+```
+/en/                     Googlebot=404
+/en/books/dracula/       Googlebot=404
+/en/authors/a-a-milne/   Googlebot=404
+```
+
+Browsers were unaffected throughout; nginx serves them the SPA. On disk `dist/ssg/en` held 104 author
+pages, 23 genres and **zero books**, where a healthy tree holds ~1990 pages.
+
+Self-inflicted, in the course of fixing the author-indexability incident earlier the same day
+([2026-08-31-authors-404-to-crawlers-only](2026-08-31-authors-404-to-crawlers-only.md)). I queued a
+full SSG rebuild, then merged an unrelated PR while it was still running.
+
+## Root cause
+
+Three defects lined up, and none of them is the merge.
+
+**The deploy's protection has a hole.** `deploy.yml` already knows vite wipes `apps/web/dist`, and
+snapshots `dist/ssg` out to `.ssg-staging` before the build, restoring it after — the step is titled
+"Snapshot SSG dir + referenced assets before vite wipes dist" and it works. It snapshots the *live*
+tree. A rebuild in flight is writing to `dist/ssg-new`, which is not snapshotted, so vite deleted it
+mid-render.
+
+**The worker trusted an exit code over the disk.** `ssg-worker.mjs` ran `atomicSwap()` whenever
+prerender exited 0. Prerender did exit 0 — it had rendered 1990 of 1992 routes successfully, and its
+report was accurate at the moment it was written. By the time the swap ran, most of those files no
+longer existed. The swap moved the 127 survivors over the good tree the deploy had just restored.
+
+**The deploy could not see the result.** "Wait for SSG rebuild to complete" polls for a sentinel file
+with a 10-minute deadline, and on timeout runs `exit 0`. A real rebuild of ~2000 routes takes ~25
+minutes, so that deadline expired on every honest rebuild and the step reported success either way —
+"SSG never refreshed" and "SSG refreshed fine" were indistinguishable. Then "Validate SSG content"
+checked that every file on disk has a real `<h1>`, which all 127 survivors did. It never asked how
+many files there should be.
+
+## Fix
+
+**The worker refuses to promote a build that lost itself** (this PR). Before the swap it counts
+`index.html` files under `ssg-new` and requires at least 90% of the route count. The floor is loose
+on purpose — pages that render noindex are legitimately skipped — because it is not trying to catch a
+few missing pages; it is there for the case that is not subtle. Today: 127 against a floor of 1792.
+The check throws, which lands in the existing catch, which calls `cleanupFailedBuild()` and marks the
+job Failed, leaving `dist/ssg` untouched. Had it existed, the site would never have gone down and the
+job would have been visibly red.
+
+**The deploy stops reporting success it did not verify.** The wait budget goes 10 min → 40 min, and a
+timeout now fails the step instead of passing it. Validation gains a coverage floor: pages on disk
+against the route list from `/ssg/routes`, same 90%, printing the surviving sections when it trips.
+
+This closes the **class** for "the tree is gone" — three independent places now have to fail silently
+together. It does **not** make deploys and rebuilds mutually exclusive; a rebuild overlapping a deploy
+still wastes ~25 minutes of rendering and now ends in a failed job rather than a broken site. A real
+lock is the follow-up, and it is worth doing because the periodic rebuild is admin-configurable and
+will eventually collide with a deploy on its own, with nobody watching.
+
+## Lesson
+
+**A process that reports what it did is not reporting what survived.** Prerender's "1990/1992
+rendered" was true and useless: it described an intention that something else had already undone. Any
+producer that hands work to a later step across a filesystem should re-measure at the handoff, not
+carry forward the number it computed at the start.
+
+The second lesson is about timeouts that pass. A deadline that expires on every normal run, wired to
+`exit 0`, is worse than no check: it is a green light that means nothing, and it trains everyone to
+read the deploy as healthy. If a wait cannot be given a budget it will actually meet, it should not
+be reported as a check.
+
+## Detection
+
+Immediately, but by luck rather than by design. I was verifying whether the author pages from the
+earlier fix had come back and requested the homepage with a Googlebot user agent out of habit — it
+returned 404. Nothing alerted: the deploy had gone green, `health-check.yml` was green because it
+requests with a default user agent and gets the SPA, and the SSG job was marked Completed.
+
+The alarm that would have caught it now exists twice over: the coverage floor fails the deploy, and
+the author-crawlability probe added the same day (see the other incident) requests pages as a crawler
+every five minutes and would have failed within minutes of the swap.
+
+---
+
+## Full write-up
+
+The misleading evidence was the worker log, which reads like success end to end: `1990 rendered, 2
+failed`, then `Atomic swap completed`, then `Job … completed successfully`. Both failures were books
+with a noindex meta, which is expected and documented. Nothing in that log is wrong, and nothing in
+it hints that the directory it was describing had been emptied.
+
+The first wrong turn was looking for the files in the wrong place. `ls /app/dist/ssg/en/authors`
+inside the worker showed 104, and `books=0` — which looked like a container/volume mismatch, since
+`/en/books/dracula/` was still serving from SSG at that moment. It was not a mismatch:
+`docker inspect` confirmed `apps/web/dist → /app/dist`, one directory. Dracula was still working
+because the deploy had restored the snapshot and my rebuild had not yet swapped. The 404s arrived a
+few minutes later, when it did.
+
+Worth recording that the nginx config contains a dead alias: `location /ssg/` points at
+`data/ssg/`, a directory that does not exist on the server. Serving works through the `root` at
+`apps/web/dist` instead. It cost some minutes and it is still there.

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -11,6 +11,7 @@ available at the time. The fix that matters is the one that closes the *class*, 
 
 | Date | Incident | Shape |
 |---|---|---|
+| 2026-08-31 | [425 author pages 404'd to Google while working for people](2026-08-31-authors-404-to-crawlers-only.md) | Split serving hides the failure |
 | 2026-08-11 | [SSG dead for five weeks — a forbidden HTTP header](2026-08-11-ssg-dead-five-weeks.md) | A mitigation that could never work |
 | 2026-08-07 | [The scrubber built to stop SQL leaks leaked SQL — twice](2026-08-07-sentry-scrubber-leaked-sql.md) | Second egress path |
 | 2026-08-07 | [Readers lost their place in books (23505 upsert race)](2026-08-07-reading-position-lost-23505.md) | Racing yourself |

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -11,6 +11,7 @@ available at the time. The fix that matters is the one that closes the *class*, 
 
 | Date | Incident | Shape |
 |---|---|---|
+| 2026-08-31 | [A deploy wiped the SSG build that was running](2026-08-31-deploy-wiped-a-running-ssg-rebuild.md) | Reported what it did, not what survived |
 | 2026-08-31 | [425 author pages 404'd to Google while working for people](2026-08-31-authors-404-to-crawlers-only.md) | Split serving hides the failure |
 | 2026-08-11 | [SSG dead for five weeks — a forbidden HTTP header](2026-08-11-ssg-dead-five-weeks.md) | A mitigation that could never work |
 | 2026-08-07 | [The scrubber built to stop SQL leaks leaked SQL — twice](2026-08-07-sentry-scrubber-leaked-sql.md) | Second egress path |


### PR DESCRIPTION
Every page on textstack.app returned **404 to crawlers for ~50 minutes** today — homepage included — while browsers saw nothing wrong. `dist/ssg` held 104 author pages, 23 genres and zero books.

I caused it by merging a PR while a full SSG rebuild was running. That is the trigger, not the defect. Three things had to line up.

## What lined up

**The deploy's protection has a hole.** `deploy.yml` already knows vite wipes `apps/web/dist` and snapshots `dist/ssg` around the build. It snapshots the *live* tree. A rebuild in flight writes to `dist/ssg-new`, which is not snapshotted, so vite deleted it mid-render.

**The worker trusted an exit code over the disk.** `atomicSwap()` ran because prerender exited 0. Prerender was not lying — it rendered 1990 of 1992 routes and that was true when it wrote the number. By swap time most of those files were gone, and it moved the 127 survivors over the good tree the deploy had just restored.

**The deploy could not see it.** "Wait for SSG rebuild" polled with a 10-minute deadline and `exit 0` on timeout, while a real rebuild takes ~25 minutes — so it expired on every honest rebuild and reported success either way. "Validate SSG content" checked that every file present has a real `<h1>`; all 127 survivors did. It never asked how many files there should be.

## The fix

- **Worker**: count `index.html` under `ssg-new` before swapping, refuse below 90% of the route count. Loose on purpose — noindex pages are legitimately skipped — because it is not for a few missing pages. Today: 127 against a floor of 1792. Throws into the existing catch → `cleanupFailedBuild()`, job marked Failed, `dist/ssg` untouched.
- **Deploy wait**: 10 min → 40 min, and a timeout now fails instead of passing.
- **Deploy validation**: coverage floor against `/ssg/routes`, same 90%, printing surviving sections when it trips.

Verified the counter on a fixture (ignores non-`index.html`, returns 0 for a missing dir) and against today's numbers: 127 trips, 1990 passes. Confirmed `/ssg/routes` returns 1992 from the deploy's own call shape (no Host header).

## What this does not fix

Deploys and rebuilds are still not mutually exclusive. An overlap now wastes ~25 minutes of rendering and ends in a red job rather than a broken site. A real lock is the follow-up and worth doing — the periodic rebuild is admin-configurable and will collide with a deploy on its own eventually, with nobody watching.

Postmortem: `docs/incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M1aebchbna44Ro65ZnVXT