### PR TITLE
Rank after deduplication, not once per matching chapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Search** — a common word stops timing out, because ranking happens after deduplication instead of over every chapter — backend · [details](docs/changelog-archive/2026-H2.md#2026-08-31-search-a-common-word-stops-timing-out)
 - **Android** — the launcher icon stops being a solid block for anyone using themed icons — mobile · [details](docs/changelog-archive/2026-H2.md#2026-08-31-android-the-launcher-icon-stops-being-a-solid-block)
 - **SSG** — a rebuild that lost its files stops promoting the remains over a working site, and the deploy stops calling that success — infra · [incident](docs/incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md)
 - **SEO** — 425 author pages stopped returning 404 to Google while working for people, and a check now asks a crawler's question — infra · [incident](docs/incidents/2026-08-31-authors-404-to-crawlers-only.md)

--- a/backend/src/Search/TextStack.Search/Providers/PostgresFts/PostgresSearchProvider.cs
+++ b/backend/src/Search/TextStack.Search/Providers/PostgresFts/PostgresSearchProvider.cs
@@ -93,15 +93,34 @@ public sealed class PostgresSearchProvider : ISearchProvider
 
                 UNION ALL
 
-                -- Strategy 4: FTS on chapter content (score = ts_rank)
-                SELECT e.id,
-                       ts_rank(c.search_vector, to_tsquery(@FtsConfig::regconfig, @TsQuery))::float8,
-                       c.id
-                FROM chapters c
-                JOIN editions e ON c.edition_id = e.id
-                WHERE e.site_id = @SiteId AND e.status = 1
-                  AND @TsQuery != ''
-                  AND c.search_vector @@ to_tsquery(@FtsConfig::regconfig, @TsQuery)
+                -- Strategy 4: FTS on chapter content (score = ts_rank), one chapter per edition.
+                --
+                -- The GIN index finds matches in milliseconds; ts_rank is what costs, because it
+                -- reads the tsvector of every row it scores and no index can help it. Scoring each
+                -- matching chapter meant 23,487 calls for a word as ordinary as love — 7.7s, and
+                -- 500s in production once a rebuild put the box under load. Deduplicating first
+                -- costs a sort on edition_id and leaves one row per book: 1,334 calls, 70ms, the
+                -- same 1,334 books. (Capping the candidate rows instead — the obvious cheap fix —
+                -- is much worse: 500 chapters in heap order are consecutive chapters of the same
+                -- few books, so it returns 36 of the 1,334.)
+                --
+                -- The trade is which chapter represents the book: the first match by DISTINCT ON
+                -- rather than the highest-scoring one, so an edition's score comes from one of its
+                -- matching chapters instead of its best. Recovering that would mean ranking all
+                -- 23,487 again, which is the thing being paid for here.
+                SELECT x.edition_id,
+                       ts_rank(x.search_vector, to_tsquery(@FtsConfig::regconfig, @TsQuery))::float8,
+                       x.chapter_id
+                FROM (
+                    SELECT DISTINCT ON (c.edition_id)
+                           c.edition_id, c.id AS chapter_id, c.search_vector
+                    FROM chapters c
+                    JOIN editions e ON c.edition_id = e.id
+                    WHERE e.site_id = @SiteId AND e.status = 1
+                      AND @TsQuery != ''
+                      AND c.search_vector @@ to_tsquery(@FtsConfig::regconfig, @TsQuery)
+                    ORDER BY c.edition_id
+                ) x
             ),
             deduped AS (
                 SELECT edition_id,

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,44 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-08-31-search-a-common-word-stops-timing-out"></a>
+
+## Search — a common word stops timing out, because ranking happens after deduplication — backend — 2026-08-31
+
+Sentry reported two `NpgsqlException: Timeout during reading attempt` from `PostgresSearchProvider`
+within the same second. Reproduced immediately: `?q=war` returned **500**, `?q=love` took 4.9s,
+`?q=dracula` took 158ms. The provider's command timeout is 5s, so anything above it is a 500 to the
+reader.
+
+The index was not the problem, which is worth stating because it is where one looks first. The GIN
+index on `chapters.search_vector` is valid, 91 MB, and matches 23,487 of 40,589 chapters for *love*
+in 9ms. Measured against the same rows:
+
+| | |
+|---|---|
+| match only | 9 ms |
+| match + `ts_rank` + order | **7,747 ms** |
+| `ts_headline` on the 20 output rows | 48 ms |
+
+`ts_rank` reads the tsvector of every row it scores and no index can help it, so strategy 4 was
+paying for 23,487 scores to return ten results. `ts_headline`, the usual suspect, is cheap here.
+
+The obvious cheap fix is to cap the candidate rows, and it is a trap: 500 chapters in heap order are
+consecutive chapters of the same few books, so ranking a 500-row cap finds 36 of the 1,334 books that
+actually match. Deduplicating first costs a sort on `edition_id` and leaves exactly one row per book
+— 1,334 scores instead of 23,487, same 1,334 books, 70 ms.
+
+End to end against production, the whole CTE with all four strategies and headlines: **125 ms**, with
+*Sons and Lovers*, *Women in Love* and *Love's Labour's Lost* at the top where they belong.
+
+The trade is which chapter represents a book: the first match by `DISTINCT ON` rather than the
+highest-scoring one, so an edition's score comes from one of its matching chapters rather than its
+best. Recovering that would mean ranking all 23,487 again, which is the cost being removed.
+
+Pre-existing, not new — it only ever surfaced on words common enough to match half the corpus, and
+search sends this site one visitor a month. It became visible because an SSG rebuild put the box
+under load and pushed a 4.9s query past 5s.
+
 <a id="2026-08-31-android-the-launcher-icon-stops-being-a-solid-block"></a>
 
 ## Android — the launcher icon stops being a solid block for anyone using themed icons — mobile — 2026-08-31


### PR DESCRIPTION
Sentry reported two `NpgsqlException: Timeout during reading attempt` from `PostgresSearchProvider` in the same second. Reproduced immediately:

```
?q=war       500     5099ms
?q=love      200     4868ms
?q=dracula   200      158ms
```

The provider's command timeout is 5s, so anything past it is a 500 to the reader.

## The index is fine

Worth stating, because it is where you look first. The GIN index on `chapters.search_vector` is valid, 91 MB, and matches 23,487 of 40,589 chapters for *love* in 9ms. Measured on the same rows:

| step | time |
|---|---|
| match only | 9 ms |
| match + `ts_rank` + order | **7,747 ms** |
| `ts_headline` on the 20 output rows | 48 ms |

`ts_rank` reads the tsvector of every row it scores and no index can help it. Strategy 4 was paying for 23,487 scores to return ten results. `ts_headline` — the usual suspect — is cheap here.

## Why not just cap the candidates

Because it is a trap. 500 chapters in heap order are consecutive chapters of the same few books, so ranking a 500-row cap finds **36** of the 1,334 books that actually match. Deduplicating first costs a sort on `edition_id` and leaves exactly one row per book: 1,334 scores instead of 23,487, the same 1,334 books, 70 ms.

## Verified against production

The whole CTE — all four strategies, dedup, headlines — run against the live database with real parameters: **125 ms**, `total_count` 1335, and *Sons and Lovers*, *Women in Love*, *Love's Labour's Lost*, *Lady Chatterley's Lover* at the top on their title-match score.

## The trade

Which chapter represents a book: the first match by `DISTINCT ON` rather than the highest-scoring one, so an edition's score comes from one of its matching chapters rather than its best. Recovering that means ranking all 23,487 again — the cost being removed.

Pre-existing; it only ever showed on words common enough to match half the corpus, and became visible when an SSG rebuild pushed a 4.9s query past 5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M1aebchbna44Ro65ZnVXT