### PR TITLE
fix(ssg): the worker finds its output directory again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **SSG** — rebuilds stopped failing on a path the workspace move invalidated, while the site looked fine — infra · [incident](docs/incidents/2026-09-01-ssg-worker-lost-its-output-path.md)
 - **CI** — dependencies refresh themselves weekly, and the lane that matters is the one that changes no versions at all — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-ci-dependencies-refresh-themselves)
 - **Security** — 125 dependency findings down to 3, none of them shipping, and something now watches — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-security-125-findings-down-to-3)
 - **Infra** — one pnpm workspace with a version catalog, the JS answer to Directory.Packages.props — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-infra-one-workspace-one-catalog)

--- a/apps/web/scripts/ssg-worker.mjs
+++ b/apps/web/scripts/ssg-worker.mjs
@@ -21,10 +21,21 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// SSG directories for atomic swap
-const SSG_DIR = '/app/dist/ssg';
-const SSG_NEW_DIR = '/app/dist/ssg-new';
-const SSG_OLD_DIR = '/app/dist/ssg-old';
+// SSG directories for atomic swap.
+//
+// Derived from this file's own location, not written out absolutely. They used
+// to be '/app/dist/...', which was true for as long as the container's WORKDIR
+// was /app — and stopped being true the moment the image started building from
+// the repository root and running out of /repo/apps/web. Every rebuild then
+// failed with EACCES on mkdir '/app/dist/ssg-new' while the site kept serving
+// the previous SSG, so nothing looked wrong from outside.
+//
+// prerender.mjs, next door, already resolved its own paths this way and was
+// untouched by the move. This is that.
+const DIST_DIR = join(__dirname, '..', 'dist');
+const SSG_DIR = join(DIST_DIR, 'ssg');
+const SSG_NEW_DIR = join(DIST_DIR, 'ssg-new');
+const SSG_OLD_DIR = join(DIST_DIR, 'ssg-old');
 
 // Configuration
 const DATABASE_URL = process.env.DATABASE_URL;

