### PR TITLE
fix(mobile): tapping an image opens it again, and languages are named not flagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 ## [Unreleased]
 
 - **Extension** — the checks its README describes now run, and can now fail — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-02-extension-a-gate-that-could-not-fail)
+- **Reader** — tapping an image opens it again, after a null `document.body` killed the listener on every load — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-reader-tapping-an-image-opens-it-again)
+- **Profile** — languages are named, not flagged — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-languages-are-named-not-flagged)
 - **Updates** — a fix lands on the next screen instead of the second cold start, but never mid-chapter — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-updates-a-fix-lands-without-two-restarts)
 - **Profile** — the build number sits on the About row and survives an update, because it comes from the installed package — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-the-build-number-survives-an-update)
 - **Profile** — the app says which build it is, and whether the JS came from the store or arrived after — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-02-profile-which-build-is-this)

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -15,7 +15,7 @@ import { useAuth } from '../../src/context/AuthContext'
 import { useTheme } from '../../src/context/ThemeContext'
 import { useOnline } from '../../src/hooks/useOnline'
 import { useNativeLanguage } from '../../src/context/NativeLanguageContext'
-import { getLanguage, getFlagEmoji } from '../../src/data/languages'
+import { getLanguage } from '../../src/data/languages'
 import { LanguagePickerModal } from '../../src/components/LanguagePickerModal'
 import { VocabReminderSettingsRow } from '../../src/components/profile/VocabReminderSettingsRow'
 import { StorageQuotaRow } from '../../src/components/library/StorageQuotaRow'
