### PR TITLE
ci: refresh dependencies weekly, by pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,13 @@ jobs:
       - name: Build admin
         run: pnpm --filter textstack-admin build
 
+      # scripts/ has its own tests and no vitest project would otherwise find
+      # them — the web config's include does not reach outside apps/web, so
+      # without this step they exist and never run. They cover the weekly
+      # dependency job, which edits pnpm-workspace.yaml unattended.
+      - name: Repo script tests
+        run: pnpm test:scripts
+
   # apps/mobile is npm + its own lockfile, not part of the pnpm workspace, so it
   # gets its own job rather than another step in `frontend`. @textstack/shared is
   # consumed from source via Metro watchFolders + tsconfig paths, so the checkout

--- a/.github/workflows/deps-refresh.yml
+++ b/.github/workflows/deps-refresh.yml
@@ -1,0 +1,193 @@
+name: Dependencies (weekly)
+
+# Two lanes, opened as pull requests and merged only on green.
+#
+# There is a workflow in four sibling repositories that bumps NuGet packages and
+# pushes straight to `main`, verified inside the job. That is right there and
+# wrong here: in those repos a push to main publishes a package, and in this one
+# **a merge to main deploys production**. So the PR is not ceremony — it is the
+# gate, and CI (1328 unit tests, e2e, both images built) is what opens it.
+#
+#   refresh — re-resolve the lockfile inside the ranges already declared.
+#             Nothing in any package.json changes.
+#   catalog — raise the shared version catalog by patch and minor.
+#             Majors are reported and left alone.
+#
+# `refresh` is first because it is the one that mattered. dompurify shipped a
+# known-vulnerable XSS sanitiser to every visitor for months while
+# `apps/web/package.json` already declared a range that allowed the fix — the
+# range was right, the lockfile was old, and nothing re-resolved it. That is not
+# a version-bump problem and no amount of bumping would have found it.
+#
+# What this must never touch is expo, react-native and react. Those decide the
+# mobile runtime fingerprint. A bot bump passes CI — tsc and the unit tests do
+# not know what an SDK compatibility matrix is — and then every installed app
+# stops receiving OTA updates, because mobile-ota.yml correctly refuses to
+# publish into a runtime nobody is running. scripts/catalogBump.mjs holds the
+# list; `refresh` cannot reach them because it never changes a declared range.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Monday, before anyone is looking
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: Which lane to run
+        type: choice
+        options: [both, refresh, catalog]
+        default: both
+      dry_run:
+        description: Report what would change and stop
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: deps-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    if: ${{ inputs.lane == null || inputs.lane == 'both' || inputs.lane == 'refresh' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      # No --frozen-lockfile: re-resolving inside the declared ranges is the
+      # entire point. Every package.json is left exactly as it is.
+      - name: Re-resolve the lockfile
+        id: resolve
+        run: |
+          set -euo pipefail
+          pnpm install --no-frozen-lockfile
+          if git diff --quiet -- pnpm-lock.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo '### Lockfile already current' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            {
+              echo '### Lockfile re-resolved'
+              echo
+              echo 'No declared range changed — these are versions the ranges already allowed.'
+              echo
+              echo '```'
+              git diff --stat -- pnpm-lock.yaml
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Verify
+        if: steps.resolve.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          pnpm --filter textstack-web build
+          pnpm --filter textstack-admin build
+          pnpm --filter textstack-web test
+          pnpm --filter @textstack/shared test
+          pnpm --filter mobile typecheck
+          pnpm --filter mobile test
+
+      # tsc and the unit tests pass while the app cannot be bundled — a broken
+      # module resolution only shows up when Metro walks the graph, and a
+      # dependency refresh is exactly what moves module resolution.
+      - name: Bundle (Metro)
+        if: steps.resolve.outputs.changed == 'true'
+        working-directory: apps/mobile
+        run: npx expo export --platform android --output-dir "$RUNNER_TEMP/bundle"
+
+      - name: Open a pull request
+        if: steps.resolve.outputs.changed == 'true' && inputs.dry_run != true
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: deps/lockfile-refresh
+          delete-branch: true
+          title: 'chore(deps): re-resolve the lockfile'
+          commit-message: |
+            chore(deps): re-resolve the lockfile
+
+            Versions the declared ranges already allowed. No package.json
+            changed. This is the lane that would have shipped the dompurify
+            fix months before anyone noticed it was missing.
+          body: |
+            Re-resolved `pnpm-lock.yaml` inside the ranges already declared. **No `package.json` changed.**
+
+            This lane exists because of dompurify: a known-vulnerable XSS sanitiser shipped to every
+            visitor for months while `apps/web/package.json` already declared a range that allowed the
+            patched version. The range was right; nothing re-resolved it.
+
+            Verified in the job: both site builds, 1328 unit tests, `tsc`, and a full Metro bundle.
+            CI has to pass here as well — merging this deploys production.
+          labels: dependencies
+
+  catalog:
+    # No `needs: refresh`. The lanes are independent — one re-resolves inside
+    # existing ranges, the other changes the ranges — and chaining them would
+    # skip this one whenever the other had nothing to do.
+    if: ${{ inputs.lane == null || inputs.lane == 'both' || inputs.lane == 'catalog' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Raise the catalog
+        id: bump
+        run: node scripts/bump-catalog.mjs ${{ inputs.dry_run == true && '--dry-run' || '' }}
+
+      - name: Install the raised versions
+        if: steps.bump.outputs.changed == 'true'
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Verify
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          pnpm --filter textstack-web build
+          pnpm --filter textstack-admin build
+          pnpm --filter textstack-web test
+          pnpm --filter @textstack/shared test
+          pnpm --filter mobile typecheck
+          pnpm --filter mobile test
+
+      - name: Bundle (Metro)
+        if: steps.bump.outputs.changed == 'true'
+        working-directory: apps/mobile
+        run: npx expo export --platform android --output-dir "$RUNNER_TEMP/bundle"
+
+      - name: Open a pull request
+        if: steps.bump.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: deps/catalog
+          delete-branch: true
+          title: ${{ steps.bump.outputs.title }}
+          commit-message: ${{ steps.bump.outputs.title }}
+          body: |
+            Raised the shared catalog in `pnpm-workspace.yaml` by patch and minor. Majors are listed
+            in the job summary and left for a person.
+
+            One entry moves every workspace member, which is what makes this worth automating — and
+            also why `react`, `react-dom` and `@types/react` are excluded: they decide the mobile
+            runtime fingerprint, and a bump there passes CI and then stops every installed app from
+            receiving OTA updates.
+
+            Verified in the job: both site builds, 1328 unit tests, `tsc`, and a full Metro bundle.
+          labels: dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **CI** — dependencies refresh themselves weekly, and the lane that matters is the one that changes no versions at all — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-ci-dependencies-refresh-themselves)
 - **Security** — 125 dependency findings down to 3, none of them shipping, and something now watches — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-security-125-findings-down-to-3)
 - **Infra** — one pnpm workspace with a version catalog, the JS answer to Directory.Packages.props — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-infra-one-workspace-one-catalog)
 - **Infra** — one Node version, declared once, and production stops running an end-of-life runtime — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-infra-one-node-version)

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,47 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-01-ci-dependencies-refresh-themselves"></a>
+
+## CI — dependencies refresh themselves weekly — infra — 2026-09-01
+
+Four sibling repositories already run a weekly job that bumps NuGet packages and pushes straight to
+`main`, verified inside the job. Copying it here would have been wrong for one reason: in those
+repos a push to `main` publishes a package, and in this one **it deploys production**. So these
+lanes open pull requests, and CI — 1328 unit tests, e2e, both images built — is the gate.
+
+**The lane that matters changes no version at all.** `dompurify` shipped a known-vulnerable XSS
+sanitiser to every visitor for months while `apps/web/package.json` already declared a range that
+allowed the fix. The range was right; nothing re-resolved it. So `refresh` re-resolves the lockfile
+inside the ranges already declared and touches no manifest. No amount of version bumping would have
+found that.
+
+`catalog` raises the shared catalog by patch and minor. One entry moves every workspace member,
+which is what makes it worth automating. Majors are reported and left for a person — of the seven
+updates available on the day this was written, all seven were majors, so the job's first real
+output is a list of things it refused to do.
+
+`react`, `react-dom` and `@types/react` are excluded outright. They decide the mobile runtime
+fingerprint: a bot bump passes CI, because `tsc` and the unit tests do not know what an SDK
+compatibility matrix is, and then every installed app stops receiving OTA updates because
+`mobile-ota.yml` correctly refuses to publish into a runtime nobody is running. `refresh` cannot
+reach them either, since it never changes a declared range.
+
+Both lanes verify with a **Metro bundle** before opening anything. `tsc` and the unit tests pass
+while an app cannot be bundled at all — module resolution only breaks when Metro walks the graph,
+and moving dependencies is precisely what moves module resolution.
+
+The decision lives in `scripts/catalogBump.mjs` as a pure function with tests, because a judgement
+that runs unattended every Monday is one worth being able to exercise. The tests earned it
+immediately: the first version compared the *installed* version reported by `pnpm outdated` while
+rewriting the *declared* one, which are different numbers and not always the same distance from
+`latest`. They also cover the case that would be worst — a patch bump of `react` sailing through —
+and the one that is easy to get wrong, a `name: value` line under `packages:` or `allowBuilds:`
+looking exactly like a catalog entry to anything reading line by line.
+
+Wiring those tests into CI needed its own step: no vitest project reaches outside its own app, so
+`scripts/catalogBump.test.mjs` would have existed and never run.
+
 <a id="2026-09-01-security-125-findings-down-to-3"></a>
 
 ## Security — 125 dependency findings down to 3, and something now watches — infra — 2026-09-01

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:web": "pnpm --filter textstack-web build",
     "build:admin": "pnpm --filter textstack-admin build",
     "test": "pnpm -r test",
-    "typecheck": "pnpm -r typecheck"
+    "typecheck": "pnpm -r typecheck",
+    "test:scripts": "vitest run scripts/"
   }
 }

