### PR TITLE
feat(mobile): the app says which build it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Profile** — the app says which build it is, and whether the JS came from the store or arrived after — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-which-build-is-this)
 - **SSG** — a deploy that waited on a prompt stopped taking 1990 prerendered pages with it — infra · [incident](docs/incidents/2026-09-02-corepack-prompt-stranded-the-ssg.md)
 - **SSG** — something finally watches whether pages are being regenerated at all — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-02-ssg-something-watches)
 - **SSG** — a worker that fails every job stops calling itself healthy — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-02-ssg-worker-honest-health)

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity, TextInput, Alert, ActivityIndicator, ScrollView, Linking } from 'react-native'
+import { View, Text, StyleSheet, TouchableOpacity, TextInput, Alert, ActivityIndicator, ScrollView, Linking, Platform } from 'react-native'
 import { useRouter } from 'expo-router'
 import { Image } from 'expo-image'
 import { Ionicons } from '@expo/vector-icons'
+import Constants from 'expo-constants'
+import * as Updates from 'expo-updates'
 
 type IoniconsName = React.ComponentProps<typeof Ionicons>['name']
 // Lazy-loaded — requires native build
@@ -19,7 +21,43 @@ import { StorageQuotaRow } from '../../src/components/library/StorageQuotaRow'
 import { authApi, getStorageUrl, getAnonymousReader } from '@textstack/shared'
 import { deleteAccount } from '../../src/lib/api'
 import { getAnonAvatarSource } from '../../src/lib/anonAvatarSource'
+import { versionLine, updateLine } from '../../src/lib/buildInfo'
 import { fonts } from '../../src/theme/typography'
+
+// Read once at module load: none of it changes while the app is running, and
+// Updates.* is a native constant rather than something to re-read.
+//
+// `versionCode` is written by EAS at build time (eas.json autoIncrement), so it
+// is present in the manifest the APK ships with and absent from one published
+// by `eas update`. That is the honest behaviour rather than a gap: running the
+// embedded bundle, the number is the build you installed; running an OTA, there
+// is no build number to state and the second line says an update is applied.
+// Reading the installed APK directly would need expo-application, a native
+// module — which would move the runtime fingerprint and make this very change
+// require a store build to arrive.
+const BUILD = {
+  version: Constants.expoConfig?.version,
+  versionCode: Constants.expoConfig?.android?.versionCode,
+  // expo-updates' web shim hardcodes isEnabled: true and isEmbeddedLaunch:
+  // false, so on web the pair reads as "an update is applied" when no update
+  // mechanism exists at all. Web is a dev preview and the e2e harness here,
+  // never a shipped target — say so rather than let the shim answer.
+  updatesEnabled: Platform.OS !== 'web' && Updates.isEnabled,
+  isEmbeddedLaunch: Updates.isEmbeddedLaunch,
+  updateCreatedAt: Updates.createdAt,
+}
+
+// Shown on both branches of this screen. A tester who cannot sign in is exactly
+// the person who needs to report which build they are on.
+function BuildFooter() {
+  const { colors } = useTheme()
+  return (
+    <View style={styles.buildInfo}>
+      <Text style={[styles.buildText, { color: colors.textSecondary }]}>{versionLine(BUILD)}</Text>
+      <Text style={[styles.buildText, { color: colors.textSecondary }]}>{updateLine(BUILD)}</Text>
+    </View>
+  )
+}
 
 const MENU_ITEMS = [
   { label: 'Reading Stats', icon: 'stats-chart-outline' as const, route: '/stats/' },
@@ -179,6 +217,7 @@ export default function ProfileScreen() {
         >
           <Text style={styles.loginText}>Sign In</Text>
         </TouchableOpacity>
+        <BuildFooter />
       </View>
     )
   }
@@ -380,6 +419,12 @@ export default function ProfileScreen() {
             </TouchableOpacity>
           </View>
         )}
+
+        {/* Which build this is. A tester could not tell from inside the app
+            whether they were holding the fixed version — and the two things
+            that can lag differ: the native build only Play can replace, the JS
+            bundle arrives on its own. */}
+        <BuildFooter />
       </View>
 
       <LanguagePickerModal
@@ -483,4 +528,6 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   dangerHint: { fontFamily: fonts.sans, fontSize: 12, marginTop: 2 },
+  buildInfo: { alignItems: 'center', marginTop: 32, marginBottom: 8, gap: 2 },
+  buildText: { fontFamily: fonts.sans, fontSize: 11 },
 })

