### PR TITLE
feat(mobile): apply an update on the next screen, not the second cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Updates** — a fix lands on the next screen instead of the second cold start, but never mid-chapter — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-updates-a-fix-lands-without-two-restarts)
 - **Profile** — the build number sits on the About row and survives an update, because it comes from the installed package — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-the-build-number-survives-an-update)
 - **Profile** — the app says which build it is, and whether the JS came from the store or arrived after — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-which-build-is-this)
 - **SSG** — a deploy that waited on a prompt stopped taking 1990 prerendered pages with it — infra · [incident](docs/incidents/2026-09-02-corepack-prompt-stranded-the-ssg.md)

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -15,6 +15,7 @@ import { NativeLanguageProvider } from '../src/context/NativeLanguageContext'
 import { ToastProvider } from '../src/context/ToastContext'
 import { ErrorBoundary } from '../src/components/ErrorBoundary'
 import { LegacyRuntimeBanner } from '../src/components/LegacyRuntimeBanner'
+import { AutoUpdater } from '../src/components/AutoUpdater'
 import { useAppFonts } from '../src/theme/fonts'
 
 SplashScreen.preventAutoHideAsync()
@@ -133,6 +134,7 @@ function AppContent() {
       <ColdResetOnResume />
       <StatusBar style={isDark ? 'light' : 'dark'} />
       <LegacyRuntimeBanner />
+      <AutoUpdater />
       <View style={{ flex: 1 }}>
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="(tabs)" />

--- a/apps/mobile/src/components/AutoUpdater.tsx
+++ b/apps/mobile/src/components/AutoUpdater.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { AppState, type AppStateStatus } from 'react-native'
+import { usePathname } from 'expo-router'
+import * as Updates from 'expo-updates'
+import { shouldApplyUpdate } from '../lib/updateApply'
+
+/**
+ * Applies an over-the-air update as soon as it is safe to, instead of on the
+ * second cold start.
+ *
+ * The default is two launches: `fallbackToCacheTimeout: 0` means the app never
+ * waits at the splash screen, so launch one downloads and launch two runs the
+ * new bundle. Nobody restarts an app twice to collect a fix — the update simply
+ * arrives days later, or whenever the phone reboots.
+ *
+ * Raising `fallbackToCacheTimeout` would fix that at the splash screen, at the
+ * price of blocking every launch on the network — and it lives in app.json, a
+ * fingerprint input, so shipping it would need a store build. This is JS, so it
+ * travels as an update itself.
+ *
+ * The one thing it will not do is restart mid-chapter. See updateApply.ts.
+ */
+export function AutoUpdater() {
+  const { isUpdatePending } = Updates.useUpdates()
+  const pathname = usePathname()
+  // reloadAsync tears the tree down, but its promise resolves before that
+  // finishes — without this, a second trigger fires another reload into the
+  // teardown.
+  const reloading = useRef(false)
+
+  const apply = useCallback(async (pending: boolean, route: string) => {
+    if (reloading.current) return
+    if (!shouldApplyUpdate({ isUpdatePending: pending, isDev: __DEV__, pathname: route })) return
+    reloading.current = true
+    try {
+      await Updates.reloadAsync()
+    } catch {
+      // A failed reload is not worth surfacing. The update is downloaded, and
+      // the next launch uses it regardless — which is the old behaviour.
+      reloading.current = false
+    }
+  }, [])
+
+  // Ask the server. Runs at startup and whenever the app returns to the
+  // foreground, which is when anything published in the meantime shows up.
+  const check = useCallback(async (route: string) => {
+    try {
+      const result = await Updates.checkForUpdateAsync()
+      if (!result.isAvailable) return
+      const fetched = await Updates.fetchUpdateAsync()
+      await apply(fetched.isNew, route)
+    } catch {
+      // Offline, or the update server is unreachable. Nothing to say to the
+      // user: they did not ask for this, and the app works either way.
+    }
+  }, [apply])
+
+  const routeRef = useRef(pathname)
+  routeRef.current = pathname
+
+  useEffect(() => {
+    if (__DEV__) return
+    void check(routeRef.current)
+    const sub = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (state === 'active') void check(routeRef.current)
+    })
+    return () => sub.remove()
+  }, [check])
+
+  // The deferral above is only half a rule. An update that arrived while the
+  // user was reading has to land when they leave the reader, or "wait" becomes
+  // "never" for whoever reads in one long session.
+  useEffect(() => {
+    if (__DEV__) return
+    void apply(isUpdatePending, pathname)
+  }, [apply, isUpdatePending, pathname])
+
+  return null
+}

