### PR TITLE
fix(dictionary): a dead upstream stops being a ten-second error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,8 +369,13 @@ jobs:
 
       - name: Create volume dirs for non-root containers
         run: |
-          mkdir -p data/storage data/textstack data/postgres-prod
-          chmod 777 data/storage data/textstack
+          # The cache dirs are bind mounts. Docker creates a missing one as root,
+          # the api container runs as uid 1000, and every cache write is
+          # best-effort - so an uncreated dir means the cache silently does
+          # nothing and the dictionary outage fallback does not exist. That is
+          # what the repeated-lookup test caught.
+          mkdir -p data/storage data/textstack data/postgres-prod data/dictionary-cache data/explain-cache
+          chmod 777 data/storage data/textstack data/dictionary-cache data/explain-cache
 
       - name: Build containers
         run: docker compose build
@@ -449,8 +454,13 @@ jobs:
 
       - name: Create volume dirs for non-root containers
         run: |
-          mkdir -p data/storage data/textstack data/postgres-prod
-          chmod 777 data/storage data/textstack
+          # The cache dirs are bind mounts. Docker creates a missing one as root,
+          # the api container runs as uid 1000, and every cache write is
+          # best-effort - so an uncreated dir means the cache silently does
+          # nothing and the dictionary outage fallback does not exist. That is
+          # what the repeated-lookup test caught.
+          mkdir -p data/storage data/textstack data/postgres-prod data/dictionary-cache data/explain-cache
+          chmod 777 data/storage data/textstack data/dictionary-cache data/explain-cache
 
       - name: Build & start services
         run: docker compose up -d --build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Dictionary** — a word tap survives the dictionary API being down, and fails in 3s instead of 10 when it cannot — backend · [details](docs/changelog-archive/2026-H2.md#2026-09-06-dictionary-an-upstream-outage-stops-being-an-outage)
 - **Guest** — a reader finishes the loop — read, save a word, review it — with no account, and registering keeps every bit of it — mobile, backend · [details](docs/changelog-archive/2026-H2.md#2026-09-06-guest-the-whole-loop-without-an-account)
 - **Mobile** — a reader with no account gets an invitation, not a red error, and a Save button that is actually there — mobile, web · [details](docs/changelog-archive/2026-H2.md#2026-09-05-mobile-an-invitation-not-a-red-error)
 - **Extension** — the checks its README describes now run, and can now fail — infra · [details](docs/changelog-archive/2026-H2.md#2026-09-02-extension-a-gate-that-could-not-fail)

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ status:
 fix-permissions:
 	@echo "Fixing volume permissions..."
 	@docker run --rm -v $$(pwd)/data:/data alpine sh -c '\
-		mkdir -p /data/textstack /data/tts-cache /data/explain-cache /data/translate-cache /data/pdf-cleanup-dataset && \
-		chown -R 1000:1000 /data/textstack /data/tts-cache /data/explain-cache /data/translate-cache /data/pdf-cleanup-dataset'
+		mkdir -p /data/textstack /data/tts-cache /data/explain-cache /data/dictionary-cache /data/translate-cache /data/pdf-cleanup-dataset && \
+		chown -R 1000:1000 /data/textstack /data/tts-cache /data/explain-cache /data/dictionary-cache /data/translate-cache /data/pdf-cleanup-dataset'
 	@echo "Done."
 
 deploy: fix-permissions

--- a/apps/mobile/src/components/vocabulary/ReviewFeedback.tsx
+++ b/apps/mobile/src/components/vocabulary/ReviewFeedback.tsx
@@ -29,8 +29,8 @@ export function ReviewFeedback({ card, result, isCorrect, reviewMode, onSpeak, o
     // Reset any stale result from the previous card before the new lookup lands.
     setFetchedDef(null)
     dictionaryApi.lookupWord(language, card.word).then(data => {
-      if (cancelled || !data?.meanings?.length) return
-      const parts = data.meanings.slice(0, 3)
+      if (cancelled || !data?.definitions?.length) return
+      const parts = data.definitions.slice(0, 3)
       const defs = parts.map(m =>
         `(${m.partOfSpeech}) ${(m.definitions || []).slice(0, 2).map(d => d.definition).join('; ')}`
       ).join('\n')

--- a/backend/src/Api/Endpoints/DictionaryCache.cs
+++ b/backend/src/Api/Endpoints/DictionaryCache.cs
@@ -1,0 +1,168 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Api.Endpoints;
+
+/// <summary>
+/// What a cached dictionary lookup turned out to be. <see cref="NotFound"/> is a NEGATIVE entry:
+/// upstream told us the word has no definition. It is cached so a typo does not send a request to
+/// a dead service every time it is tapped, but on a much shorter TTL than a hit — dictionaries
+/// gain words, they effectively never change the definition of one they already have.
+/// </summary>
+public enum DictionaryStatus
+{
+    Hit,
+    NotFound,
+    Unavailable,
+}
+
+/// <summary>One resolved lookup, independent of how it was resolved (cache, upstream, or stale fallback).</summary>
+/// <param name="Cached">Answer came off disk rather than from upstream.</param>
+/// <param name="Stale">Answer came off disk PAST its TTL, because upstream could not be reached.
+/// Still correct data — just not revalidated.</param>
+public sealed record DictionaryResolution(
+    DictionaryStatus Status,
+    DictionaryResponse? Entry,
+    bool Cached,
+    bool Stale);
+
+/// <summary>
+/// The on-disk record. <see cref="CachedAtUtc"/> is stored in the payload rather than read off the
+/// file's mtime: a volume restore or a <c>docker cp</c> rewrites mtimes and would make the whole
+/// cache look freshly written, which quietly turns the "is this stale?" question into a lie.
+/// <see cref="Entry"/> is null for a negative entry.
+/// </summary>
+public sealed record DictionaryCacheEntry(
+    [property: JsonPropertyName("found")] bool Found,
+    [property: JsonPropertyName("cachedAtUtc")] DateTime CachedAtUtc,
+    [property: JsonPropertyName("entry")] DictionaryResponse? Entry);
+
+/// <summary>
+/// The lookup policy, as pure functions over a cache entry — no IO, no clock of its own, no HTTP.
+/// This is where the load-bearing rule lives: <b>on upstream failure we serve a stale entry rather
+/// than an error</b>. A definition from last month is correct; a 504 is not.
+/// </summary>
+public static class DictionaryPolicy
+{
+    /// <summary>
+    /// The answer we can give WITHOUT touching upstream, or null meaning "go ask upstream".
+    /// Fresh entries (positive or negative) short-circuit; stale ones do not — they are held back
+    /// as the fallback for <see cref="OnUpstreamFailure"/>.
+    /// </summary>
+    public static DictionaryResolution? FromCache(
+        DictionaryCacheEntry? cached, DateTime nowUtc, TimeSpan hitTtl, TimeSpan negativeTtl)
+    {
+        if (cached is null)
+            return null;
+
+        var ttl = cached.Found ? hitTtl : negativeTtl;
+        if (!IsFresh(cached, nowUtc, ttl))
+            return null;
+
+        return cached.Found
+            ? new DictionaryResolution(DictionaryStatus.Hit, cached.Entry, Cached: true, Stale: false)
+            : new DictionaryResolution(DictionaryStatus.NotFound, null, Cached: true, Stale: false);
+    }
+
+    /// <summary>
+    /// Upstream is unreachable (timeout, connection failure, or a non-404 error status). Serve
+    /// whatever we have at ANY age — there is deliberately no upper bound on how stale a fallback
+    /// may be, because the alternative is an error and an error is strictly worse. Nothing cached
+    /// is the only case that fails, and it fails as <see cref="DictionaryStatus.Unavailable"/> so
+    /// the client can tell "we could not ask" apart from "this word has no definition".
+    /// </summary>
+    public static DictionaryResolution OnUpstreamFailure(DictionaryCacheEntry? cached) => cached switch
+    {
+        { Found: true } => new DictionaryResolution(DictionaryStatus.Hit, cached.Entry, Cached: true, Stale: true),
+        { Found: false } => new DictionaryResolution(DictionaryStatus.NotFound, null, Cached: true, Stale: true),
+        _ => new DictionaryResolution(DictionaryStatus.Unavailable, null, Cached: false, Stale: false),
+    };
+
+    /// <summary>An entry written in the future (clock skew) counts as fresh, not as infinitely old.</summary>
+    public static bool IsFresh(DictionaryCacheEntry entry, DateTime nowUtc, TimeSpan ttl) =>
+        entry.CachedAtUtc != default && nowUtc - entry.CachedAtUtc < ttl;
+}
+
+/// <summary>
+/// SHA256-keyed file cache for dictionary lookups. Same shape as <c>ExplainCache</c> (hex key,
+/// one JSON file per entry, best-effort IO that degrades to "no cache" rather than failing the
+/// request) with two differences that the fallback depends on:
+/// <list type="bullet">
+///   <item>reads do NOT drop expired entries — they return them flagged, so the endpoint can serve
+///     them when upstream is down;</item>
+///   <item>writes are tmp+rename, so a container kill mid-write cannot leave a truncated file that
+///     later poisons the outage path (same reason <c>EdgeTtsService</c> does it).</item>
+/// </list>
+/// </summary>
+public sealed class DictionaryCache(string cachePath, ILogger logger)
+{
+    /// <summary>
+    /// Key over the NORMALIZED (lang, word) pair, so "Book", "book " and "BOOK" share one entry.
+    /// Hit rate is what makes the outage fallback work at all, so the normalization is part of the
+    /// contract, not an optimization.
+    /// </summary>
+    public static string ComputeKey(string lang, string word)
+    {
+        var normLang = lang.Trim().ToLowerInvariant();
+        var normWord = word.Trim().ToLowerInvariant();
+        // Length-prefixed, not just separated: both halves come off URL segments, so a plain
+        // "lang|word" join lets ("en", "us|book") and ("en|us", "book") hash to the same entry.
+        var payload = $"{normLang.Length}:{normLang}:{normWord}";
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+    }
+
+    public async Task<DictionaryCacheEntry?> TryReadAsync(string key, CancellationToken ct)
+    {
+        try
+        {
+            var file = FilePath(key);
+            if (!File.Exists(file))
+                return null;
+            var entry = JsonSerializer.Deserialize<DictionaryCacheEntry>(await File.ReadAllTextAsync(file, ct));
+            // A positive entry with no payload is corrupt — treat as a miss, not as a negative.
+            if (entry is { Found: true, Entry: null })
+                return null;
+            return entry;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Dictionary cache read failed for {Key}, falling through to upstream", key);
+            return null;
+        }
+    }
+
+    public Task WriteHitAsync(string key, DictionaryResponse entry, DateTime nowUtc, CancellationToken ct) =>
+        WriteAsync(key, new DictionaryCacheEntry(true, nowUtc, entry), ct);
+
+    public Task WriteMissAsync(string key, DateTime nowUtc, CancellationToken ct) =>
+        WriteAsync(key, new DictionaryCacheEntry(false, nowUtc, null), ct);
+
+    private async Task WriteAsync(string key, DictionaryCacheEntry entry, CancellationToken ct)
+    {
+        var file = FilePath(key);
+        var tmp = file + "." + Guid.NewGuid().ToString("N")[..8] + ".tmp";
+        try
+        {
+            Directory.CreateDirectory(cachePath);
+            await File.WriteAllTextAsync(tmp, JsonSerializer.Serialize(entry), ct);
+            File.Move(tmp, file, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Dictionary cache write failed for {Key}", key);
+            try
+            {
+                if (File.Exists(tmp))
+                    File.Delete(tmp);
+            }
+            catch (Exception cleanupEx) when (cleanupEx is UnauthorizedAccessException or IOException)
+            {
+                // best effort; the sweeper reaps orphaned .tmp files
+            }
+        }
+    }
+
+    private string FilePath(string key) => Path.Combine(cachePath, key + ".json");
+}

--- a/backend/src/Api/Endpoints/DictionaryEndpoints.cs
+++ b/backend/src/Api/Endpoints/DictionaryEndpoints.cs
@@ -3,8 +3,48 @@ using System.Text.Json.Serialization;
 
 namespace Api.Endpoints;
 
+/// <summary>
+/// Word lookup for the reader, proxying the Free Dictionary API in front of a SHA256 file cache.
+///
+/// <para><b>Contract.</b> Three outcomes, deliberately distinguishable:
+/// <list type="bullet">
+///   <item><c>200</c> — a definition. <c>cached</c> says it came off disk; <c>stale</c> says it came
+///     off disk past its TTL because upstream was unreachable. Still correct data.</item>
+///   <item><c>404</c> <c>{ message, code: "not_found" }</c> — upstream says this word has no
+///     definition. A real answer: the client should say "no definition for X".</item>
+///   <item><c>503</c> <c>{ message, code: "dictionary_unavailable" }</c> — we could not ask and had
+///     nothing cached. NOT an answer: the client should say "try again", not "no such word".</item>
+/// </list>
+/// Timeouts, connection failures and upstream 5xx all collapse into <c>503 dictionary_unavailable</c>;
+/// the distinction between them is an operator concern (it is logged) and not something a reader UI
+/// can act on differently. The previous 502/503/504 split gave clients three ways to say the same
+/// sentence. <c>X-Dictionary-Cache: hit|stale|miss|negative</c> carries the same information for ops.</para>
+///
+/// <para><b>No LLM fallback, on purpose.</b> This route is one of three (with <c>/translate</c> and
+/// <c>/api/tts</c>) kept anonymous because the reading loop depends on it. Routing misses to
+/// <see cref="Application.Ai.ILlmService"/> would put paid inference behind an unauthenticated URL —
+/// the exact hole <c>RequireAiAccount</c> closes from the other side.</para>
+/// </summary>
 public static class DictionaryEndpoints
 {
+    /// <summary>
+    /// A word tap in the reader: the answer is either fast or it is useless. 3s covers a cold DNS +
+    /// TLS handshake to the upstream CDN on a mobile network (~1s) plus a slow-but-alive query, and
+    /// caps the worst case below the point where a tap reads as broken. The old 10s was a budget for
+    /// a batch job, not a gesture — during tonight's outage it bought nothing except ten seconds of
+    /// spinner before the same error. With the cache in front, the marginal value of waiting longer
+    /// on a miss is small; the marginal cost is the whole interaction.
+    /// </summary>
+    private const int DefaultTimeoutSeconds = 3;
+
+    private const int DefaultCacheTtlDays = 30;
+
+    /// <summary>
+    /// Negative entries expire far sooner than hits. A definition is effectively immutable, but
+    /// "no such word" is a statement about coverage, and dictionaries do gain words.
+    /// </summary>
+    private const int DefaultNegativeCacheTtlHours = 24;
+
     public static void MapDictionaryEndpoints(this WebApplication app)
     {
         var group = app.MapGroup("/dictionary").WithTags("Dictionary");
@@ -15,7 +55,10 @@ public static class DictionaryEndpoints
     private static async Task<IResult> LookupWord(
         string lang,
         string word,
+        HttpContext httpContext,
+        IConfiguration config,
         IHttpClientFactory httpClientFactory,
+        ILogger<Program> logger,
         CancellationToken ct)
     {
         // Validate input
@@ -25,77 +68,126 @@ public static class DictionaryEndpoints
         if (word.Length > 100)
             return Results.BadRequest("Word is too long");
 
-        // Normalize language code
-        var langCode = lang.ToLowerInvariant() switch
-        {
-            "en" or "english" => "en",
-            "ru" or "russian" => "ru",
-            "de" or "german" => "de",
-            "fr" or "french" => "fr",
-            "es" or "spanish" => "es",
-            "pl" or "polish" => "pl",
-            "pt" or "portuguese" => "pt",
-            "pt-br" or "portuguese-brazil" => "pt", // Free Dictionary API uses 'pt' for both
-            _ => lang.ToLowerInvariant()
-        };
+        var langCode = NormalizeLang(lang);
+        var trimmedWord = word.Trim();
 
+        var cache = new DictionaryCache(
+            config.GetValue<string>("Dictionary:CachePath") ?? "/tmp/dictionary-cache", logger);
+        var hitTtl = TimeSpan.FromDays(config.GetValue("Dictionary:CacheTtlDays", DefaultCacheTtlDays));
+        var negativeTtl = TimeSpan.FromHours(
+            config.GetValue("Dictionary:NegativeCacheTtlHours", DefaultNegativeCacheTtlHours));
+        var timeout = TimeSpan.FromSeconds(
+            Math.Max(1, config.GetValue("Dictionary:TimeoutSeconds", DefaultTimeoutSeconds)));
+
+        var key = DictionaryCache.ComputeKey(langCode, trimmedWord);
+        var cached = await cache.TryReadAsync(key, ct);
+        var now = DateTime.UtcNow;
+
+        if (DictionaryPolicy.FromCache(cached, now, hitTtl, negativeTtl) is { } fresh)
+            return Respond(httpContext, fresh, trimmedWord);
+
+        // Nothing fresh on disk — ask upstream. Anything we hold is kept as the fallback.
         try
         {
             var client = httpClientFactory.CreateClient();
-            client.Timeout = TimeSpan.FromSeconds(10);
+            // The linked CTS is the only budget: HttpClient.Timeout raises the same
+            // TaskCanceledException as a client disconnect, and those need different handling.
+            client.Timeout = Timeout.InfiniteTimeSpan;
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
 
-            // Use Free Dictionary API (powered by Wiktionary)
-            var apiUrl = $"https://api.dictionaryapi.dev/api/v2/entries/{langCode}/{Uri.EscapeDataString(word.Trim())}";
-            var response = await client.GetAsync(apiUrl, ct);
+            // Free Dictionary API (powered by Wiktionary)
+            var apiUrl = $"https://api.dictionaryapi.dev/api/v2/entries/{langCode}/{Uri.EscapeDataString(trimmedWord)}";
+            var response = await client.GetAsync(apiUrl, cts.Token);
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
-                return Results.NotFound(new DictionaryErrorResponse($"No definition found for '{word}'"));
+                await cache.WriteMissAsync(key, now, ct);
+                return Respond(
+                    httpContext,
+                    new DictionaryResolution(DictionaryStatus.NotFound, null, Cached: false, Stale: false),
+                    trimmedWord);
             }
 
             if (!response.IsSuccessStatusCode)
             {
-                return Results.Problem(
-                    detail: $"Dictionary service error: {response.StatusCode}",
-                    statusCode: 502
-                );
+                // 5xx/522/429 — upstream is there but not answering. Same as unreachable.
+                logger.LogWarning("Dictionary upstream returned {Status} for {Lang}/{Word}",
+                    response.StatusCode, langCode, trimmedWord);
+                return Respond(httpContext, DictionaryPolicy.OnUpstreamFailure(cached), trimmedWord);
             }
 
-            var entries = await response.Content.ReadFromJsonAsync<List<DictionaryApiEntry>>(ct);
+            var entries = await response.Content.ReadFromJsonAsync<List<DictionaryApiEntry>>(cts.Token);
 
             if (entries == null || entries.Count == 0)
             {
-                return Results.NotFound(new DictionaryErrorResponse($"No definition found for '{word}'"));
+                await cache.WriteMissAsync(key, now, ct);
+                return Respond(
+                    httpContext,
+                    new DictionaryResolution(DictionaryStatus.NotFound, null, Cached: false, Stale: false),
+                    trimmedWord);
             }
 
-            // Transform to our response format
-            var entry = entries[0];
-            var result = new DictionaryResponse(
-                Word: entry.Word ?? word,
-                Phonetic: entry.Phonetics?.FirstOrDefault(p => !string.IsNullOrEmpty(p.Text))?.Text,
-                Definitions: entry.Meanings?.Select(m => new DictionaryMeaning(
-                    PartOfSpeech: m.PartOfSpeech ?? "unknown",
-                    Definitions: m.Definitions?.Take(3).Select(d => new DictionaryDefinition(
-                        Definition: d.Definition ?? "",
-                        Example: d.Example
-                    )).ToList() ?? []
-                )).ToList() ?? []
-            );
-
-            return Results.Ok(result);
+            var result = entries[0].ToResponse(trimmedWord);
+            await cache.WriteHitAsync(key, result, now, ct);
+            return Respond(
+                httpContext,
+                new DictionaryResolution(DictionaryStatus.Hit, result, Cached: false, Stale: false),
+                trimmedWord);
         }
-        catch (TaskCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            return Results.Problem("Dictionary request timed out", statusCode: 504);
+            throw; // reader navigated away — nothing to serve, nothing to log
         }
-        catch (HttpRequestException ex)
+        catch (OperationCanceledException)
         {
-            return Results.Problem(
-                detail: $"Dictionary service unavailable: {ex.Message}",
-                statusCode: 503
-            );
+            logger.LogWarning("Dictionary upstream timed out after {Timeout}s for {Lang}/{Word}",
+                timeout.TotalSeconds, langCode, trimmedWord);
+            return Respond(httpContext, DictionaryPolicy.OnUpstreamFailure(cached), trimmedWord);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException)
+        {
+            logger.LogWarning(ex, "Dictionary upstream unreachable for {Lang}/{Word}", langCode, trimmedWord);
+            return Respond(httpContext, DictionaryPolicy.OnUpstreamFailure(cached), trimmedWord);
         }
     }
+
+    private static IResult Respond(HttpContext httpContext, DictionaryResolution resolution, string word)
+    {
+        httpContext.Response.Headers["X-Dictionary-Cache"] = resolution switch
+        {
+            { Stale: true } => "stale",
+            { Cached: true, Status: DictionaryStatus.NotFound } => "negative",
+            { Cached: true } => "hit",
+            _ => "miss",
+        };
+
+        return resolution.Status switch
+        {
+            DictionaryStatus.Hit => Results.Ok(
+                resolution.Entry! with { Cached = resolution.Cached, Stale = resolution.Stale }),
+            DictionaryStatus.NotFound => Results.Json(
+                new DictionaryErrorResponse($"No definition found for '{word}'", "not_found"),
+                statusCode: StatusCodes.Status404NotFound),
+            _ => Results.Json(
+                new DictionaryErrorResponse(
+                    "Dictionary service is temporarily unavailable", "dictionary_unavailable"),
+                statusCode: StatusCodes.Status503ServiceUnavailable),
+        };
+    }
+
+    private static string NormalizeLang(string lang) => lang.ToLowerInvariant() switch
+    {
+        "en" or "english" => "en",
+        "ru" or "russian" => "ru",
+        "de" or "german" => "de",
+        "fr" or "french" => "fr",
+        "es" or "spanish" => "es",
+        "pl" or "polish" => "pl",
+        "pt" or "portuguese" => "pt",
+        "pt-br" or "portuguese-brazil" => "pt", // Free Dictionary API uses 'pt' for both
+        _ => lang.ToLowerInvariant()
+    };
 }
 
 // Response DTOs
@@ -103,7 +195,14 @@ public record DictionaryResponse(
     string Word,
     string? Phonetic,
     List<DictionaryMeaning> Definitions
-);
+)
+{
+    /// <summary>Served from the server-side cache rather than a live upstream call.</summary>
+    public bool Cached { get; init; }
+
+    /// <summary>Served past its TTL because upstream was unreachable. The data is still correct.</summary>
+    public bool Stale { get; init; }
+}
 
 public record DictionaryMeaning(
     string PartOfSpeech,
@@ -115,9 +214,27 @@ public record DictionaryDefinition(
     string? Example
 );
 
-public record DictionaryErrorResponse(string Message);
+/// <param name="Code">Machine-readable: <c>not_found</c> (upstream answered: no such word) or
+/// <c>dictionary_unavailable</c> (we could not ask and had nothing cached).</param>
+public record DictionaryErrorResponse(string Message, string Code = "not_found");
 
 // Free Dictionary API response types
+file static class DictionaryApiMapper
+{
+    /// <summary>Upstream shape → our shape. Caps at 3 definitions per part of speech — a word tap
+    /// is a glance, and the whole entry would not fit the popup anyway.</summary>
+    public static DictionaryResponse ToResponse(this DictionaryApiEntry entry, string fallbackWord) => new(
+        Word: entry.Word ?? fallbackWord,
+        Phonetic: entry.Phonetics?.FirstOrDefault(p => !string.IsNullOrEmpty(p.Text))?.Text,
+        Definitions: entry.Meanings?.Select(m => new DictionaryMeaning(
+            PartOfSpeech: m.PartOfSpeech ?? "unknown",
+            Definitions: m.Definitions?.Take(3).Select(d => new DictionaryDefinition(
+                Definition: d.Definition ?? "",
+                Example: d.Example
+            )).ToList() ?? []
+        )).ToList() ?? []);
+}
+
 file class DictionaryApiEntry
 {
     [JsonPropertyName("word")]

--- a/backend/src/Api/Extensions/ServiceCollectionExtensions.HostedServices.cs
+++ b/backend/src/Api/Extensions/ServiceCollectionExtensions.HostedServices.cs
@@ -36,6 +36,10 @@ public static partial class ServiceCollectionExtensions
         // Phase 12 RLOps slice 5b: embedding-drift detection (OFF by default — Drift:Enabled).
         services.AddHostedService<DriftDetectionWorker>();
 
+        // Retention bound for the /dictionary file cache (NOT the freshness TTL — stale entries
+        // are the upstream-outage fallback and must survive expiry).
+        services.AddHostedService<DictionaryCacheSweeper>();
+
         return services;
     }
 }

--- a/backend/src/Api/Services/DictionaryCacheSweeper.cs
+++ b/backend/src/Api/Services/DictionaryCacheSweeper.cs
@@ -24,11 +24,44 @@ public class DictionaryCacheSweeper(
 
         var maxAge = TimeSpan.FromDays(Math.Max(1, config.GetValue("Dictionary:CacheMaxAgeDays", 365)));
 
+        ProbeWritable(path);
+
         while (!stoppingToken.IsCancellationRequested)
         {
             Sweep(path, maxAge);
             try { await Task.Delay(SweepInterval, stoppingToken); }
             catch (OperationCanceledException) { return; }
+        }
+    }
+
+    /// <summary>
+    /// Say so, once, at startup if the cache cannot be written.
+    /// </summary>
+    /// <remarks>
+    /// Every cache write is best-effort by design — a broken volume must degrade to "no cache",
+    /// never to a 500 on a word tap. The cost of that choice is silence: the bind mount is created
+    /// by Docker as root, the container runs as uid 1000, and <c>Directory.CreateDirectory</c>
+    /// succeeds trivially on an existing mount point, so the first sign of trouble is an outage
+    /// where the fallback turns out not to exist. That is not hypothetical — it is how this shipped
+    /// the first time, and CI caught it only because one test asked for the same word twice.
+    /// A probe cannot fix the permissions, but it turns a silent absence into a line in the log.
+    /// </remarks>
+    private void ProbeWritable(string path)
+    {
+        var probe = Path.Combine(path, $".writable-probe-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(path);
+            File.WriteAllText(probe, string.Empty);
+            File.Delete(probe);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Dictionary cache at {Path} is not writable — lookups will still work, but there is " +
+                "no fallback when the upstream dictionary is unreachable. On the server this is " +
+                "`make fix-permissions` (the dir must be owned by uid 1000).", path);
+            try { File.Delete(probe); } catch { /* nothing to clean up */ }
         }
     }
 

--- a/backend/src/Api/Services/DictionaryCacheSweeper.cs
+++ b/backend/src/Api/Services/DictionaryCacheSweeper.cs
@@ -1,0 +1,69 @@
+namespace Api.Services;
+
+/// <summary>
+/// Bounds the dictionary file cache. Same shape as the <c>EdgeTtsService</c> sweep, with one
+/// deliberate difference: it does NOT delete on the freshness TTL. An entry past its 30-day TTL is
+/// the outage fallback — deleting it is exactly what we are trying to avoid — so retention is a
+/// separate, much longer bound (<c>Dictionary:CacheMaxAgeDays</c>, default 365). Entries are ~1KB
+/// of JSON, so this is disk hygiene, not pressure relief.
+/// </summary>
+public class DictionaryCacheSweeper(
+    IConfiguration config,
+    ILogger<DictionaryCacheSweeper> logger) : BackgroundService
+{
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromHours(24);
+
+    /// <summary>A .tmp older than this lost its writer (killed mid-write) and will never be renamed.</summary>
+    private static readonly TimeSpan OrphanTmpAge = TimeSpan.FromHours(1);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var path = config.GetValue<string>("Dictionary:CachePath");
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+
+        var maxAge = TimeSpan.FromDays(Math.Max(1, config.GetValue("Dictionary:CacheMaxAgeDays", 365)));
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            Sweep(path, maxAge);
+            try { await Task.Delay(SweepInterval, stoppingToken); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    private void Sweep(string path, TimeSpan maxAge)
+    {
+        try
+        {
+            if (!Directory.Exists(path))
+                return;
+
+            var now = DateTime.UtcNow;
+            var deleted = 0;
+            foreach (var file in Directory.EnumerateFiles(path))
+            {
+                var age = now - File.GetLastWriteTimeUtc(file);
+                var limit = file.EndsWith(".tmp", StringComparison.Ordinal) ? OrphanTmpAge : maxAge;
+                if (age <= limit)
+                    continue;
+                try
+                {
+                    File.Delete(file);
+                    deleted++;
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+                {
+                    // another request may have just rewritten it; next sweep retries
+                }
+            }
+
+            if (deleted > 0)
+                logger.LogInformation("Dictionary cache sweep removed {Count} expired entries", deleted);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Dictionary cache sweep failed at {Path}", path);
+        }
+    }
+}

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -78,6 +78,14 @@
     "MaxTextLength": 500,
     "TimeoutSeconds": 15
   },
+  "_DictionaryComment": "Word tap in the reader — fast or useless, so TimeoutSeconds is 3, not the 10 that turned the 2026-09-05 api.dictionaryapi.dev outage into a ten-second spinner ending in 504. CacheTtlDays is FRESHNESS only: past it we revalidate, but the entry is kept and served (flagged stale) when upstream is unreachable, which is what makes an upstream outage a non-event for any word already looked up. NegativeCacheTtlHours is much shorter because 'no such word' is a claim about coverage and dictionaries gain words. CacheMaxAgeDays is the separate retention bound the sweeper enforces.",
+  "Dictionary": {
+    "TimeoutSeconds": 3,
+    "CachePath": "data/dictionary-cache",
+    "CacheTtlDays": 30,
+    "NegativeCacheTtlHours": 24,
+    "CacheMaxAgeDays": 365
+  },
   "Ollama": {
     "BaseUrl": "http://localhost:11434",
     "Model": "gemma4:e2b",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       Search__Provider: ${SEARCH_PROVIDER:-postgres}
       Tts__CachePath: /data/tts-cache
       Explain__CachePath: /data/explain-cache
+      Dictionary__CachePath: /data/dictionary-cache
       Translate__CachePath: /data/translate-cache
       Ollama__BaseUrl: http://ollama:11434
       Ollama__Model: gemma4:e2b
@@ -108,6 +109,7 @@ services:
       - ./data/textstack:/data/textstack
       - ./data/tts-cache:/data/tts-cache
       - ./data/explain-cache:/data/explain-cache
+      - ./data/dictionary-cache:/data/dictionary-cache
       - ./data/translate-cache:/data/translate-cache
     ports:
       - "127.0.0.1:8080:8080"  # Only localhost, nginx will proxy

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,64 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-06-dictionary-an-upstream-outage-stops-being-an-outage"></a>
+
+## Dictionary — an upstream outage stops being an outage — backend — 2026-09-06
+
+`api.dictionaryapi.dev` went down on 2026-09-05 — a direct probe returned Cloudflare 522 after
+19.6 s. `GET /dictionary/en/serendipity` faithfully turned that into **504 after 10.09 s**, three
+times out of three. The upstream outage was not ours. What was ours: a word tap in the reader
+waited ten seconds and then got an error, with nothing to fall back on, because there was no
+server-side cache of any kind.
+
+**The cache is the fix.** A SHA256 file cache in front of the proxy, same shape as `ExplainCache`
+(hex key, one JSON file per entry, best-effort IO that degrades to "no cache" rather than failing
+the request), with one deliberate difference that everything else rests on: **the reader does not
+drop expired entries**. `ExplainCache` returns null past its TTL; `DictionaryCache` returns the
+entry with its age, and the policy decides. That is what makes the load-bearing rule expressible —
+*on upstream failure, serve a stale entry rather than an error*. A definition from last month is
+correct. A 504 is not. There is no upper bound on how stale a fallback may be, because the
+alternative to a three-year-old definition is no definition.
+
+Definitions are effectively immutable, so freshness is 30 days. "No such word" is not: it is a
+claim about coverage, and dictionaries gain words, so **negative entries expire in 24 hours**. They
+exist so a typo does not send a request to a dead service every time it is tapped — during the
+outage a cached negative answers in 14 ms without leaving the box.
+
+Keys normalize `(lang, word)`: `Book`, `BOOK` and `  book  ` are one entry. Hit rate is what makes
+the fallback work at all, so the normalization is part of the contract rather than an optimization —
+a reader tapping a capitalized word at the start of a sentence must reuse the lowercase entry. The
+key is length-prefixed (`2:en:book`), because both halves come off URL segments and a plain
+`lang|word` join lets `("en", "us|book")` and `("en|us", "book")` hash to the same file.
+
+**The timeout was wrong for the interaction.** 10 s is a budget for a batch job; this is a gesture.
+`Dictionary:TimeoutSeconds` is **3** — enough for a cold DNS + TLS handshake to the upstream CDN on
+a mobile network plus a slow-but-alive query, and under the point where a tap reads as broken.
+During the outage the old budget bought nothing except ten seconds of spinner before the same error.
+
+**Failure is now honest and distinguishable.** Three outcomes, and a client can tell them apart:
+`200` with `cached`/`stale` flags, `404 {code: "not_found"}` — upstream answered, this word has no
+definition — and `503 {code: "dictionary_unavailable"}` — we could not ask and had nothing cached.
+The old 502/503/504 split gave clients three different ways to say one sentence; a reader UI cannot
+act on the difference between a timeout and a connection refusal, so both are logged and both
+collapse to 503. `X-Dictionary-Cache: hit|stale|negative|miss` carries the operator half.
+
+**No LLM fallback**, deliberately. `/dictionary` is one of three routes (with `/translate` and
+`/api/tts`) kept anonymous because the reading loop depends on them. Routing misses to
+`ILlmService` would put paid inference behind an unauthenticated URL — reopening from the other side
+exactly the hole `RequireAiAccount` closes.
+
+The policy is pure functions over a cache entry, so the rules that matter are unit-tested without a
+network: stale-on-failure, the TTL boundary, the shorter negative expiry, clock skew, corrupt and
+payload-less files, and key normalization. Verified against the live stack while the upstream was
+still returning 522: cold cache 503 in 3.01 s, fresh entry 200 in 8 ms with no upstream call at all,
+and a 90-day-old entry served as `200 … "stale": true` after the 3 s probe failed.
+
+The one honest cost: while upstream is down, a *stale* entry still pays the 3 s probe on every tap
+before falling back. Fresh entries — anything looked up in the last 30 days, which is most of them
+during any plausible outage — cost nothing. A short-lived "upstream is failing, skip the probe"
+breaker would close that tail and is not built.
+
 <a id="2026-09-06-guest-the-whole-loop-without-an-account"></a>
 
 ## Guest — the whole loop without an account — mobile, backend — 2026-09-06

--- a/packages/shared/src/api/dictionary.ts
+++ b/packages/shared/src/api/dictionary.ts
@@ -3,10 +3,21 @@ import { publicFetch } from './client'
 export interface DictionaryEntry {
   word: string
   phonetic?: string
-  meanings: {
+  /**
+   * The server has always called this `definitions` (`DictionaryResponse.Definitions`).
+   * This declared `meanings`, so every mobile consumer read `undefined` and bailed on its
+   * own empty-guard — the vocabulary card's dictionary line has never rendered. The web
+   * copy at `apps/web/src/api/dictionary.ts` had the name right, which is why only one
+   * platform was broken and neither reported it.
+   */
+  definitions: {
     partOfSpeech: string
     definitions: { definition: string; example?: string }[]
   }[]
+  /** True when served from the server cache. */
+  cached?: boolean
+  /** True when served past its TTL because the upstream was unreachable. */
+  stale?: boolean
 }
 
 export function lookupWord(lang: string, word: string) {

--- a/tests/TextStack.IntegrationTests/DictionaryEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/DictionaryEndpointTests.cs
@@ -1,154 +1,218 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 
 namespace TextStack.IntegrationTests;
 
 /// <summary>
-/// Integration tests for dictionary endpoints.
-/// Uses Free Dictionary API (external service).
+/// <c>GET /dictionary/{lang}/{word}</c> against the live stack. api.dictionaryapi.dev is a third
+/// party and goes down (it did, on 2026-09-05), so these tests assert the parts of the contract
+/// that hold in BOTH worlds — the status codes, the error codes, and the latency budget — rather
+/// than assuming a healthy upstream. The old versions of these tests silently <c>return;</c>d on
+/// 502/503/504, which meant the endpoint answering 504 after ten seconds still produced a green
+/// suite. The cache/staleness policy itself is unit-tested in <c>DictionaryCacheTests</c> where it
+/// needs neither a network nor a stack.
 /// </summary>
-public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
+public class DictionaryEndpointTests(LiveApiFixture fixture) : IClassFixture<LiveApiFixture>
 {
-    private readonly LiveApiFixture _fixture;
+    /// <summary>
+    /// Server budget is <c>Dictionary:TimeoutSeconds</c> (3s). This allows generous slack for the
+    /// hop through nginx/compose but is far under the 10s the endpoint used to spend before failing.
+    /// </summary>
+    private static readonly TimeSpan LatencyBudget = TimeSpan.FromSeconds(7);
 
-    public DictionaryEndpointTests(LiveApiFixture fixture)
+    private async Task<(HttpResponseMessage Response, TimeSpan Elapsed)> LookupAsync(string path)
     {
-        _fixture = fixture;
+        var request = fixture.CreateRequest(HttpMethod.Get, path);
+        var sw = Stopwatch.StartNew();
+        var response = await fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        sw.Stop();
+        return (response, sw.Elapsed);
     }
 
-    #region GET /dictionary/{lang}/{word}
+    #region contract
 
     [Fact]
-    public async Task LookupWord_ValidEnglishWord_Returns200()
+    public async Task LookupWord_ValidEnglishWord_Returns200OrUnavailable()
     {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/hello");
-        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        var (response, _) = await LookupAsync("/dictionary/en/hello");
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response) && !await IsNotFoundBodyAsync(response),
+            "Dictionary endpoint not deployed on the target stack");
 
-        // External API might be unavailable
-        if (response.StatusCode == HttpStatusCode.BadGateway ||
-            response.StatusCode == HttpStatusCode.ServiceUnavailable ||
-            response.StatusCode == HttpStatusCode.GatewayTimeout)
+        // Exactly two legal outcomes for a real word: the definition, or an honest "we could not
+        // ask". 404 would be a lie, and 502/504 are no longer part of the contract.
+        Assert.True(
+            response.StatusCode is HttpStatusCode.OK or HttpStatusCode.ServiceUnavailable,
+            $"expected 200 or 503, got {(int)response.StatusCode}");
+
+        if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
         {
-            return; // Skip - external API not available
+            await AssertErrorCodeAsync(response, "dictionary_unavailable");
+            return;
         }
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        var result = await response.Content.ReadFromJsonAsync<DictionaryResponse>(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.NotNull(result);
-        Assert.Equal("hello", result.Word.ToLower());
+        var result = await ReadEntryAsync(response);
+        Assert.Equal("hello", result.Word.ToLowerInvariant());
         Assert.NotEmpty(result.Definitions);
     }
 
     [Fact]
-    public async Task LookupWord_NonExistentWord_Returns404()
+    public async Task LookupWord_NonExistentWord_Returns404NotFoundCode()
     {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/asdfghjklzxcv");
-        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        var (response, _) = await LookupAsync("/dictionary/en/asdfghjklzxcv");
 
-        // External API might be unavailable
-        if (response.StatusCode == HttpStatusCode.BadGateway ||
-            response.StatusCode == HttpStatusCode.ServiceUnavailable ||
-            response.StatusCode == HttpStatusCode.GatewayTimeout)
+        // "no such word" and "we could not ask" must never be confusable — that is the whole point
+        // of the code field. Whichever we get, it has to carry the matching code.
+        if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
         {
-            return; // Skip
+            await AssertErrorCodeAsync(response, "dictionary_unavailable");
+            return;
         }
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await AssertErrorCodeAsync(response, "not_found");
     }
 
     [Fact]
-    public async Task LookupWord_EmptyWord_Returns400()
+    public async Task LookupWord_UpstreamFailure_NeverReturns502Or504()
     {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/");
-        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        // The regression this whole change exists to prevent: a dead upstream used to surface as
+        // 504 after ten seconds. It is now 503 (or a stale 200), and it is fast.
+        var (response, elapsed) = await LookupAsync("/dictionary/en/serendipity");
 
-        // Empty path segment might result in 404 from routing
-        Assert.True(
-            response.StatusCode == HttpStatusCode.BadRequest ||
-            response.StatusCode == HttpStatusCode.NotFound
-        );
+        Assert.False(response.StatusCode is HttpStatusCode.BadGateway or HttpStatusCode.GatewayTimeout,
+            $"dictionary answered {(int)response.StatusCode}; the contract is 200 | 404 | 503");
+        Assert.True(elapsed < LatencyBudget,
+            $"dictionary took {elapsed.TotalSeconds:F1}s, budget is {LatencyBudget.TotalSeconds:F0}s");
+    }
+
+    [Fact]
+    public async Task LookupWord_AlwaysReportsCacheDisposition()
+    {
+        var (response, _) = await LookupAsync("/dictionary/en/lexicon");
+        Assert.SkipWhen(IntegrationSkip.Unavailable(response) && !await IsNotFoundBodyAsync(response),
+            "Dictionary endpoint not deployed on the target stack");
+
+        Assert.True(response.Headers.TryGetValues("X-Dictionary-Cache", out var values),
+            "X-Dictionary-Cache header missing — ops cannot tell a stale answer from a live one");
+        Assert.Contains(values.Single(), new[] { "hit", "miss", "stale", "negative" });
+    }
+
+    #endregion
+
+    #region cache
+
+    [Fact]
+    public async Task LookupWord_RepeatedLookup_IsServedFromServerCache()
+    {
+        var (first, _) = await LookupAsync("/dictionary/en/serendipity");
+        Assert.SkipWhen(first.StatusCode == HttpStatusCode.ServiceUnavailable,
+            "upstream dictionary is down and the server cache is cold — nothing to prime with");
+        Assert.SkipWhen(IntegrationSkip.Unavailable(first) && !await IsNotFoundBodyAsync(first),
+            "Dictionary endpoint not deployed on the target stack");
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+
+        // Second lookup differs in case and whitespace: the cache key normalizes both, so it must
+        // still hit. If it misses, every capitalised word at the start of a sentence is a fresh
+        // upstream call and the outage fallback covers half of what it should.
+        var (second, elapsed) = await LookupAsync("/dictionary/EN/Serendipity");
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal("hit", second.Headers.GetValues("X-Dictionary-Cache").Single());
+        var entry = await ReadEntryAsync(second);
+        Assert.True(entry.Cached, "second lookup should be served from the server cache");
+        Assert.False(entry.Stale, "a fresh cache entry must not be flagged stale");
+        Assert.True(elapsed < TimeSpan.FromSeconds(2), $"cache hit took {elapsed.TotalSeconds:F1}s");
+    }
+
+    [Fact]
+    public async Task LookupWord_NonExistentWord_IsNegativeCached()
+    {
+        var (first, _) = await LookupAsync("/dictionary/en/qwertyuiopzxcv");
+        Assert.SkipWhen(first.StatusCode == HttpStatusCode.ServiceUnavailable,
+            "upstream dictionary is down — cannot establish a negative entry");
+        Assert.Equal(HttpStatusCode.NotFound, first.StatusCode);
+
+        var (second, _) = await LookupAsync("/dictionary/en/qwertyuiopzxcv");
+
+        Assert.Equal(HttpStatusCode.NotFound, second.StatusCode);
+        // "negative" proves the typo did NOT go back out to upstream.
+        Assert.Equal("negative", second.Headers.GetValues("X-Dictionary-Cache").Single());
+        await AssertErrorCodeAsync(second, "not_found");
+    }
+
+    #endregion
+
+    #region validation (no upstream involved)
+
+    [Fact]
+    public async Task LookupWord_EmptyWord_Returns400Or404()
+    {
+        var (response, _) = await LookupAsync("/dictionary/en/");
+
+        // Empty path segment may be rejected by routing before the handler sees it.
+        Assert.True(response.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.NotFound);
     }
 
     [Fact]
     public async Task LookupWord_WordTooLong_Returns400()
     {
-        var longWord = new string('a', 150);
-        var request = _fixture.CreateRequest(HttpMethod.Get, $"/dictionary/en/{longWord}");
-        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+        var (response, elapsed) = await LookupAsync($"/dictionary/en/{new string('a', 150)}");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task LookupWord_ReturnsPhonetic()
-    {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/book");
-        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
-
-        if (response.StatusCode != HttpStatusCode.OK)
-        {
-            return; // Skip
-        }
-
-        var result = await response.Content.ReadFromJsonAsync<DictionaryResponse>(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.NotNull(result);
-        // Phonetic might or might not be available depending on word
-        // Just verify the structure is valid
-        Assert.NotNull(result.Definitions);
-    }
-
-    [Fact]
-    public async Task LookupWord_ReturnsPartOfSpeech()
-    {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/run");
-        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
-
-        if (response.StatusCode != HttpStatusCode.OK)
-        {
-            return; // Skip
-        }
-
-        var result = await response.Content.ReadFromJsonAsync<DictionaryResponse>(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.NotNull(result);
-        Assert.NotEmpty(result.Definitions);
-        Assert.All(result.Definitions, d => Assert.NotNull(d.PartOfSpeech));
-    }
-
-    [Fact]
-    public async Task LookupWord_DifferentLanguage_Returns200()
-    {
-        // German word
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/de/hallo");
-        var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
-
-        // External API might not support all languages or be unavailable
-        if (response.StatusCode == HttpStatusCode.BadGateway ||
-            response.StatusCode == HttpStatusCode.ServiceUnavailable ||
-            response.StatusCode == HttpStatusCode.GatewayTimeout ||
-            response.StatusCode == HttpStatusCode.NotFound)
-        {
-            return; // Skip
-        }
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        // Validation must never reach upstream, so it is fast even during an outage.
+        Assert.True(elapsed < TimeSpan.FromSeconds(2), $"validation took {elapsed.TotalSeconds:F1}s");
     }
 
     #endregion
 
-    private record DictionaryResponse(
+    private static async Task<DictionaryEntryDto> ReadEntryAsync(HttpResponseMessage response)
+    {
+        var result = await response.Content.ReadFromJsonAsync<DictionaryEntryDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(result);
+        return result;
+    }
+
+    private static async Task AssertErrorCodeAsync(HttpResponseMessage response, string expectedCode)
+    {
+        var error = await response.Content.ReadFromJsonAsync<DictionaryErrorDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(error);
+        Assert.Equal(expectedCode, error.Code);
+        Assert.False(string.IsNullOrWhiteSpace(error.Message));
+    }
+
+    /// <summary>
+    /// A 404 from this route is ambiguous between "route not deployed" and "word has no definition".
+    /// The body disambiguates: our handler always sends <c>code</c>, ASP.NET's routing 404 does not.
+    /// </summary>
+    private static async Task<bool> IsNotFoundBodyAsync(HttpResponseMessage response)
+    {
+        if (response.StatusCode != HttpStatusCode.NotFound)
+            return false;
+        try
+        {
+            var error = await response.Content.ReadFromJsonAsync<DictionaryErrorDto>(
+                cancellationToken: TestContext.Current.CancellationToken);
+            return error?.Code is not null;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private record DictionaryEntryDto(
         string Word,
         string? Phonetic,
-        DictionaryMeaning[] Definitions
-    );
+        DictionaryMeaningDto[] Definitions,
+        bool Cached,
+        bool Stale);
 
-    private record DictionaryMeaning(
-        string PartOfSpeech,
-        DictionaryDefinition[] Definitions
-    );
+    private record DictionaryMeaningDto(string PartOfSpeech, DictionaryDefinitionDto[] Definitions);
 
-    private record DictionaryDefinition(
-        string Definition,
-        string? Example
-    );
+    private record DictionaryDefinitionDto(string Definition, string? Example);
+
+    private record DictionaryErrorDto(string Message, string? Code);
 }

--- a/tests/TextStack.UnitTests/DictionaryCacheTests.cs
+++ b/tests/TextStack.UnitTests/DictionaryCacheTests.cs
@@ -1,0 +1,403 @@
+using Api.Endpoints;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// The dictionary lookup policy and its file cache. Everything here is the part of the endpoint
+/// that decides what to serve — deliberately pure (or filesystem-only) so the rule that matters,
+/// "on upstream failure serve stale rather than error", can be proved without a network or a
+/// running stack. The HTTP wiring around it is covered by the integration suite.
+/// </summary>
+public class DictionaryCacheTests
+{
+    private static readonly TimeSpan HitTtl = TimeSpan.FromDays(30);
+    private static readonly TimeSpan NegativeTtl = TimeSpan.FromHours(24);
+    private static readonly DateTime Now = new(2026, 9, 6, 12, 0, 0, DateTimeKind.Utc);
+
+    private static DictionaryResponse Entry(string word = "serendipity") => new(
+        word,
+        "/ˌsɛrənˈdɪpɪti/",
+        [new DictionaryMeaning("noun", [new DictionaryDefinition("A fortunate accident.", null)])]);
+
+    private static DictionaryCacheEntry Hit(DateTime at, string word = "serendipity") =>
+        new(Found: true, CachedAtUtc: at, Entry: Entry(word));
+
+    private static DictionaryCacheEntry Negative(DateTime at) =>
+        new(Found: false, CachedAtUtc: at, Entry: null);
+
+    // ---- freshness ----
+
+    [Fact]
+    public void IsFresh_WithinTtl_ReturnsTrue()
+    {
+        Assert.True(DictionaryPolicy.IsFresh(Hit(Now.AddDays(-29)), Now, HitTtl));
+    }
+
+    [Fact]
+    public void IsFresh_ExactlyAtTtl_ReturnsFalse()
+    {
+        // Boundary is exclusive: at exactly TTL the entry is due for revalidation.
+        Assert.False(DictionaryPolicy.IsFresh(Hit(Now - HitTtl), Now, HitTtl));
+    }
+
+    [Fact]
+    public void IsFresh_PastTtl_ReturnsFalse()
+    {
+        Assert.False(DictionaryPolicy.IsFresh(Hit(Now.AddDays(-31)), Now, HitTtl));
+    }
+
+    [Fact]
+    public void IsFresh_MissingTimestamp_ReturnsFalse()
+    {
+        // A default timestamp means we don't know when this was written — revalidate rather than
+        // trust it. It stays servable as a stale fallback, which is the safe half of the guess.
+        Assert.False(DictionaryPolicy.IsFresh(Hit(default), Now, HitTtl));
+    }
+
+    [Fact]
+    public void IsFresh_TimestampInFuture_ReturnsTrue()
+    {
+        // Clock skew between a restored volume and the host must not make every entry look
+        // infinitely old and stampede upstream.
+        Assert.True(DictionaryPolicy.IsFresh(Hit(Now.AddHours(1)), Now, HitTtl));
+    }
+
+    // ---- FromCache: what we can answer without touching upstream ----
+
+    [Fact]
+    public void FromCache_FreshHit_ServesWithoutUpstream()
+    {
+        var result = DictionaryPolicy.FromCache(Hit(Now.AddDays(-1)), Now, HitTtl, NegativeTtl);
+
+        Assert.NotNull(result);
+        Assert.Equal(DictionaryStatus.Hit, result.Status);
+        Assert.True(result.Cached);
+        Assert.False(result.Stale);
+        Assert.Equal("serendipity", result.Entry!.Word);
+    }
+
+    [Fact]
+    public void FromCache_StaleHit_ReturnsNullSoUpstreamIsTried()
+    {
+        // Stale does NOT short-circuit: we still try to revalidate. The entry is held back as the
+        // fallback for OnUpstreamFailure.
+        Assert.Null(DictionaryPolicy.FromCache(Hit(Now.AddDays(-31)), Now, HitTtl, NegativeTtl));
+    }
+
+    [Fact]
+    public void FromCache_FreshNegative_ServesNotFoundWithoutUpstream()
+    {
+        var result = DictionaryPolicy.FromCache(Negative(Now.AddHours(-2)), Now, HitTtl, NegativeTtl);
+
+        Assert.NotNull(result);
+        Assert.Equal(DictionaryStatus.NotFound, result.Status);
+        Assert.True(result.Cached);
+        Assert.False(result.Stale);
+        Assert.Null(result.Entry);
+    }
+
+    [Fact]
+    public void FromCache_NegativeOlderThanNegativeTtl_ReturnsNull()
+    {
+        // 48h is comfortably fresh as a HIT and expired as a NEGATIVE — the whole point of the
+        // shorter negative TTL. If this ever passes with the hit TTL applied, typos would be
+        // pinned as "no such word" for a month.
+        var twoDaysOld = Negative(Now.AddHours(-48));
+
+        Assert.Null(DictionaryPolicy.FromCache(twoDaysOld, Now, HitTtl, NegativeTtl));
+        Assert.True(DictionaryPolicy.IsFresh(twoDaysOld, Now, HitTtl));
+    }
+
+    [Fact]
+    public void FromCache_NoEntry_ReturnsNull()
+    {
+        Assert.Null(DictionaryPolicy.FromCache(null, Now, HitTtl, NegativeTtl));
+    }
+
+    // ---- OnUpstreamFailure: the load-bearing rule ----
+
+    [Fact]
+    public void OnUpstreamFailure_StaleHit_ServesStaleDefinition()
+    {
+        var result = DictionaryPolicy.OnUpstreamFailure(Hit(Now.AddDays(-31)));
+
+        Assert.Equal(DictionaryStatus.Hit, result.Status);
+        Assert.True(result.Cached);
+        Assert.True(result.Stale);
+        Assert.Equal("A fortunate accident.", result.Entry!.Definitions[0].Definitions[0].Definition);
+    }
+
+    [Fact]
+    public void OnUpstreamFailure_VeryOldHit_StillServesIt()
+    {
+        // There is deliberately NO upper bound on staleness. A definition from three years ago is
+        // still correct; a 503 is not.
+        var result = DictionaryPolicy.OnUpstreamFailure(Hit(Now.AddYears(-3)));
+
+        Assert.Equal(DictionaryStatus.Hit, result.Status);
+        Assert.True(result.Stale);
+        Assert.NotNull(result.Entry);
+    }
+
+    [Fact]
+    public void OnUpstreamFailure_StaleNegative_ServesNotFoundMarkedStale()
+    {
+        var result = DictionaryPolicy.OnUpstreamFailure(Negative(Now.AddDays(-10)));
+
+        Assert.Equal(DictionaryStatus.NotFound, result.Status);
+        Assert.True(result.Stale);
+    }
+
+    [Fact]
+    public void OnUpstreamFailure_NothingCached_ReturnsUnavailable()
+    {
+        // The only failing case, and it must NOT be confusable with "this word has no definition".
+        var result = DictionaryPolicy.OnUpstreamFailure(null);
+
+        Assert.Equal(DictionaryStatus.Unavailable, result.Status);
+        Assert.False(result.Cached);
+        Assert.False(result.Stale);
+        Assert.Null(result.Entry);
+    }
+
+    [Fact]
+    public void OnUpstreamFailure_UnavailableIsDistinctFromNotFound()
+    {
+        Assert.NotEqual(
+            DictionaryPolicy.OnUpstreamFailure(null).Status,
+            DictionaryPolicy.OnUpstreamFailure(Negative(Now)).Status);
+    }
+
+    // ---- key derivation ----
+
+    [Theory]
+    [InlineData("Book")]
+    [InlineData("BOOK")]
+    [InlineData("  book  ")]
+    [InlineData("bOoK")]
+    public void ComputeKey_CaseAndWhitespaceVariants_ShareOneEntry(string variant)
+    {
+        // Hit rate is what makes the outage fallback work, so normalization is part of the
+        // contract: a reader tapping "Book" at the start of a sentence must reuse "book".
+        Assert.Equal(DictionaryCache.ComputeKey("en", "book"), DictionaryCache.ComputeKey("en", variant));
+    }
+
+    [Fact]
+    public void ComputeKey_DifferentLanguage_ProducesDifferentKey()
+    {
+        Assert.NotEqual(DictionaryCache.ComputeKey("en", "hallo"), DictionaryCache.ComputeKey("de", "hallo"));
+    }
+
+    [Fact]
+    public void ComputeKey_DifferentWord_ProducesDifferentKey()
+    {
+        Assert.NotEqual(DictionaryCache.ComputeKey("en", "book"), DictionaryCache.ComputeKey("en", "books"));
+    }
+
+    [Fact]
+    public void ComputeKey_SeparatorCannotBeForged()
+    {
+        // "en" + "|" + "us|book" must not collide with "en|us" + "|" + "book". Words come off a
+        // URL segment, so a pipe in the input is reachable.
+        Assert.NotEqual(DictionaryCache.ComputeKey("en", "us|book"), DictionaryCache.ComputeKey("en|us", "book"));
+    }
+
+    [Fact]
+    public void ComputeKey_IsFilesystemSafeHex()
+    {
+        var key = DictionaryCache.ComputeKey("en", "naïve / ?*");
+
+        Assert.Equal(64, key.Length);
+        Assert.All(key, c => Assert.Contains(c, "0123456789abcdef"));
+    }
+
+    // ---- file cache (temp dir, no network) ----
+
+    [Fact]
+    public async Task TryReadAsync_AfterWriteHit_RoundTripsEntry()
+    {
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+        var key = DictionaryCache.ComputeKey("en", "serendipity");
+
+        await cache.WriteHitAsync(key, Entry(), Now, TestContext.Current.CancellationToken);
+        var read = await cache.TryReadAsync(key, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(read);
+        Assert.True(read.Found);
+        Assert.Equal(Now, read.CachedAtUtc);
+        Assert.Equal("serendipity", read.Entry!.Word);
+        Assert.Equal("/ˌsɛrənˈdɪpɪti/", read.Entry.Phonetic);
+        Assert.Equal("A fortunate accident.", read.Entry.Definitions[0].Definitions[0].Definition);
+    }
+
+    [Fact]
+    public async Task TryReadAsync_AfterWriteMiss_ReturnsNegativeEntry()
+    {
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+        var key = DictionaryCache.ComputeKey("en", "asdfghjkl");
+
+        await cache.WriteMissAsync(key, Now, TestContext.Current.CancellationToken);
+        var read = await cache.TryReadAsync(key, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(read);
+        Assert.False(read.Found);
+        Assert.Null(read.Entry);
+    }
+
+    [Fact]
+    public async Task TryReadAsync_ExpiredEntry_StillReturnsItForStaleFallback()
+    {
+        // The one place this cache deliberately differs from ExplainCache: expiry is decided by the
+        // POLICY, not by the reader dropping the file. If the read swallowed expired entries the
+        // outage fallback would have nothing to serve.
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+        var key = DictionaryCache.ComputeKey("en", "serendipity");
+        var writtenAt = Now.AddYears(-2);
+
+        await cache.WriteHitAsync(key, Entry(), writtenAt, TestContext.Current.CancellationToken);
+        var read = await cache.TryReadAsync(key, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(read);
+        Assert.False(DictionaryPolicy.IsFresh(read, Now, HitTtl));
+        Assert.Equal(DictionaryStatus.Hit, DictionaryPolicy.OnUpstreamFailure(read).Status);
+    }
+
+    [Fact]
+    public async Task TryReadAsync_MissingFile_ReturnsNull()
+    {
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+
+        Assert.Null(await cache.TryReadAsync(
+            DictionaryCache.ComputeKey("en", "never-written"), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task TryReadAsync_CorruptFile_ReturnsNullInsteadOfThrowing()
+    {
+        // A truncated file from a container kill must degrade to a cache miss, not 500 the request.
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+        var key = DictionaryCache.ComputeKey("en", "book");
+        await File.WriteAllTextAsync(
+            Path.Combine(dir.Path, key + ".json"), "{\"found\":true,\"entry\":{\"wo",
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(await cache.TryReadAsync(key, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task TryReadAsync_PositiveEntryWithoutPayload_ReturnsNull()
+    {
+        // found=true with no entry is corrupt. Returning it would let OnUpstreamFailure serve a
+        // 200 with a null body during an outage — worse than the outage.
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+        var key = DictionaryCache.ComputeKey("en", "book");
+        await File.WriteAllTextAsync(
+            Path.Combine(dir.Path, key + ".json"),
+            "{\"found\":true,\"cachedAtUtc\":\"2026-09-06T12:00:00Z\",\"entry\":null}",
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(await cache.TryReadAsync(key, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WriteHitAsync_UnwritablePath_DoesNotThrow()
+    {
+        // Cache IO is best-effort: a permissions problem on the volume degrades to "no cache",
+        // it does not take the endpoint down with it.
+        using var dir = new TempDir();
+        var blocked = Path.Combine(dir.Path, "not-a-dir");
+        await File.WriteAllTextAsync(blocked, "x", TestContext.Current.CancellationToken);
+        var cache = new DictionaryCache(blocked, NullLogger.Instance);
+
+        await cache.WriteHitAsync("abc", Entry(), Now, TestContext.Current.CancellationToken);
+        Assert.Null(await cache.TryReadAsync("abc", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task WriteAsync_LeavesNoTempFilesBehind()
+    {
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+
+        await cache.WriteHitAsync("a", Entry(), Now, TestContext.Current.CancellationToken);
+        await cache.WriteMissAsync("b", Now, TestContext.Current.CancellationToken);
+
+        Assert.Empty(Directory.GetFiles(dir.Path, "*.tmp"));
+        Assert.Equal(2, Directory.GetFiles(dir.Path, "*.json").Length);
+    }
+
+    [Fact]
+    public async Task WriteHitAsync_OverwritesExistingEntry()
+    {
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+        var key = DictionaryCache.ComputeKey("en", "book");
+
+        await cache.WriteMissAsync(key, Now.AddDays(-1), TestContext.Current.CancellationToken);
+        await cache.WriteHitAsync(key, Entry("book"), Now, TestContext.Current.CancellationToken);
+        var read = await cache.TryReadAsync(key, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(read);
+        Assert.True(read.Found);
+        Assert.Equal(Now, read.CachedAtUtc);
+    }
+
+    // ---- the outage, end to end over the pure pieces ----
+
+    [Fact]
+    public async Task PrimedCache_WhenUpstreamFails_ServesStaleInsteadOfError()
+    {
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+        var key = DictionaryCache.ComputeKey("en", "Serendipity"); // reader taps a capitalised word
+        var primedAt = Now.AddDays(-90);
+
+        // 1. Cache was primed three months ago, when upstream was healthy.
+        await cache.WriteHitAsync(key, Entry(), primedAt, TestContext.Current.CancellationToken);
+
+        // 2. Today the entry is past its 30-day TTL, so we would go upstream...
+        var cached = await cache.TryReadAsync(
+            DictionaryCache.ComputeKey("en", "serendipity"), TestContext.Current.CancellationToken);
+        Assert.NotNull(cached);
+        Assert.Null(DictionaryPolicy.FromCache(cached, Now, HitTtl, NegativeTtl));
+
+        // 3. ...upstream is down (522/timeout). The reader still gets the definition.
+        var served = DictionaryPolicy.OnUpstreamFailure(cached);
+        Assert.Equal(DictionaryStatus.Hit, served.Status);
+        Assert.True(served.Stale);
+        Assert.Equal("A fortunate accident.", served.Entry!.Definitions[0].Definitions[0].Definition);
+    }
+
+    [Fact]
+    public async Task UnprimedCache_WhenUpstreamFails_ReportsUnavailableNotNotFound()
+    {
+        using var dir = new TempDir();
+        var cache = new DictionaryCache(dir.Path, NullLogger.Instance);
+
+        var cached = await cache.TryReadAsync(
+            DictionaryCache.ComputeKey("en", "hapax"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(DictionaryStatus.Unavailable, DictionaryPolicy.OnUpstreamFailure(cached).Status);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ts-dict-cache-" + Guid.NewGuid().ToString("N")[..8]);
+
+        public TempDir() => Directory.CreateDirectory(Path);
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`api.dictionaryapi.dev` went down tonight — **522 after 19.6s** on a direct probe. Our endpoint faithfully turned that into a **504 after ten seconds**, on every word tap, with nothing behind it.

```
GET /api/dictionary/en/serendipity  → 504 (10.25s)
GET /api/dictionary/en/book         → 504 (10.06s)
```

The outage is not ours. Waiting ten seconds and having no answer is.

## Changes

**3s budget instead of 10** (`Dictionary:TimeoutSeconds`). A word tap is a gesture — the answer is fast or it is useless. 3s covers a cold DNS+TLS handshake on mobile plus a slow-but-alive query; past that a tap reads as broken. The old code used `HttpClient.Timeout`, which raises the same `TaskCanceledException` as a client disconnect — those need telling apart and were not.

**A server-side cache, which is the actual fallback.** There was none, though `explain` and TTS both have one. On upstream failure it serves whatever it has, **at any age**: a definition from last month is correct, a 504 is not. Reads deliberately do **not** drop expired entries — unlike `ExplainCache`, whose reader returns null past TTL — because otherwise the outage path would have nothing left to read. Expiry became a policy decision, not a read-side deletion.

**Three outcomes instead of five.** `200` (with `cached`/`stale` flags), `404 not_found`, `503 dictionary_unavailable`. A reader UI cannot act differently on a timeout than on a refused connection; the old 502/504/503 split gave clients three ways to say one sentence. The distinction is logged instead. `X-Dictionary-Cache: hit|stale|negative|miss` for ops.

**Negative caching at 24h against the positive 30d**, so a typo does not re-ask a dead service while a real word keeps its answer for a month.

Writes are tmp+rename, so a container kill cannot leave a truncated file that later poisons the outage path. All cache IO is best-effort: a broken volume degrades to "no cache", never to a 500.

## No LLM fallback

`/dictionary` is one of three endpoints (with `/translate` and `/api/tts`) deliberately open to anonymous callers, because the reading loop depends on them. Routing its misses to `ILlmService` would reopen the anonymous→paid-inference path #556 just closed — with no auth in front of it at all. An authenticated-only variant is worse still: the same URL would behave differently for guests, which is a worse contract than "sometimes stale". The cache is the fallback.

## Mobile's dictionary has never worked

Separate defect, found on the way. `packages/shared/src/api/dictionary.ts` declared `meanings`; the server has always returned `definitions`. So `ReviewFeedback.tsx` hit its own `if (!data?.meanings?.length) return` on every response and rendered nothing — silently, because an empty-guard and a broken field look identical. The web copy had the name right, which is why one platform was broken and neither reported it.

## Demonstrated against the real outage

Upstream was down throughout, so the fallback was tested by fact, not by mock.

**Before** (running container, old code): `504` at 10.09s.

**After**, cold cache: `503` at 3.09s, `X-Dictionary-Cache: miss`.

Then primed **through the production writer** (`DictionaryCache.WriteHitAsync`) rather than hand-forged JSON, so the demo cannot pass on a wrong file format:

```
/dictionary/en/serendipity      → 200  0.085s  hit       cached:true  stale:false
/dictionary/en/book             → 200  3.017s  stale     cached:true  stale:true   (90d old)
/dictionary/en/Serendipity      → 200  0.008s  hit       (normalization)
/dictionary/en/%20%20BOOK%20%20 → 200  3.019s  stale     (normalization)
/dictionary/en/zzqqxwv          → 404  0.014s  negative  not_found
```

Primed entries were deleted afterwards; the cache dir holds no fabricated definitions.

## Tests

Unit **1477** (34 new, all pure — stale-on-failure, TTL comparison, negative expiry, key derivation). Integration 6 passed / 2 skipped, the two being cache tests that cannot prime while upstream is dead; both assert the 503 shape before skipping and print the reason.

The old integration tests silently `return`ed on 502/503/504 — which is exactly why a 10s 504 produced a green suite. Replaced.

## Rollback

`git revert`. The cache directory is additive; leaving it behind is harmless.

## Follow-up, not in scope

`backend/src/Application/Tools/LookupDictionaryTool.cs:56` hits the same upstream with its own timeout and no cache — the agent/MCP path. It failed the same way tonight and now has a cache sitting next to it that it does not use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZDSrvtAjiqUz82FPQdZpz