### PR TITLE
ci(mobile): publish an OTA on merge, and refuse when it would reach nobody

### DIFF
--- a/.github/workflows/mobile-ota.yml
+++ b/.github/workflows/mobile-ota.yml
@@ -60,14 +60,20 @@ jobs:
       # as an authentication failure three steps later. Read from env rather
       # than a step-level `if`: the secrets context is not dependably available
       # in one.
-      - name: Fail early without a token
+      - name: Fail early without a usable token
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
-          if [ -z "${EXPO_TOKEN:-}" ]; then
-            echo "::error::EXPO_TOKEN is not set. Create one at expo.dev → Account → Access tokens, then add it as a repository secret."
-            exit 1
-          fi
+          # Empty and placeholder are the same failure to a reader: the workflow
+          # cannot talk to EAS. The secret was created with a placeholder so the
+          # field exists in Settings; catching it here means the run says what to
+          # do instead of dying on an authentication error two steps later.
+          case "${EXPO_TOKEN:-}" in
+            '' | REPLACE_ME*)
+              echo "::error::EXPO_TOKEN is unset or still the placeholder. Create a token at expo.dev → Account → Access tokens, then replace the secret at Settings → Secrets and variables → Actions."
+              exit 1
+              ;;
+          esac
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/mobile-ota.yml
+++ b/.github/workflows/mobile-ota.yml
@@ -1,0 +1,185 @@
+name: Mobile OTA (auto)
+
+# Publishes a JS-only change to installed Android apps when it lands on main.
+#
+# Separate from mobile-release.yml on purpose. That workflow is workflow_dispatch
+# only and says so in its own header: nothing reaches the STORE without a human
+# clicking. This one never touches the store — `eas update` republishes the JS
+# bundle to apps that are already installed.
+#
+# The guard is the point of this file.
+#
+# app.json sets `runtimeVersion: { policy: "fingerprint" }`, so an update only
+# reaches builds whose fingerprint matches. When a merge changes a native
+# dependency, an Expo plugin or app.json, the fingerprint moves — and `eas
+# update` still SUCCEEDS, publishing to a runtime nobody has installed. A green
+# check and zero delivery. That is the same shape as the SSG rebuild that
+# reported success after losing its files
+# (docs/incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md), and it is
+# worse here because nothing else would ever notice.
+#
+# So: compute the fingerprint, compare it with the runtime of the newest
+# finished production build, and publish only on a match. A mismatch FAILS the
+# run rather than skipping quietly — "this merge did not reach anyone, it needs
+# a build" is information, and a silent skip looks exactly like a success.
+#
+# Android only. iOS has no released build for an update to land on.
+#
+# Requires repo secret EXPO_TOKEN (expo.dev → Account → Access tokens).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/**'
+      - 'packages/**'          # consumed from source by Metro, so it ships in the bundle
+      - '.github/workflows/mobile-ota.yml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Compare the runtime and stop before publishing
+        type: boolean
+        default: true
+
+# Shared with mobile-release.yml so an automatic update can never run alongside
+# a manual build or store submit.
+concurrency:
+  group: mobile-release
+  cancel-in-progress: false
+
+jobs:
+  ota:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - uses: actions/checkout@v5
+
+      # Before the expo action, so a missing token says so instead of surfacing
+      # as an authentication failure three steps later. Read from env rather
+      # than a step-level `if`: the secrets context is not dependably available
+      # in one.
+      - name: Fail early without a token
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "${EXPO_TOKEN:-}" ]; then
+            echo "::error::EXPO_TOKEN is not set. Create one at expo.dev → Account → Access tokens, then add it as a repository secret."
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/mobile/package-lock.json
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # @textstack/shared is consumed from source (Metro watchFolders), so the
+      # checkout already carries it; only the app's own deps need installing.
+      - name: Install dependencies
+        run: npm ci
+
+      # MUST run from apps/mobile. From the repo root the command computes a
+      # different hash and reports it as valid — see docs/03-ops/play-store-release.md.
+      # `working-directory` above covers it; do not "simplify" this to a root run.
+      - name: Resolve the runtime this commit would have
+        id: fp
+        run: |
+          set -euo pipefail
+          # runtimeversion:resolve, not fingerprint:generate — it answers the
+          # question being asked ("what runtime would this commit produce"),
+          # and it is the command docs/03-ops/play-store-release.md already
+          # prescribes for this comparison. fingerprint:generate is kept as a
+          # fallback for CLI versions that lack it.
+          out=$(npx expo-updates runtimeversion:resolve --platform android 2>/dev/null \
+            || npx expo-updates fingerprint:generate --platform android)
+          echo "$out"
+          hash=$(printf '%s' "$out" | jq -r '.runtimeVersion // .hash // empty' 2>/dev/null || true)
+          if [ -z "$hash" ]; then
+            # Plain-text output: take the hash it printed.
+            hash=$(printf '%s' "$out" | grep -oE '[0-9a-f]{32,}' | head -1 || true)
+          fi
+          if [ -z "$hash" ]; then
+            echo "::error::Could not read a runtime version out of: $out"
+            exit 1
+          fi
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+
+      - name: Read the runtime of the newest production build
+        id: build
+        run: |
+          set -euo pipefail
+          # Filtered in jq, not with a CLI flag — the profile filter has been
+          # spelled --profile and --buildProfile across EAS versions, and a
+          # wrong flag name fails the run for a reason that has nothing to do
+          # with the app. Match on either field the JSON might carry.
+          json=$(eas build:list \
+            --platform android \
+            --status finished \
+            --limit 20 \
+            --json --non-interactive)
+          prod=$(printf '%s' "$json" | jq -c '[.[] | select(.buildProfile == "production" or .channel == "production")][0] // empty')
+          rt=$(printf '%s' "$prod" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)
+          id=$(printf '%s' "$prod" | jq -r '.id // empty' 2>/dev/null || true)
+          if [ -z "$rt" ]; then
+            echo "::error::No finished Android production build to publish against. Run mobile-release.yml → build first."
+            exit 1
+          fi
+          echo "runtime=$rt" >> "$GITHUB_OUTPUT"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse to publish into a runtime nobody is running
+        if: ${{ steps.fp.outputs.hash != steps.build.outputs.runtime }}
+        run: |
+          {
+            echo "### OTA not published"
+            echo
+            echo "This commit's runtime does not match the installed build, so an update"
+            echo "would publish to a runtime no one has and report success."
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| this commit | \`${{ steps.fp.outputs.hash }}\` |"
+            echo "| newest production build | \`${{ steps.build.outputs.runtime }}\` (\`${{ steps.build.outputs.id }}\`) |"
+            echo
+            echo "Something native changed — a dependency, an Expo plugin, or app.json."
+            echo "Ship it with **mobile-release.yml → build-submit**, not an update."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Runtime mismatch — this change needs a build, not an OTA update."
+          exit 1
+
+      # Commit subject only, passed through the environment rather than
+      # interpolated into the script: a commit message is attacker-controlled
+      # text and `${{ }}` inside `run:` would execute what it contains.
+      - name: Publish the update
+        if: ${{ inputs.dry_run != true }}
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          msg=$(printf '%s' "${COMMIT_MSG:-manual run}" | head -1 | cut -c1-140)
+          eas update \
+            --branch production \
+            --platform android \
+            --environment production \
+            --message "$msg" \
+            --non-interactive
+
+      - name: Say what happened
+        if: ${{ success() }}
+        run: |
+          {
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              echo "### Runtime matches — dry run, nothing published"
+            else
+              echo "### OTA published to the production channel"
+            fi
+            echo
+            echo "Runtime \`${{ steps.fp.outputs.hash }}\`, matching build \`${{ steps.build.outputs.id }}\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **CI** — an OTA goes out on merge, and refuses to when the runtime says it would reach nobody — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-ci-an-ota-goes-out-on-merge)
 - **Beta** — the site and the README carry a standing Android beta badge, not a Play badge that leads to a 404 — web · [details](docs/changelog-archive/2026-H2.md#2026-09-01-beta-a-standing-android-badge)
 - **Selection** — extending a long-press into a sentence reaches the app, so Listen stops reading one word — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-01-selection-extending-a-long-press-reaches-the-app)
 - **Reader** — speech starts when asked, and the Listen button reads the passage you picked — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-01-reader-speech-starts-when-asked)

--- a/docs/03-ops/play-store-release.md
+++ b/docs/03-ops/play-store-release.md
@@ -58,8 +58,19 @@ npx expo-updates runtimeversion:resolve --platform android
 eas build:list --platform android --status finished --limit 1 --json | jq -r '.[0].runtimeVersion'
 ```
 
-If they differ, you need a build, not an update. `npm run check:runtime-version` does
-this comparison if it has been wired up.
+If they differ, you need a build, not an update.
+
+`npm run check:runtime-version` was named here as the thing that would do this
+comparison. It was never written. What does it now is
+[`.github/workflows/mobile-ota.yml`](../../.github/workflows/mobile-ota.yml): on every
+push to `main` touching `apps/mobile/**` or `packages/**` it resolves the runtime,
+compares it with the newest finished Android production build, and publishes the OTA
+only on a match. A mismatch **fails the run** and says a build is needed — deliberately,
+because `eas update` succeeds either way, and a silent skip is indistinguishable from a
+delivered update.
+
+Run it by hand from Actions → Mobile OTA (auto) with `dry_run` on to see the comparison
+without publishing. It needs the `EXPO_TOKEN` secret, like every other EAS workflow here.
 
 ## Permissions
 

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,45 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-01-ci-an-ota-goes-out-on-merge"></a>
+
+## CI — an OTA goes out on merge, and refuses to when it would reach nobody — infra — 2026-09-01
+
+Shipping a JS-only mobile change meant running `eas update` from a laptop. `mobile-release.yml`
+already had an `ota-update` action; it went unused because the `EXPO_TOKEN` secret has never been
+set, which is still the one thing blocking every EAS path in CI.
+
+New workflow `mobile-ota.yml` publishes to the production channel on any push to `main` touching
+`apps/mobile/**` or `packages/**`. Kept separate from `mobile-release.yml` rather than bolted onto
+it: that file's header states it is `workflow_dispatch` only so nothing reaches the store without a
+human clicking, and that remains true — an OTA republishes the JS bundle to apps already installed
+and never touches the store.
+
+The guard is the reason the file exists. `app.json` sets `runtimeVersion.policy: "fingerprint"`, so
+an update only lands on builds whose runtime matches. When a merge moves a native dependency, a
+config plugin or `app.json`, the runtime moves with it — and `eas update` **still succeeds**,
+publishing into a runtime nobody has installed. A green check and zero delivery, with nothing else
+in the system positioned to notice. It is the shape of the
+[SSG rebuild that reported success after losing its files](../incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md),
+and worse, because that one was eventually visible on the site.
+
+So the workflow resolves the runtime, compares it with the newest finished Android production build,
+and publishes only on a match. A mismatch **fails the run** with what to do instead. Failing is the
+deliberate choice: a skipped step and a delivered update look identical in a green tick.
+
+Two things are decided rather than guessed, since neither can be tested before the token exists: the
+production build is selected in `jq` on `buildProfile`/`channel` rather than through a CLI filter
+flag that has been spelled both `--profile` and `--buildProfile` across EAS versions, and the missing
+token is detected by reading it from `env` rather than a step-level `if`, where the `secrets` context
+is not dependably available. The commit message reaches `eas update` through `env` too — it is
+attacker-controlled text, and `${{ }}` inside a `run:` block executes what it contains.
+
+`docs/03-ops/play-store-release.md` promised `npm run check:runtime-version` "if it has been wired
+up". It never was; the runbook now points at the workflow that does it.
+
+Untested end to end, and cannot be until `EXPO_TOKEN` is set — which is why `workflow_dispatch`
+carries a `dry_run` input, defaulting to on, so the first run compares without publishing.
+
 <a id="2026-09-01-beta-a-standing-android-badge"></a>
 
 ## Beta — a standing Android badge on the site and the README — web — 2026-09-01


### PR DESCRIPTION
Shipping a JS-only mobile change currently means running `eas update` from a laptop.
`mobile-release.yml` already has an `ota-update` action — it goes unused because the **`EXPO_TOKEN`
secret has never been set**, which is still the one thing blocking every EAS path in CI.
`gh secret list` shows only `CLAUDE_CODE_OAUTH_TOKEN`.

New workflow `mobile-ota.yml`: publishes to the production channel on any push to `main` touching
`apps/mobile/**` or `packages/**`.

Kept separate from `mobile-release.yml` rather than bolted onto it. That file's header states it is
`workflow_dispatch` only so nothing reaches the store without a human clicking, and that stays true
— an OTA republishes the JS bundle to apps already installed and never touches the store. Both share
a `concurrency` group so an automatic update cannot run alongside a manual build or submit.

## The guard is the point

`app.json` sets `runtimeVersion.policy: "fingerprint"`, so an update only lands on builds whose
runtime matches. When a merge moves a native dependency, a config plugin or `app.json`, the runtime
moves with it — and `eas update` **still succeeds**, publishing into a runtime nobody has installed.
A green check and zero delivery, with nothing else in the system positioned to notice. Same shape as
the SSG rebuild that reported success after losing its files, and worse, because that one was
eventually visible on the site.

So: resolve the runtime, compare it with the newest finished Android production build, publish only
on a match. A mismatch **fails the run** and says a build is needed. Failing rather than skipping is
deliberate — a skipped step and a delivered update look identical in a green tick.

## Decided, not guessed

None of this can be exercised before the token exists, so the parts that would otherwise be a guess
are pinned to something that does not depend on one:

- the production build is selected in `jq` on `buildProfile`/`channel`, not through a CLI filter flag
  that has been spelled both `--profile` and `--buildProfile` across EAS versions;
- the missing token is detected by reading it from `env`, not a step-level `if`, where the `secrets`
  context is not dependably available;
- the commit message reaches `eas update` through `env` — it is attacker-controlled text, and
  `${{ }}` inside a `run:` block executes what it contains;
- the runtime is resolved with `runtimeversion:resolve`, the command
  `docs/03-ops/play-store-release.md` already prescribes, with `fingerprint:generate` as a fallback;
- it runs from `apps/mobile`, because from the repo root the command silently computes a different
  hash and reports it as valid.

## Not verified

**Cannot run at all until `EXPO_TOKEN` is set** (expo.dev → Account → Access tokens → add as a repo
secret). That is why `workflow_dispatch` carries a `dry_run` input defaulting to **on**: the first
run after the token lands compares the runtimes and stops, so the comparison can be trusted before
anything is published to real phones.

YAML parses; the logic is untested.

Also fixes a dangling promise in the runbook — it named `npm run check:runtime-version` as the thing
that would do this comparison "if it has been wired up". It never was; it now points here.

## Rollback

Delete the workflow file. Nothing else depends on it, and `mobile-release.yml` keeps working exactly
as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F