--- a/scripts/bump-catalog.mjs
+++ b/scripts/bump-catalog.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+//
+// CLI around scripts/catalogBump.mjs: ask pnpm what is outdated, raise the
+// catalog by patch and minor, report the majors it refused.
+//
+// Run: node scripts/bump-catalog.mjs [--dry-run]
+
+import { readFileSync, writeFileSync, appendFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { bumpCatalog, report } from './catalogBump.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const WORKSPACE = join(ROOT, 'pnpm-workspace.yaml')
+const DRY = process.argv.includes('--dry-run')
+
+// `pnpm outdated` exits 1 whenever anything is outdated, which is the normal
+// case here and not a failure. The output still arrives on stdout.
+function readOutdated() {
+  const args = ['outdated', '-r', '--format', 'json']
+  const opts = { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+  let out
+  try {
+    out = execFileSync('pnpm', args, { ...opts, stdio: ['ignore', 'pipe', 'ignore'] })
+  } catch (e) {
+    out = e.stdout?.toString() ?? ''
+    // Distinguish "nothing to report" from "pnpm could not run". Silence from a
+    // broken command would otherwise read as a clean catalog.
+    if (!out.trim()) {
+      console.error('pnpm outdated produced no output — treating as a failure rather than as "nothing outdated"')
+      process.exit(1)
+    }
+  }
+  return JSON.parse(out || '{}')
+}
+
+const result = bumpCatalog(readFileSync(WORKSPACE, 'utf8'), readOutdated())
+if (result.applied.length && !DRY) writeFileSync(WORKSPACE, result.text)
+
+const text = report(result)
+console.log(text)
+if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, text + '\n')
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `changed=${result.applied.length > 0 && !DRY}\n`)
+  // One line for the PR title, so it says what moved without anyone opening it.
+  const title = result.applied.length === 1
+    ? `chore(deps): ${result.applied[0].replace(/ \((patch|minor)\)$/, '')}`
+    : `chore(deps): raise ${result.applied.length} catalog versions`
+  appendFileSync(process.env.GITHUB_OUTPUT, `title=${title}\n`)
+}