--- a/apps/mobile/src/lib/updateApply.test.ts
+++ b/apps/mobile/src/lib/updateApply.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { shouldApplyUpdate, isReading } from './updateApply'
+
+const ready = { isUpdatePending: true, isDev: false, pathname: '/library' }
+
+describe('shouldApplyUpdate', () => {
+  it('applies as soon as an update is ready', () => {
+    expect(shouldApplyUpdate(ready)).toBe(true)
+  })
+
+  it('waits while the user is reading', () => {
+    // The one interruption this product cannot justify. The next check offers
+    // the same update again, so waiting costs nothing.
+    expect(shouldApplyUpdate({ ...ready, pathname: '/reader/dracula/chapter-1' })).toBe(false)
+    expect(shouldApplyUpdate({ ...ready, pathname: '/my-books/read/12/ch-3' })).toBe(false)
+  })
+
+  it('does nothing without an update, and nothing in development', () => {
+    expect(shouldApplyUpdate({ ...ready, isUpdatePending: false })).toBe(false)
+    // Reloading a Metro-served build drops the dev session and gains nothing.
+    expect(shouldApplyUpdate({ ...ready, isDev: true })).toBe(false)
+  })
+})
+
+describe('isReading', () => {
+  it('matches a reader route and its children, not its neighbours', () => {
+    expect(isReading('/reader')).toBe(true)
+    expect(isReading('/reader/dracula/ch-1')).toBe(true)
+    expect(isReading('/my-books/read/9')).toBe(true)
+    // Not reading: the book's detail screen, and a route that merely starts
+    // with the same letters.
+    expect(isReading('/my-books/9')).toBe(false)
+    expect(isReading('/readers-club')).toBe(false)
+    expect(isReading('/library')).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/updateApply.ts
+++ b/apps/mobile/src/lib/updateApply.ts
@@ -1,0 +1,32 @@
+// When may a downloaded update replace the running app?
+//
+// `reloadAsync` restarts the JS. That is cheap in the abstract and expensive at
+// the wrong moment: this app's whole premise is uninterrupted long-form reading,
+// and a restart mid-chapter is the one interruption it cannot justify to itself.
+//
+// So the update lands as soon as it is ready, except where landing would take
+// something away — and then it waits, because the next check will offer it again.
+
+/** Routes where a restart would interrupt reading rather than refresh a screen. */
+const READING_ROUTES = ['/reader', '/my-books/read']
+
+export type ApplyInput = {
+  /** An update is downloaded and will be used on the next launch. */
+  isUpdatePending: boolean
+  /** Metro-served build: there is nothing to apply and reloading loses the session. */
+  isDev: boolean
+  /** Current route, from the router. */
+  pathname: string
+}
+
+export function shouldApplyUpdate(s: ApplyInput): boolean {
+  if (s.isDev) return false
+  if (!s.isUpdatePending) return false
+  return !isReading(s.pathname)
+}
+
+export function isReading(pathname: string): boolean {
+  // Prefix match rather than equality: reader routes carry a book slug and a
+  // chapter, so the path is always longer than the segment being matched.
+  return READING_ROUTES.some(r => pathname === r || pathname.startsWith(r + '/'))
+}

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,44 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-02-updates-a-fix-lands-without-two-restarts"></a>
+
+## Updates — a fix lands without two restarts — mobile — 2026-09-02
+
+An over-the-air update used to need **two** cold starts. `fallbackToCacheTimeout: 0` means the app
+never waits at the splash screen, so the first launch downloads the bundle and the second one runs
+it. Nobody restarts an app twice to collect a fix, so in practice the update arrived days later, or
+whenever the phone rebooted.
+
+The obvious lever is `fallbackToCacheTimeout`, and it is the wrong one twice over: it blocks every
+launch on the network to serve the rare launch with an update waiting, and it lives in `app.json` —
+a fingerprint input, so shipping it would need a store build. This is JS, so it travels as an update
+itself.
+
+`AutoUpdater` checks at startup and whenever the app returns to the foreground, downloads, and
+reloads.
+
+### Except while someone is reading
+
+This app's premise is uninterrupted long-form reading, and a restart mid-chapter is the one
+interruption it cannot justify to itself. So the update waits on `/reader` and `/my-books/read`.
+
+That deferral is only half a rule. An update that arrives during a long reading session has to land
+when the reader is closed, or "wait" quietly becomes "never" for exactly the people who use the app
+most. A second effect watches the route and applies as soon as it changes to something that is not
+reading.
+
+The policy is a pure function in `apps/mobile/src/lib/updateApply.ts` with four tests, including the
+prefix-matching one — `/readers-club` is not the reader, and `/my-books/9` is a detail screen while
+`/my-books/read/9` is not.
+
+### What is not verified
+
+`__DEV__` disables the whole component, so a development build cannot exercise the path that
+matters. What the emulator confirmed is that it does nothing in development: the app launches
+clean, with no errors and no reload loop. The apply path itself is first exercised by the next
+update published to a production build.
+
 <a id="2026-09-02-profile-the-build-number-survives-an-update"></a>
 
 ## Profile — the build number survives an update — mobile — 2026-09-02


### PR DESCRIPTION
An over-the-air update needed **two** cold starts. `fallbackToCacheTimeout: 0` means the app never waits at the splash screen, so the first launch downloads the bundle and the second runs it. Nobody restarts an app twice to collect a fix — in practice the update arrived days later, or when the phone rebooted.

`fallbackToCacheTimeout` is the wrong lever twice over: it blocks *every* launch on the network to serve the rare launch with an update waiting, and it lives in `app.json` — a fingerprint input, so shipping it would need a store build. This is JS, so it travels as an update itself.

`AutoUpdater` checks at startup and on return to the foreground, downloads, and reloads.

### Except while someone is reading

A restart mid-chapter is the one interruption this product cannot justify to itself, so `/reader` and `/my-books/read` defer.

That deferral is only half a rule. An update arriving during a long session has to land when the reader closes, or "wait" quietly becomes "never" for exactly the people who use the app most. A second effect watches the route and applies as soon as it is no longer a reading one.

Policy is a pure function in `src/lib/updateApply.ts`, four tests, prefix matching included — `/readers-club` is not the reader, and `/my-books/9` is a detail screen while `/my-books/read/9` is not.

### Not verified

`__DEV__` disables the component, so a development build cannot exercise the path that matters. The emulator confirms only the negative: the app launches clean, no errors, no reload loop. The apply path is first exercised by the next update published to a production build — which makes this PR's own OTA the test.

214 mobile tests, typecheck clean.