### PR TITLE
fix(ci): the EAS workflows install from the workspace, so an OTA can publish

### DIFF
--- a/.github/workflows/mobile-ota.yml
+++ b/.github/workflows/mobile-ota.yml
@@ -75,24 +75,33 @@ jobs:
               ;;
           esac
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v7
         with:
           # Version comes from .nvmrc, the one place that declares it. It must
           # stay >= 22: eas-cli 23 pulls @oclif/plugin-autocomplete, which
           # declares engines.node >= 22 and will not install below it.
           node-version-file: .nvmrc
-          cache: npm
-          cache-dependency-path: apps/mobile/package-lock.json
+          cache: pnpm
 
       - uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      # @textstack/shared is consumed from source (Metro watchFolders), so the
-      # checkout already carries it; only the app's own deps need installing.
+      # One workspace, one lockfile — apps/mobile stopped having its own the day
+      # this repo became a pnpm workspace. `npm ci` kept looking for a
+      # package-lock.json that no longer exists, and setup-node failed before it
+      # even got there: "Some specified paths were not resolved, unable to cache
+      # dependencies." ci.yml's mobile job was converted at the time; these two
+      # were missed, so the first OTA after the move never published.
+      #
+      # Installs the whole workspace rather than this app alone: packages/shared
+      # is consumed from source and Metro resolves it through the workspace root.
       - name: Install dependencies
-        run: npm ci
+        working-directory: ${{ github.workspace }}
+        run: pnpm install --frozen-lockfile
 
       # MUST run from apps/mobile. From the repo root the command computes a
       # different hash and reports it as valid — see docs/03-ops/play-store-release.md.

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -61,24 +61,31 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v7
         with:
           # Version comes from .nvmrc, the one place that declares it. It must
           # stay >= 22: eas-cli 23 pulls @oclif/plugin-autocomplete, which
           # declares engines.node >= 22 and will not install below it.
           node-version-file: .nvmrc
-          cache: npm
-          cache-dependency-path: apps/mobile/package-lock.json
+          cache: pnpm
 
       - uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      # @textstack/shared is consumed from source (Metro watchFolders), so the repo
-      # checkout already carries it; only the app's own deps need installing.
+      # One workspace, one lockfile — apps/mobile stopped having its own the day
+      # this repo became a pnpm workspace, and `npm ci` kept looking for a
+      # package-lock.json that no longer exists. ci.yml's mobile job was
+      # converted at the time; this file and mobile-ota.yml were missed.
+      #
+      # Installs the whole workspace rather than this app alone: packages/shared
+      # is consumed from source and Metro resolves it through the workspace root.
       - name: Install dependencies
-        run: npm ci
+        working-directory: ${{ github.workspace }}
+        run: pnpm install --frozen-lockfile
 
       - name: OTA update
         if: ${{ inputs.action == 'ota-update' }}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -53,7 +53,6 @@
     "expo-notifications": "~55.0.19",
     "expo-router": "~55.0.8",
     "expo-secure-store": "~55.0.9",
-    "expo-speech": "~55.0.9",
     "expo-splash-screen": "~55.0.13",
     "expo-sqlite": "~55.0.11",
     "expo-status-bar": "~55.0.4",

--- a/apps/mobile/src/hooks/useTts.ts
+++ b/apps/mobile/src/hooks/useTts.ts
@@ -174,7 +174,7 @@ export function useTts() {
       const req = ++reqRef.current
 
       // Tear down any current playback before starting another download —
-      // bites the same race expo-speech.stop() handles, just made explicit.
+      // bites the same race a speech API's stop() handles, just made explicit.
       releasePlayer()
       currentTextRef.current = trimmed
       setPhase('loading')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       expo-secure-store:
         specifier: ~55.0.9
         version: 55.0.18(expo@55.0.31)
-      expo-speech:
-        specifier: ~55.0.9
-        version: 55.0.18(expo@55.0.31)
       expo-splash-screen:
         specifier: ~55.0.13
         version: 55.0.25(expo@55.0.31)(typescript@5.9.3)
@@ -3500,11 +3497,6 @@ packages:
   expo-server@55.0.12:
     resolution: {integrity: sha512-yuNHbxobUKCXWn9Z/H+lgYk6heXEFub6q1h8Yo9kCLxgL2afluWZ/YylbtxgHgmFwDVUmi6milQYfL+wwQMlzw==}
     engines: {node: '>=20.16.0'}
-
-  expo-speech@55.0.18:
-    resolution: {integrity: sha512-8Tsr2HYtFSxabYIpLitDbMGzSp2tZv5m1PqqrdqZHAvP7JEYt5F29oR+tlnJGA3lhfNDZwn+VumNHnfq9iVOxA==}
-    peerDependencies:
-      expo: '*'
 
   expo-splash-screen@55.0.25:
     resolution: {integrity: sha512-Jl3VPbNqbgGjXlkH93hi4Y4p6GB5DasLNbpL2Gb4kl8grujKaIGi4rXL25qYbYxIzefSlt96NqG9czanxxooPg==}
@@ -9245,10 +9237,6 @@ snapshots:
       expo: 55.0.31(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
 
   expo-server@55.0.12: {}
-
-  expo-speech@55.0.18(expo@55.0.31):
-    dependencies:
-      expo: 55.0.31(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
 
   expo-splash-screen@55.0.25(expo@55.0.31)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
**The first OTA after the workspace move never published.** #512 merged, the workflow fired, and it
failed before reaching any of its own logic:

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

`setup-node` choked on `cache-dependency-path: apps/mobile/package-lock.json` — a file #514 deleted
when the repo became a pnpm workspace — before `npm ci` even got its turn to fail for the same
reason.

`ci.yml`'s mobile job was converted to pnpm when the workspace landed. `mobile-ota.yml` and
`mobile-release.yml` were missed, so **the manual release path was broken too**, and nobody would
have found out until someone tried to ship a build.

Both now install the whole workspace rather than the app alone: `packages/shared` is consumed from
source and Metro resolves it through the workspace root.

## Also: dropped expo-speech

Dependabot offered `expo-speech 55.0.18 → 57.0.2` (#523), and its CI was **green** — which is
exactly the shape I flagged: `tsc` and the unit tests do not know what an SDK compatibility matrix
is. Merging it would have moved the runtime fingerprint and stopped every installed app from
receiving OTA updates.

Then it turned out the package is not used at all. The only mention left in the source is a comment
in `useTts.ts`, from before speech moved to `expo-audio`:

```
apps/mobile/src/hooks/useTts.ts:177: // bites the same race expo-speech.stop() handles
```

So rather than bumping a dependency nothing calls, or holding a PR forever, it is removed. That
shrinks the fingerprint surface instead of moving it. #523 can be closed.

## Verification

`tsc` clean, 203 mobile tests, and a **full Metro bundle** — the check that would notice if removing
a package broke resolution.

Not verified: the OTA actually publishing. That needs this merged, and then the workflow run to get
past `Install dependencies` and reach the runtime comparison, which was already proven working
(`Runtime e92c88a8… matching build aa4d265d…`).

## Rollback

Revert. The EAS workflows go back to failing at setup-node, and `expo-speech` returns unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F