### PR TITLE
fix(api): every rate limit in the application was inert, and the partition key was wrong

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,8 +374,27 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # Everything EXCEPT the rate-limit enforcement test. That one deliberately drains the whole
+      # guest-session bucket (60 consecutive POST /auth/guest until one is rejected), and the bucket
+      # is keyed on client IP with a 5-minute window — in CI every request comes from one host, so
+      # sharing a window with the functional guest suite means one of them starves. Measured: run
+      # together, the enforcement test finishes in ~2.7s and fifteen guest/merge tests then SKIP,
+      # which is precisely the "green with no coverage" outcome the guest PR exists to prevent.
+      # Raising the limit cannot resolve it: the enforcement test consumes limit+1 by construction.
       - name: Integration tests
-        run: dotnet test tests/TextStack.IntegrationTests
+        run: dotnet test tests/TextStack.IntegrationTests --filter "FullyQualifiedName!~RateLimitEnforcement"
+        env:
+          API_URL: http://localhost:8080
+
+      # Restarting the API drops the in-memory limiter partitions, so this starts from a full
+      # bucket and cannot be starved by the run above.
+      - name: Restart API to reset rate-limiter state
+        run: |
+          docker compose up -d --force-recreate --no-deps api
+          timeout 120 bash -c 'until curl -sf http://localhost:8080/health; do sleep 3; done'
+
+      - name: Rate limit enforcement test (isolated)
+        run: dotnet test tests/TextStack.IntegrationTests --filter "FullyQualifiedName~RateLimitEnforcement"
         env:
           API_URL: http://localhost:8080
 
@@ -406,6 +425,9 @@ jobs:
           ASPNETCORE_ENVIRONMENT=Development
           ENABLE_TEST_AUTH=true
           GUEST_SESSION_PERMIT_LIMIT=50
+          USER_LOGIN_PERMIT_LIMIT=100
+          CLIP_PERMIT_LIMIT=200
+          ACCOUNT_DELETE_PERMIT_LIMIT=50
           GUEST_DAILY_ENRICHMENT_CAP=3
           ADMIN_EMAIL=admin@textstack.app
           ADMIN_PASSWORD=admin

--- a/backend/src/Api/Extensions/RateLimitSettings.cs
+++ b/backend/src/Api/Extensions/RateLimitSettings.cs
@@ -28,4 +28,57 @@ public sealed class RateLimitSettings
     public int EffectiveGuestSessionPermitLimit =>
         GuestSessionPermitLimit > 0 ? GuestSessionPermitLimit : DefaultGuestSessionPermitLimit;
 
+    // The three knobs below exist only because the limiter started being reached (UseRateLimiter
+    // moved below UseRouting). Until then no per-endpoint policy ran, so no production value here
+    // could throttle anything, including the integration suite. They belong with that change, not
+    // with the guest-session knob above, which was needed even while the limiter was inert.
+
+    /// <summary>Register / login / forgot-password / reset-password attempts allowed per IP per
+    /// minute. Production default is 10.</summary>
+    /// <remarks>
+    /// Configurable for the same reason as the guest limit, and it became necessary the moment the
+    /// limiter started running: the guest-merge suite drives ~15 register+login calls from one host
+    /// inside a minute, so at the production value it would rate-limit itself into skips — a green
+    /// CI with zero merge coverage, which is the exact failure this PR is trying to stop happening.
+    /// </remarks>
+    public int UserLoginPermitLimit { get; set; } = DefaultUserLoginPermitLimit;
+
+    public const int DefaultUserLoginPermitLimit = 10;
+
+    /// <inheritdoc cref="EffectiveGuestSessionPermitLimit"/>
+    public int EffectiveUserLoginPermitLimit => Effective(UserLoginPermitLimit, DefaultUserLoginPermitLimit);
+
+    /// <summary>Web-clip / "send to TextStack" receives allowed per IP per minute. Production
+    /// default is 20.</summary>
+    /// <remarks>
+    /// The integration suite seeds a user book by clipping one, in a dozen different test classes,
+    /// so a single run makes well over twenty clips from one host. At the production value most of
+    /// those classes skip on "clip seed unavailable" — silently, and across user-books, highlights,
+    /// reading-sessions and RAG coverage at once.
+    /// </remarks>
+    public int ClipPermitLimit { get; set; } = DefaultClipPermitLimit;
+
+    public const int DefaultClipPermitLimit = 20;
+
+    /// <inheritdoc cref="EffectiveGuestSessionPermitLimit"/>
+    public int EffectiveClipPermitLimit => Effective(ClipPermitLimit, DefaultClipPermitLimit);
+
+    /// <summary>Account hard-deletes allowed per IP per 5 minutes. Production default is 3.</summary>
+    /// <remarks>
+    /// A person never needs more than one, which is why the production number is tiny — but the GDPR
+    /// delete suite legitimately calls it four times in one test class (unauthenticated probe, the
+    /// delete, the repeat-delete that must be a clean 401, and the cleanup of the re-created user).
+    /// </remarks>
+    public int AccountDeletePermitLimit { get; set; } = DefaultAccountDeletePermitLimit;
+
+    public const int DefaultAccountDeletePermitLimit = 3;
+
+    /// <inheritdoc cref="EffectiveGuestSessionPermitLimit"/>
+    public int EffectiveAccountDeletePermitLimit =>
+        Effective(AccountDeletePermitLimit, DefaultAccountDeletePermitLimit);
+
+    /// <summary>Shared normalization: a configured 0 or negative is a typo, and a zero permit limit
+    /// is an outage, so it degrades to the production default rather than to a lockout.</summary>
+    private static int Effective(int configured, int productionDefault) =>
+        configured > 0 ? configured : productionDefault;
 }

