### PR TITLE
chore(deps): migrate to JsonSchema.Net 9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,7 +55,7 @@
          TextStack.Ai.Mcp http transport branch. -->
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <!-- Tool-args validation (AI-030): real JSON Schema draft 2020-12 evaluation before dispatch -->
-    <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.4.0" />
     <!-- AI eval framework (MEAI.Evaluation). Stable 10.6.0 — IChatClient seam +
          IEvaluator/EvaluationMetric + Reporting (response cache, HTML report).
          Used by tests/TextStack.AiEvals; see docs/eval-migration.md. -->

--- a/backend/src/Ai/TextStack.Ai.Tools/ToolDispatcher.cs
+++ b/backend/src/Ai/TextStack.Ai.Tools/ToolDispatcher.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Json.Schema;
 using Microsoft.Extensions.DependencyInjection;
 using TextStack.Ai.Core;
@@ -29,6 +28,11 @@ public sealed record ToolResult(string CallId, string ToolName, bool Ok, JsonEle
 public sealed class ToolDispatcher(IToolRegistry registry)
 {
     private static readonly EvaluationOptions SchemaOptions = new() { OutputFormat = OutputFormat.List };
+
+    /// A JSON null to validate against when a call arrives with no arguments at
+    /// all. Held once: JsonDocument owns unmanaged memory, and parsing "null"
+    /// per call would allocate and leak a document on every tool invocation.
+    private static readonly JsonElement NullInstance = JsonDocument.Parse("null").RootElement;
 
     public async Task<ToolResult> DispatchAsync(ToolCall call, ToolContext ctx, CancellationToken ct)
     {
@@ -79,20 +83,26 @@ public sealed class ToolDispatcher(IToolRegistry registry)
             return $"tool schema is invalid: {ex.Message}"; // a wiring bug, surfaced loudly
         }
 
-        var node = args.ValueKind == JsonValueKind.Undefined ? null : JsonNode.Parse(args.GetRawText());
-        var evaluation = compiled.Evaluate(node, SchemaOptions);
+        // JsonSchema.Net 9 evaluates a JsonElement directly; 7 took a JsonNode,
+        // so this used to round-trip the arguments through JsonNode.Parse for no
+        // reason other than the old signature. A missing argument object still
+        // has to be validated as JSON null rather than skipped — a schema with
+        // required properties must fail, not pass, when the model sends nothing.
+        var instance = args.ValueKind == JsonValueKind.Undefined ? NullInstance : args;
+        var evaluation = compiled.Evaluate(instance, SchemaOptions);
         if (evaluation.IsValid)
             return null;
 
         var violations = evaluation.Details
-            .Where(d => d.HasErrors)
+            .Where(d => d.Errors is { Count: > 0 })
             .SelectMany(d => d.Errors!.Select(e => $"{Location(d)}: {e.Value}"))
             .Distinct()
             .Take(5)
             .ToList();
         return violations.Count > 0 ? string.Join("; ", violations) : "arguments do not match the tool schema";
 
+        // JsonSchema.Net 9 renamed JsonPointer.Count to SegmentCount.
         static string Location(EvaluationResults d) =>
-            d.InstanceLocation.Count == 0 ? "$" : d.InstanceLocation.ToString();
+            d.InstanceLocation.SegmentCount == 0 ? "$" : d.InstanceLocation.ToString();
     }
 }

--- a/tests/TextStack.UnitTests/ToolDispatcherTests.cs
+++ b/tests/TextStack.UnitTests/ToolDispatcherTests.cs
@@ -152,4 +152,29 @@ public class ToolDispatcherTests
         Assert.NotNull(error);
         Assert.Contains("text", error); // names the offending property/requirement
     }
+
+    [Fact]
+    public void ValidateArgs_NoArgumentsAtAll_StillFailsRequiredProperties()
+    {
+        // A model that calls a tool and sends no argument object at all. The
+        // default JsonElement is JsonValueKind.Undefined, and the tempting
+        // reading is "nothing to validate, so it passes" — which would let every
+        // required property through unchecked.
+        //
+        // Untested until the JsonSchema.Net 9 migration, which is when it
+        // mattered: 7 evaluated a JsonNode and 9 evaluates a JsonElement, so the
+        // undefined case had to be re-expressed rather than carried over.
+        //
+        // The complaint is a type mismatch at the root rather than the missing
+        // property, which is the more accurate thing to say — nothing was sent,
+        // so there is no object to be missing a property from. Asserting the
+        // exact text also pins the two other pieces of that migration: the "$"
+        // comes from JsonPointer.SegmentCount (renamed from Count in 9), and
+        // reaching the message at all goes through the Errors dictionary that
+        // replaced EvaluationResults.HasErrors.
+        var error = ToolDispatcher.ValidateArgs(EchoSchema, default);
+        Assert.NotNull(error);
+        Assert.Contains("but should be", error);
+        Assert.StartsWith("$:", error);
+    }
 }


### PR DESCRIPTION
Closes the work #526 was asking for. Three API changes, found by building against 9.4.0 and reading
the compiler rather than guessing at release notes:

| 7.3.4 | 9.4.0 |
|---|---|
| `Evaluate(JsonNode, …)` | `Evaluate(JsonElement, …)` |
| `EvaluationResults.HasErrors` | gone — check `Errors is { Count: > 0 }` |
| `JsonPointer.Count` | `SegmentCount` |

The `JsonElement` signature removes a `JsonNode.Parse` round-trip that only existed to satisfy the
old one — the arguments arrive as a `JsonElement` already.

A call carrying **no arguments at all** still has to be validated as JSON null rather than skipped: a
schema with required properties must fail when the model sends nothing. That is now an explicit
`JsonElement` holding null, parsed once and held, because `JsonDocument` owns unmanaged memory and
doing it per call would leak a document on every tool invocation.

## The one case worth a test

That case had none — and it is the only one of the three that had to be *re-expressed* rather than
renamed, so it is the only one where the migration could silently change behaviour.

It fails with:

```
$: Value is "null" but should be "object"
```

A type mismatch at the root rather than a missing property, which is the more accurate complaint —
nothing was sent, so there is no object to be missing a property from. My first assertion looked for
`"text"` and was simply wrong about what the library should say.

Asserting that exact string also pins the other two migrations: the `$` comes from `SegmentCount`,
and reaching the message at all goes through the `Errors` dictionary that replaced `HasErrors`.

## A trap worth recording

`dotnet test --no-build` after a package version change **runs the previous binaries**. It reported
886 passing here while the test assembly was still linked against JsonSchema.Net 7 — the DLL in
`bin/` was dated March. The real result only appeared after deleting `bin/obj`.

That is the same shape as three other things today: green from an artifact that was not the artifact
under test.

## Verification

Clean build. Release build succeeds, `dotnet format --verify-no-changes` clean, **1422 unit tests
pass** (1421 existing + the new one).

## Rollback

Revert. `Directory.Packages.props` goes back to JsonSchema.Net 7.3.4 and `ToolDispatcher` to the
`JsonNode` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F