### PR TITLE
ci(mobile): the OTA build lookup reads the field EAS actually returns

### DIFF
--- a/.github/workflows/mobile-ota.yml
+++ b/.github/workflows/mobile-ota.yml
@@ -155,8 +155,8 @@ jobs:
               echo
               echo "Either no production build exists yet — run **mobile-release.yml → build** —"
               echo "or the fields above are not the ones this step matches on."
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "::error::No finished Android production build to publish against. See the job summary for what was searched."
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "::error::No finished Android production build to publish against. See above for what was searched."
             exit 1
           fi
           echo "runtime=$rt" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mobile-ota.yml
+++ b/.github/workflows/mobile-ota.yml
@@ -132,13 +132,31 @@ jobs:
           json=$(eas build:list \
             --platform android \
             --status finished \
-            --limit 20 \
+            --limit 50 \
             --json --non-interactive)
           prod=$(printf '%s' "$json" | jq -c '[.[] | select(.buildProfile == "production" or .channel == "production")][0] // empty')
           rt=$(printf '%s' "$prod" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)
           id=$(printf '%s' "$prod" | jq -r '.id // empty' 2>/dev/null || true)
           if [ -z "$rt" ]; then
-            echo "::error::No finished Android production build to publish against. Run mobile-release.yml → build first."
+            # Say what was actually looked at. "No production build exists" and
+            # "matched on the wrong field" produce identical silence otherwise,
+            # and the first version of this step could not tell them apart —
+            # which cost a round trip. Profiles, channels and key names only.
+            {
+              echo "### No production build to publish against"
+              echo
+              echo "Searched $(printf '%s' "$json" | jq 'length') finished Android builds."
+              echo
+              echo "Build profiles seen: \`$(printf '%s' "$json" | jq -r '[.[].buildProfile // "null"] | unique | join(", ")')\`"
+              echo
+              echo "Channels seen: \`$(printf '%s' "$json" | jq -r '[.[].channel // "null"] | unique | join(", ")')\`"
+              echo
+              echo "Keys on the newest record: \`$(printf '%s' "$json" | jq -r '(.[0] // {}) | keys | join(", ")')\`"
+              echo
+              echo "Either no production build exists yet — run **mobile-release.yml → build** —"
+              echo "or the fields above are not the ones this step matches on."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::No finished Android production build to publish against. See the job summary for what was searched."
             exit 1
           fi
           echo "runtime=$rt" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mobile-ota.yml
+++ b/.github/workflows/mobile-ota.yml
@@ -206,7 +206,7 @@ jobs:
             echo
             echo "Something native changed — a dependency, an Expo plugin, or app.json."
             echo "Ship it with **mobile-release.yml → build-submit**, not an update."
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
           echo "::error::Runtime mismatch — this change needs a build, not an OTA update."
           exit 1
 
@@ -238,4 +238,4 @@ jobs:
             fi
             echo
             echo "Runtime \`${{ steps.fp.outputs.hash }}\`, matching build \`${{ steps.build.outputs.id }}\`."
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mobile-ota.yml
+++ b/.github/workflows/mobile-ota.yml
@@ -134,9 +134,37 @@ jobs:
             --status finished \
             --limit 50 \
             --json --non-interactive)
-          prod=$(printf '%s' "$json" | jq -c '[.[] | select(.buildProfile == "production" or .channel == "production")][0] // empty')
-          rt=$(printf '%s' "$prod" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)
+          prod=$(printf '%s' "$json" | jq -c '[.[] | select(.buildProfile == "production" or .updateChannel == "production")][0] // empty')
           id=$(printf '%s' "$prod" | jq -r '.id // empty' 2>/dev/null || true)