--- a/backend/src/Api/Extensions/ServiceCollectionExtensions.RateLimiting.cs
+++ b/backend/src/Api/Extensions/ServiceCollectionExtensions.RateLimiting.cs
@@ -11,7 +11,12 @@ public static partial class ServiceCollectionExtensions
     /// All rate-limiter policies (login, device grant, guest, clip/upload, TTS,
     /// translation, dictionary, explain, semantic search, RAG, agents, crews,
     /// account-delete) plus the shared rejection/Retry-After behavior.
-    /// Verbatim move from Program.cs — no policy, limit, or window changed.
+    /// <para>
+    /// Originally a verbatim move from Program.cs. Since then two things changed, both forced by the
+    /// limiter actually being reached (it used to sit above <c>UseRouting</c> and never ran):
+    /// <c>admin-login</c>/<c>user-login</c> are now per-IP rather than one global bucket, and
+    /// <c>user-login</c>'s permit limit is configurable. No window and no ceiling was loosened.
+    /// </para>
     /// </summary>
     public static IServiceCollection AddTextStackRateLimiting(
         this IServiceCollection services,
@@ -25,17 +30,40 @@ public static partial class ServiceCollectionExtensions
 
         services.AddRateLimiter(options =>
         {
-            options.AddFixedWindowLimiter("admin-login", opt =>
+            // admin-login / user-login are per-IP, like every other policy in this file. They were
+            // GLOBAL single buckets — 5 and 10 attempts per minute for the entire site — which was
+            // harmless only for as long as the limiter never ran (it sat above UseRouting, so no
+            // per-endpoint policy was ever consulted; see Program.cs). Switching it on made that
+            // shape live, and a global login bucket is not a stronger brute-force defence: an
+            // attacker with a handful of IPs defeats it either way, while any single script hitting
+            // /auth/login ten times locks EVERY user out of signing in — including password reset,
+            // which shares the policy. Partitioning keeps the same per-attacker ceiling and removes
+            // the collateral.
+            options.AddPolicy("admin-login", httpContext =>
             {
-                opt.Window = TimeSpan.FromMinutes(1);
-                opt.PermitLimit = 5;
-                opt.QueueLimit = 0;
+                var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+                return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+                {
+                    Window = TimeSpan.FromMinutes(1),
+                    PermitLimit = 5,
+                    QueueLimit = 0,
+                });
             });
-            options.AddFixedWindowLimiter("user-login", opt =>
+            // The permit limit is a deployment knob for the same reason the guest one is: the
+            // guest-merge suite makes ~15 register+login calls from a single host inside one minute,
+            // so at the production value CI would throttle itself into skips and report green with
+            // no merge coverage at all. Window, partition key and policy are identical everywhere —
+            // a knob, not a test-only bypass.
+            var userLoginPermitLimit = rateLimits.EffectiveUserLoginPermitLimit;
+            options.AddPolicy("user-login", httpContext =>
             {
-                opt.Window = TimeSpan.FromMinutes(1);
-                opt.PermitLimit = 10;
-                opt.QueueLimit = 0;
+                var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+                return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+                {
+                    Window = TimeSpan.FromMinutes(1),
+                    PermitLimit = userLoginPermitLimit,
+                    QueueLimit = 0,
+                });
             });
             // Device Authorization Grant (RFC 8628, AI-050a) — all per-IP.
             // device-code: CLI requests a device_code; one per CLI session, 5/min is ample.
@@ -95,13 +123,17 @@ public static partial class ServiceCollectionExtensions
             // "Send to TextStack" web clip receiver — per-IP cap. Each clip queues an
             // ingestion job + stores HTML, so this blocks scripted bulk-clipping while
             // staying generous for a human saving a handful of articles in a session.
+            // Permit limit is a knob for the same reason as the guest one: a dozen integration test
+            // classes seed a user book by clipping one, so a single suite run exceeds 20 from one
+            // host and they all skip on "clip seed unavailable" instead of running.
+            var clipPermitLimit = rateLimits.EffectiveClipPermitLimit;
             options.AddPolicy("clip", httpContext =>
             {
                 var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
                 return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
                 {
                     Window = TimeSpan.FromMinutes(1),
-                    PermitLimit = 20,
+                    PermitLimit = clipPermitLimit,
                     QueueLimit = 0,
                 });
             });
@@ -306,13 +338,16 @@ public static partial class ServiceCollectionExtensions
             // never needs to call this more than once, so a tight per-IP cap blocks abuse
             // (e.g. scripted churn against the cascade delete) while staying out of the way
             // of a legitimate retry after a transient failure.
+            // Knob, same doctrine: the GDPR delete suite legitimately calls this four times in one
+            // class, which is one more than production wants to allow a human.
+            var accountDeletePermitLimit = rateLimits.EffectiveAccountDeletePermitLimit;
             options.AddPolicy("account-delete", httpContext =>
             {
                 var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
                 return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
                 {
                     Window = TimeSpan.FromMinutes(5),
-                    PermitLimit = 3,
+                    PermitLimit = accountDeletePermitLimit,
                     QueueLimit = 0,
                 });
             });

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -86,18 +86,60 @@ if (app.Environment.IsDevelopment())
     app.MapScalarApiReference();
 }
 