--- a/scripts/catalogBump.mjs
+++ b/scripts/catalogBump.mjs
@@ -1,0 +1,99 @@
+// Deciding which shared versions may move, and rewriting them in place.
+//
+// Kept separate from the workflow that calls it because the interesting part is
+// a judgement — patch and minor yes, major no, some packages never — and a
+// judgement that runs once a week unattended is one you want a test for. The
+// first version of this compared against the *installed* version reported by
+// `pnpm outdated` while rewriting the *declared* one, which are not the same
+// number and are not always the same distance from `latest`.
+//
+// Edits line by line rather than round-tripping the YAML: pnpm-workspace.yaml
+// is more comment than data, and each comment records something that cost a
+// debugging session.
+
+/** Never moved automatically. These reach the mobile runtime, where Expo pins
+ *  them against its SDK compatibility matrix and React Native declares a peer
+ *  range around them. A bot bump passes CI — tsc and the unit tests do not know
+ *  what an SDK matrix is — and it surfaces as a mobile build that no longer
+ *  matches what is installed on phones. */
+export const MANUAL_ONLY = new Set(['react', 'react-dom', '@types/react'])
+
+const parse = (v) => {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(String(v))
+  return m ? { major: +m[1], minor: +m[2], patch: +m[3] } : null
+}
+
+/** How far `to` sits above `from`: 'major' | 'minor' | 'patch' | null. */
+export function jump(from, to) {
+  const a = parse(from), b = parse(to)
+  if (!a || !b) return null
+  if (b.major !== a.major) return b.major > a.major ? 'major' : null
+  if (b.minor !== a.minor) return b.minor > a.minor ? 'minor' : null
+  if (b.patch !== a.patch) return b.patch > a.patch ? 'patch' : null
+  return null
+}
+
+/** A `name: version` line inside the catalog block, keeping quotes and range prefix. */
+const ENTRY = /^(\s+)(['"]?)([^'":]+)\2:\s*(['"]?)([\^~]?)(\d[\w.-]*)\4\s*$/
+
+/**
+ * @param {string} yamlText  contents of pnpm-workspace.yaml
+ * @param {Record<string, {latest?: string}>} outdated  `pnpm outdated --format json`
+ * @returns {{text: string, applied: string[], skipped: string[]}}
+ */
+export function bumpCatalog(yamlText, outdated) {
+  const lines = yamlText.split('\n')
+  const applied = [], skipped = []
+  // Only inside `catalog:`. A two-space `name: value` under `packages:` or
+  // `allowBuilds:` looks identical and must not be touched.
+  let inCatalog = false
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (/^catalog:\s*$/.test(line)) { inCatalog = true; continue }
+    if (inCatalog && /^\S/.test(line)) inCatalog = false
+    if (!inCatalog) continue
+
+    const m = ENTRY.exec(line)
+    if (!m) continue
+    const [, indent, nq, name, vq, prefix, declared] = m
+
+    const latest = outdated[name]?.latest
+    if (!latest) continue
+
+    // Report the declaration as written, prefix included — that is the string
+    // someone will go looking for in the file.
+    const written = `${prefix}${declared}`
+
+    if (MANUAL_ONLY.has(name)) {
+      skipped.push(`${name} ${written} → ${latest} — pinned to the mobile runtime, move it by hand`)
+      continue
+    }
+
+    // Compare what is written here, not what happens to be installed. Those
+    // differ whenever the range has floated, and it is the declaration being
+    // rewritten.
+    const kind = jump(declared, latest)
+    if (!kind) continue
+    if (kind === 'major') {
+      skipped.push(`${name} ${written} → ${latest} — major`)
+      continue
+    }
+
+    lines[i] = `${indent}${nq}${name}${nq}: ${vq}${prefix}${latest}${vq}`
+    applied.push(`${name} ${written} → ${latest} (${kind})`)
+  }
+
+  return { text: lines.join('\n'), applied, skipped }
+}
+
+/** Markdown for the job summary and the PR body. */
+export function report({ applied, skipped }) {
+  const out = [applied.length ? '### Catalog raised' : '### Catalog already current', '']
+  for (const a of applied) out.push(`- ${a}`)
+  if (skipped.length) {
+    out.push('', '### Left alone', '')
+    for (const s of skipped) out.push(`- ${s}`)
+  }
+  return out.join('\n')
+}