--- a/apps/mobile/src/lib/buildInfo.test.ts
+++ b/apps/mobile/src/lib/buildInfo.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { versionLine, updateLine } from './buildInfo'
+
+const embedded = { updatesEnabled: true, isEmbeddedLaunch: true }
+
+describe('versionLine', () => {
+  it('names the version and the build', () => {
+    expect(versionLine({ ...embedded, version: '1.0.0', versionCode: 24 })).toBe('TextStack 1.0.0 (24)')
+  })
+
+  it('drops the parenthetical when no build number is known', () => {
+    // The local dev client and Expo Go both get here: versionCode is written
+    // by EAS at build time and simply is not present otherwise.
+    expect(versionLine({ ...embedded, version: '1.0.0' })).toBe('TextStack 1.0.0')
+    expect(versionLine({ ...embedded, version: '1.0.0', versionCode: null })).toBe('TextStack 1.0.0')
+  })
+
+  it('says nothing it cannot back up', () => {
+    // Better a bare name than "TextStack undefined", which reads as a bug in
+    // the screen rather than as a missing value.
+    expect(versionLine({ ...embedded })).toBe('TextStack')
+    expect(versionLine({ ...embedded, version: '  ' })).toBe('TextStack')
+  })
+})
+
+describe('updateLine', () => {
+  it('distinguishes the shipped bundle from one that arrived later', () => {
+    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: true })).toBe('Bundled with the app')
+    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: false, updateCreatedAt: new Date('2026-09-02T07:04:00Z') }))
+      .toBe('Updated 2 Sep 2026')
+  })
+
+  it('still reports an update whose date is missing or unusable', () => {
+    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: false })).toBe('Updated over the air')
+    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: false, updateCreatedAt: null }))
+      .toBe('Updated over the air')
+    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: false, updateCreatedAt: new Date('nonsense') }))
+      .toBe('Updated over the air')
+  })
+
+  it('does not call a dev client an over-the-air update', () => {
+    // expo-updates reports isEmbeddedLaunch: false when it is not running at
+    // all — on web, in Expo Go and in a dev client. Caught by looking at the
+    // rendered screen, which claimed "Updated over the air" in dev.
+    expect(updateLine({ updatesEnabled: false, isEmbeddedLaunch: false })).toBe('Development build')
+    expect(updateLine({ updatesEnabled: false, isEmbeddedLaunch: true })).toBe('Development build')
+  })
+})