-// Forward headers from reverse proxy (nginx/cloudflare)
+// Forward headers from the reverse proxy chain (Cloudflare → cloudflared → nginx → here).
+//
+// This block decides what Connection.RemoteIpAddress is, and therefore what every per-IP rate-limit
+// partition is keyed on. It was previously "trust everything, one hop", which was harmless only
+// while the limiter never ran (it sat above UseRouting). Turning the limiter on made two latent
+// defects live, both measured against the running stack:
+//
+//   1. ONE BUCKET FOR THE WHOLE INTERNET. nginx sets X-Forwarded-For with
+//      $proxy_add_x_forwarded_for, which APPENDS its own $remote_addr — and its peer is cloudflared
+//      on the same host, so the rightmost entry is 127.0.0.1 on every request ever made. With the
+//      default ForwardLimit of 1 the middleware takes exactly that rightmost entry, so every
+//      request in production resolves to the same address. Verified here: draining the bucket with
+//      `XFF: 1.1.1.1, 9.9.9.9` then sending `XFF: 2.2.2.2, 9.9.9.9` returns 429 — a different
+//      client behind the same proxy shares the partition. Shipped as-is, "3 guest sessions per 5
+//      minutes per IP" would have meant 3 per 5 minutes for everyone on earth, and the same for
+//      translate (30/min), dictionary (60/min) and tts (120/min).
+//
+//   2. TRIVIAL BYPASS. With KnownProxies and KnownIPNetworks both empty, ANY caller is trusted to
+//      declare its own address. Verified: after exhausting the limit, three requests carrying a
+//      self-chosen `X-Forwarded-For` all returned 200.
+//
+// The fix is the standard walk: trust hops only while they are inside the private ranges the proxy
+// chain actually lives in, and keep walking right-to-left until the first address that is not.
+// Cloudflare appends the true client IP to X-Forwarded-For at the edge, so anything a caller
+// injects ends up to the LEFT of it and is never reached — the walk stops at the Cloudflare-written
+// entry. Both defects close with the same change: the key becomes the real client, and it stops
+// being caller-controlled from outside the trusted network.
 var forwardedHeadersOptions = new ForwardedHeadersOptions
 {
-    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+    // Unbounded hops: the chain length is nginx + tunnel today and must not be a magic number that
+    // silently truncates to the wrong entry when a hop is added. The KnownIPNetworks list below is
+    // what bounds trust, not a count.
+    ForwardLimit = null,
 };
-// Trust all proxies in production (behind nginx/cloudflare)
 forwardedHeadersOptions.KnownIPNetworks.Clear();
 forwardedHeadersOptions.KnownProxies.Clear();
