### PR TITLE
docs(qa): the selection fix passes on a phone, and says which phone

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -40,10 +40,10 @@ answers "what happened" and nothing answered "what is half-finished right now".
   **Build 24** (`versionCode 24`, 2026-09-02) is on Internal Testing, carrying the selection-speech
   fixes (#509). It exists because the pnpm workspace migration moved the runtime fingerprint — 122 of
   135 fingerprint sources now resolve through the workspace root — so the OTA that had been verified
-  working an hour earlier could no longer reach the installed build. **The six-step checklist in
+  working an hour earlier could no longer reach the installed build. The six-step checklist in
   [`docs/qa/reports/2026-09-01-android-tts-selection.md`](qa/reports/2026-09-01-android-tts-selection.md)
-  has not been run on a real Galaxy S24 yet**; everything in it was verified on a Pixel 7 Pro
-  emulator, which is not One UI.
+  passes on the owner's own phone against this build (2026-09-02). **It has still not been run on the
+  reporter's Galaxy S24**, which is not the same input stack.
 
   Build 22 was the first build whose runtime is a fingerprint rather than the shared `1.0.0`. A manual pass against build 21 found 24 defects —
   [`docs/qa/reports/2026-08-26-android-manual-pass.md`](qa/reports/2026-08-26-android-manual-pass.md).
@@ -117,11 +117,13 @@ someone's memory.
   launcher/badge permissions from ShortcutBadger via `expo-notifications` (the app never sets a
   badge). Both are on the WATCH list in `apps/mobile/scripts/check-android-permissions.mjs` and need
   a device to settle.
-- **The S24 checklist has never been run on an S24.** Every defect in
-  [`2026-09-01-android-tts-selection.md`](qa/reports/2026-09-01-android-tts-selection.md) was found and
-  verified on a Pixel 7 Pro emulator. The bug that started it was described as behaving differently on
-  different phones, and the cause turned out to be a 30 ms timing margin — which is exactly the kind of
-  thing an emulator cannot settle.
+- **The selection fix passes on a phone, but not yet on the phone that reported it.** All six steps of
+  [`2026-09-01-android-tts-selection.md`](qa/reports/2026-09-01-android-tts-selection.md) pass on the
+  owner's own Android device against build 24 — the first run on real hardware rather than a Pixel 7
+  Pro emulator. Still open: the reporter's Galaxy S24. One UI is a different input stack, and the
+  decisive defect turned on a suppression window with about 30 ms of margin, which is why the bug
+  looked device-specific. The fix removes the race rather than widening the margin, so it should hold
+  anywhere — until that phone says so, "should" is the whole claim.
 - **Three dependency findings have no fix available.** `extract-zip@2.0.1` inside puppeteer has an
   advisory demanding `>=2.0.2`, and **2.0.2 does not exist** — an override was tried and pnpm refused
   it. `decode-uri-component` and `uuid` sit inside Expo's own tree, where forcing versions to quiet an

--- a/docs/qa/reports/2026-09-01-android-tts-selection.md
+++ b/docs/qa/reports/2026-09-01-android-tts-selection.md
@@ -130,9 +130,9 @@ that silently is not. Worth its own pass.
 
 ---
 
-## Not verified — Galaxy S24 acceptance
+## Acceptance — the six steps
 
-Needs a real device. Ships as an OTA (JS only).
+Run on the owner's own Android phone, 2026-09-02, on Play build 24. All six pass.
 
 1. Select a sentence → **no sound at all** before pressing anything.
 2. Press Listen → brief spinner → **the whole sentence** is read, to the end.
@@ -158,3 +158,22 @@ All six passed on the Pixel 7 Pro. Evidence, in order:
 
 Highlight could not be exercised — the pass ran as a guest, and the highlight button is gated on
 `isAuthenticated`.
+
+## Device pass — 2026-09-02
+
+The owner ran all six steps on their own phone against Play build `versionCode 24` and reported
+them passing. That is the first time this work has been exercised on real hardware rather than on
+a Pixel 7 Pro emulator, and it closes the question the report was opened to answer.
+
+Two things it deliberately does not claim:
+
+- **It was not the reporter's Galaxy S24.** The symptom was reported on One UI, and One UI is a
+  different input stack. The decisive defect turned on a suppression window with roughly 30 ms of
+  margin, which is why the bug looked device-specific in the first place. The fix removes the race
+  rather than widening the margin, so it should hold anywhere — "should" being the operative word
+  until the phone that showed the bug says otherwise.
+- **It was an informal pass, not a logged one.** The emulator run above has per-step evidence:
+  frame counts, timestamps, log lines. This one is a person saying it looked right, which is worth
+  more for step 5 and less for anything a log could have settled.
+
+Remaining: the reporter confirming on the S24. Everything else this report asked for is done.


### PR DESCRIPTION
All six steps of the selection/TTS checklist run against Play build 24 on the owner's own Android device and pass. First exercise on real hardware — everything before this was a Pixel 7 Pro emulator.

Recorded with two limits rather than as a clean close:

- **Not the reporter's Galaxy S24.** One UI is a different input stack, and the decisive defect turned on a suppression window with ~30 ms of margin — which is why the bug looked device-specific. The fix removes the race rather than widening the margin, so it should hold anywhere; "should" is the whole claim until that phone says otherwise.
- **Informal, not logged.** The emulator run carries frame counts and timestamps per step. This one is a person saying it looked right — worth more for step 5 than any log, and less for the steps a log could have settled.

Updates the report and both places `docs/STATUS.md` said the checklist had never been run.