### PR TITLE
ci(mobile): eas-cli needs Node 22, both EAS workflows pinned 20

### DIFF
--- a/.github/workflows/mobile-ota.yml
+++ b/.github/workflows/mobile-ota.yml
@@ -77,7 +77,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          # 22, not 20: eas-cli 23 pulls @oclif/plugin-autocomplete, which
+          # declares engines.node >= 22, and yarn refuses to install it on 20.
+          # Both workflows were pinned to 20 and neither had ever run far enough
+          # to find out.
+          node-version: 22
           cache: npm
           cache-dependency-path: apps/mobile/package-lock.json
 

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -63,7 +63,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          # 22, not 20: eas-cli 23 pulls @oclif/plugin-autocomplete, which
+          # declares engines.node >= 22, and yarn refuses to install it on 20.
+          # Both workflows were pinned to 20 and neither had ever run far enough
+          # to find out.
+          node-version: 22
           cache: npm
           cache-dependency-path: apps/mobile/package-lock.json
 

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -42,6 +42,12 @@ up". It never was; the runbook now points at the workflow that does it.
 Untested end to end, and cannot be until `EXPO_TOKEN` is set — which is why `workflow_dispatch`
 carries a `dry_run` input, defaulting to on, so the first run compares without publishing.
 
+**Update, same day.** The token landed and the first run failed before reaching any of the above:
+`eas-cli@23.2.0` pulls `@oclif/plugin-autocomplete`, which declares `engines.node >= 22`, and yarn
+refuses to install it on the Node 20 both workflows pinned. `mobile-release.yml` carried the same
+pin, so the manual OTA path had a second reason not to work beyond the missing secret — and neither
+workflow had ever run far enough to find out. Both now use Node 22.
+
 <a id="2026-09-01-beta-a-standing-android-badge"></a>
 
 ## Beta — a standing Android badge on the site and the README — web — 2026-09-01


### PR DESCRIPTION
The first real run of `mobile-ota.yml` failed before reaching any of its own logic:

```
error @oclif/plugin-autocomplete@3.3.0: The engine "node" is incompatible
with this module. Expected version ">=22.0.0". Got "20.20.2"
error Found incompatible module.
##[error]The process '/usr/local/bin/yarn' failed with exit code 1
```

`eas-cli@23.2.0` pulls `@oclif/plugin-autocomplete`, which declares `engines.node >= 22`.

`mobile-release.yml` had the same `node-version: 20` — I copied it from there — so the manual OTA
path had a second reason not to work beyond the missing `EXPO_TOKEN`, and neither workflow had ever
run far enough to find out. Both bumped to 22.

The token check passed, so the secret itself is good.

Once this lands the workflow is in its own trigger paths, so it re-runs immediately and finally
exercises the part that matters: resolving the runtime and comparing it with the newest production
build. That comparison is still unproven.

## Rollback

Revert. Both workflows go back to failing at install, which is where they were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F