+// Loopback + RFC1918 + IPv6 loopback/ULA: every hop between the public internet and this process
+// (cloudflared, nginx, the docker bridge) is inside one of these, and no genuine client is.
+foreach (var network in new[]
+{
+    new System.Net.IPNetwork(System.Net.IPAddress.Parse("127.0.0.0"), 8),
+    new System.Net.IPNetwork(System.Net.IPAddress.Parse("10.0.0.0"), 8),
+    new System.Net.IPNetwork(System.Net.IPAddress.Parse("172.16.0.0"), 12),
+    new System.Net.IPNetwork(System.Net.IPAddress.Parse("192.168.0.0"), 16),
+    new System.Net.IPNetwork(System.Net.IPAddress.Parse("::1"), 128),
+    new System.Net.IPNetwork(System.Net.IPAddress.Parse("fc00::"), 7),
+})
+{
+    forwardedHeadersOptions.KnownIPNetworks.Add(network);
+}
 app.UseForwardedHeaders(forwardedHeadersOptions);
 
 app.UseCors();
-app.UseRateLimiter();
 app.UseExceptionMiddleware();
 
 // Static files for uploaded content (author photos, book covers)
@@ -236,6 +278,26 @@ app.UseLanguageContext();
 
 // Explicit routing after middleware so path rewriting works
 app.UseRouting();
+
+// Rate limiting MUST come after UseRouting. `RequireRateLimiting("policy")` attaches
+// EnableRateLimitingAttribute to ENDPOINT METADATA, and the limiter reads that metadata off
+// HttpContext.GetEndpoint() — which is null until routing has matched. While this call sat above
+// UseRouting (next to UseCors) every per-endpoint policy in AddTextStackRateLimiting was inert:
+// 60 consecutive anonymous POST /auth/guest from one IP returned 60x 200 and zero 429, and no
+// GlobalLimiter was configured to cover the gap. Anonymous User-row creation was unbounded.
+//
+// Placement within the post-routing segment, and why each neighbour sits where it does:
+//   * ForwardedHeaders is still FIRST in the whole pipeline, so Connection.RemoteIpAddress is the
+//     real client here exactly as it was before — every per-IP partition key is unaffected.
+//   * ExceptionMiddleware now WRAPS the limiter instead of sitting under it; a throw from a policy
+//     factory becomes a handled 500 rather than an unhandled one.
+//   * SiteContext/Language must stay above UseRouting (they rewrite the path that routing matches),
+//     so a rejected request does pay for those two. Both are in-memory for this path — SiteContext
+//     skips /auth/ outright and the language middleware is string parsing — so a 429 still costs no
+//     database work.
+//   * GuestActivity is deliberately BELOW this line: it writes users.LastActiveAt, and a request
+//     the limiter rejected must not reach the database at all.
+app.UseRateLimiter();
 
 // Guest activity tracking (update LastActiveAt, debounced hourly)
 app.UseMiddleware<Api.Middleware.GuestActivityMiddleware>();

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -151,7 +151,10 @@
   },
   "_RateLimitsComment": "Only the rate-limiter values a deployment has to move. Everything else is a literal in AddTextStackRateLimiting next to the comment that justifies it. GuestSessionPermitLimit is guest-creates per IP per 5-minute window; production keeps 3, CI raises it via RateLimits__GuestSessionPermitLimit because the guest-merge suite needs >=6 guests from one host. It is a knob, not a bypass: the policy, window and partition key are the same code in CI and in production. A configured <=0 degrades to 3 rather than locking everyone out.",
   "RateLimits": {
-    "GuestSessionPermitLimit": 3
+    "GuestSessionPermitLimit": 3,
+    "UserLoginPermitLimit": 10,
+    "ClipPermitLimit": 20,
+    "AccountDeletePermitLimit": 3
   },
   "_EntitlementsComment": "Per-tier quotas. The tier is stored on users.tier (Guest|Free|Supporter|Staff). Staff is additionally granted by StaffEmails — but NEVER to a guest (guest emails are synthesized, so a collision must not mint a 5GB anonymous session). A user row may carry storage_limit_override_bytes, which wins over the tier and is clamped to MaxStorageLimitBytes. MaxSingleUploadBytes is a PLATFORM constraint, not a tier perk: Cloudflare caps one request body at ~100MB (verified — 90MB reached the API, 110MB returned 413 cloudflare), so it is deliberately NOT expressible per tier and config may only LOWER it. Bigger files must use the chunked upload endpoints. An unknown tier key, or an absent/<=0 value, falls back to Default and then to a compiled-in 500MB — this section can never brick uploads. DailyEnrichmentCap is new-vocabulary-words-per-UTC-day that a tier may push through paid LLM enrichment (distractors+hint+explanation fire on every word save). Only Guest sets it: /auth/guest + word saving is otherwise an account-less path to unmetered paid inference. 50/day is an honest first encounter, not a farm. Absent or <=0 means unlimited, same as MaxBooks. AiEnabled is the ON/OFF switch above that cap: false closes the whole paid-inference surface (librarian, tutor, ask, book chat, study buddy, RAG indexing) for the tier, server-side, with 403 account_required. Only Guest sets it. Unset means allowed — a missing key must cost us a call, not silently kill AI for paying users.",
   "Entitlements": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,15 @@ services:
       # guest suites need >=6 guests and every request there comes from one host. A knob, not
       # a bypass: the limiter policy itself is identical in both.
       RateLimits__GuestSessionPermitLimit: ${GUEST_SESSION_PERMIT_LIMIT:-3}