--- a/scripts/catalogBump.test.mjs
+++ b/scripts/catalogBump.test.mjs
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { bumpCatalog, jump, MANUAL_ONLY } from './catalogBump.mjs'
+
+const YAML = `# a comment that cost a debugging session
+nodeLinker: hoisted
+
+packages:
+  - apps/web
+  - apps/mobile
+
+allowBuilds:
+  esbuild: true
+
+# why these are shared
+catalog:
+  '@playwright/test': ^1.60.0
+  react: ^19.2.6
+  typescript: ~5.9.2
+  vitest: ^3.2.6
+`
+
+describe('jump', () => {
+  it('names the distance', () => {
+    expect(jump('1.2.3', '1.2.4')).toBe('patch')
+    expect(jump('1.2.3', '1.3.0')).toBe('minor')
+    expect(jump('1.2.3', '2.0.0')).toBe('major')
+    expect(jump('1.2.3', '1.2.3')).toBeNull()
+  })
+
+  it('never reports a downgrade as an upgrade', () => {
+    // pnpm can report an older `latest` for a package pinned off a dist-tag.
+    // Rewriting the catalog downwards would be worse than doing nothing.
+    expect(jump('2.0.0', '1.9.9')).toBeNull()
+    expect(jump('1.3.0', '1.2.9')).toBeNull()
+  })
+})
+
+describe('bumpCatalog', () => {
+  it('applies patch and minor', () => {
+    const { text, applied } = bumpCatalog(YAML, {
+      '@playwright/test': { latest: '1.62.1' },
+      typescript: { latest: '5.9.3' },
+    })
+    expect(applied).toEqual([
+      '@playwright/test ^1.60.0 → 1.62.1 (minor)',
+      'typescript ~5.9.2 → 5.9.3 (patch)',
+    ])
+    expect(text).toContain("'@playwright/test': ^1.62.1")
+    // The range prefix is part of the declaration, not noise: ~ pins the minor.
+    expect(text).toContain('typescript: ~5.9.3')
+  })
+
+  it('refuses majors and says so', () => {
+    const { text, applied, skipped } = bumpCatalog(YAML, { vitest: { latest: '4.1.11' } })
+    expect(applied).toEqual([])
+    expect(skipped).toEqual(['vitest ^3.2.6 → 4.1.11 — major'])
+    expect(text).toContain('vitest: ^3.2.6')
+  })
+
+  it('refuses the packages tied to the mobile runtime, even for a patch', () => {
+    // The one that would pass CI and strand every installed app.
+    const { text, applied, skipped } = bumpCatalog(YAML, { react: { latest: '19.2.9' } })
+    expect(applied).toEqual([])
+    expect(skipped[0]).toContain('pinned to the mobile runtime')
+    expect(text).toContain('react: ^19.2.6')
+    expect(MANUAL_ONLY.has('react-dom')).toBe(true)
+  })
+
+  it('leaves every comment and unrelated line untouched', () => {
+    const { text } = bumpCatalog(YAML, { typescript: { latest: '5.9.3' } })
+    const commentsBefore = YAML.split('\n').filter(l => l.trim().startsWith('#')).length
+    const commentsAfter = text.split('\n').filter(l => l.trim().startsWith('#')).length
+    expect(commentsAfter).toBe(commentsBefore)
+    expect(text).toContain('nodeLinker: hoisted')
+    expect(text).toContain('  - apps/mobile')
+  })
+
+  it('does not touch name: value lines outside the catalog block', () => {
+    // `esbuild: true` under allowBuilds, and the `packages:` list, are the same
+    // shape as a catalog entry to anything reading line by line.
+    const { text, applied } = bumpCatalog(YAML, {
+      esbuild: { latest: '0.28.3' },
+      nodeLinker: { latest: '9.9.9' },
+    })
+    expect(applied).toEqual([])
+    expect(text).toContain('  esbuild: true')
+    expect(text).toContain('nodeLinker: hoisted')
+  })
+
+  it('ignores a package that is not in the catalog', () => {
+    const { applied, skipped } = bumpCatalog(YAML, { 'some-app-dep': { latest: '9.0.0' } })
+    expect(applied).toEqual([])
+    expect(skipped).toEqual([])
+  })
+})


