### PR TITLE
fix(mobile): selecting a sentence and pressing Listen reads the sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Selection** — extending a long-press into a sentence reaches the app, so Listen stops reading one word — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-01-selection-extending-a-long-press-reaches-the-app)
+- **Reader** — speech starts when asked, and the Listen button reads the passage you picked — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-01-reader-speech-starts-when-asked)
+- **Selection** — a passage longer than 300 characters stops disappearing instead of opening a toolbar — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-01-selection-a-long-passage-stops-disappearing)
 - **Search** — a common word stops timing out, because ranking happens after deduplication instead of over every chapter — backend · [details](docs/changelog-archive/2026-H2.md#2026-08-31-search-a-common-word-stops-timing-out)
 - **Android** — the launcher icon stops being a solid block for anyone using themed icons — mobile · [details](docs/changelog-archive/2026-H2.md#2026-08-31-android-the-launcher-icon-stops-being-a-solid-block)
 - **SSG** — a rebuild that lost its files stops promoting the remains over a working site, and the deploy stops calling that success — infra · [incident](docs/incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Beta** — the site and the README carry a standing Android beta badge, not a Play badge that leads to a 404 — web · [details](docs/changelog-archive/2026-H2.md#2026-09-01-beta-a-standing-android-badge)
 - **Selection** — extending a long-press into a sentence reaches the app, so Listen stops reading one word — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-01-selection-extending-a-long-press-reaches-the-app)
 - **Reader** — speech starts when asked, and the Listen button reads the passage you picked — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-01-reader-speech-starts-when-asked)
 - **Selection** — a passage longer than 300 characters stops disappearing instead of opening a toolbar — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-01-selection-a-long-passage-stops-disappearing)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
 [![Docker](https://img.shields.io/badge/docker-compose-2496ED?logo=docker&logoColor=white)](https://docs.docker.com/compose/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/mrviduus/textstack/pulls)
+[![Android — closed beta](https://img.shields.io/badge/Android-closed%20beta-3DDC84?logo=android&logoColor=white)](https://play.google.com/apps/testing/app.textstack.mobile)
 [![GitHub stars](https://img.shields.io/github/stars/mrviduus/textstack?style=social)](https://github.com/mrviduus/textstack/stargazers)
 
 <p align="center">
@@ -18,6 +19,12 @@
 
 <p align="center">
   <a href="https://textstack.app"><img src="https://img.shields.io/badge/▶%20Open%20TextStack-textstack.app-2ea44f?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Open TextStack — read books in English with native-language translation"></a>
+  <a href="https://play.google.com/apps/testing/app.textstack.mobile"><img src="https://img.shields.io/badge/Android-join%20the%20beta-3DDC84?style=for-the-badge&logo=android&logoColor=white" alt="Join the TextStack Android closed beta"></a>
+</p>
+
+<p align="center">
+  <sub><b>The Android app is in closed testing and looking for readers.</b> Join, keep it installed, read something.<br>
+  That is the whole job — Google needs 12 testers for 14 days before it can go public.</sub>
 </p>
 
 <p align="center">

--- a/apps/mobile/scripts/smoke-reader-html.mjs
+++ b/apps/mobile/scripts/smoke-reader-html.mjs
@@ -43,10 +43,31 @@ function parseOrDie(label, code) {
   }
 }
 
-// 1. Overlay script parses standalone.
-const overlayScript = extractTemplate(readSource('src/lib/readerOverlayScript.ts'), 'READER_OVERLAY_SCRIPT')
-parseOrDie('READER_OVERLAY_SCRIPT', overlayScript)
-console.log(`ok overlay-script — ${overlayScript.length} bytes`)
+// 1. The selection bridge parses standalone.
+//
+// This used to point at READER_OVERLAY_SCRIPT in readerOverlayScript.ts. That
+// module became a one-line re-export of the generated bundle in April, so the
+// marker stopped being found and this script has exited non-zero — unnoticed,
+// since nothing runs it — ever since. The generated bundle is covered by
+// readerOverlayMobileBundle.test.ts, which loads it into JSDOM.
+//
+// READER_SELECTION_BRIDGE is the hand-written template that was left
+// unguarded: 27KB of JavaScript inside a TypeScript string, where a stray
+// brace is invisible to tsc and shows up as a reader with no word tap, no
+// selection toolbar and no highlights.
+const bridgeRaw = extractTemplate(readSource('src/lib/readerBridge.ts'), 'READER_SELECTION_BRIDGE')
+// Decode the escapes rather than parsing the source slice. A regex strip does
+// not round-trip them — `\\p{L}` in the source is `\p{L}` in the string the
+// WebView receives, and parsing the former fails on a regex that is fine. The
+// template carries no `${…}`, so evaluating it as a literal runs no code; that
+// is asserted rather than assumed, because it stops being true silently.
+if (bridgeRaw.includes('${')) {
+  console.error('[FAIL] READER_SELECTION_BRIDGE gained an interpolation — this check decodes it as a plain literal')
+  process.exit(1)
+}
+const bridge = vm.runInNewContext('`' + bridgeRaw + '`')
+parseOrDie('READER_SELECTION_BRIDGE', bridge)
+console.log(`ok selection-bridge — ${bridge.length} bytes`)
 
 // 2. readerHtml.ts interpolates it under the expected flag gate.
 const readerHtml = readSource('src/lib/readerHtml.ts')

--- a/apps/mobile/src/components/SelectionActionBar.tsx
+++ b/apps/mobile/src/components/SelectionActionBar.tsx
@@ -46,6 +46,10 @@ interface SelectionActionBarProps {
    *  multi-word passages (a single quoted word is redundant with the vocab actions). */
   onAskAbout?: () => void
   isSpeaking?: boolean
+  /** Audio is being fetched — there is no sound yet. Distinct from `isSpeaking`
+   *  because the fetch takes about a second, and a button that still says
+   *  "Listen" through it invites the second press that cancels the first. */
+  isTtsLoading?: boolean
   wordSaved?: boolean
   vocabStage?: number | null
   isAuthenticated?: boolean
@@ -85,6 +89,7 @@ export function SelectionActionBar({
   onRemove,
   onAskAbout,
   isSpeaking,
+  isTtsLoading,
   wordSaved,
   vocabStage,
   isAuthenticated,
@@ -209,15 +214,26 @@ export function SelectionActionBar({
             <Text style={[styles.btnLabel, { color: colors.textSecondary }]}>Explain</Text>
           </TouchableOpacity>
         )}
+        {/* One control, three states: idle → fetching → playing. The spinner
+            stays pressable and cancels, so a download that never lands can't
+            trap the reader in a button that does nothing. */}
         <TouchableOpacity
           style={styles.btn}
           onPress={onSpeak}
           accessibilityRole="button"
-          accessibilityLabel={isSpeaking ? 'Stop speech' : 'Read selection aloud'}
-          accessibilityState={{ selected: !!isSpeaking }}
+          accessibilityLabel={
+            isTtsLoading ? 'Loading speech, tap to cancel'
+              : isSpeaking ? 'Stop speech'
+              : 'Read selection aloud'
+          }
+          accessibilityState={{ selected: !!isSpeaking, busy: !!isTtsLoading }}
         >
-          <Ionicons name={isSpeaking ? 'stop' : 'volume-high-outline'} size={19} color={colors.text} />
-          <Text style={[styles.btnLabel, { color: colors.textSecondary }]}>{isSpeaking ? 'Stop' : 'Listen'}</Text>
+          {isTtsLoading
+            ? <ActivityIndicator size="small" color={colors.text} style={styles.btnSpinner} />
+            : <Ionicons name={isSpeaking ? 'stop' : 'volume-high-outline'} size={19} color={colors.text} />}
+          <Text style={[styles.btnLabel, { color: colors.textSecondary }]}>
+            {isTtsLoading ? 'Loading' : isSpeaking ? 'Stop' : 'Listen'}
+          </Text>
         </TouchableOpacity>
 
         {/* "Ask about this" — quote the passage into the persistent Book Chat. Multi-word only. */}
@@ -366,6 +382,12 @@ const styles = StyleSheet.create({
     fontFamily: fonts.sansMedium,
     fontSize: 9,
     marginTop: 1,
+  },
+  // Match the 19px icon box the spinner replaces, so the row doesn't shift
+  // height the moment someone presses Listen.
+  btnSpinner: {
+    height: 19,
+    width: 19,
   },
   btn: {
     minWidth: 46,

--- a/apps/mobile/src/components/SelectionActionBar.tsx
+++ b/apps/mobile/src/components/SelectionActionBar.tsx
@@ -176,6 +176,18 @@ export function SelectionActionBar({
         </View>
       )}
 
+      {/* Say why three buttons are dead. Dimming them alone reads as "broken":
+          the reader presses, nothing happens, and that is exactly the
+          impression this toolbar is supposed to stop giving. */}
+      {tooLong && (
+        <View style={styles.noticeRow}>
+          <Ionicons name="information-circle-outline" size={13} color={colors.textSecondary} />
+          <Text style={[styles.notice, { color: colors.textSecondary }]} numberOfLines={1}>
+            Too long to listen, translate or explain
+          </Text>
+        </View>
+      )}
+
       <View style={styles.actionsRow}>
         {isAuthenticated && onHighlight && (
           <>
@@ -200,7 +212,7 @@ export function SelectionActionBar({
           <Text style={[styles.btnLabel, { color: colors.textSecondary }]}>Copy</Text>
         </TouchableOpacity>
         <TouchableOpacity
-          style={styles.btn}
+          style={[styles.btn, tooLong && styles.btnDisabled]}
           onPress={onTranslate}
           disabled={tooLong}
           accessibilityRole="button"
@@ -212,7 +224,7 @@ export function SelectionActionBar({
         </TouchableOpacity>
         {onExplain && (
           <TouchableOpacity
-            style={styles.btn}
+            style={[styles.btn, tooLong && styles.btnDisabled]}
             onPress={onExplain}
             disabled={tooLong}
             accessibilityRole="button"
@@ -227,7 +239,7 @@ export function SelectionActionBar({
             stays pressable and cancels, so a download that never lands can't
             trap the reader in a button that does nothing. */}
         <TouchableOpacity
-          style={styles.btn}
+          style={[styles.btn, tooLong && styles.btnDisabled]}
           onPress={onSpeak}
           disabled={tooLong}
           accessibilityRole="button"
@@ -403,6 +415,26 @@ const styles = StyleSheet.create({
   btnSpinner: {
     height: 19,
     width: 19,
+  },
+  // Opacity, not a colour swap. text vs textSecondary on the icon is
+  // indistinguishable in the light theme — verified on a device, where the
+  // three dead buttons looked exactly like the live ones.
+  btnDisabled: {
+    opacity: 0.35,
+  },
+  noticeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    paddingBottom: 6,
+    marginBottom: 4,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(127,127,127,0.18)',
+  },
+  notice: {
+    fontFamily: fonts.sansMedium,
+    fontSize: 11,
   },
   btn: {
     minWidth: 46,

--- a/apps/mobile/src/components/SelectionActionBar.tsx
+++ b/apps/mobile/src/components/SelectionActionBar.tsx
@@ -45,6 +45,10 @@ interface SelectionActionBarProps {
    *  (persistent chat, AI-027). Only wired when the reader has an ask target; shown for
    *  multi-word passages (a single quoted word is redundant with the vocab actions). */
   onAskAbout?: () => void
+  /** Selection is past the 500-character ceiling the speech and translation
+   *  endpoints enforce. Those two and Explain are disabled; Copy, Highlight
+   *  and Ask still work, which is why the toolbar opens at all. */
+  tooLong?: boolean
   isSpeaking?: boolean
   /** Audio is being fetched — there is no sound yet. Distinct from `isSpeaking`
    *  because the fetch takes about a second, and a button that still says
@@ -88,6 +92,7 @@ export function SelectionActionBar({
   onMarkKnown,
   onRemove,
   onAskAbout,
+  tooLong,
   isSpeaking,
   isTtsLoading,
   wordSaved,
@@ -197,20 +202,24 @@ export function SelectionActionBar({
         <TouchableOpacity
           style={styles.btn}
           onPress={onTranslate}
+          disabled={tooLong}
           accessibilityRole="button"
-          accessibilityLabel="Translate selection in full sheet"
+          accessibilityLabel={tooLong ? 'Translate — selection too long' : 'Translate selection in full sheet'}
+          accessibilityState={{ disabled: !!tooLong }}
         >
-          <Ionicons name="language-outline" size={19} color={colors.text} />
+          <Ionicons name="language-outline" size={19} color={tooLong ? colors.textSecondary : colors.text} />
           <Text style={[styles.btnLabel, { color: colors.textSecondary }]}>Translate</Text>
         </TouchableOpacity>
         {onExplain && (
           <TouchableOpacity
             style={styles.btn}
             onPress={onExplain}
+            disabled={tooLong}
             accessibilityRole="button"
-            accessibilityLabel="Explain selection in context"
+            accessibilityLabel={tooLong ? 'Explain — selection too long' : 'Explain selection in context'}
+            accessibilityState={{ disabled: !!tooLong }}
           >
-            <Ionicons name="bulb-outline" size={19} color={colors.text} />
+            <Ionicons name="bulb-outline" size={19} color={tooLong ? colors.textSecondary : colors.text} />
             <Text style={[styles.btnLabel, { color: colors.textSecondary }]}>Explain</Text>
           </TouchableOpacity>
         )}
@@ -220,17 +229,23 @@ export function SelectionActionBar({
         <TouchableOpacity
           style={styles.btn}
           onPress={onSpeak}
+          disabled={tooLong}
           accessibilityRole="button"
           accessibilityLabel={
-            isTtsLoading ? 'Loading speech, tap to cancel'
+            tooLong ? 'Listen — selection too long'
+              : isTtsLoading ? 'Loading speech, tap to cancel'
               : isSpeaking ? 'Stop speech'
               : 'Read selection aloud'
           }
-          accessibilityState={{ selected: !!isSpeaking, busy: !!isTtsLoading }}
+          accessibilityState={{ selected: !!isSpeaking, busy: !!isTtsLoading, disabled: !!tooLong }}
         >
           {isTtsLoading
             ? <ActivityIndicator size="small" color={colors.text} style={styles.btnSpinner} />
-            : <Ionicons name={isSpeaking ? 'stop' : 'volume-high-outline'} size={19} color={colors.text} />}
+            : <Ionicons
+                name={isSpeaking ? 'stop' : 'volume-high-outline'}
+                size={19}
+                color={tooLong ? colors.textSecondary : colors.text}
+              />}
           <Text style={[styles.btnLabel, { color: colors.textSecondary }]}>
             {isTtsLoading ? 'Loading' : isSpeaking ? 'Stop' : 'Listen'}
           </Text>

--- a/apps/mobile/src/components/reader/ReaderShell.tsx
+++ b/apps/mobile/src/components/reader/ReaderShell.tsx
@@ -914,6 +914,7 @@ export function ReaderShell(props: ReaderShellProps) {
             highlightColor={settings.lastHighlightColor}
             onMarkKnown={handleMarkKnown}
             onRemove={handleRemoveWord}
+            tooLong={selection.tooLong}
             isSpeaking={isSpeaking}
             isTtsLoading={isTtsLoading}
             wordSaved={wordSaved}

--- a/apps/mobile/src/components/reader/ReaderShell.tsx
+++ b/apps/mobile/src/components/reader/ReaderShell.tsx
@@ -191,7 +191,7 @@ export function ReaderShell(props: ReaderShellProps) {
   const { colors } = useTheme()
   const { language } = useLanguage()
   const { nativeLanguage } = useNativeLanguage()
-  const { toggle: toggleTts, isSpeaking } = useTts()
+  const { toggle: toggleTts, isSpeaking, isLoading: isTtsLoading } = useTts()
   const quickStats = useQuickStats(isAuthenticated)
   const haptics = useHaptics()
   const { show: showToast } = useToast()
@@ -496,11 +496,14 @@ export function ReaderShell(props: ReaderShellProps) {
         // impact confirms the hold registered before the WordCard opens.
         haptics.play('flip')
       } else if (data.type === 'selection') {
+        // No speech here. A single-word selection used to auto-speak, but the
+        // message carrying it arrives from the 450ms long-press — which is also
+        // the first frame of a drag that is on its way to selecting a sentence.
+        // The word started playing under a gesture that had not finished saying
+        // what it wanted, and then owned the player the toolbar's Listen button
+        // needed. Speech is now only ever started by pressing a button.
         const mode: 'tap' | 'drag' = data.mode === 'tap' ? 'tap' : 'drag'
-        const nextId = openSelection(data.text ? { ...data, mode } : null)
-        if (nextId !== null && !data.text.includes(' ')) {
-          toggleTts(data.text, { rate: settings.ttsSpeed, lang: language })
-        }
+        openSelection(data.text ? { ...data, mode } : null)
       } else if (data.type === 'pdfHighlightCreate') {
         // Original PDF: the viewer resolved a quad-rect anchor for the current
         // selection. Persist it (chapterless userbook highlight) with the color
@@ -562,7 +565,7 @@ export function ReaderShell(props: ReaderShellProps) {
     } catch (err) {
       if (__DEV__) console.warn('[reader] postMessage handler threw', err, event?.nativeEvent?.data)
     }
-  }, [chapters, chapterSlug, language, settings.ttsSpeed, toggleTts, toggleBars, showBars, hideBars,
+  }, [chapters, chapterSlug, toggleBars, showBars, hideBars,
       setEditingHighlight, updateSessionProgress, onChapterLoaded, onRequestNextChapter, onRestoreLanded, openSelection, bumpProgress, haptics,
       original, recordSessionActivity, maybeInitialPdfJump, persistPdfPage, createPdfHighlight, repaintPdf])
 
@@ -912,6 +915,7 @@ export function ReaderShell(props: ReaderShellProps) {
             onMarkKnown={handleMarkKnown}
             onRemove={handleRemoveWord}
             isSpeaking={isSpeaking}
+            isTtsLoading={isTtsLoading}
             wordSaved={wordSaved}
             vocabStage={vocabMapRef.current[selection.text.toLowerCase()]?.stage ?? null}
             isAuthenticated={isAuthenticated}

--- a/apps/mobile/src/hooks/useReaderSelection.ts
+++ b/apps/mobile/src/hooks/useReaderSelection.ts
@@ -8,6 +8,9 @@ export type Selection = {
   /** 'tap' = single-finger tap that always shows WordCard. 'drag' = native long-press / drag
    * selection; routed by content (single word → WordCard, multi → SelectionActionBar). */
   mode: 'tap' | 'drag'
+  /** Longer than the 500 characters the speech and translation endpoints accept.
+   * The toolbar still opens — Copy, Highlight and Ask have no such limit. */
+  tooLong?: boolean
 }
 
 export type LookupState = {
@@ -67,7 +70,7 @@ export function useReaderSelection({ flushVocabMap }: Options) {
    * itself — WordCard's auto-dismiss timer keys off it.
    */
   const openSelection = useCallback(
-    (payload: { text: string; sentence?: string; anchor?: any; mode?: 'tap' | 'drag' } | null): void => {
+    (payload: { text: string; sentence?: string; anchor?: any; mode?: 'tap' | 'drag'; tooLong?: boolean } | null): void => {
       if (!payload || !payload.text) {
         if (__DEV__) console.log('[diag] setSelection NULL (empty-data branch)')
         setSelection(null)
@@ -80,6 +83,7 @@ export function useReaderSelection({ flushVocabMap }: Options) {
         anchor: payload.anchor || null,
         selectionId: ++selectionIdRef.current,
         mode: payload.mode || 'drag',
+        tooLong: !!payload.tooLong,
       })
       setWordSaved(false)
       setLookupState(null)

--- a/apps/mobile/src/hooks/useReaderSelection.ts
+++ b/apps/mobile/src/hooks/useReaderSelection.ts
@@ -59,29 +59,30 @@ export function useReaderSelection({ flushVocabMap }: Options) {
 
   /**
    * Opens or closes the selection in response to a WebView postMessage.
-   * Returns the freshly minted `selectionId` for single-word callers that
-   * still need to wire up auto-TTS / auto-save (the hook stays out of those
-   * concerns to avoid coupling to vocab/TTS internals).
+   *
+   * Returns nothing. It used to hand back the freshly minted `selectionId` so
+   * the caller could start auto-TTS for a single word; that auto-speak is gone
+   * (it fired on the long-press that opens a sentence drag), and no other
+   * caller ever read the id. `selectionId` still travels inside the selection
+   * itself — WordCard's auto-dismiss timer keys off it.
    */
   const openSelection = useCallback(
-    (payload: { text: string; sentence?: string; anchor?: any; mode?: 'tap' | 'drag' } | null): number | null => {
+    (payload: { text: string; sentence?: string; anchor?: any; mode?: 'tap' | 'drag' } | null): void => {
       if (!payload || !payload.text) {
         if (__DEV__) console.log('[diag] setSelection NULL (empty-data branch)')
         setSelection(null)
-        return null
+        return
       }
       if (__DEV__) console.log('[diag] setSelection OPEN', payload.text, 'mode=', payload.mode || 'drag')
-      const nextId = ++selectionIdRef.current
       setSelection({
         text: payload.text,
         sentence: payload.sentence || '',
         anchor: payload.anchor || null,
-        selectionId: nextId,
+        selectionId: ++selectionIdRef.current,
         mode: payload.mode || 'drag',
       })
       setWordSaved(false)
       setLookupState(null)
-      return nextId
     },
     [],
   )

--- a/apps/mobile/src/hooks/useTts.ts
+++ b/apps/mobile/src/hooks/useTts.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { API_URL } from '../lib/api'
 import { trackTtsPlayed } from '../lib/analytics'
+import { ttsRequestDecision, TtsPhase } from '../lib/ttsRequest'
 
 // Lazy + safe loads — these native modules ship with the dev build only
 // after their respective `expo install`. An older dev build (before the
@@ -124,7 +125,13 @@ export interface TtsSpeakOptions {
 }
 
 export function useTts() {
-  const [isSpeaking, setIsSpeaking] = useState(false)
+  // Three phases, not one boolean. 'loading' covers the ~1s fetch before any
+  // sound, which the UI has to be able to show — without it a reader presses
+  // Listen, hears nothing, presses again, and cancels their own playback.
+  const [phase, setPhase] = useState<TtsPhase>('idle')
+  // Text being fetched or played. `toggle` compares against it to tell "stop
+  // this" from "play that instead"; see lib/ttsRequest.ts.
+  const currentTextRef = useRef<string | null>(null)
   // One player instance per hook usage. createAudioPlayer (vs useAudioPlayer)
   // gives us direct control over replace/release without a re-render cycle.
   const playerRef = useRef<AudioPlayerLike | null>(null)
@@ -148,7 +155,8 @@ export function useTts() {
     // Bump req so any in-flight download knows it's stale.
     reqRef.current++
     releasePlayer()
-    setIsSpeaking(false)
+    currentTextRef.current = null
+    setPhase('idle')
   }, [releasePlayer])
 
   const speak = useCallback(
@@ -168,7 +176,8 @@ export function useTts() {
       // Tear down any current playback before starting another download —
       // bites the same race expo-speech.stop() handles, just made explicit.
       releasePlayer()
-      setIsSpeaking(true)
+      currentTextRef.current = trimmed
+      setPhase('loading')
 
       const spaceCount = trimmed.split(/\s+/).length
       const kind: 'word' | 'sentence' | 'selection' =
@@ -180,7 +189,8 @@ export function useTts() {
       // Another speak() ran while we were downloading — drop this one.
       if (req !== reqRef.current) return
       if (!file) {
-        setIsSpeaking(false)
+        currentTextRef.current = null
+        setPhase('idle')
         return
       }
 
@@ -190,13 +200,16 @@ export function useTts() {
         try { player.setPlaybackRate?.(1.0) } catch { /* rate already baked in by server */ }
         player.addListener('playbackStatusUpdate', status => {
           if (status.didJustFinish) {
-            setIsSpeaking(false)
+            currentTextRef.current = null
+            setPhase('idle')
             releasePlayer()
           }
         })
         player.play()
+        setPhase('playing')
       } catch {
-        setIsSpeaking(false)
+        currentTextRef.current = null
+        setPhase('idle')
         releasePlayer()
       }
     },
@@ -205,10 +218,15 @@ export function useTts() {
 
   const toggle = useCallback(
     (text: string, opts: TtsSpeakOptions | number = {}) => {
-      if (isSpeaking) stop()
-      else void speak(text, opts)
+      const decision = ttsRequestDecision({
+        phase,
+        currentText: currentTextRef.current,
+        requestedText: text,
+      })
+      if (decision === 'stop') stop()
+      else if (decision === 'start') void speak(text, opts)
     },
-    [isSpeaking, speak, stop],
+    [phase, speak, stop],
   )
 
   useEffect(() => {
@@ -218,5 +236,14 @@ export function useTts() {
     }
   }, [releasePlayer])
 
-  return { speak, stop, toggle, isSpeaking }
+  return {
+    speak,
+    stop,
+    toggle,
+    phase,
+    /** Fetching audio — no sound yet. Show a spinner, not a play icon. */
+    isLoading: phase === 'loading',
+    /** Busy in either sense, so a press is a stop. Kept for existing callers. */
+    isSpeaking: phase !== 'idle',
+  }
 }

--- a/apps/mobile/src/hooks/useTts.ts
+++ b/apps/mobile/src/hooks/useTts.ts
@@ -205,8 +205,12 @@ export function useTts() {
             releasePlayer()
           }
         })
-        player.play()
+        // Phase before play(), not after. The listener above is already
+        // attached, so a clip short enough to finish inside play() would set
+        // 'idle' and then be overwritten back to 'playing' — leaving a Stop
+        // button with no player behind it. This way the listener wins.
         setPhase('playing')
+        player.play()
       } catch {
         currentTextRef.current = null
         setPhase('idle')

--- a/apps/mobile/src/lib/readerBridge.ts
+++ b/apps/mobile/src/lib/readerBridge.ts
@@ -271,6 +271,12 @@ export const READER_SELECTION_BRIDGE = `
      * the typical 50-100ms settle time on iOS 17+ WebKit.
      */
     var _suppressSelectionChangeUntil = 0;
+    // Longest passage the server-backed actions accept: Tts:MaxTextLength and
+    // OpenAI:Translate:MaxTextLength are both 500. A longer selection used to
+    // be dropped here without a message, so the toolbar never appeared at all
+    // and Copy and Highlight — which have no limit — were lost with it. It is
+    // dispatched now, flagged, and the toolbar disables only what cannot work.
+    var SELECTION_MAX_CHARS = 500;
     var _lastDispatchedText = '';
     // When the last dispatch came from the tap path (selectWordAtPoint),
     // we MUST NOT notify the parent of a "selection cleared" event on the
@@ -285,7 +291,7 @@ export const READER_SELECTION_BRIDGE = `
       if (!sel || sel.isCollapsed) { console.log('[diag] dispatchSelection: no selection'); return; }
       var text = sel.toString().trim();
       if (!text) { console.log('[diag] dispatchSelection: empty text'); return; }
-      if (text.length > 300) { console.log('[diag] dispatchSelection: text too long', text.length); return; }
+      if (text.length > SELECTION_MAX_CHARS) { console.log('[diag] dispatchSelection: text too long', text.length); return; }
       if (!text.includes(' ') && text.length <= 50) applyTapPulse(sel);
       var sentence = '';
       try { sentence = extractSentence(sel.anchorNode); } catch(e) {}
@@ -552,7 +558,6 @@ export const READER_SELECTION_BRIDGE = `
         return;
       }
       var text = sel.toString().trim();
-      if (text.length > 300) return;
       // Drop duplicates — if the user re-selected the exact same text (e.g.
       // iOS magnifier re-firing), don't re-render the popup.
       if (text === _lastDispatchedText) return;
@@ -574,7 +579,8 @@ export const READER_SELECTION_BRIDGE = `
         mode: 'drag',
         text: text,
         sentence: sentence,
-        anchor: anchor
+        anchor: anchor,
+        tooLong: text.length > SELECTION_MAX_CHARS
       }));
     }
     document.addEventListener('selectionchange', function() {

--- a/apps/mobile/src/lib/readerBridge.ts
+++ b/apps/mobile/src/lib/readerBridge.ts
@@ -539,12 +539,34 @@ export const READER_SELECTION_BRIDGE = `
     var _selChangeTimer = null;
     function _runSelectionDispatch() {
       _selChangeTimer = null;
-      // Re-check suppression at fire time — a tap dispatched DURING the debounce
-      // window must still get the full suppression treatment.
-      if (Date.now() < _suppressSelectionChangeUntil) return;
       if (_hlOverlayer && _hlOverlayer.isJustAnchored && _hlOverlayer.isJustAnchored()) return;
       var sel = window.getSelection();
+      // The suppression window swallows NOISE about the selection we just made
+      // — an ActionMode spawning or dismissing, iOS re-firing the same range.
+      // It used to swallow everything, including the reader extending a
+      // long-press into a phrase, and that is the bug it caused: after the
+      // 450ms hold selects a word, dragging the handles out to a sentence
+      // produces selectionchange events that all landed inside the 1500ms
+      // window and were dropped. The app never heard about the sentence, so
+      // Listen read the single word it still had — the "I selected a sentence
+      // and it read one word" report. Verified on an emulator: the identical
+      // gesture delivered the full sentence the moment the window had expired.
+      //
+      // The release path that was supposed to prevent this — touchmove setting
+      // the deadline to 0 once the finger passes SELECT_EXTEND_TOLERANCE —
+      // carried the comment "Needs on-device validation" and does not fire:
+      // once Android's selection ActionMode owns the gesture, the page stops
+      // receiving touchmove at all.
+      //
+      // So the window no longer gates a genuinely different, non-empty
+      // selection. Noise cannot invent one: an echo repeats the text we last
+      // sent (caught by the dedupe below) and a dismiss collapses it (caught
+      // here).
+      var suppressed = Date.now() < _suppressSelectionChangeUntil;
       if (!sel || sel.isCollapsed || !sel.toString().trim()) {
+        // A collapse inside the window is the ActionMode going away, not the
+        // reader letting go.
+        if (suppressed) return;
         // Only notify parent of "selection cleared" when WE previously
         // dispatched a drag-select via this listener. If the last dispatch
         // was a tap, there was no Selection-API selection to begin with,
@@ -559,7 +581,9 @@ export const READER_SELECTION_BRIDGE = `
       }
       var text = sel.toString().trim();
       // Drop duplicates — if the user re-selected the exact same text (e.g.
-      // iOS magnifier re-firing), don't re-render the popup.
+      // iOS magnifier re-firing), don't re-render the popup. This is also what
+      // absorbs the echo of a selection we made ourselves, which is why the
+      // window above no longer needs to.
       if (text === _lastDispatchedText) return;
       // No tap-pulse here. range.surroundContents() mutates the DOM under
       // the live Selection — Android aborts the long-press extension when

--- a/apps/mobile/src/lib/ttsRequest.test.ts
+++ b/apps/mobile/src/lib/ttsRequest.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { ttsRequestDecision, TtsPhase } from './ttsRequest'
+
+const SENTENCE = 'It is a truth universally acknowledged, that a single man must be in want of a wife.'
+
+describe('ttsRequestDecision', () => {
+  it('starts when nothing is speaking', () => {
+    expect(ttsRequestDecision({
+      phase: 'idle', currentText: null, requestedText: SENTENCE,
+    })).toBe('start')
+  })
+
+  it('stops when the press lands on what is already playing', () => {
+    expect(ttsRequestDecision({
+      phase: 'playing', currentText: SENTENCE, requestedText: SENTENCE,
+    })).toBe('stop')
+  })
+
+  it('plays the sentence when a word is already playing', () => {
+    // The reported bug: tap a word, hear it, select a sentence, press Listen —
+    // and get silence, because the press was read as "stop" purely from the
+    // fact that sound was coming out.
+    expect(ttsRequestDecision({
+      phase: 'playing', currentText: 'acknowledged', requestedText: SENTENCE,
+    })).toBe('start')
+  })
+
+  it('supersedes a download that has not made a sound yet', () => {
+    expect(ttsRequestDecision({
+      phase: 'loading', currentText: 'acknowledged', requestedText: SENTENCE,
+    })).toBe('start')
+  })
+
+  it('cancels its own download when pressed again during the wait', () => {
+    // The impatient second press. It must stop, not queue a duplicate fetch.
+    expect(ttsRequestDecision({
+      phase: 'loading', currentText: SENTENCE, requestedText: SENTENCE,
+    })).toBe('stop')
+  })
+
+  it('treats surrounding whitespace as the same passage', () => {
+    // The selection bridge trims; the speak path trims. A press must not read
+    // as a new passage just because one side kept a trailing space.
+    expect(ttsRequestDecision({
+      phase: 'playing', currentText: SENTENCE, requestedText: `  ${SENTENCE}\n`,
+    })).toBe('stop')
+  })
+
+  it('ignores an empty request', () => {
+    for (const phase of ['idle', 'loading', 'playing'] as TtsPhase[]) {
+      expect(ttsRequestDecision({
+        phase, currentText: SENTENCE, requestedText: '   ',
+      })).toBe('ignore')
+    }
+  })
+
+  it('starts when the phase says busy but the text was lost', () => {
+    // Defensive: a null currentText while non-idle should not read as a match
+    // and silently swallow the press.
+    expect(ttsRequestDecision({
+      phase: 'playing', currentText: null, requestedText: SENTENCE,
+    })).toBe('start')
+  })
+})

--- a/apps/mobile/src/lib/ttsRequest.ts
+++ b/apps/mobile/src/lib/ttsRequest.ts
@@ -1,0 +1,48 @@
+/**
+ * What a press of a speak button should do.
+ *
+ * The reader's Listen button used to branch on one boolean — "is something
+ * playing" — and stop whenever it was true. That is right for the button that
+ * started the sound and wrong for every other one. A reader who tapped a word,
+ * heard it, then selected a sentence and pressed Listen got silence: the press
+ * was read as "stop the word", and only a second press started the sentence.
+ * Whether a press means stop or start depends on *which* text is playing, not
+ * on whether anything is.
+ *
+ * The other half is the gap before sound. Fetching the audio takes about a
+ * second on a first play, and nothing on screen said so, so the natural second
+ * press landed while the first was still downloading — and cancelled it. That
+ * is why a `loading` phase exists here rather than being folded into `idle`:
+ * the UI has to be able to show that the press registered.
+ *
+ * Pure on purpose — the reader's speech path can only be exercised on a device,
+ * so the part that decides is kept where a test can reach it.
+ */
+
+/** Where playback is right now. `loading` is fetching audio, before any sound. */
+export type TtsPhase = 'idle' | 'loading' | 'playing'
+
+export interface TtsRequestInput {
+  phase: TtsPhase
+  /** Text being fetched or played. Null when `phase` is 'idle'. */
+  currentText: string | null
+  /** Text of the button that was just pressed. */
+  requestedText: string
+}
+
+export type TtsRequestDecision =
+  /** Play `requestedText`, superseding anything already in flight. */
+  | 'start'
+  /** Stop — the press was on whatever is already speaking. */
+  | 'stop'
+  /** Nothing to say. */
+  | 'ignore'
+
+export function ttsRequestDecision(s: TtsRequestInput): TtsRequestDecision {
+  const requested = s.requestedText.trim()
+  if (!requested) return 'ignore'
+  if (s.phase === 'idle') return 'start'
+  // Same passage → the press means "I've heard enough". Different passage →
+  // the reader is asking for the new one, not to silence the old one.
+  return requested === (s.currentText ?? '').trim() ? 'stop' : 'start'
+}

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { LocalizedLink } from './LocalizedLink'
 import { useTranslation } from '../hooks/useTranslation'
+import { OPT_IN_URL } from './AndroidTesterBanner'
 
 export function Footer() {
   const { t } = useTranslation()
@@ -23,6 +24,36 @@ export function Footer() {
           <LocalizedLink to="/contact" className="site-footer__link">{t('footer.contact')}</LocalizedLink>
           <LocalizedLink to="/sitemap" className="site-footer__link">{t('footer.sitemap')}</LocalizedLink>
         </nav>
+        {/* Deliberately not the official "Get it on Google Play" badge. That badge
+            links to a store listing, and ours returns 404 while the app is in
+            closed testing — so it would send every visitor to a Not Found page
+            and misrepresent a beta as a shipped app. Swap it in the day the
+            production track goes live; the link is the only thing that changes.
+
+            Shown to everyone, unlike AndroidTesterBanner, which waits for an
+            Android device and a reader who has actually opened a book. This is
+            the standing "we have an app" line; that one is the invitation. */}
+        <div className="site-footer__android">
+          <a
+            className="site-footer__android-badge"
+            href={OPT_IN_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg className="site-footer__android-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                fill="currentColor"
+                d="M17.6 9.48l1.84-3.18a.4.4 0 0 0-.7-.4l-1.86 3.22a11.4 11.4 0 0 0-9.76 0L5.26 5.9a.4.4 0 1 0-.7.4L6.4 9.48A10.8 10.8 0 0 0 1 18h22a10.8 10.8 0 0 0-5.4-8.52zM7 15.25a1.25 1.25 0 1 1 0-2.5 1.25 1.25 0 0 1 0 2.5zm10 0a1.25 1.25 0 1 1 0-2.5 1.25 1.25 0 0 1 0 2.5z"
+              />
+            </svg>
+            <span className="site-footer__android-text">
+              <span className="site-footer__android-label">{t('androidBeta.badgeLabel')}</span>
+              <span className="site-footer__android-action">{t('androidBeta.badgeAction')}</span>
+            </span>
+          </a>
+          <p className="site-footer__android-note">{t('androidBeta.badgeNote')}</p>
+        </div>
+
         <div className="site-footer__bottom">
           <span className="site-footer__logo">TextStack</span>
           <span className="site-footer__copyright">&copy; {new Date().getFullYear()} TextStack Reader Library Project.</span>

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -219,7 +219,10 @@
     "title": "Read on your phone?",
     "body": "The Android app is in closed testing — same books, same saved words, offline. Join, keep it installed, and read. That is the whole job.",
     "join": "Join the test",
-    "dismiss": "Not now"
+    "dismiss": "Not now",
+    "badgeLabel": "Android app",
+    "badgeAction": "Join the beta",
+    "badgeNote": "In closed testing — open to anyone with an Android phone."
   },
   "reader": {
     "ask": {

--- a/apps/web/src/styles/home.css
+++ b/apps/web/src/styles/home.css
@@ -937,6 +937,67 @@
   color: var(--color-text);
 }
 
+/* Android beta badge — shaped like a store badge (icon + two-line lockup) so it
+   reads as one at a glance, but says what it actually is. */
+.site-footer__android {
+  margin-top: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.site-footer__android-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 20px 10px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  text-decoration: none;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.site-footer__android-badge:hover {
+  border-color: var(--color-text-secondary);
+  transform: translateY(-1px);
+}
+
+.site-footer__android-icon {
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+}
+
+.site-footer__android-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+  text-align: left;
+}
+
+.site-footer__android-label {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.site-footer__android-action {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.site-footer__android-note {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
 .site-footer__bottom {
   margin-top: 48px;
   padding-top: 48px;

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,35 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-01-beta-a-standing-android-badge"></a>
+
+## Beta — a standing Android badge on the site and the README — web — 2026-09-01
+
+`AndroidTesterBanner` already invites Android readers into the closed test, but deliberately
+narrowly: an Android device, a reader who has already opened a book, once, dismissible. That is the
+right shape for an invitation and the wrong shape for "this project has an app" — a visitor on a
+laptop, or anyone reading the repo, never learns the app exists.
+
+So: a badge in the site footer, shown to everyone, and one in the README's badge row plus a line
+under the call-to-action.
+
+**Not the official "Get it on Google Play" badge**, which was the obvious thing to copy. That badge
+links to a store listing, and ours does not exist yet:
+
+```
+play.google.com/store/apps/details?id=app.textstack.mobile   →  404 Not Found
+play.google.com/apps/testing/app.textstack.mobile            →  200
+```
+
+It would have sent every visitor to a Not Found page, and Google's brand guidelines scope the badge
+to published apps in the first place. The footer badge borrows the shape — icon plus a two-line
+lockup, so it reads as a store badge at a glance — and says what it is: ANDROID APP / Join the beta,
+with "In closed testing — open to anyone with an Android phone" underneath. The day the production
+track goes live, the link is the only thing that changes.
+
+Built from the existing theme tokens, so it inverts with the rest of the footer; checked in both
+light and dark.
+
 <a id="2026-09-01-selection-extending-a-long-press-reaches-the-app"></a>
 
 ## Selection — extending a long-press into a sentence reaches the app — mobile — 2026-09-01

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,125 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-01-selection-extending-a-long-press-reaches-the-app"></a>
+
+## Selection — extending a long-press into a sentence reaches the app — mobile — 2026-09-01
+
+Found on an emulator while verifying the speech fix, and it turned out to be the defect that
+actually decided what got read aloud. The reader could select a sentence and have Listen read a
+single word — not because speech picked the wrong text, but because the app never heard about the
+sentence.
+
+After the 450 ms hold selects a word, dragging the handles out to a phrase fires `selectionchange`.
+Every one of those events landed inside the 1500 ms suppression window the tap path arms, so all of
+them were dropped and the app's selection stayed on the word. Listen, Translate and Explain all
+acted on that word, and Ask stayed hidden because `isMultiWord` was still false.
+
+Confirmed by nudging a selection handle *after* the window had expired: the identical event
+delivered the full sentence immediately.
+
+| | |
+|---|---|
+| word selected (long-press) | `12:18:18.349` |
+| suppression window closes | `≈12:18:19.849` |
+| debounced dispatch would fire | `≈12:18:19.82` |
+
+Thirty milliseconds inside. That margin is why the report was "it behaves differently on different
+phones" — a device that completes the drag slightly slower lands on the other side of the window and
+works fine.
+
+The release path built to prevent exactly this — `touchmove` zeroing the deadline once the finger
+passes `SELECT_EXTEND_TOLERANCE` — carries the comment *"Needs on-device validation of the
+extend-from-tap gesture"*. It was never validated, and it does not fire: once Android's selection
+ActionMode owns the gesture, the page stops receiving `touchmove` at all.
+
+The window now gates only what it was built for. A collapse inside it is the ActionMode going away;
+an echo of a selection we made ourselves repeats text the existing dedupe already drops. Neither can
+produce a *different, non-empty* selection, so that one is dispatched regardless.
+
+Reproducing it needs `adb shell input motionevent`, not `input swipe`: swipe starts moving
+immediately, the finger passes `DRAG_TOLERANCE` at 8 px, and the word timer is cancelled before it
+fires — the gesture under test never happens. Full pass, with logs:
+[`docs/qa/reports/2026-09-01-android-tts-selection.md`](../qa/reports/2026-09-01-android-tts-selection.md).
+
+<a id="2026-09-01-reader-speech-starts-when-asked"></a>
+
+## Reader — speech starts when asked, and the button reads what you picked — mobile — 2026-09-01
+
+A tester on a Galaxy S24 reported that selecting a sentence and pressing Listen produced silence, or
+a cut-off word, depending on timing. Tapping a single word worked. The phrasing that reached us was
+"the voice breaks off", which pointed at the audio, and the audio turned out to be fine.
+
+Production `/api/tts` was measured first, because a truncated MP3 would have explained everything:
+
+| input | response | bytes | duration |
+|---|---|---|---|
+| 44 chars | 200 | 22 KB | 3.72 s |
+| 375 chars | 200 | 123 KB | 20.52 s |
+
+Whole file, 1.18 s to synthesise. Nothing server-side was cutting anything off. Three client
+defects were stacking into one symptom.
+
+**The word spoke itself.** A single-word selection auto-played. The message carrying it is posted by
+the 450 ms long-press in `readerBridge.ts` — which is also the first frame of the drag that selects a
+sentence. So the gesture that means "I am choosing a phrase" began by reading its first word aloud,
+under a finger that had not finished moving. On a device with Samsung's own long-press timing this
+lands differently than on a Pixel, which is why it looked device-specific.
+
+**Then the button meant the wrong thing.** `toggle` branched on a single boolean — something is
+playing, so stop. That is correct for the button that started the sound and wrong for every other
+one. With the word still playing, pressing Listen on the sentence was read as "stop the word", and
+the sentence never played at all. A second press worked, because by then nothing was playing. That
+is the whole of "it works every other time".
+
+**And the wait was invisible.** Fetching audio takes about a second on a first play. The button said
+Listen throughout, so the natural response — press it again — cancelled the fetch that was already
+running. Even with the comparison fixed, that press would still have read as stop.
+
+The decision now lives in `apps/mobile/src/lib/ttsRequest.ts` as a pure function over
+`(phase, currentText, requestedText)`, tested, following `pdfWritePolicy.ts`. It is a small piece of
+logic to extract, and it is extracted because the path around it can only be exercised on a phone:
+`apps/mobile/e2e` runs Chromium against `expo start --web`, where there is no `expo-audio` and no
+native long-press, so nothing automated reaches the reader's speech path.
+
+Auto-speak is gone rather than rescued. It was the root of the race, and unrequested audio during a
+selection gesture is the thing the reader is supposed not to do. Speech now only ever starts from a
+button. The web reader was already right on all three counts — `speak()` there begins with `stop()`,
+and `isLoading` has always been separate from `isPlaying` — so this is mobile catching up to a
+contract that already existed, not a new design.
+
+Deleting the sentence button was considered and rejected: it would not have fixed anything. The word
+would still have spoken itself mid-drag; there would simply have been no way left to hear the
+sentence.
+
+None of this was the whole story, which is the argument for testing a fix rather than reasoning it
+closed. Verifying on an emulator showed the sentence was not reaching the app at all — see the entry
+above. Speech had been reading the only text the app had.
+
+<a id="2026-09-01-selection-a-long-passage-stops-disappearing"></a>
+
+## Selection — a long passage stops disappearing instead of opening a toolbar — mobile — 2026-09-01
+
+Found while tracing the speech bug. Selecting more than 300 characters posted no message to the app
+at all, so no toolbar appeared — not just no Listen, but no Copy and no Highlight either, neither of
+which has any length limit. From the reader's side the selection simply did nothing.
+
+The number was wrong as well as the behaviour. `Tts:MaxTextLength` and
+`OpenAI:Translate:MaxTextLength` are both 500, so a passage between 300 and 500 characters was
+refused by the client on behalf of a server that would have accepted it.
+
+The selection is now always dispatched, carrying whether it exceeds 500, and the toolbar disables
+only the three actions that genuinely cannot work — Listen, Translate, Explain. Copy, Highlight and
+Ask stay live.
+
+The reader-html smoke test was repointed in the same change. It parsed `READER_OVERLAY_SCRIPT` out of
+`readerOverlayScript.ts`, which became a one-line re-export of the generated bundle in April; the
+marker has been absent and the script exiting non-zero, unnoticed, ever since — nothing runs it. It
+now parses `READER_SELECTION_BRIDGE` instead, the 27 KB of hand-written JavaScript living inside a
+TypeScript template string, which had no syntax check of any kind. A stray brace there is invisible
+to `tsc` and arrives as a reader with no word tap, no selection toolbar and no highlights. Confirmed
+it fails against a deliberately broken bridge rather than passing vacuously.
+
 <a id="2026-08-31-search-a-common-word-stops-timing-out"></a>
 
 ## Search — a common word stops timing out, because ranking happens after deduplication — backend — 2026-08-31

--- a/docs/qa/reports/2026-09-01-android-tts-selection.md
+++ b/docs/qa/reports/2026-09-01-android-tts-selection.md
@@ -107,6 +107,17 @@ Fetching audio takes about a second, and the button said "Listen" throughout, so
 press cancelled the first fetch. It now shows a spinner labelled "Loading" (`shots/s13.png`), stays
 pressable so a download that never lands cannot trap the reader, and the row does not change height.
 
+## D4 — the disabled state was invisible · **fixed during the pass**
+
+Caught by running the checklist rather than by reading the diff. On an over-long selection the
+toolbar opened and Listen/Translate/Explain were correctly inert — and looked exactly like the
+working buttons. `colors.text` → `colors.textSecondary` on the icon is indistinguishable in the
+light theme, and the labels were already `textSecondary`.
+
+Functionally right, and still the wrong outcome: press Listen, nothing happens, back to "it doesn't
+work" — the impression this whole change exists to remove. Now dimmed by opacity with a line above
+the row saying why (`shots/q15.png`).
+
 ---
 
 ## Found while here, not fixed
@@ -131,3 +142,19 @@ Needs a real device. Ships as an OTA (JS only).
    This is the one that was broken; it must not be silent.
 6. Select a paragraph longer than ~500 characters → the toolbar appears, Copy and Highlight work,
    Listen/Translate/Explain are visibly unavailable. Previously nothing appeared at all.
+
+## Emulator results
+
+All six passed on the Pixel 7 Pro. Evidence, in order:
+
+| step | evidence |
+|---|---|
+| 1 | sentence arrives as `mode:'drag'` 1.48 s after the word; `tts_played` count unchanged |
+| 2 | `tts_played kind:'sentence'`; AudioTrack delivered **98496 frames @ 24 kHz = 4.10 s**, and the server returns exactly 4.10 s for that text — read to the end, nothing cut |
+| 3 | second press returns the button to "Listen"; no full-length stop logged |
+| 4 | long-press logs `selected word: motorcar` with no `tts_played`; the toolbar's speaker then logs `kind:'word'`, 43776 frames = 1.82 s |
+| 5 | word starts at `12:36:11.644` (1.82 s long); Listen on the sentence pressed at `12:36:12.319` — 0.675 s in, still playing — logs `kind:'sentence'`. Under the old code this press was a stop. |
+| 6 | 569-character selection opens the toolbar (previously nothing at all); Listen logs no `tts_played`, Translate opens no sheet |
+
+Highlight could not be exercised — the pass ran as a guest, and the highlight button is gated on
+`isAuthenticated`.

--- a/docs/qa/reports/2026-09-01-android-tts-selection.md
+++ b/docs/qa/reports/2026-09-01-android-tts-selection.md
@@ -1,0 +1,133 @@
+# Android — selection speech, emulator pass
+
+**Date:** 2026-09-01 · **Build:** local debug (`expo run:android`) on the fix branch ·
+**Backend:** production · **Device:** Pixel 7 Pro emulator, Android 17 (`sdk_gphone16k_arm64`) ·
+**Account:** guest · **Book:** *At the Villa Rose*, chapter I
+
+Triggered by a report from a tester on a Galaxy S24: selecting a sentence and pressing Listen
+gave silence, or the wrong thing, depending on timing. Tapping a single word worked.
+
+**No Galaxy S24 was used for this pass.** An emulator is not One UI, and the gesture timing that
+made this device-specific is exactly what an emulator cannot reproduce. What it can settle is
+message ordering, and that is where all three defects lived. S24 acceptance is still open — see
+the checklist at the end.
+
+---
+
+## Verdict
+
+Three defects, all reproduced and all fixed. The reported symptom needed all three explained;
+fixing any two would still have shipped something visibly wrong.
+
+---
+
+## Ruled out first: the server
+
+| input | response | bytes | duration |
+|---|---|---|---|
+| 44 chars | 200 | 22 KB | 3.72 s |
+| 375 chars | 200 | 123 KB | 20.52 s |
+
+Whole file, 1.18 s to synthesise. Nothing was being cut off, so "the voice breaks off" was never
+about the audio.
+
+## Driving the gesture
+
+`adb shell input swipe` cannot reproduce this. It starts moving immediately, so the finger passes
+`DRAG_TOLERANCE` (8 px) and the 450 ms word timer is cancelled before it fires — the gesture under
+test never happens. `input motionevent` DOWN / MOVE / UP holds the finger still, which is the whole
+point:
+
+```
+motionevent DOWN 140 1289 ; sleep 0.7   # past LONGPRESS_MS → word selected
+motionevent MOVE 170 1289 ; sleep 0.3
+motionevent MOVE 340 1289 ; sleep 0.3
+motionevent MOVE 1300 1289 ; sleep 0.4  # past the 220ms selectionchange debounce
+motionevent UP  1300 1289
+```
+
+---
+
+## D1 — a word spoke itself mid-gesture · **fixed**
+
+Logcat, before the fix:
+
+```
+12:18:18.349 [WV] [diag] selected word: travel
+12:18:18.350 [diag] setSelection OPEN 'travel' mode= 'tap'
+```
+
+That `mode:'tap'` message is posted by the 450 ms long-press — which is also the first frame of the
+drag. `ReaderShell` auto-spoke any single-word selection, so the gesture that means "I am choosing a
+phrase" began by reading its first word aloud. Auto-speak is removed; speech now only starts from a
+button. After the fix the same two lines appear with no `tts_played` following them.
+
+## D2 — the sentence never reached the app · **fixed**
+
+The one that actually decided what got read. After the word was selected, the drag fired
+`selectionchange` — and every event landed inside the 1500 ms suppression window the tap path arms,
+so all were dropped. The app's selection stayed `travel`.
+
+Pressing Listen therefore did exactly what it was told:
+
+```
+12:19:00.690 [analytics] tts_played { language: 'en', kind: 'word' }
+```
+
+Confirmed the window was the cause by nudging a selection handle **after** it had expired — the
+identical event delivered the sentence immediately:
+
+```
+12:20:00.998 [diag] setSelection OPEN 'travel to Aix-les-Bains, in Savoy, where for' mode= 'drag'
+```
+
+The release path that should have prevented this (`touchmove` zeroing the deadline once the finger
+passes `SELECT_EXTEND_TOLERANCE`) carries the comment *"Needs on-device validation of the
+extend-from-tap gesture"*. It does not fire — once Android's selection ActionMode owns the gesture,
+the page stops receiving `touchmove` at all.
+
+Timing is why this looked device-specific. The window closed at ≈`12:18:19.849`; the debounced
+dispatch would have fired at ≈`12:18:19.82`. Thirty milliseconds. A phone that completes the drag
+slightly slower lands on the other side of it and works.
+
+After the fix, same gesture:
+
+```
+12:21:50.715 [diag] setSelection OPEN 'travel' mode= 'tap'
+12:21:52.028 [diag] setSelection OPEN 'travel to Aix-les-Bains, in Savoy, where' mode= 'drag'
+12:23:02.865 [analytics] tts_played { language: 'en', kind: 'sentence' }
+```
+
+Visible side effect confirming the state was wrong before: **Ask now appears** in the toolbar. It is
+gated on `isMultiWord`, which was false while the selection was still a single tapped word.
+
+## D3 — the wait was invisible · **fixed**
+
+Fetching audio takes about a second, and the button said "Listen" throughout, so the natural second
+press cancelled the first fetch. It now shows a spinner labelled "Loading" (`shots/s13.png`), stays
+pressable so a download that never lands cannot trap the reader, and the row does not change height.
+
+---
+
+## Found while here, not fixed
+
+**A WebView error fires on every reader load.** `window.onerror: Uncaught TypeError: Cannot read
+properties of null (reading 'addEventListener')`, thrown from the injected script on `about:blank`.
+Present on an unmodified checkout, so it predates this work. Every `X.addEventListener` on a
+nullable target lives in `readerHtml.ts`; the reader appears to work, so something is being wired up
+that silently is not. Worth its own pass.
+
+---
+
+## Not verified — Galaxy S24 acceptance
+
+Needs a real device. Ships as an OTA (JS only).
+
+1. Select a sentence → **no sound at all** before pressing anything.
+2. Press Listen → brief spinner → **the whole sentence** is read, to the end.
+3. Press Listen again while it reads → stops.
+4. Long-press a word → card opens, **no sound**; the card's speaker reads the word.
+5. With a word playing, select a sentence and press Listen → reads the **sentence**.
+   This is the one that was broken; it must not be silent.
+6. Select a paragraph longer than ~500 characters → the toolbar appears, Copy and Highlight work,
+   Listen/Translate/Explain are visibly unavailable. Previously nothing appeared at all.


### PR DESCRIPTION
A tester on a Galaxy S24 reported that selecting a sentence and pressing Listen gave silence, or a
single word, depending on timing. Tapping one word worked.

The server was ruled out first: `/api/tts` on 375 characters returns 200, 123 KB, **20.52 s of audio
in one piece**, in 1.18 s. Nothing was being cut off. Three client defects were stacking.

## What was wrong

**1. A word spoke itself mid-gesture.** A single-word selection auto-played. The message carrying it
is posted by the 450 ms long-press — which is also the first frame of the drag that selects a
sentence. So the gesture meaning "I am choosing a phrase" began by reading its first word aloud.
Auto-speak is removed; speech now only starts from a button.

**2. The button meant the wrong thing.** `toggle` branched on one boolean — something is playing, so
stop. Right for the button that started the sound, wrong for every other one. With the word playing,
pressing Listen on a sentence was read as "stop the word". A second press worked, which is the whole
of "it works every other time". The decision moved to `lib/ttsRequest.ts` as a pure function over
`(phase, currentText, requestedText)`, with tests.

**3. The sentence never reached the app** — the one that actually decided what got read. After the
hold selects a word, dragging the handles out fires `selectionchange`, and every one of those events
landed inside the 1500 ms suppression window the tap path arms. All dropped. The app's selection
stayed on the word, so Listen read the word, and Ask stayed hidden because `isMultiWord` was still
false. The release path meant to prevent this carries the comment *"Needs on-device validation of the
extend-from-tap gesture"* — it does not fire, because once Android's selection ActionMode owns the
gesture the page stops receiving `touchmove`.

The window closed at ≈`12:18:19.849`; the dispatch would have fired at ≈`12:18:19.82`. Thirty
milliseconds — which is why this looked device-specific.

Also here: the ~1 s fetch is now visible as a spinner (the silence invited the second press that
cancelled the first fetch), and a selection over 300 characters no longer vanishes silently — it
opens the toolbar flagged, with Copy/Highlight/Ask live and only the 500-char-capped actions
disabled.

## Verification

Pixel 7 Pro emulator against production, gesture driven with `input motionevent` (`input swipe`
cannot reproduce it — it moves immediately and cancels the word timer).

| | before | after |
|---|---|---|
| messages from the gesture | one, `mode:'tap'`, `"travel"` | `mode:'tap'` then `mode:'drag'` with the sentence |
| audio before pressing anything | the word | none |
| `tts_played` after pressing Listen | `kind: 'word'` | `kind: 'sentence'` |

Confirmed the window was the cause by nudging a handle after it expired: the identical event
delivered the sentence at once. Full pass with logs:
`docs/qa/reports/2026-09-01-android-tts-selection.md`.

`tsc` clean, 203 unit tests pass (8 new). The reader-html smoke test was dead — it parsed a marker
out of a module that became a one-line re-export in April — and now parses the 27 KB hand-written
selection bridge instead, which had no syntax check at all; verified it fails on a deliberately
broken bridge rather than passing vacuously.

## Not verified

**No Galaxy S24 was used.** An emulator is not One UI. Acceptance checklist for the tester is at the
end of the QA report; this ships as an OTA (JS only).

Found and left open: a `window.onerror: Cannot read properties of null (reading 'addEventListener')`
fires on every reader load, present on an unmodified checkout.

## Rollback

Revert the branch. Each defect is its own commit and reverts alone; reverting only the bridge commit
restores the old suppression window and brings back "Listen reads one word".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F