--- a/docs/incidents/2026-09-01-ssg-worker-lost-its-output-path.md
+++ b/docs/incidents/2026-09-01-ssg-worker-lost-its-output-path.md
@@ -1,0 +1,78 @@
+# SSG rebuilds failed silently after the workspace move
+
+**Date:** 2026-09-01 · **Detected:** ~30 minutes · **Impact:** no page could be re-prerendered;
+the site kept serving the previous SSG throughout · **Cause:** an absolute path in a script,
+invalidated by an image layout change
+
+## What happened
+
+Moving the repository to a pnpm workspace ([#514](https://github.com/mrviduus/textstack/pull/514))
+required both production images to build from the repository root — `catalog:` cannot be resolved
+without `pnpm-workspace.yaml` in scope. The `ssg-worker` container's working directory moved with
+it, from `/app` to `/repo/apps/web`.
+
+`apps/web/scripts/ssg-worker.mjs` had its output directories written out absolutely:
+
+```js
+const SSG_DIR = '/app/dist/ssg';
+const SSG_NEW_DIR = '/app/dist/ssg-new';
+const SSG_OLD_DIR = '/app/dist/ssg-old';
+```
+
+Every rebuild after the deploy failed at the first write:
+
+```
+[prerender] Found 1992 routes to prerender
+[prerender stderr] Prerender failed: Error: EACCES: permission denied, mkdir '/app/dist/ssg-new'
+    at main (file:///repo/apps/web/scripts/prerender.mjs:478:3)
+Job 17fcbc80-6385-4e25-a561-d3c0f8759a48 failed with exit code 1
+```
+
+## Why nothing looked wrong
+
+The site was fine. `https://textstack.app/en` returned 200 with `x-seo-render: ssg` the entire time,
+because the previous SSG output was still on disk and nginx was still serving it. The container was
+`Up (healthy)` — its healthcheck is `pgrep -f ssg-worker.mjs`, which asks whether the process exists,
+not whether it can do its job.
+
+This is the shape of the
+[five-week SSG outage](2026-08-11-ssg-dead-five-weeks.md): the failure is invisible from outside
+because stale output looks exactly like fresh output. It was caught in thirty minutes this time
+only because the deploy was being watched step by step — the `Wait for SSG rebuild to complete`
+step sat there instead of finishing, which is the guard added after
+[the deploy that wiped a running rebuild](2026-08-31-deploy-wiped-a-running-ssg-rebuild.md) doing
+its job.
+
+## The fix
+
+Derive the paths from the script's own location, so they survive any layout:
+
+```js
+const DIST_DIR = join(__dirname, '..', 'dist');
+const SSG_DIR = join(DIST_DIR, 'ssg');
+```
+
+`prerender.mjs`, in the same directory, already did exactly this — `join(__dirname, '..', 'dist')` —
+and came through the move untouched. The two scripts disagreed about how to find the same folder,
+and only one of them was right.
+
+## What this says about the checks that passed
+
+CI was green on #514, including the `docker` job, which builds both images. Building an image proves
+it builds. It does not run the container against its volumes, and the failure needed all three: the
+new WORKDIR, the compose volume at its new mount point, and a script writing to the old absolute
+path.
+
+The e2e suite did not cover it either, because e2e exercises the site — and the site was serving the
+old output correctly.
+
+## Follow-ups
+
+- **The healthcheck answers the wrong question.** `pgrep -f ssg-worker.mjs` reports a process, not a
+  working one. A worker that has failed every job for an hour is `healthy`. Something closer to
+  "the last job succeeded, or at least one has succeeded recently" would have said so.
+- **Still no SSG freshness alarm.** `docs/STATUS.md` has carried this item since the five-week
+  outage: nothing alerts on "the newest generated page is older than N hours". It would have caught
+  this one too, and it is the single check that would have caught all three.
+- **Absolute paths in scripts that run in containers.** This was the only one left in
+  `apps/web/scripts/`; worth a grep before the next layout change rather than after.


### PR DESCRIPTION
**Production is degraded right now.** SSG rebuilds have failed since #514 deployed. The site is up
and serving — that is the problem.

## What broke

The workspace move made both images build from the repository root, and `ssg-worker`'s WORKDIR moved
from `/app` to `/repo/apps/web`. `ssg-worker.mjs` had its directories written out absolutely:

```js
const SSG_DIR = '/app/dist/ssg';
const SSG_NEW_DIR = '/app/dist/ssg-new';
```

Every rebuild since fails at the first write:

```
[prerender] Found 1992 routes to prerender
[prerender stderr] Prerender failed: Error: EACCES: permission denied, mkdir '/app/dist/ssg-new'
    at main (file:///repo/apps/web/scripts/prerender.mjs:478:3)
Job 17fcbc80-6385-4e25-a561-d3c0f8759a48 failed with exit code 1
```

## Why it looked fine

`https://textstack.app/en` returned 200 with `x-seo-render: ssg` throughout, because the previous
output is still on disk and nginx is still serving it. The container reports `Up (healthy)` — its
healthcheck is `pgrep -f ssg-worker.mjs`, which asks whether the process exists, not whether it can
do its job.

Same shape as the [five-week SSG outage](../blob/main/docs/incidents/2026-08-11-ssg-dead-five-weeks.md):
stale output is indistinguishable from fresh output from outside. Caught in thirty minutes this time
only because the deploy was being watched step by step, and `Wait for SSG rebuild to complete` sat
there instead of finishing — the guard added after the wiped-rebuild incident doing its job.

## The fix

Derive from the script's own location, so it survives any layout:

```js
const DIST_DIR = join(__dirname, '..', 'dist');
const SSG_DIR = join(DIST_DIR, 'ssg');
```

`prerender.mjs`, in the same directory, already did exactly this and came through the move
untouched. The two scripts disagreed about how to find the same folder and only one was right.
No absolute `/app/` paths remain in `apps/web/scripts/`.

## Honestly: CI could not have caught this

#514 was green, `docker` job included. Building an image proves it builds. It does not run the
container against its volumes, and this needed three things together — the new WORKDIR, the compose
volume at its new mount point, and the stale absolute path. The e2e suite exercises the site, and
the site was correctly serving the old output.

The postmortem records the two follow-ups that would change that: the healthcheck answers the wrong
question, and there is still no SSG freshness alarm — the item `docs/STATUS.md` has carried since
the five-week outage, which would have caught all three of these.

## Verification

The module loads and reaches its own `DATABASE_URL` guard, so imports and paths resolve. The real
proof is the next deploy: watch `Wait for SSG rebuild to complete` finish rather than hang, and
`docker compose logs ssg-worker` for a job that completes.

## Rollback

Revert. Rebuilds go back to failing on a path that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F