### PR TITLE
feat(mobile): put the build on the About row, and keep it after an update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Profile** — the build number sits on the About row and survives an update, because it comes from the installed package — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-the-build-number-survives-an-update)
 - **Profile** — the app says which build it is, and whether the JS came from the store or arrived after — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-which-build-is-this)
 - **SSG** — a deploy that waited on a prompt stopped taking 1990 prerendered pages with it — infra · [incident](docs/incidents/2026-09-02-corepack-prompt-stranded-the-ssg.md)
 - **SSG** — something finally watches whether pages are being regenerated at all — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-02-ssg-something-watches)

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -5,6 +5,7 @@ import { Image } from 'expo-image'
 import { Ionicons } from '@expo/vector-icons'
 import Constants from 'expo-constants'
 import * as Updates from 'expo-updates'
+import * as Application from 'expo-application'
 
 type IoniconsName = React.ComponentProps<typeof Ionicons>['name']
 // Lazy-loaded — requires native build
@@ -27,21 +28,23 @@ import { fonts } from '../../src/theme/typography'
 // Read once at module load: none of it changes while the app is running, and
 // Updates.* is a native constant rather than something to re-read.
 //
-// `versionCode` is written by EAS at build time (eas.json autoIncrement), so it
-// is present in the manifest the APK ships with and absent from one published
-// by `eas update`. That is the honest behaviour rather than a gap: running the
-// embedded bundle, the number is the build you installed; running an OTA, there
-// is no build number to state and the second line says an update is applied.
-// Reading the installed APK directly would need expo-application, a native
-// module — which would move the runtime fingerprint and make this very change
-// require a store build to arrive.
+// The version and build number come from the installed package, not from the
+// manifest. The manifest carries the versionCode EAS wrote at build time, and an
+// update published by `eas update` has none — so after any OTA the number would
+// simply vanish, exactly when someone is trying to report which build they hold.
+//
+// expo-application is a native module, and one that already ships here:
+// expo-notifications depends on it, so it is compiled into the APK already.
+// Measured before and after adding it as a direct dependency and the runtime
+// fingerprint is 1065515f… both ways, so this still travels as an OTA.
 const BUILD = {
-  version: Constants.expoConfig?.version,
-  versionCode: Constants.expoConfig?.android?.versionCode,
+  version: Application.nativeApplicationVersion ?? Constants.expoConfig?.version,
+  versionCode: Application.nativeBuildVersion,
   // expo-updates' web shim hardcodes isEnabled: true and isEmbeddedLaunch:
   // false, so on web the pair reads as "an update is applied" when no update
   // mechanism exists at all. Web is a dev preview and the e2e harness here,
   // never a shipped target — say so rather than let the shim answer.
+  isDev: __DEV__,
   updatesEnabled: Platform.OS !== 'web' && Updates.isEnabled,
   isEmbeddedLaunch: Updates.isEmbeddedLaunch,
   updateCreatedAt: Updates.createdAt,
@@ -360,7 +363,7 @@ export default function ProfileScreen() {
 
         {/* Info pages */}
         {([
-          { label: 'About', icon: 'information-circle-outline' as const, route: '/about' },
+          { label: 'About', icon: 'information-circle-outline' as const, route: '/about', value: versionLine(BUILD, { short: true }) },
           { label: 'Privacy', icon: 'shield-outline' as const, route: '/privacy' },
           { label: 'Terms', icon: 'document-text-outline' as const, route: '/terms' },
           // Users upload their own books from this app, so rights holders need a
@@ -368,7 +371,7 @@ export default function ProfileScreen() {
           // web page, hence the external link rather than a route.
           { label: 'Copyright / DMCA', icon: 'alert-circle-outline' as const, url: 'https://textstack.app/dmca' },
           { label: 'Contact', icon: 'mail-outline' as const, route: '/contact' },
-        ] as { label: string; icon: IoniconsName; route?: string; url?: string }[]).map(item => (
+        ] as { label: string; icon: IoniconsName; route?: string; url?: string; value?: string }[]).map(item => (
           <TouchableOpacity
             key={item.route ?? item.url}
             style={[styles.menuItem, { borderBottomColor: colors.border }]}
@@ -377,6 +380,9 @@ export default function ProfileScreen() {
           >
             <Ionicons name={item.icon} size={20} color={colors.textSecondary} style={styles.menuIcon} />
             <Text style={[styles.menuText, { color: colors.text }]}>{item.label}</Text>
+            {item.value ? (
+              <Text style={[styles.menuValue, { color: colors.textSecondary }]}>{item.value}</Text>
+            ) : null}
             <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
           </TouchableOpacity>
         ))}
@@ -488,6 +494,7 @@ const styles = StyleSheet.create({
   },
   menuIcon: { marginRight: 12 },
   menuText: { flex: 1, fontFamily: fonts.sans, fontSize: 16 },
+  menuValue: { fontFamily: fonts.sans, fontSize: 14, marginRight: 8 },
   sectionLabel: { fontFamily: fonts.sansMedium, fontSize: 12, textTransform: 'uppercase', letterSpacing: 1, marginTop: 20, marginBottom: 4 },
   avatarBadge: {
     position: 'absolute',

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -36,6 +36,7 @@
     "@sentry/react-native": "^8.23.0",
     "expo": "~55.0.9",
     "expo-apple-authentication": "~55.0.9",
+    "expo-application": "~55.0.19",
     "expo-asset": "^55.0.10",
     "expo-audio": "~55.0.14",
     "expo-build-properties": "~55.0.17",

--- a/apps/mobile/src/lib/buildInfo.test.ts
+++ b/apps/mobile/src/lib/buildInfo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { versionLine, updateLine } from './buildInfo'
 
-const embedded = { updatesEnabled: true, isEmbeddedLaunch: true }
+const embedded = { isDev: false, updatesEnabled: true, isEmbeddedLaunch: true }
 
 describe('versionLine', () => {
   it('names the version and the build', () => {
@@ -15,6 +15,13 @@ describe('versionLine', () => {
     expect(versionLine({ ...embedded, version: '1.0.0', versionCode: null })).toBe('TextStack 1.0.0')
   })
 
+  it('drops the app name for the About row, which already names the app', () => {
+    expect(versionLine({ ...embedded, version: '1.0.0', versionCode: 24 }, { short: true })).toBe('1.0.0 (24)')
+    expect(versionLine({ ...embedded, version: '1.0.0' }, { short: true })).toBe('1.0.0')
+    // A row with a label and an empty value beside it reads as a broken row.
+    expect(versionLine({ ...embedded }, { short: true })).toBe('—')
+  })
+
   it('says nothing it cannot back up', () => {
     // Better a bare name than "TextStack undefined", which reads as a bug in
     // the screen rather than as a missing value.
@@ -25,16 +32,16 @@ describe('versionLine', () => {
 
 describe('updateLine', () => {
   it('distinguishes the shipped bundle from one that arrived later', () => {
-    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: true })).toBe('Bundled with the app')
-    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: false, updateCreatedAt: new Date('2026-09-02T07:04:00Z') }))
+    expect(updateLine({ isDev: false, updatesEnabled: true, isEmbeddedLaunch: true })).toBe('Bundled with the app')
+    expect(updateLine({ isDev: false, updatesEnabled: true, isEmbeddedLaunch: false, updateCreatedAt: new Date('2026-09-02T07:04:00Z') }))
       .toBe('Updated 2 Sep 2026')
   })
 
   it('still reports an update whose date is missing or unusable', () => {
-    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: false })).toBe('Updated over the air')
-    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: false, updateCreatedAt: null }))
+    expect(updateLine({ isDev: false, updatesEnabled: true, isEmbeddedLaunch: false })).toBe('Updated over the air')
+    expect(updateLine({ isDev: false, updatesEnabled: true, isEmbeddedLaunch: false, updateCreatedAt: null }))
       .toBe('Updated over the air')
-    expect(updateLine({ updatesEnabled: true, isEmbeddedLaunch: false, updateCreatedAt: new Date('nonsense') }))
+    expect(updateLine({ isDev: false, updatesEnabled: true, isEmbeddedLaunch: false, updateCreatedAt: new Date('nonsense') }))
       .toBe('Updated over the air')
   })
 
@@ -42,7 +49,10 @@ describe('updateLine', () => {
     // expo-updates reports isEmbeddedLaunch: false when it is not running at
     // all — on web, in Expo Go and in a dev client. Caught by looking at the
     // rendered screen, which claimed "Updated over the air" in dev.
-    expect(updateLine({ updatesEnabled: false, isEmbeddedLaunch: false })).toBe('Development build')
-    expect(updateLine({ updatesEnabled: false, isEmbeddedLaunch: true })).toBe('Development build')
+    expect(updateLine({ isDev: false, updatesEnabled: false, isEmbeddedLaunch: false })).toBe('Development build')
+    expect(updateLine({ isDev: false, updatesEnabled: false, isEmbeddedLaunch: true })).toBe('Development build')
+    // The case the emulator caught: expo-updates is configured and enabled in a
+    // development build, so isEnabled is true while the bundle came from Metro.
+    expect(updateLine({ isDev: true, updatesEnabled: true, isEmbeddedLaunch: false })).toBe('Development build')
   })
 })

--- a/apps/mobile/src/lib/buildInfo.ts
+++ b/apps/mobile/src/lib/buildInfo.ts
@@ -14,31 +14,45 @@ const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', '
 
 export type BuildInfo = {
   version?: string | null
-  /** Android versionCode of the build the JS was published from. */
+  /**
+   * Android versionCode read from the installed package, not from the manifest —
+   * so it keeps naming the build you installed after an OTA replaces the JS.
+   */
   versionCode?: number | string | null
-  /** False in a dev client, Expo Go and on web, where no update can exist. */
+  /** True when running from Metro — a dev client, Expo Go, or web. */
+  isDev: boolean
+  /** False where expo-updates is not active, so no update can exist. */
   updatesEnabled: boolean
   /** True when running the bundle shipped inside the APK, false after an OTA. */
   isEmbeddedLaunch: boolean
   updateCreatedAt?: Date | null
 }
 
-/** `TextStack 1.0.0 (24)`, or without the parenthetical when no build number is known. */
-export function versionLine(info: BuildInfo): string {
+/**
+ * `TextStack 1.0.0 (24)` — or `1.0.0 (24)` with `short`, for the About row,
+ * where the app's name is already the screen it sits on.
+ *
+ * The parenthetical is dropped when no build number is known, which is the
+ * normal state in a dev client: versionCode belongs to an installed package.
+ */
+export function versionLine(info: BuildInfo, opts?: { short?: boolean }): string {
+  const name = opts?.short ? '' : 'TextStack'
   const version = info.version?.trim()
-  if (!version) return 'TextStack'
+  if (!version) return name || '—'
   // 0 is not a versionCode any build carries, so falsy is the right test:
   // a missing value and a zero both mean "nothing to show here".
-  const code = info.versionCode
-  return code ? `TextStack ${version} (${code})` : `TextStack ${version}`
+  const withCode = info.versionCode ? `${version} (${info.versionCode})` : version
+  return name ? `${name} ${withCode}` : withCode
 }
 
 /** What produced the JS currently running. */
 export function updateLine(info: BuildInfo): string {
-  // Without expo-updates running there is no embedded-vs-OTA distinction to
-  // draw, and `isEmbeddedLaunch` is false — which would otherwise be read as
-  // "an update is applied" on a dev client, where none can be.
-  if (!info.updatesEnabled) return 'Development build'
+  // Two separate ways there is no update to speak of, and both were needed.
+  // `isEnabled` alone was not enough: a development build has expo-updates
+  // configured and reports true, while `isEmbeddedLaunch` is false because the
+  // bundle came from Metro — which rendered as "Updated over the air" on a
+  // dev client. Seen on the emulator, not deduced.
+  if (info.isDev || !info.updatesEnabled) return 'Development build'
   if (info.isEmbeddedLaunch) return 'Bundled with the app'
   const at = info.updateCreatedAt
   // An update with no date is still an update, and saying so beats claiming

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,66 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-02-profile-the-build-number-survives-an-update"></a>
+
+## Profile — the build number survives an update — mobile — 2026-09-02
+
+Two corrections to the version footer shipped hours earlier, both from putting it on a screen.
+
+### It was where nobody looked
+
+The footer sat below Sign Out and the danger zone — past six rows, off the first screenful. The
+first person to look for it did not find it.
+
+The build number now rides the **About** row as a trailing value:
+
+```
+ⓘ  About                    1.0.0 (24)  ›
+```
+
+That is a pattern the screen already uses — `I know · Русский` sits the same way — so it reads as
+part of the list rather than an addition to it. The update line stays at the foot, because it
+answers a different question and only matters when it disagrees with the build.
+
+### The number used to vanish exactly when it was needed
+
+The first version read `versionCode` from `Constants.expoConfig`, which carries what EAS wrote at
+build time. An update published by `eas update` has no such field — so the number would disappear
+after the first OTA, which is precisely the moment someone is trying to say which build they hold.
+
+`expo-application` reads it from the installed package instead. It is a native module, and the
+earlier write-up rejected it for that reason: a native addition moves the runtime fingerprint, and
+a change whose whole purpose is telling testers what they have would then need a store build to
+reach them.
+
+That reasoning was sound and the premise was wrong. `expo-notifications` already depends on
+`expo-application`, so it is compiled into the APK already. Measured rather than assumed:
+
+```
+baseline:              1065515fb7b75ee76efe35c56ec1d6ced76a8bc3
+with expo-application: 1065515fb7b75ee76efe35c56ec1d6ced76a8bc3
+```
+
+Identical. The fingerprint hashes the resolved native module set, not the direct dependency list, so
+this still travels as an OTA — and the number now names the installed APK on both sides of one.
+
+### And it called a development build an update
+
+Shown on the emulator as:
+
+```
+TextStack 1.0.0 (1)
+Updated over the air
+```
+
+`(1)` is the debug APK's versionCode, which is the new reading working. The second line was wrong:
+a development build has expo-updates configured, so `isEnabled` is true, while `isEmbeddedLaunch` is
+false because the bundle came from Metro. The previous guard tested only the first. Now gated on
+`__DEV__` as well, and it reads `Development build`.
+
+Three defects in this footer so far, and all three were found by opening the screen — none by the
+types, the tests, or reading the diff.
+
 <a id="2026-09-02-profile-which-build-is-this"></a>
 
 ## Profile — which build is this — mobile — 2026-09-02

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       expo-apple-authentication:
         specifier: ~55.0.9
         version: 55.0.17(expo@55.0.31)(react-native@0.83.10(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0))
+      expo-application:
+        specifier: ~55.0.19
+        version: 55.0.19(expo@55.0.31)
       expo-asset:
         specifier: ^55.0.10
         version: 55.0.20(expo@55.0.31)(react-native@0.83.10(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)


### PR DESCRIPTION
Three corrections to the version footer from #542, all found by opening the screen.

### It was where nobody looked

Below Sign Out and the danger zone, past six rows. The first person to look for it did not find it. The build number now rides the **About** row as a trailing value — the pattern the screen already uses for `I know · Русский`:

```
ⓘ  About                    1.0.0 (24)  ›
```

The update line stays at the foot: different question, and it only matters when it disagrees with the build.

### The number used to vanish exactly when it was needed

`Constants.expoConfig` carries the versionCode EAS wrote at build time, and an update published by `eas update` has no such field — so it would disappear after the first OTA, precisely when someone is trying to report which build they hold.

#542 rejected `expo-application` because a native module moves the runtime fingerprint, which would force a store build. Sound reasoning, wrong premise — `expo-notifications` already depends on it, so it is compiled into the APK already. Measured:

```
baseline:              1065515fb7b75ee76efe35c56ec1d6ced76a8bc3
with expo-application: 1065515fb7b75ee76efe35c56ec1d6ced76a8bc3
```

The fingerprint hashes the resolved native module set, not the direct dependency list. This still travels as an OTA.

### And it called a development build an update

On the emulator: `TextStack 1.0.0 (1)` / `Updated over the air`. The `(1)` is the debug APK's versionCode — the new reading working. The second line was wrong: a dev build has expo-updates configured so `isEnabled` is true, while `isEmbeddedLaunch` is false because the bundle came from Metro. Now gated on `__DEV__` as well, and it reads `Development build`.

### Verified

Signed-out Profile on a Pixel 7 Pro emulator, before and after the fix. 210 mobile tests, typecheck clean.

**Not verified:** the About row itself renders only on the signed-in branch, and there is no test account on this machine. I did not create one against production for a UI check. The row is the same `.map` that already renders five others, with an optional `Text` before the chevron — the same shape as the language row visible on that screen — so the risk is layout-only.