+          # The field is `runtime`, not `runtimeVersion` — confirmed from a real
+          # response, whose keys are: buildProfile, runtime, updateChannel,
+          # fingerprint, … The first version of this step guessed
+          # `runtimeVersion` and `channel`, matched nothing, and reported it as
+          # "no production build". Accept a bare string or an object, and fall
+          # back to the fingerprint hash, since under a fingerprint policy that
+          # is the same value.
+          rt=$(printf '%s' "$prod" | jq -r '
+            (.runtime | if type == "object" then (.version // .runtimeVersion // empty) else . end)
+            // .runtimeVersion
+            // (.fingerprint | if type == "object" then (.hash // empty) else . end)
+            // empty' 2>/dev/null || true)
+
+          # A build that was found but carries no runtime is a different problem
+          # from no build at all, and the two used to share one message.
+          if [ -n "$prod" ] && [ -z "$rt" ]; then
+            {
+              echo "### Production build found, but no runtime on it"
+              echo
+              echo "Build \`$id\`."
+              echo
+              echo "\`runtime\`: \`$(printf '%s' "$prod" | jq -c '.runtime // "absent"')\`"
+              echo
+              echo "\`fingerprint\`: \`$(printf '%s' "$prod" | jq -c '.fingerprint // "absent"')\`"
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "::error::The newest production build carries no runtime this step can read. See above."
+            exit 1
+          fi
+
           if [ -z "$rt" ]; then
             # Say what was actually looked at. "No production build exists" and
             # "matched on the wrong field" produce identical silence otherwise,
@@ -149,7 +177,7 @@ jobs:
               echo
               echo "Build profiles seen: \`$(printf '%s' "$json" | jq -r '[.[].buildProfile // "null"] | unique | join(", ")')\`"
               echo
-              echo "Channels seen: \`$(printf '%s' "$json" | jq -r '[.[].channel // "null"] | unique | join(", ")')\`"
+              echo "Update channels seen: \`$(printf '%s' "$json" | jq -r '[.[].updateChannel // "null"] | unique | join(", ")')\`"
               echo
               echo "Keys on the newest record: \`$(printf '%s' "$json" | jq -r '(.[0] // {}) | keys | join(", ")')\`"
               echo

--- a/docs/03-ops/play-store-release.md
+++ b/docs/03-ops/play-store-release.md
@@ -55,7 +55,10 @@ Before publishing an OTA, confirm the runtime still matches the shipped build:
 ```bash
 cd apps/mobile
 npx expo-updates runtimeversion:resolve --platform android
-eas build:list --platform android --status finished --limit 1 --json | jq -r '.[0].runtimeVersion'
+# The field is `runtime`, not `runtimeVersion` — the latter returns null, which
+# reads as "no runtime" and means the opposite of what it looks like.
+eas build:list --platform android --status finished --limit 50 --json \
+  | jq -r '[.[] | select(.buildProfile == "production")][0].runtime'
 ```
 
 If they differ, you need a build, not an update.


### PR DESCRIPTION
The runtime comparison had never run. It failed at `Read the runtime of the newest production build`
with "No finished Android production build to publish against" — a message that could not
distinguish *no build exists* from *matched on the wrong field*, which was the entire question.

So the failure now reports what it searched. One dispatched run answered it:

```
Searched 50 finished Android builds.
Build profiles seen: `development, preview, production`
Update channels seen: `null`
Keys on the newest record: app, appBuildVersion, appIdentifier, appVersion,
artifacts, buildProfile, completedAt, createdAt, distribution, expirationDate,
fingerprint, gitCommitHash, gitCommitMessage, id, initiatingActor,
isForIosSimulator, logFiles, metrics, platform, priority, runtime, sdkVersion,
status, updateChannel, updatedAt
```

Production builds existed all along and `buildProfile` was right. Both other guesses were wrong:
the field is **`runtime`**, not `runtimeVersion`, and **`updateChannel`**, not `channel`. It now
reads a string or an object and falls back to the fingerprint hash, which under a fingerprint policy
is the same value.

Two failures that shared one message are now separate: *no production build* and *a build with no
runtime on it* are different problems, and conflating them is what pointed the first failure at the
wrong thing.

## It works, and the runtimes match

```
### Runtime matches — dry run, nothing published
Runtime `e92c88a8a138bf4734f82ccfd7cdf32b285ace30`,
matching build `aa4d265d-dc7c-4640-9446-9246e7ffbe58`.
```

Verified by dispatching this branch with `dry_run: true` — the guard step was skipped, meaning the
condition was false, meaning the runtimes match. So an OTA from `main` will reach the installed
build rather than publishing into a runtime nobody has.

**Merging this publishes for real.** The workflow is in its own trigger paths, so the merge fires it
with `dry_run` unset, and the selection-speech fixes from #509 go out to installed apps.

## Also here

`docs/03-ops/play-store-release.md` prescribes the manual check as `jq -r '.[0].runtimeVersion'` —
the same wrong field. It returns `null`, which reads as "no runtime" and means the opposite of what
it looks like; it also took the newest build of any profile rather than the production one. Fixed.

Every summary now tees to the log. A step summary is rendered on the run page and is not reachable
through the API, so the one output that mattered could not be read from a terminal — which cost a
round trip during this very investigation.

## Rollback

Revert. The workflow goes back to failing at the lookup, which is where it was; nothing is published
either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F