### PR TITLE
Wait for a swap that happened after we asked, not for a recent-looking file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,6 +230,9 @@ jobs:
 
       - name: Queue SSG rebuild
         run: |
+          # Stamp the moment we asked, so the wait below can require a swap that happened
+          # *after* it rather than guessing from a file's age.
+          echo "SSG_QUEUED_AT=$(date +%s)" >> $GITHUB_ENV
           curl -sf -X POST http://localhost:8080/internal/ssg/rebuild-all && echo "SSG rebuild queued" || echo "SSG rebuild queue failed (non-blocking)"
 
       - name: Health check frontend
@@ -284,7 +287,12 @@ jobs:
           # were wrong: the budget is now 40 min, and running out of it fails the step.
           DEADLINE=$(( $(date +%s) + 2400 ))
           SENTINEL="$SSG_DIR/en/books/dracula/index.html"
-          until [ -f "$SENTINEL" ] && [ "$(find "$SENTINEL" -mmin -45)" ]; do
+          # Not "is the file recent" — that has no honest window. A 15-minute window expired on
+          # every real rebuild; widening it to 45 made a tree from the previous rebuild look
+          # current and the wait returned in zero seconds. The question is whether a swap
+          # happened after we queued, which is a comparison, not a guess.
+          SINCE=${SSG_QUEUED_AT:-0}
+          until [ -f "$SENTINEL" ] && [ "$(stat -c %Y "$SENTINEL")" -gt "$SINCE" ]; do
             if [ "$(date +%s)" -ge "$DEADLINE" ]; then
               echo "FAIL: SSG rebuild did not finish within 40 min — crawlers may be served a stale or partial tree"
               exit 1

--- a/docs/incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md
+++ b/docs/incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md
@@ -105,3 +105,21 @@ few minutes later, when it did.
 Worth recording that the nginx config contains a dead alias: `location /ssg/` points at
 `data/ssg/`, a directory that does not exist on the server. Serving works through the `root` at
 `apps/web/dist` instead. It cost some minutes and it is still there.
+
+## Follow-up, same day
+
+The first attempt at the wait step fixed the deadline and broke the signal. Raising the budget from
+10 to 40 minutes was right; widening the sentinel's freshness window from `-mmin -15` to `-mmin -45`
+alongside it was not. The next deploy queued a rebuild at 18:04:58 UTC against a `dracula/index.html`
+last written at 17:30:52 — 34 minutes old, inside the new window — so the wait was satisfied by the
+previous rebuild's output and returned in zero seconds. Same failure as before, arrived at from the
+opposite direction.
+
+There is no honest number for that window: too small and it expires on every real rebuild, too large
+and a stale tree passes for a fresh one. The question was never "is this file recent" but "did a swap
+happen after I asked", which is a comparison rather than a guess. The queue step now stamps
+`SSG_QUEUED_AT` and the wait requires the sentinel's mtime to exceed it.
+
+Worth naming plainly: this was introduced while writing the fix for the incident above, and it went
+out because the change looked like a strictly-larger tolerance rather than what it was — a weakening
+of the only thing being tested.


### PR DESCRIPTION
Fixing the wait step in #505 I raised the deadline (right) and widened the sentinel's freshness window from `-mmin -15` to `-mmin -45` (wrong).

The very next deploy proved it:

```
dracula/index.html mtime   17:30:52Z   (previous rebuild)
wait step ran              18:04:58Z → completed 18:04:58Z
```

34 minutes old, inside the new window, so the wait was satisfied by the *previous* rebuild's output and returned in zero seconds — the same failure #505 was written to fix, reached from the opposite direction. (The site was fine: the deploy's snapshot/restore had put a complete tree back, and the coverage floor from #505 correctly passed it.)

There is no honest number for that window. Too small and it expires on every real rebuild, which made the original 15 minutes useless. Too large and a stale tree passes for a fresh one. The question was never whether the file is recent — it is whether a swap happened after we asked, which is a comparison, not a guess.

Queue stamps `SSG_QUEUED_AT`; the wait requires the sentinel's mtime to exceed it. No window.

Verified against the real timing — at 40 minutes old: `-mmin -15` waits, `-mmin -45` returns immediately, the comparison waits, and accepts once a genuine swap lands.

Postmortem updated with a "Follow-up, same day" section, including why the change read as a harmless larger tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M1aebchbna44Ro65ZnVXT