--- a/apps/mobile/src/lib/buildInfo.ts
+++ b/apps/mobile/src/lib/buildInfo.ts
@@ -1,0 +1,53 @@
+// Which build is this?
+//
+// The app could not answer that from inside itself. The store shows a
+// versionCode, the app showed nothing, and an OTA replaces the JS without
+// moving either number — so "is the fix in the copy I am holding?" had no
+// answer that did not involve Play Console.
+//
+// Two lines, because there are two things that can be out of date: the native
+// build, which only Play can replace, and the JS bundle, which arrives on its
+// own. A tester needs to tell them apart; the day this was written was spent
+// on exactly that distinction.
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+export type BuildInfo = {
+  version?: string | null
+  /** Android versionCode of the build the JS was published from. */
+  versionCode?: number | string | null
+  /** False in a dev client, Expo Go and on web, where no update can exist. */
+  updatesEnabled: boolean
+  /** True when running the bundle shipped inside the APK, false after an OTA. */
+  isEmbeddedLaunch: boolean
+  updateCreatedAt?: Date | null
+}
+
+/** `TextStack 1.0.0 (24)`, or without the parenthetical when no build number is known. */
+export function versionLine(info: BuildInfo): string {
+  const version = info.version?.trim()
+  if (!version) return 'TextStack'
+  // 0 is not a versionCode any build carries, so falsy is the right test:
+  // a missing value and a zero both mean "nothing to show here".
+  const code = info.versionCode
+  return code ? `TextStack ${version} (${code})` : `TextStack ${version}`
+}
+
+/** What produced the JS currently running. */
+export function updateLine(info: BuildInfo): string {
+  // Without expo-updates running there is no embedded-vs-OTA distinction to
+  // draw, and `isEmbeddedLaunch` is false — which would otherwise be read as
+  // "an update is applied" on a dev client, where none can be.
+  if (!info.updatesEnabled) return 'Development build'
+  if (info.isEmbeddedLaunch) return 'Bundled with the app'
+  const at = info.updateCreatedAt
+  // An update with no date is still an update, and saying so beats claiming
+  // the bundle is the embedded one.
+  if (!at || Number.isNaN(at.getTime())) return 'Updated over the air'
+  // Spelled out by hand rather than through toLocaleDateString. Hermes ships
+  // without full ICU unless the build opts in, so the platform formatter is
+  // not dependable here — and even where it works it drifts with the ICU
+  // version ('Sep' vs 'Sept'). This is a diagnostic read back over chat; it
+  // should look the same on every device.
+  return `Updated ${at.getDate()} ${MONTHS[at.getMonth()]} ${at.getFullYear()}`
+}

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,56 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-02-profile-which-build-is-this"></a>
+
+## Profile — which build is this — mobile — 2026-09-02
+
+Two quiet lines at the bottom of Profile:
+
+```
+TextStack 1.0.0 (24)
+Bundled with the app
+```
+
+The app could not answer "which build am I holding" from inside itself. Play Console shows a
+versionCode; the app showed nothing. That gap cost real time the day a tester was asked to confirm
+a fix and the only way to check was to open the store listing.
+
+The second line exists because there are **two** things that can be out of date, and they fail
+differently. The native build is replaced only through Play. The JS bundle arrives on its own over
+the air — and when the runtime fingerprint moves, it stops arriving with no visible sign. A tester
+reporting "still broken" needs to say which of those they are on, and now can.
+
+### What the render check found that the types did not
+
+Written, typechecked clean, tests green — and then two defects, both found only by looking at the
+screen:
+
+- **The signed-out branch is a separate early return**, and the footer was not in it. The person who
+  cannot sign in is precisely the one who needs to report their build number.
+- **It called a dev client an over-the-air update.** `Updates.isEmbeddedLaunch` is `false` when
+  expo-updates is not running at all, which reads as "an update is applied" in the one context where
+  none can be. Gated on `Updates.isEnabled` — and then on `Platform.OS` too, because the web shim
+  hardcodes `isEnabled = true` and `isEmbeddedLaunch = false`, so on web the pair asserts an update
+  that cannot exist. Web is the dev preview and the e2e harness here, never a shipped target.
+
+### Two decisions worth stating
+
+**No `expo-application`.** It reads the versionCode from the installed APK, which is strictly more
+correct than the manifest. It is also a native module, so adding it would move the runtime
+fingerprint — and a change whose entire purpose is telling testers what they have would have needed
+a store build to reach them. The manifest value is honest instead of merely available: EAS writes
+`versionCode` at build time, so it is present in the bundle shipped inside the APK and absent from
+one published by `eas update`. Running embedded, the number is the build you installed. Running an
+OTA, there is no build number to state and the second line says so.
+
+**The date is formatted by hand.** Hermes ships without full ICU unless the build opts in, and
+`toLocaleDateString('en-GB', …)` drifts with the ICU version — `2 Sep 2026` on one machine,
+`2 Sept 2026` on another. This string gets read back over chat; it should be the same everywhere.
+
+Logic in `apps/mobile/src/lib/buildInfo.ts` with six tests, following the same shape as
+`ttsRequest.ts`: the decision is a pure function, the screen only renders it.
+
 <a id="2026-09-01-ci-dependencies-refresh-themselves"></a>
 
 ## CI — dependencies refresh themselves weekly — infra — 2026-09-01


### PR DESCRIPTION
Two quiet lines at the bottom of Profile:

```
TextStack 1.0.0 (24)
Bundled with the app
```

The app could not answer "which build am I holding" from inside itself — Play Console shows a versionCode, the app showed nothing. Confirming a fix with a tester meant opening the store listing.

The second line is the useful half. **Two things can be out of date and they fail differently:** the native build, which only Play replaces, and the JS bundle, which arrives over the air on its own — and silently stops arriving when the runtime fingerprint moves. "Still broken" needs to say which one you are on.

### What opening the screen found

Typecheck and tests were green before the screen was ever rendered, and rendering it found two defects:

- **The signed-out branch is a separate early return** and had no footer. That is the person who most needs to report a build number.
- **It called a dev client an over-the-air update.** `isEmbeddedLaunch` is `false` when expo-updates is not running at all. Now gated on `Updates.isEnabled`, and on `Platform.OS` as well — the web shim hardcodes `isEnabled = true` and `isEmbeddedLaunch = false`, so on web the pair asserts an update that cannot exist.

### Two deliberate choices

**No `expo-application`,** though it reads the installed APK and the manifest does not. It is a native module, so it would move the runtime fingerprint — and a change that exists to tell testers what they have would then need a store build to reach them. The manifest value is honest rather than merely available: EAS writes `versionCode` at build time, so it is present in the embedded bundle and absent after an OTA, where the second line carries the information instead.

**The date is formatted by hand.** Hermes ships without full ICU unless the build opts in, and `en-GB` yields `2 Sep` or `2 Sept` depending on ICU version. This string gets read back over chat.

Logic in `apps/mobile/src/lib/buildInfo.ts`, six tests, same shape as `ttsRequest.ts` — the decision is a pure function, the screen only renders it. 209 mobile tests pass.

This is JS-only, so it should reach build 24 as an OTA — which also makes it the first real delivery through that path since the fingerprint was realigned.