### PR TITLE
ci(extension): run the checks its README describes, and make them able to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,21 @@ jobs:
           package-manager-cache: false
       - run: node scripts/check-node-version.mjs
 
+  # The extension has no build step and no package.json, so nothing else in this
+  # file would ever look at it. Its README documented a check and asked a person
+  # to remember it; nothing ran it, and it could not have failed if it had.
+  extension:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          # Same reason as above: one plain Node script, no install, and the
+          # pnpm cache priming would fail in a job with no pnpm.
+          package-manager-cache: false
+      - run: node scripts/check-extension.mjs
+
   backend:
     runs-on: ubuntu-latest
     services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Extension** — the checks its README describes now run, and can now fail — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-02-extension-a-gate-that-could-not-fail)
 - **Updates** — a fix lands on the next screen instead of the second cold start, but never mid-chapter — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-updates-a-fix-lands-without-two-restarts)
 - **Profile** — the build number sits on the About row and survives an update, because it comes from the installed package — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-the-build-number-survives-an-update)
 - **Profile** — the app says which build it is, and whether the JS came from the store or arrived after — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-which-build-is-this)

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,45 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-02-extension-a-gate-that-could-not-fail"></a>
+
+## Extension — a gate that could not fail — infra — 2026-09-02
+
+A review of `extension/` after a month of changes elsewhere. The API surface it depends on is
+intact — `/auth/me`, `/auth/device/code`, `/auth/device/token`, `/auth/refresh-mobile`,
+`/me/books/clip`, `/me/books?shelf=readlater`, `DELETE /me/books/{id}` all still exist, the
+`ClipRequest` DTO still matches field for field, the `clip` rate-limit policy is registered, and
+the oversize-article error reaches the popup as its own words rather than a bare status code. The
+`/connect-extension` override of the backend's `/device` is deliberate; both routes exist and both
+render `DeviceVerifyPage`.
+
+What was not intact was the checking.
+
+`extension/README.md` documented a gate — a `for` loop running `node --check "$f"` over every
+script, to be run "before loading or committing". Two things were wrong with it.
+
+**Nothing ran it.** No workflow in `.github/` mentions the folder. The extension has no build step
+and no `package.json`, so nothing else was going to look at it either.
+
+**It could not have failed.** Appending `const x = ;` to `background.js` and running the documented
+command exits **0** on Node 24 — module-syntax detection swallows the parse error when the file is
+passed by path. Piping the same bytes through stdin with `--input-type=module` reports it. So even
+a developer who remembered the instruction would have been told the extension was fine.
+
+`scripts/check-extension.mjs` now runs in CI and checks three things:
+
+1. **Every `.js` parses**, through stdin, the way that actually reports errors. Without a build
+   step, a typo in `background.js` ships a service worker that never starts.
+2. **The manifest names only files that exist.** A renamed icon or page makes Chrome refuse to load
+   the entire extension, and no syntax check can see that.
+3. **`host_permissions` carries no localhost.** The README tells developers to add
+   `http://localhost:8080/*` for local work and to remove it before packaging — a rule previously
+   enforced by memory.
+
+Each of the three was verified by breaking the extension on purpose and confirming the check said
+so. The first one is why: it passed the deliberate syntax error on the first attempt, which is how
+the underlying `node --check` behaviour was found at all.
+
 <a id="2026-09-02-updates-a-fix-lands-without-two-restarts"></a>
 
 ## Updates — a fix lands without two restarts — mobile — 2026-09-02

--- a/extension/README.md
+++ b/extension/README.md
@@ -26,17 +26,27 @@ Clips are private; the server enforces per-user ownership.
 > Real sign-in is **owner-only** — only the account owner has TextStack
 > credentials. The Connect flow opens the web app where you log in normally.
 
-## The `node --check` gate
-
-Every `.js` file must parse. Run before loading or committing:
+## Checks
 
 ```sh
-cd extension
-for f in $(find . -name '*.js' -not -path './lib/readability.js'); do node --check "$f" || exit 1; done
-node --check lib/readability.js   # vendored third-party — also checked
+node scripts/check-extension.mjs
 ```
 
-(`lib/readability.js` is vendored verbatim from Mozilla; see `lib/THIRDPARTY.md`.)
+Runs in CI on every pull request, so it is not something to remember. It checks
+three things: every `.js` parses, the manifest names only files that exist, and
+`host_permissions` carries no localhost entry left over from local development.
+
+The second matters because there is no build step — a renamed icon or page makes
+Chrome refuse the whole extension, and no syntax check can see that.
+
+**This replaced a gate that could not fail.** The instructions here used to be a
+`for` loop calling `node --check "$f"` by path. On Node 24 that exits 0 on a file
+containing `const x = ;` — module-syntax detection swallows the parse error. The
+script pipes each file through stdin with an explicit `--input-type=module`,
+which reports it.
+
+(`lib/readability.js` is vendored verbatim from Mozilla; see `lib/THIRDPARTY.md`.
+It is checked too — vendored code is still code that has to parse.)
 
 ## Developer: pointing at a local API
 

