### PR TITLE
feat(ssg): a worker that fails every job stops calling itself healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 - **SSG** — a deploy that waited on a prompt stopped taking 1990 prerendered pages with it — infra · [incident](docs/incidents/2026-09-02-corepack-prompt-stranded-the-ssg.md)
 - **SSG** — something finally watches whether pages are being regenerated at all — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-02-ssg-something-watches)
+- **SSG** — a worker that fails every job stops calling itself healthy — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-02-ssg-worker-honest-health)
 - **SSG** — rebuilds stopped failing on a path the workspace move invalidated, while the site looked fine — infra · [incident](docs/incidents/2026-09-01-ssg-worker-lost-its-output-path.md)
 - **CI** — dependencies refresh themselves weekly, and the lane that matters is the one that changes no versions at all — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-ci-dependencies-refresh-themselves)
 - **Security** — 125 dependency findings down to 3, none of them shipping, and something now watches — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-01-security-125-findings-down-to-3)

--- a/apps/web/scripts/ssg-worker.mjs
+++ b/apps/web/scripts/ssg-worker.mjs
@@ -102,9 +102,27 @@ async function updateJobProgress(jobId, rendered, failed) {
 }
 
 /**
- * Set job status
+ * Set job status.
+ *
+ * Also records the outcome next to the heartbeat, because the heartbeat alone
+ * says the wrong thing. The container healthcheck used to ask only whether this
+ * loop was still ticking, so a worker that had failed every job for an hour
+ * reported `Up (healthy)` — which is exactly what `docker compose ps` showed
+ * while every rebuild died on EACCES and the site served stale pages to
+ * crawlers. A process that is running and getting nothing done is not healthy.
+ *
+ * Written here rather than at the call sites: this is the one funnel every
+ * outcome passes through, including the catch, so a new code path cannot forget.
  */
+const LAST_JOB_FILE = '/tmp/ssg-worker-last-job';
+
 async function setJobStatus(jobId, status, error = null) {
+  try {
+    writeFileSync(LAST_JOB_FILE, status);
+  } catch {
+    // Never let the marker stop the job from being recorded in the database,
+    // which is the part that matters.
+  }
   if (error) {
     await pool.query(
       `UPDATE ssg_rebuild_jobs SET status = $1, error = $2, finished_at = NOW() WHERE id = $3`,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,8 +253,18 @@ services:
       - ./apps/web/dist:/repo/apps/web/dist
     restart: always
     healthcheck:
-      # ssg-worker.mjs writes /tmp/ssg-worker-alive every 30s.
-      test: ["CMD-SHELL", "find /tmp/ssg-worker-alive -mmin -2 | grep -q ."]
+      # Two questions, because the first one alone gave the wrong answer.
+      #
+      # ssg-worker.mjs writes /tmp/ssg-worker-alive every 30s — that is
+      # liveness, and it is all this used to ask. So a worker that had failed
+      # every rebuild for an hour reported "Up (healthy)", which is what
+      # `docker compose ps` said while crawlers were being served stale pages.
+      # A process that is running and getting nothing done is not healthy.
+      #
+      # The second file holds the outcome of the last job, written by
+      # setJobStatus. Absent means nothing has run yet, which is fine on a
+      # fresh container and must not read as failure.
+      test: ["CMD-SHELL", "find /tmp/ssg-worker-alive -mmin -2 | grep -q . && { [ ! -f /tmp/ssg-worker-last-job ] || [ \"$$(cat /tmp/ssg-worker-last-job)\" != Failed ]; }"]
       interval: 60s
       timeout: 5s
       retries: 3

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -127,6 +127,30 @@ it is not an alarm.
 
 A missing `ssg` field is treated as "the API predates this check" and warns rather than fails, which
 is the normal state for the forty minutes between merging it and the deploy finishing.
+<a id="2026-09-02-ssg-worker-honest-health"></a>
+
+## SSG — a worker that fails every job stops calling itself healthy — infra — 2026-09-02
+
+`docker compose ps` said `ssg-worker Up 7 hours (healthy)` while every rebuild it attempted died on
+`EACCES` and the site served pages nobody had regenerated. That is not a lie the container told; it
+is the question the healthcheck asked. It looked for a heartbeat file the poll loop touches every
+30 seconds — liveness, and nothing else. A process that is running and getting nothing done answered
+yes.
+
+The loop now records the outcome of each job beside the heartbeat, and the healthcheck wants both:
+recent heartbeat **and** a last job that did not fail. Written inside `setJobStatus`, the one funnel
+every outcome passes through including the `catch`, so a future code path cannot forget to.
+
+An absent marker means nothing has run yet. That is the normal state of a fresh container and must
+not read as failure — it is the case worth getting right, because getting it wrong makes every
+deploy look broken for the first few minutes and teaches everyone to ignore the signal.
+
+All four states exercised before shipping: fresh container, last job completed, last job failed,
+and heartbeat gone stale.
+
+Nothing depends on this container being healthy, so the change is informational rather than
+operational — which is the point. `docker compose ps` was the first place I looked during the
+incident, and it was reassuring.
 
 <a id="2026-09-01-infra-one-workspace-one-catalog"></a>
 


### PR DESCRIPTION
During yesterday's incident, `docker compose ps` said:

```
ssg-worker    Up 7 hours (healthy)
```

while every rebuild it attempted died on `EACCES` and the site served pages nobody had regenerated.

That is not a lie the container told. It is the question the healthcheck asked: it looked for a
heartbeat file the poll loop touches every 30 seconds — liveness, and nothing else. **A process that
is running and getting nothing done answered yes.**

`docker compose ps` was the first place I looked, and it was reassuring.

## The change

The loop records each job's outcome beside the heartbeat, and the check now wants both: a recent
heartbeat **and** a last job that did not fail.

Written inside `setJobStatus` — the one funnel every outcome passes through, including the `catch`
— so a future code path cannot forget to.

## The case worth getting right

An absent marker means nothing has run yet. That is the normal state of a fresh container and must
not read as failure; otherwise every deploy looks broken for its first few minutes and everyone
learns to ignore the signal.

All four states exercised:

```
fresh container, no jobs yet:      healthy
running, last job Completed:       healthy
running, last job Failed:          UNHEALTHY
process wedged (no heartbeat):     UNHEALTHY
```

## Scope

Nothing `depends_on` this container being healthy, so the change is **informational rather than
operational** — it does not gate traffic or trigger restarts. That is deliberate: restarting a
worker will not fix a path bug, and the value here is that the status line stops being reassuring
when it should not be.

## Rollback

Revert. The healthcheck goes back to reporting liveness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkGcwmi1fuGCBLmGwdEZ1F