### PR DESCRIPTION
Two lanes, weekly, opened as PRs. Plus the Dependabot config that landed with #514 for NuGet and
GitHub Actions.

## Why not the workflow we already have

Four sibling repos run a weekly job that bumps NuGet and **pushes straight to `main`**, verified
inside the job. Copying it here would be wrong for exactly one reason: in those repos a push to
`main` publishes a package, and in this one **it deploys production**. So these open pull requests,
and CI — 1328 unit tests, e2e, both images built — is the gate rather than ceremony.

## The lane that matters changes no version at all

`dompurify` shipped a known-vulnerable XSS sanitiser to every visitor for months while
`apps/web/package.json` already declared a range that allowed the fix. **The range was right;
nothing re-resolved it.** No amount of version bumping would have found that.

So `refresh` re-resolves `pnpm-lock.yaml` inside the ranges already declared and touches no
manifest. It is first in the file because it is the one with a body count.

`catalog` raises the shared catalog by patch and minor — one entry moves every workspace member,
which is what makes it worth automating. Majors are reported and left for a person. Of the seven
updates available today, **all seven are majors**, so the job's first real output is a list of what
it refused to do:

```
### Catalog already current

### Left alone
- @vitejs/plugin-react ^4.7.0 → 6.1.1 — major
- @vitest/coverage-v8 ^3.2.6 → 4.1.11 — major
- jsdom ^28.1.0 → 30.0.1 — major
- pdfjs-dist 4.10.38 → 6.3.289 — major
- typescript ~5.9.2 → 7.0.2 — major
- vite ^6.4.2 → 8.2.2 — major
- vitest ^3.2.6 → 4.1.11 — major
```