+      # Register/login/password-reset attempts per IP per minute. Production keeps 10; CI raises it
+      # because the guest-merge suite makes ~15 of them from one host inside a minute and would
+      # otherwise throttle itself into skips — a green run with no merge coverage.
+      RateLimits__UserLoginPermitLimit: ${USER_LOGIN_PERMIT_LIMIT:-10}
+      # Web clips per IP per minute, and account hard-deletes per IP per 5 min. Production keeps
+      # 20 and 3; CI raises both because the integration suite seeds user books by clipping and the
+      # GDPR delete test legitimately deletes four times.
+      RateLimits__ClipPermitLimit: ${CLIP_PERMIT_LIMIT:-20}
+      RateLimits__AccountDeletePermitLimit: ${ACCOUNT_DELETE_PERMIT_LIMIT:-3}
       # New vocabulary words a GUEST may push through paid LLM enrichment per UTC day. Production
       # keeps 50 (appsettings). CI lowers it so the cap is reachable in a test: proving that
       # promoting a parked lookup respects it takes `cap` real saves, and 50 is not testable.

--- a/tests/TextStack.IntegrationTests/ForwardedClientIpTests.cs
+++ b/tests/TextStack.IntegrationTests/ForwardedClientIpTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Every per-IP rate-limit partition is keyed on <c>Connection.RemoteIpAddress</c>, which behind a
+/// proxy is whatever <c>UseForwardedHeaders</c> decides it is. That made the ForwardedHeaders
+/// configuration part of the limiter, and it was wrong in both directions.
+///
+/// nginx writes <c>X-Forwarded-For</c> with <c>$proxy_add_x_forwarded_for</c>, which APPENDS its own
+/// peer — cloudflared, on the same host — so the RIGHTMOST entry is 127.0.0.1 on every request the
+/// site has ever served. The default <c>ForwardLimit</c> of 1 takes exactly that entry. While the
+/// limiter never ran this was invisible; the moment it ran, "3 guest sessions per 5 minutes per IP"
+/// would have meant three per five minutes for the entire internet, and the same for translate,
+/// dictionary and TTS. In the other direction, an empty <c>KnownProxies</c>/<c>KnownIPNetworks</c>
+/// let any caller nominate its own address and step around the limit entirely.
+///
+/// This test pins the property that matters, at the only layer that can observe it from outside: two
+/// different clients arriving through the SAME trusted proxy hop must not share a bucket.
+///
+/// It uses <c>admin-login</c> (5/min/IP) with deliberately wrong credentials — cheap, creates no
+/// rows, and its partitions here are synthetic addresses, so it cannot starve the real guest suite
+/// the way the guest-session bucket does.
+/// </summary>
+public class ForwardedClientIpTests(LiveApiFixture fixture) : IClassFixture<LiveApiFixture>
+{
+    /// <summary>Matches <c>admin-login</c>'s compiled-in permit limit.</summary>
+    private const int AdminLoginPermitLimit = 5;
+
+    /// <summary>Private, therefore trusted: stands in for the cloudflared/nginx hop that the real
+    /// deployment appends to every request.</summary>
+    private const string TrustedProxyHop = "10.0.0.9";
+
+    private async Task<HttpStatusCode> FailedAdminLoginAsync(string clientIp, CancellationToken ct)
+    {
+        var req = fixture.CreateAdminRequest(HttpMethod.Post, "/admin/auth/login");
+        req.Headers.TryAddWithoutValidation("X-Forwarded-For", $"{clientIp}, {TrustedProxyHop}");
+        req.Content = JsonContent.Create(new { email = "nobody@textstack.invalid", password = "wrong" });
+        var resp = await fixture.Client.SendAsync(req, ct);
+        return resp.StatusCode;
+    }
+
+    [Fact]
+    public async Task RateLimit_TwoClientsBehindTheSameProxyHop_DoNotShareABucket()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Unique per run: the limiter's partitions are process-wide and outlive a single test.
+        var suffix = Random.Shared.Next(1, 250);
+        var clientA = $"198.51.100.{suffix}";
+        var clientB = $"203.0.113.{suffix}";
+
+        var first = await FailedAdminLoginAsync(clientA, ct);
+        Assert.SkipWhen(first == HttpStatusCode.NotFound, "/admin/auth/login unavailable");
+        Assert.SkipWhen(first == HttpStatusCode.TooManyRequests,
+            "admin-login bucket already exhausted for this synthetic client");
+
+        // Exhaust client A's own bucket.
+        var exhausted = false;
+        for (var i = 1; i < AdminLoginPermitLimit + 3 && !exhausted; i++)
+            exhausted = await FailedAdminLoginAsync(clientA, ct) == HttpStatusCode.TooManyRequests;
+
+        Assert.True(exhausted,
+            $"{AdminLoginPermitLimit + 2} failed admin logins from one client were never rejected — "
+            + "the admin-login limiter is not enforced.");
+
+        // The assertion. Client B differs from A only in the LEFT (real client) entry; the proxy hop
+        // on the right is identical, exactly as it is for every request in production.
+        var otherClient = await FailedAdminLoginAsync(clientB, ct);
+        Assert.True(
+            otherClient != HttpStatusCode.TooManyRequests,
+            "a second client behind the same proxy hop was rate-limited by the first client's "
+            + "traffic: UseForwardedHeaders is resolving RemoteIpAddress to the PROXY rather than to "
+            + "the client, so every per-IP limit in the app is really one global bucket. In "
+            + "production that proxy entry is the cloudflared hop nginx appends to every single "
+            + "request.");
+    }
+}

