### PR TITLE
feat(ssg): alarm when pages stop being regenerated

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -48,6 +48,46 @@ jobs:
           # map, so it says "you look like a bot", not "SSG was served".
           [ "$size" -gt 5000 ] || { echo "SSG page is only $size bytes — probably a 404"; exit 1; }
           printf '%s' "$body" | grep -q '<title>' || { echo "no <title> in the prerendered page"; exit 1; }
+      # Two ways SSG dies, and they need different patience.
+      #
+      # A failing rebuild is a malfunction whatever the cadence — the next one
+      # will not help either — so it alarms at once. Staleness alone needs a
+      # generous window: rebuilds here are deploy-driven, and the production
+      # history shows a healthy 19-hour gap between them on a quiet day. 72
+      # hours is well past anything normal and still catches the failure that
+      # actually happened, when nothing rebuilt for five weeks.
+      - name: SSG freshness
+        run: |
+          set -euo pipefail
+          body=$(curl -sf $CURL_RETRY https://textstack.app/api/health/ready)
+          ssg=$(printf '%s' "$body" | jq -c '.components.ssg // empty')
+          # Missing field means the API predates this check, which is the
+          # normal state for the ~40 minutes between merging it and the deploy
+          # finishing. Not an SSG problem, so not an alarm.
+          if [ -z "$ssg" ]; then
+            echo "::warning::readiness probe has no ssg component yet — API not redeployed"
+            exit 0
+          fi
+          echo "$ssg"
+
+          status=$(printf '%s' "$ssg" | jq -r '.status')
+          age=$(printf '%s' "$ssg" | jq -r '.ageHours // empty')
+          failed=$(printf '%s' "$ssg" | jq -r '.lastRunFailed // false')
+
+          if [ "$failed" = "true" ]; then
+            echo "::error::The most recent SSG rebuild failed. Pages go stale from here."
+            exit 1
+          fi
+          if [ "$status" = "unknown" ]; then
+            echo "::warning::No completed SSG rebuild on record."
+            exit 0
+          fi
+          # bash has no floats; compare whole hours.
+          if [ "${age%.*}" -ge 72 ]; then
+            echo "::error::Newest SSG rebuild is ${age}h old. Nothing has regenerated in three days."
+            exit 1
+          fi
+          echo "SSG last rebuilt ${age}h ago"
 
       - name: Smoke — book listing
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 ## [Unreleased]
 
 - **SSG** — a deploy that waited on a prompt stopped taking 1990 prerendered pages with it — infra · [incident](docs/incidents/2026-09-02-corepack-prompt-stranded-the-ssg.md)
+- **SSG** — something finally watches whether pages are being regenerated at all — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-02-ssg-something-watches)
 - **SSG** — rebuilds stopped failing on a path the workspace move invalidated, while the site looked fine — infra · [incident](docs/incidents/2026-09-01-ssg-worker-lost-its-output-path.md)
 - **CI** — dependencies refresh themselves weekly, and the lane that matters is the one that changes no versions at all — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-ci-dependencies-refresh-themselves)
 - **Security** — 125 dependency findings down to 3, none of them shipping, and something now watches — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-security-125-findings-down-to-3)

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -173,6 +173,50 @@ app.MapGet("/health/ready", async (AppDbContext db, IHttpClientFactory httpFacto
         components["ollama"] = new { status = "degraded" };
     }
 
+    // SSG: the one thing about this site that breaks invisibly.
+    //
+    // Three incidents in three weeks — a five-week outage, a rebuild promoted
+    // after losing its files, and rebuilds failing on a path that had moved —
+    // and in every one of them the site answered 200, the containers were
+    // healthy, and readers saw nothing, because humans get the SPA and it
+    // renders fine. Each was found by a person eventually noticing.
+    //
+    // Reported, never fatal: stale pages are an SEO problem, not a reason to
+    // fail a probe that gates traffic. The alarm lives in health-check.yml,
+    // which reads this.
+    try
+    {
+        var newest = await db.SsgRebuildJobs
+            .Where(j => j.Status == SsgRebuildJobStatus.Completed && j.FinishedAt != null)
+            .OrderByDescending(j => j.FinishedAt)
+            .Select(j => j.FinishedAt)
+            .FirstOrDefaultAsync(ct);
+
+        // A run that is currently failing matters sooner than one that is
+        // merely old: rebuilds here are deploy-driven, so a quiet day can
+        // legitimately leave the newest one 19 hours behind — measured, not
+        // guessed — while a failure means the next one will not help either.
+        var lastFailed = await db.SsgRebuildJobs
+            .Where(j => j.FinishedAt != null)
+            .OrderByDescending(j => j.FinishedAt)
+            .Select(j => j.Status)
+            .FirstOrDefaultAsync(ct) == SsgRebuildJobStatus.Failed;
+
+        components["ssg"] = newest is null
+            ? new { status = "unknown", lastSuccessAt = (DateTimeOffset?)null, ageHours = (double?)null, lastRunFailed = lastFailed }
+            : new
+            {
+                status = lastFailed ? "degraded" : "ok",
+                lastSuccessAt = newest,
+                ageHours = Math.Round((DateTimeOffset.UtcNow - newest.Value).TotalHours, 1),
+                lastRunFailed = lastFailed,
+            };
+    }
+    catch (Exception ex)
+    {
+        components["ssg"] = new { status = "unknown", error = ex.GetType().Name };
+    }
+
     var elapsed = DateTimeOffset.UtcNow - started;
     var payload = new
     {

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -98,6 +98,36 @@ available for months. Alerts are a repo setting and still need turning on by han
 Actions whose majors move silently. It notes its own limitation: Dependabot understands `catalog:`
 poorly, so `pnpm audit` from the root stays the check that sees everything.
 
+<a id="2026-09-02-ssg-something-watches"></a>
+
+## SSG — something finally watches whether pages are being regenerated — infra — 2026-09-02
+
+`docs/STATUS.md` has carried this line since 2026-08-11: *"No SSG freshness alarm. The five-week
+outage was found by a screenshot. Nothing yet alerts on 'newest generated page is older than N
+hours' — the single change that would have caught it on day one."*
+
+Three incidents later it is the single change that would have caught all three. It exists now.
+
+`/health/ready` already reported per-component status for ops, so `ssg` joins `db`, `storage` and
+`ollama` there: when the last rebuild succeeded, how many hours ago, and whether the most recent run
+failed. Reported, never fatal — stale pages are an SEO problem, not a reason to fail a probe that
+gates traffic. The judgement lives in `health-check.yml`, which runs every five minutes and already
+had somewhere to put it.
+
+**Two failure modes, two patiences.** A *failing* rebuild is a malfunction whatever the cadence —
+the next one will not help either — so it alarms at once. *Staleness alone* needs a generous window,
+because rebuilds here are deploy-driven rather than scheduled. The threshold is not a guess:
+production history shows a healthy 19-hour gap between rebuilds on a quiet day, so 72 hours sits
+well past anything normal and still catches nothing-for-five-weeks.
+
+Exercised against all five real shapes before shipping — healthy, the measured 19-hour quiet day,
+yesterday's failing run, a five-week outage, and a fresh install with no rebuilds on record. The
+quiet day is the one that matters most: an alarm that cries on a normal Sunday gets muted, and then
+it is not an alarm.
+
+A missing `ssg` field is treated as "the API predates this check" and warns rather than fails, which
+is the normal state for the forty minutes between merging it and the deploy finishing.
+
 <a id="2026-09-01-infra-one-workspace-one-catalog"></a>
 
 ## Infra — one workspace, one catalog — infra — 2026-09-01


### PR DESCRIPTION
`docs/STATUS.md` has carried this line since **2026-08-11**:

> No SSG freshness alarm. The five-week outage was found by a screenshot. Nothing yet alerts on
> "newest generated page is older than N hours" — the single change that would have caught it on
> day one.

Three incidents later it is the single change that would have caught **all three**. It exists now.

## Where it lives

`/health/ready` already reported per-component status for ops, so `ssg` joins `db`, `storage` and
`ollama`: when the last rebuild succeeded, its age in hours, and whether the most recent run failed.

Reported, **never fatal** — stale pages are an SEO problem, not a reason to fail a probe that gates
traffic. The judgement lives in `health-check.yml`, which runs every five minutes and already had
somewhere to put it.

## Two failure modes, two patiences

A **failing** rebuild is a malfunction whatever the cadence — the next one will not help either — so
it alarms at once. That is yesterday's incident.

**Staleness alone** needs a generous window, because rebuilds here are deploy-driven rather than
scheduled. The threshold is not a guess. Production history:

```
2026-09-01 17:00   ← 19 hours after the previous one, on a perfectly healthy day
2026-08-31 22:00
```

So 72 hours sits well past anything normal and still catches nothing-for-five-weeks.

## Exercised against every real shape

```
healthy 1.7h            -> ok, 1.7h ago            exit=0
quiet day 19h           -> ok, 19.0h ago           exit=0   ← the measured gap
yesterday: failing run  -> ERROR: last rebuild failed   exit=1
five-week outage 840h   -> ERROR: 840.0h old       exit=1
fresh install           -> warn: no rebuild on record   exit=0
```

The quiet day is the one that matters most. An alarm that cries on a normal Sunday gets muted, and
then it is not an alarm.

A missing `ssg` field is treated as "the API predates this check" and warns rather than fails —
which is the normal state for the forty minutes between merging this and the deploy finishing.

## Verification

Release build, `dotnet format` clean, 1422 unit tests. The alarm logic exercised against the five
shapes above. Live behaviour needs the deploy: the field appears once the API restarts, and the next
health-check run reads it.

## Rollback

Revert. `/health/ready` loses the `ssg` component and the health check stops asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F