## What it must never touch

`react`, `react-dom` and `@types/react` are excluded outright. They decide the mobile runtime
fingerprint. A bot bump **passes CI** — `tsc` and the unit tests do not know what an SDK
compatibility matrix is — and then every installed app stops receiving OTA updates, because
`mobile-ota.yml` correctly refuses to publish into a runtime nobody is running. `refresh` cannot
reach them either: it never changes a declared range.

Both lanes verify with a **Metro bundle** before opening anything. `tsc` and the unit tests pass
while an app cannot be bundled at all, and moving dependencies is precisely what moves module
resolution.

## The decision is testable, and the tests earned it

`scripts/catalogBump.mjs` is a pure function over `(yamlText, outdated)`. A judgement that runs
unattended every Monday is one worth being able to exercise.

The 8 tests caught a real bug on their first run: the initial version compared the **installed**
version reported by `pnpm outdated` while rewriting the **declared** one — different numbers, and
not always the same distance from `latest`. They also cover a patch bump of `react` sailing
through, and a `name: value` line under `packages:` or `allowBuilds:` looking identical to a catalog
entry to anything reading line by line.

Wiring them into CI needed its own step: no vitest project's include reaches outside its own app, so
`scripts/catalogBump.test.mjs` would have existed and never run — which is the failure mode this
repo already has a paragraph about in `docs/STATUS.md`.

## Verification

- `pnpm test:scripts` — 8 tests pass.
- `node scripts/bump-catalog.mjs --dry-run` against the real repo — output above, workspace file
  untouched.
- `node scripts/check-node-version.mjs` — 10 declarations agree.
- Both workflow files parse.

**Not verified:** a real scheduled run. The lanes cannot be exercised end to end until something is
actually outdated by a patch or minor, and today nothing is. `workflow_dispatch` takes `lane` and
`dry_run` so the first run can be watched rather than discovered on a Monday.

## Rollback

Delete `.github/workflows/deps-refresh.yml`. The scripts are inert without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F