--- a/tests/TextStack.IntegrationTests/RateLimitEnforcementTests.cs
+++ b/tests/TextStack.IntegrationTests/RateLimitEnforcementTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Does <c>RequireRateLimiting("guest-session")</c> actually limit anything?
+///
+/// This PR adds a whole slice around that policy — <c>RateLimitSettings</c>,
+/// <c>RateLimits__GuestSessionPermitLimit</c> in compose, <c>GUEST_SESSION_PERMIT_LIMIT</c> in CI,
+/// <c>RateLimitSettingsTests</c>, and the "a knob, not a bypass" argument in three docblocks. All of
+/// it rests on the limiter running. <c>RateLimitSettingsTests</c> cannot see whether it does: it
+/// binds the options object and asserts on the number, never on a response.
+///
+/// The limiter does not run. <c>Program.cs</c> calls <c>app.UseRateLimiter()</c> at line ~100 and
+/// <c>app.UseRouting()</c> at line ~238. <c>RequireRateLimiting</c> attaches
+/// <c>EnableRateLimitingAttribute</c> to endpoint METADATA, and the rate-limiting middleware reads
+/// it off <c>HttpContext.GetEndpoint()</c> — which is null until routing has run. Every per-endpoint
+/// policy in <c>AddTextStackRateLimiting</c> is therefore inert, and no global limiter is
+/// configured to take over.
+///
+/// Measured against the running stack: 56 consecutive anonymous <c>POST /auth/guest</c> from one IP
+/// with <c>GuestSessionPermitLimit=50</c> → 56× 200, zero 429. Nine consecutive failed
+/// <c>POST /admin/auth/login</c> (policy: 5/min) → nine 401s, zero 429. Fourteen failed
+/// <c>POST /auth/login</c> (policy: 10/min) → fourteen 401s, zero 429.
+///
+/// Why it matters more after this PR than before it: <c>/auth/guest</c> used to be a web-only,
+/// cookie-driven path. It is now the first request every mobile install makes, it needs no
+/// credentials, and each call inserts a <c>User</c> row that the cleanup worker will keep for 30
+/// days and that unlocks the whole <c>/me/*</c> write surface plus the daily enrichment allowance.
+///
+/// Fix is one line — move <c>UseRateLimiter</c> below <c>UseRouting</c> — but it is a pipeline
+/// reorder with its own consequences (the site/language/guest-activity middleware would then run
+/// before the limiter rejects), so this test names the defect rather than assuming the shape of the
+/// fix.
+/// </summary>
+public class RateLimitEnforcementTests(LiveApiFixture fixture) : IClassFixture<LiveApiFixture>
+{
+    /// <summary>
+    /// Comfortably above every configured value the guest policy takes: 3 in production, 50 in CI
+    /// and in the local compose stack. Kept as an upper bound rather than read from config so the
+    /// test asserts the SERVER's behaviour and not the test host's environment — the CI value lives
+    /// in the compose <c>.env</c>, which the test process never sees.
+    /// </summary>
+    private const int Attempts = 60;
+
+    [Fact]
+    public async Task GuestSession_FarBeyondAnyConfiguredLimit_IsRateLimited()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var statuses = new List<HttpStatusCode>(Attempts);
+        for (var i = 0; i < Attempts; i++)
+        {
+            var req = fixture.CreateRequest(HttpMethod.Post, "/auth/guest");
+            req.Headers.Add("X-Client", "mobile");
+            var resp = await fixture.Client.SendAsync(req, ct);
+
+            if (i == 0) Assert.SkipWhen(IntegrationSkip.Unavailable(resp), "/auth/guest unavailable");
+
+            statuses.Add(resp.StatusCode);
+            // A working limiter short-circuits here, so the happy path costs ~4 or ~51 rows, not 60.
+            if (resp.StatusCode == HttpStatusCode.TooManyRequests) break;
+        }
+
+        Assert.True(
+            statuses.Contains(HttpStatusCode.TooManyRequests),
+            $"{statuses.Count} consecutive POST /auth/guest from one IP, none rejected "
+            + $"(distinct statuses: {string.Join(", ", statuses.Distinct().Select(s => (int)s))}). "
+            + "The guest-session limiter is not enforced: UseRateLimiter() runs before UseRouting() "
+            + "in Program.cs, so RequireRateLimiting metadata is never visible to it. Anonymous "
+            + "User-row creation is unbounded, and RateLimits:GuestSessionPermitLimit is a no-op.");
+    }
+}