@@ -317,9 +317,8 @@ export default function ProfileScreen() {
           <Ionicons name="chatbubble-outline" size={20} color={colors.textSecondary} style={styles.menuIcon} />
           <Text style={[styles.menuText, { color: colors.text }]}>I know</Text>
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-            <Text style={{ fontSize: 18 }}>{getFlagEmoji(nativeLanguage)}</Text>
             <Text style={{ fontFamily: fonts.sansMedium, fontSize: 14, color: colors.textSecondary }}>
-              {getLanguage(nativeLanguage)?.nativeName || nativeLanguage}
+              {getLanguage(nativeLanguage)?.englishName || nativeLanguage}
             </Text>
             <Ionicons name="chevron-forward" size={16} color={colors.textSecondary} />
           </View>

--- a/apps/mobile/src/components/LanguageList.tsx
+++ b/apps/mobile/src/components/LanguageList.tsx
@@ -7,7 +7,6 @@ import {
   LANGUAGES,
   POPULAR_LANGUAGES,
   OTHER_LANGUAGES,
-  getFlagEmoji,
   type LanguageEntry,
 } from '../data/languages'
 
@@ -125,7 +124,6 @@ export const LanguageList = forwardRef<LanguageListHandle, Props>(function Langu
                 }
                 accessibilityState={{ selected }}
               >
-                <Text style={styles.flag}>{getFlagEmoji(lang.code)}</Text>
                 <View style={{ flex: 1 }}>
                   <Text
                     style={[
@@ -181,7 +179,6 @@ const styles = StyleSheet.create({
     gap: 12,
     borderRadius: 4,
   },
-  flag: { fontSize: 22 },
   rowNative: { fontSize: 15 },
   rowEnglish: { fontSize: 12, marginTop: 2 },
   empty: { textAlign: 'center', padding: 24, fontSize: 14 },

--- a/apps/mobile/src/data/languages.ts
+++ b/apps/mobile/src/data/languages.ts
@@ -1,5 +1,11 @@
 // Native language catalogue for mobile — mirrors apps/web/src/data/languages.ts.
-// Flag derived from ISO 3166 country code → regional indicator emoji (rendered natively on iOS/Android).
+//
+// `flagCountry` and `getFlagEmoji` are no longer rendered anywhere. A flag names
+// a country and these rows name a language, and for most of the 88 entries here
+// the two do not line up: English is filed under GB, which is not where most of
+// its speakers live; Arabic under SA, one of twenty-odd; Spanish under ES, which
+// leaves out Latin America. The rows now carry names, which are unambiguous.
+// The field stays because it is data, and removing it buys nothing.
 
 export interface LanguageEntry {
   code: string          // BCP 47 / ISO 639-1 lang code ('hi')

--- a/apps/mobile/src/lib/readerHtml.test.ts
+++ b/apps/mobile/src/lib/readerHtml.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { buildReaderHtml } from './readerHtml'
+
+// Second argument is the theme, and its default is load-bearing — passing {}
+// strips fontFamily and throws inside buildFontFace.
+const html = buildReaderHtml('<p>Hello</p><img src="a.png" alt="a">')
+
+/**
+ * Every script this file emits lives inside <head>, so anything running at parse
+ * time sees `document.body === null`. That cost the image lightbox: its setup
+ * ended with `document.body.addEventListener(...)`, which threw on every reader
+ * load and left tapping an image doing nothing — silently, on every book with
+ * images, for as long as the code existed.
+ *
+ * A general "nothing touches document.body before <body>" rule is what you want
+ * here and is not what these tests are: most body access in the head script sits
+ * inside functions that run later, and telling those apart from immediate
+ * statements needs a parser, not a string search. A version that tried flagged
+ * `document.body.appendChild(sep)` — which is fine — on its first run. So this
+ * pins the one construct that broke instead.
+ */
+describe('reader document', () => {
+  const headEnd = html.lastIndexOf('</head>')
+  const head = html.slice(0, headEnd)
+
+  it('emits its scripts inside head, which is what makes the rest of this matter', () => {
+    expect(headEnd).toBeGreaterThan(-1)
+    expect(head).toContain('<script>')
+  })
+
+  it('delegates the image lightbox on document, not on a body that does not exist yet', () => {
+    const start = head.indexOf('function isLightboxImg')
+    expect(start).toBeGreaterThan(-1)
+    const lightbox = head.slice(start)
+    expect(lightbox).toContain("document.addEventListener('click'")
+    expect(lightbox).not.toContain('document.body.addEventListener')
+  })
+})

--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -1175,8 +1175,20 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
         return t && t.tagName === 'IMG' && !t.closest('.ts-img-lightbox');
       }
 
-      // Delegate on body. Use click (after touchend), iOS WebKit fires it ~300ms after.
-      document.body.addEventListener('click', function(e) {
+      // Delegated on document, NOT on document.body.
+      //
+      // Every script in this file is emitted inside <head>, and this IIFE runs
+      // as the parser reaches it — before <body> exists. document.body is null
+      // at that moment, so the old line threw "Cannot read properties of null
+      // (reading 'addEventListener')" on every single reader load. It was the
+      // last statement in the IIFE, so nothing downstream broke visibly: the
+      // lightbox simply never got a listener, and tapping an image did nothing,
+      // on every book with images.
+      //
+      // click bubbles to document, so delegation there is equivalent — and
+      // document exists while <head> is parsed, which body does not.
+      // Use click (after touchend), iOS WebKit fires it ~300ms after.
+      document.addEventListener('click', function(e) {
         var t = e.target;
         if (!isLightboxImg(t)) return;
         // Don't open if image is inside an overlay layer (defensive).

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -41,6 +41,59 @@ a developer who remembered the instruction would have been told the extension wa
 Each of the three was verified by breaking the extension on purpose and confirming the check said
 so. The first one is why: it passed the deliberate syntax error on the first attempt, which is how
 the underlying `node --check` behaviour was found at all.
+<a id="2026-09-02-reader-tapping-an-image-opens-it-again"></a>
+
+## Reader — tapping an image opens it again — mobile — 2026-09-02
+
+Every script `readerHtml.ts` emits sits inside `<head>`. The image-lightbox setup is an IIFE that
+runs as the parser reaches it — before `<body>` exists — and its **last statement** was:
+
+```js
+document.body.addEventListener('click', function (e) { … })
+```
+
+`document.body` is null at that moment, so it threw
+`Cannot read properties of null (reading 'addEventListener')` on **every reader load**, in every
+book. Because it was the last statement, nothing downstream broke visibly. The reader looked
+perfect. Tapping an image simply did nothing, and had never done anything.
+
+Delegated on `document` instead. Click bubbles there, so the behaviour is identical, and `document`
+exists while `<head>` is being parsed.
+
+The error had been sitting in
+[`2026-09-01-android-tts-selection.md`](../qa/reports/2026-09-01-android-tts-selection.md) under
+"found while here, not fixed", with the note that "something is being wired up that silently is
+not". This is what.
+
+### The test, and the test that was too clever
+
+The rule you want is "nothing touches `document.body` before `<body>` exists". That is not a rule a
+string search can enforce: most body access in the head script is inside functions that run later,
+and a first attempt duly flagged `document.body.appendChild(sep)`, which is fine. Telling them apart
+needs a parser.
+
+So the test pins the construct that actually broke, and its comment says why it is narrow. It was
+verified the only way worth trusting: by putting `document.body` back and watching it fail.
+
+<a id="2026-09-02-profile-languages-are-named-not-flagged"></a>
+
+## Profile — languages are named, not flagged — mobile — 2026-09-02
+
+The "I know" row showed a flag emoji and the language's own name — 🇷🇺 Русский — on a screen where
+every other label is English.
+
+A flag names a country and these rows name a language, and across the 88 entries in the catalogue
+the two rarely line up. The data says so plainly: English is filed under **GB**, which is not where
+most of its speakers are; Arabic under **SA**, one of twenty-odd; Spanish under **ES**, which leaves
+out Latin America. The catalogue's own comment about promoting `pt-BR` "for Brazil audience" is the
+same problem being worked around.
+
+The row now reads `I know    Russian ›` — matching the English labels beside it, and the build number
+added to the About row the same day. The picker keeps each language's native name, which is the point
+of a picker: someone choosing their language should find it in their own script. It loses the flag.
+
+`flagCountry` and `getFlagEmoji` stay in the catalogue. Nothing renders them now, and deleting data
+that costs nothing to keep buys nothing.
 
 <a id="2026-09-02-updates-a-fix-lands-without-two-restarts"></a>
 


### PR DESCRIPTION
### The reader threw on every load, and nobody could see it

Every script `readerHtml.ts` emits sits inside `<head>`. The image-lightbox setup is an IIFE that runs as the parser reaches it — before `<body>` exists — and its **last statement** was:

```js
document.body.addEventListener('click', function (e) { … })
```

`document.body` is null there, so it threw `Cannot read properties of null (reading 'addEventListener')` on **every reader load, in every book**. Being the last statement, nothing downstream broke visibly. The reader looked perfect; tapping an image simply did nothing, and never had.

Delegated on `document` — click bubbles there, and `document` exists while `<head>` is parsed.

This error was already recorded in `docs/qa/reports/2026-09-01-android-tts-selection.md` under "found while here, not fixed", with the note that "something is being wired up that silently is not". This is what.

**The test pins that construct, not the general rule.** "Nothing touches `document.body` before `<body>`" is the rule you want and is not enforceable by string search — most body access in the head script is inside functions that run later, and a first attempt flagged `document.body.appendChild(sep)`, which is fine. Verified by putting the bug back and watching the test fail.

### Languages are named, not flagged

The "I know" row showed 🇷🇺 Русский on a screen where every other label is English.

A flag names a country; the row names a language. Across the 88 entries in the catalogue they rarely line up — English is filed under **GB**, Arabic under **SA**, Spanish under **ES**. The row now reads `I know  Russian ›`, matching its neighbours and the build number added to the About row today.

The picker keeps each language's native name — that is the point of a picker — and loses the flag. `flagCountry` stays in the catalogue as data; nothing renders it.

216 mobile tests, typecheck clean.