--- a/scripts/check-extension.mjs
+++ b/scripts/check-extension.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+//
+// The extension's checks, actually run.
+//
+// extension/README.md documents a `node --check` loop and asks the developer to
+// remember it before committing. Nothing in .github/workflows mentions the
+// folder, so for the life of the extension nothing has enforced it — the same
+// shape as the SSG rebuild that reported success while writing nowhere, and the
+// mobile OTA that published to a runtime nobody had installed. A check a person
+// has to remember is a check that eventually is not run.
+//
+// Three things, in the order they would bite:
+//
+//   1. Every .js parses. A typo in background.js ships a service worker that
+//      never starts, and the extension has no build step to catch it.
+//   2. The manifest parses, and every file it names exists. Renaming an icon or
+//      a page breaks the extension in a way no syntax check can see — Chrome
+//      refuses to load the whole thing.
+//   3. host_permissions carries no localhost. The README tells developers to add
+//      `http://localhost:8080/*` for local work and to remove it before
+//      packaging. That is a rule enforced by memory; this makes it mechanical.
+//
+// Run: node scripts/check-extension.mjs
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const EXT = join(ROOT, 'extension')
+const problems = []
+
+/** Every .js under extension/, recursively. */
+function scripts(dir = EXT) {
+  return readdirSync(dir).flatMap(name => {
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) return scripts(full)
+    return name.endsWith('.js') ? [full] : []
+  })
+}
+
+// 1 — every script parses.
+for (const file of scripts()) {
+  const rel = file.slice(ROOT.length + 1)
+  try {
+    // Piped through stdin with an explicit --input-type, NOT `node --check
+    // <path>`. That is what extension/README.md documents, and on Node 24 it
+    // exits 0 on a file containing `const x = ;` — module-syntax detection
+    // swallows the parse error rather than reporting it. The documented gate
+    // would have passed anything put in front of it. Verified by hand both
+    // ways before this line was written.
+    execFileSync(process.execPath, ['--input-type=module', '--check'], {
+      input: readFileSync(file),
+      stdio: ['pipe', 'ignore', 'pipe'],
+    })
+  } catch (e) {
+    problems.push(`${rel} does not parse:\n  ${String(e.stderr).trim().split('\n').slice(0, 3).join('\n  ')}`)
+  }
+}
+
+// 2 — the manifest parses, and everything it names is on disk.
+const manifestPath = join(EXT, 'manifest.json')
+let manifest
+try {
+  manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+} catch (e) {
+  problems.push(`extension/manifest.json does not parse: ${e.message}`)
+}
+
+if (manifest) {
+  const referenced = [
+    manifest.background?.service_worker,
+    manifest.action?.default_popup,
+    manifest.options_page,
+    ...Object.values(manifest.action?.default_icon ?? {}),
+    ...Object.values(manifest.icons ?? {}),
+  ].filter(Boolean)
+
+  for (const rel of new Set(referenced)) {
+    if (!existsSync(join(EXT, rel))) {
+      problems.push(`extension/manifest.json names "${rel}", which does not exist`)
+    }
+  }
+
+  // 3 — no local host permission left behind.
+  for (const host of manifest.host_permissions ?? []) {
+    if (/localhost|127\.0\.0\.1|0\.0\.0\.0/.test(host)) {
+      problems.push(
+        `extension/manifest.json still grants "${host}". The README asks for this during local ` +
+        `development and for its removal before packaging — remove it before merging.`
+      )
+    }
+  }
+}
+
+if (problems.length) {
+  console.error('Extension checks failed:\n')
+  for (const p of problems) console.error(`  • ${p}\n`)
+  process.exit(1)
+}
+
+console.log(`Extension OK — ${scripts().length} scripts parse, manifest names only files that exist.`)


### PR DESCRIPTION
A review of `extension/` after a month of changes elsewhere.

### The code is fine

Every endpoint it calls still exists — `/auth/me`, `/auth/device/code`, `/auth/device/token`, `/auth/refresh-mobile`, `/me/books/clip`, `/me/books?shelf=readlater`, `DELETE /me/books/{id}`. `ClipRequest` matches field for field, the `clip` rate-limit policy is registered, and the oversize-article error reaches the popup as its own words rather than a bare status. The `/connect-extension` override of the backend's `/device` is deliberate — both routes exist, both render `DeviceVerifyPage`.

### The checking was not

`extension/README.md` documented a `node --check` loop to run "before loading or committing". Two things were wrong with it:

**Nothing ran it.** No workflow mentions the folder, and with no build step and no `package.json`, nothing else was going to look at it.

**It could not have failed.** Append `const x = ;` to `background.js` and the documented command exits **0** on Node 24 — module-syntax detection swallows the parse error when the file is passed by path. Piped through stdin with `--input-type=module`, it reports it. A developer who remembered the instruction would still have been told the extension was fine.

### What now runs

`scripts/check-extension.mjs`, in CI:

1. **Every `.js` parses** — through stdin, the way that actually reports errors.
2. **The manifest names only files that exist** — Chrome refuses the whole extension over a renamed icon, and no syntax check sees that.
3. **`host_permissions` carries no localhost** — the README asks developers to add it for local work and remove it before packaging; that was enforced by memory.

Each verified by breaking the extension on purpose and confirming the check says so. The first one passed the deliberate syntax error on the first attempt — which is how the `node --check` behaviour was found at all.