--- a/tests/TextStack.UnitTests/RateLimitSettingsTests.cs
+++ b/tests/TextStack.UnitTests/RateLimitSettingsTests.cs
@@ -47,4 +47,32 @@ public class RateLimitSettingsTests
         Assert.Equal(3, Bind(("RateLimits:GuestSessionPermitLimit", "-1")).EffectiveGuestSessionPermitLimit);
     }
 
+    // The other three knobs, added when the limiter started actually running: user-login, clip and
+    // account-delete all have production values the integration suite legitimately exceeds from a
+    // single host. Same contract as the guest one in all three cases.
+
+    [Fact]
+    public void UserLoginPermitLimit_UnconfiguredConfiguredAndInvalid_BehavesLikeGuestKnob()
+    {
+        Assert.Equal(10, Bind().EffectiveUserLoginPermitLimit);
+        Assert.Equal(100, Bind(("RateLimits:UserLoginPermitLimit", "100")).EffectiveUserLoginPermitLimit);
+        Assert.Equal(10, Bind(("RateLimits:UserLoginPermitLimit", "0")).EffectiveUserLoginPermitLimit);
+        Assert.Equal(10, Bind(("RateLimits:UserLoginPermitLimit", "-5")).EffectiveUserLoginPermitLimit);
+    }
+
+    [Fact]
+    public void ClipPermitLimit_UnconfiguredConfiguredAndInvalid_BehavesLikeGuestKnob()
+    {
+        Assert.Equal(20, Bind().EffectiveClipPermitLimit);
+        Assert.Equal(200, Bind(("RateLimits:ClipPermitLimit", "200")).EffectiveClipPermitLimit);
+        Assert.Equal(20, Bind(("RateLimits:ClipPermitLimit", "0")).EffectiveClipPermitLimit);
+    }
+
+    [Fact]
+    public void AccountDeletePermitLimit_UnconfiguredConfiguredAndInvalid_BehavesLikeGuestKnob()
+    {
+        Assert.Equal(3, Bind().EffectiveAccountDeletePermitLimit);
+        Assert.Equal(50, Bind(("RateLimits:AccountDeletePermitLimit", "50")).EffectiveAccountDeletePermitLimit);
+        Assert.Equal(3, Bind(("RateLimits:AccountDeletePermitLimit", "-1")).EffectiveAccountDeletePermitLimit);
+    }
 }


### PR DESCRIPTION
## Summary

