### PR TITLE
chore(deps): raise the Microsoft.Extensions family past the downgrade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,13 +29,13 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
     <!-- Application Layer -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
     <!-- Authentication -->
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.74.0" />
@@ -84,12 +84,12 @@
     <PackageVersion Include="Dapper" Version="2.1.72" />
     <PackageVersion Include="Meilisearch" Version="0.16.0" />
     <!-- Hosting -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
     <!-- Image Optimization -->
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <!-- Worker -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
     <PackageVersion Include="VersOne.Epub" Version="3.3.6" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="PdfPig" Version="0.1.14" />


### PR DESCRIPTION
Two Dependabot PRs were failing on the same error, and neither of them was the cause:

```
#529  ModelContextProtocol 2.2.0 -> Microsoft.Extensions.Hosting.Abstractions (>= 10.0.10)
#524  Microsoft.Extensions.Http 10.0.11 -> ... Diagnostics 10.0.11
```

`NU1109`, detected package downgrade. `Directory.Packages.props` pinned the `Microsoft.Extensions.*`
family at `10.0.8`, so anything reaching for a newer one transitively could not restore.

Central package management is what made both PRs fail — and it is also why **one edit fixes both**.
That is the trade, visible from both sides in the same afternoon.

Ten pins raised to `10.0.11`. Deliberately **not** touching the AspNetCore or EntityFrameworkCore
pins still on `10.0.8`: different families, not implicated in either error, and moving them would
widen this past what was diagnosed. `Microsoft.Extensions.AI` stays on its own `10.6.0` line.

## Verification

`dotnet restore` clean, Release build succeeds, **886 unit tests pass**.

Once this lands, #524 and #529 should rebase green on their own.

## Rollback

Revert. Both Dependabot PRs go back to failing at restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F