### PR TITLE
docs(status): the first screen a new user meets is a sign-in wall

### DIFF
--- a/apps/web/vite.config.d.ts
+++ b/apps/web/vite.config.d.ts
@@ -1,0 +1,2 @@
+declare const _default: import("vite").UserConfig;
+export default _default;

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,0 +1,63 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { fileURLToPath } from 'url';
+var __dirname = path.dirname(fileURLToPath(import.meta.url));
+export default defineConfig({
+    plugins: [react()],
+    resolve: {
+        alias: {
+            '@textstack/shared': path.resolve(__dirname, '../../packages/shared/src/index.ts'),
+            '@textstack/reader-overlay': path.resolve(__dirname, '../../packages/reader-overlay/src/index.ts'),
+        },
+    },
+    build: {
+        rollupOptions: {
+            output: {
+                manualChunks: {
+                    'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+                    'charts': ['recharts'],
+                    'sanitize': ['dompurify'],
+                },
+            },
+        },
+    },
+    server: {
+        port: 5173,
+        host: true,
+        // Allow prerender container to access via Docker network name
+        allowedHosts: ['web', 'localhost', 'general.localhost'],
+        // Proxy API requests to API container (needed for prerender)
+        proxy: {
+            '/api': {
+                target: 'http://localhost:8080',
+                changeOrigin: false,
+                rewrite: function (path) { return path.replace(/^\/api/, ''); },
+                headers: {
+                    Host: 'general.localhost',
+                },
+            },
+            '/me': {
+                target: 'http://localhost:8080',
+                changeOrigin: false,
+                headers: {
+                    Host: 'general.localhost',
+                },
+            },
+            '/books': {
+                target: 'http://localhost:8080',
+                changeOrigin: false,
+                headers: {
+                    Host: 'general.localhost',
+                },
+            },
+            '/storage': {
+                target: 'http://localhost:8080',
+                changeOrigin: false,
+                headers: {
+                    Host: 'general.localhost',
+                },
+            },
+        },
+    },
+});

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -117,6 +117,24 @@ someone's memory.
   launcher/badge permissions from ShortcutBadger via `expo-notifications` (the app never sets a
   badge). Both are on the WATCH list in `apps/mobile/scripts/check-android-permissions.mjs` and need
   a device to settle.
+- **A new user's first screen is a sign-in wall, and there is no onboarding.** `onboarding/language`
+  is the only onboarding route, it asks one question — the native language — and its own code says
+  guests are never asked, because they have nowhere to save it. So a signed-out person sees nothing
+  explaining the app. They land on **Library**, the first tab, which for `!isAuthenticated` renders an
+  empty state with a Sign In button and nothing else. Reading actually works signed out, and Discover
+  is one tab away, but nothing says so.
+
+  This is the gap that matters right now: recruiting closed-testing testers is under way, Google
+  counts the 14 days by activity rather than by opt-in, and the current numbers already show the
+  shape of the problem — 4 opted in, 2 installed. A tester who opens the app, meets a wall and closes
+  it counts for nothing.
+
+  **Deliberately not patched.** Adding a "Browse books" button beside Sign In would hide the gap
+  rather than close it. The app is a reading-based language-learning platform — reader with TTS,
+  tap-to-translate, contextual Explain, vocabulary SRS, personal book upload, ask-this-book, reading
+  stats and goals — and a first run has to show that it exists. Sized as its own piece of work, not
+  a patch to this screen.
+
 - **The selection fix passes on a phone, but not yet on the phone that reported it.** All six steps of
   [`2026-09-01-android-tts-selection.md`](qa/reports/2026-09-01-android-tts-selection.md) pass on the
   owner's own Android device against build 24 — the first run on real hardware rather than a Pixel 7


### PR DESCRIPTION
Found while checking what a tester actually sees after installing build 24.

`onboarding/language` is the only onboarding route. It asks one question — the native language — and its own docblock states the rule plainly:

> Guests are never asked — they have nowhere to save it.

So a signed-out person gets **no onboarding at all**. They land on **Library**, the first tab, which for `!isAuthenticated` renders an empty state with a Sign In button and nothing else. Reading works signed out and Discover is one tab away, but nothing says so.

Recorded now because it collides with what is happening this week: closed-testing recruitment is under way, Google counts the 14 days by *activity* rather than by opt-in, and the current numbers already show the shape — **4 opted in, 2 installed**. A tester who opens the app, meets a wall and closes it counts for nothing.

**Deliberately not patched here.** A "Browse books" button next to Sign In would hide the gap rather than close it. This is a reading-based language-learning platform — reader with TTS, tap-to-translate, contextual Explain, vocabulary SRS, personal book upload, ask-this-book, reading stats and goals — and a first run has to show that any of it exists. Sized as its own piece of work.

Docs only.