`app.UseRateLimiter()` sat 138 lines **above** `app.UseRouting()`. `RequireRateLimiting` attaches endpoint *metadata*, and the limiter reads it off `HttpContext.GetEndpoint()` — null before routing. No `GlobalLimiter` covered the gap.

**Every rate limit in this application has been decorative.** Measured against a running stack:

```
56 consecutive POST /auth/guest from one IP  →  56× 200, zero 429
 9 failed admin logins                        →   9× 401, zero 429
14 failed user logins                         →  14× 401, zero 429
```

Found while building guest sessions (#554), which is what turns it from latent into urgent: `/auth/guest` needs no credentials, is the first request every mobile install makes, and each call inserts a `User` row that unlocks the whole `/me/*` write surface plus a daily embedding budget. Unbounded anonymous row creation, trivially scriptable.

**Based on #554 — merge that first.** Its integration suite is green today *only because the limiter is inert*; the two-step CI split and the three new knobs below are what keep it green afterwards.

## Two more defects, found by probing after the fix

Neither was visible while the limiter did nothing.

**In production every per-IP limit was one bucket for the whole internet.** `infra/nginx/textstack.conf` uses `$proxy_add_x_forwarded_for`, which *appends* nginx's peer — cloudflared, on the same host. The default `ForwardLimit = 1` takes the **rightmost** entry, so every request on earth resolved to `127.0.0.1`:

```
drain with 'XFF: 1.1.1.1, 9.9.9.9'  → 429 at 51
then       'XFF: 2.2.2.2, 9.9.9.9'  → 429    ← different client, same bucket
then       'XFF: 1.1.1.1, 8.8.8.8'  → 200    ← the rightmost entry is the key
```

So "3 guest sessions per 5 min per IP" meant 3 per 5 min for everyone; likewise translate 30/min, dictionary 60/min, TTS 120/min.

**And it was trivially bypassable.** `KnownIPNetworks.Clear()` + `KnownProxies.Clear()` trusts any caller to declare its own address — three requests with a self-chosen `X-Forwarded-For` returned 200 after the limit was exhausted.

Both close the same way: `ForwardLimit = null` plus a trusted-network list (loopback + RFC1918 + `::1`/`fc00::/7`), so the middleware walks right-to-left through private hops and stops at the first public address — the entry Cloudflare writes. Anything injected lands to its left and is never reached.

`infra/nginx/textstack.conf` is deliberately **not** touched: the server-side walk is correct against the config as it stands, and adding `real_ip` there is a production networking change with its own blast radius.

## `admin-login` and `user-login` were global, not per-IP

`AddFixedWindowLimiter`, not `AddPolicy` — 5 and 10 attempts per minute **for the entire site**. Harmless while inert; the moment the limiter works, ten failed logins from anyone would lock every user out of signing in *and* out of password reset. Now per-IP like every other policy. Same ceiling per attacker, no collateral.

Fixing the ordering without this would have shipped a trivial site-wide DoS.

## Fallout, measured

Three policies bound the test suite once the limiter woke up — `user-login` was not even the worst:

1. `RateLimitEnforcementTests` drains the `guest-session` bucket by construction (it consumes `limit+1`), starving 15 guest/merge tests. **Not fixable with a bigger number** — no value satisfies both it and ~16 legitimate guest creates in one IP-keyed window. Fixed by isolation: CI runs the suite without it, restarts the API to drop in-memory partitions, then runs it alone.
2. `clip` (20/min) — a dozen test classes seed a book by clipping. 11 skips + 1 hard failure.
3. `account-delete` (3/5 min) — the GDPR suite legitimately calls it 4×.

New knobs, same doctrine as the existing guest one: `UserLoginPermitLimit`, `ClipPermitLimit`, `AccountDeletePermitLimit`. Production defaults unchanged.

## Verification

```
dotnet build                                    0 errors
dotnet format --verify-no-changes               clean
dotnet test tests/TextStack.UnitTests           1443 passed, 0 skipped
integration, CI shape step 1                    192 passed, 45 skipped
integration, CI shape step 2 (isolated)         1 passed
```

A single-process run shows **57** skips — that is the documented starvation above, and exactly why this branch carries the two-step CI and can only merge second.

Probe re-run after the fix:
```
200 ×50  429      first 429 at attempt 51, Retry-After: 300
admin-login:  401 401 401 401 401 429 429 429
```

## Rollback

`git revert`. Reverting restores the previous behaviour exactly — which is to say, no rate limiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZDSrvtAjiqUz82FPQdZpz