### PR TITLE
fix(mobile): stop paying twice for a word tap, and stop refetching behind the reader

### DIFF
--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -21,6 +21,7 @@ import { OfflineBanner } from '../../src/components/ui/OfflineBanner'
 import { getAllCachedBooks } from '../../src/lib/offlineDb'
 import { FirstBookState } from '../../src/components/library/FirstBookState'
 import { LibraryViewSheet, type LibrarySource } from '../../src/components/library/LibraryViewSheet'
+import { useSheetMount } from '../../src/hooks/useSheetMount'
 import { LibrarySearch } from '../../src/components/library/LibrarySearch'
 import { StorageQuotaRow } from '../../src/components/library/StorageQuotaRow'
 import { LibraryStatusTabs } from '../../src/components/library/LibraryStatusTabs'
@@ -50,6 +51,9 @@ export default function LibraryScreen() {
   const [viewMode, setViewMode] = useState<ViewMode>('list')
   const [source, setSource] = useState<LibrarySource>('all')
   const [sheetOpen, setSheetOpen] = useState(false)
+  // The sheet's `useCollections` fired `GET /me/library/collections` on every
+  // tab open just by being in the tree. See useSheetMount.
+  const sheetMounted = useSheetMount(sheetOpen)
   const [activeCollectionId, setActiveCollectionId] = useState<string | null>(null)
   const [collectionSavedIds, setCollectionSavedIds] = useState<Set<string> | null>(null)
   const [collectionUploadIds, setCollectionUploadIds] = useState<Set<string> | null>(null)
@@ -372,7 +376,7 @@ export default function LibraryScreen() {
         viewMode={viewMode}
         listHeader={listHeader}
       />
-      <LibraryViewSheet
+      {sheetMounted && <LibraryViewSheet
         visible={sheetOpen}
         source={source}
         counts={{ all: library.length + userBooks.length, uploads: userBooks.length, catalog: library.length }}
@@ -384,7 +388,7 @@ export default function LibraryScreen() {
         onSelectViewMode={toggleView}
         onCollectionSelect={setActiveCollectionId}
         onClose={() => setSheetOpen(false)}
-      />
+      />}
     </View>
   )
 }

--- a/apps/mobile/app/book/[slug].tsx
+++ b/apps/mobile/app/book/[slug].tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { View, Text, ScrollView, StyleSheet, TouchableOpacity, Share } from 'react-native'
 import { Image } from 'expo-image'
 import { useFocusEffect, useLocalSearchParams, useRouter, Stack } from 'expo-router'
@@ -11,6 +11,7 @@ import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
 import { useToast } from '../../src/context/ToastContext'
 import { AddToCollectionSheet } from '../../src/components/library/AddToCollectionSheet'
+import { useSheetMount } from '../../src/hooks/useSheetMount'
 import {
   isBookFullyCached,
   getAllCachedBooks,
@@ -30,16 +31,47 @@ export default function BookDetailScreen() {
   const toast = useToast()
   const { downloads, startDownload, cancelDownload, removeDownload, retryFailed } = useDownload()
   const [book, setBook] = useState<BookDetail | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [bookLoading, setBookLoading] = useState(true)
+  /**
+   * Have the session-dependent follow-ups (library membership + progress)
+   * answered yet?
+   *
+   * A one-way latch, never set back to `true`. It exists because the single
+   * `loading` flag used to cover BOTH round-trips: library and progress were
+   * awaited inside `getBook`'s own `.then`, so the skeleton stayed up until the
+   * hero could be painted with the right button. Splitting the fetches into two
+   * effects (see below) would otherwise paint "Start Reading" for one RTT on a
+   * book the reader is 40% through.
+   *
+   * Seeded from `isAuthenticated` at mount, so a signed-out reader is never
+   * held for a fetch that will not happen; and because it is never re-raised, a
+   * session that arrives later (guest minting inside the reader) refreshes the
+   * data underneath without throwing this screen back to a skeleton.
+   */
+  const [sessionLoading, setSessionLoading] = useState(isAuthenticated)
+  // `book != null` so a failed load falls through to the error screen instead
+  // of sitting on a skeleton forever waiting for follow-ups that never run.
+  const loading = bookLoading || (sessionLoading && book != null)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [cached, setCached] = useState(false)
   const [inLibrary, setInLibrary] = useState(false)
   const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
+  // Not mounted until first opened — see useSheetMount. This screen is public,
+  // so the sheet's `useCollections` was 401ing on every open for a signed-out
+  // reader.
+  const collectionSheetMounted = useSheetMount(collectionSheetOpen)
   const [continueSlug, setContinueSlug] = useState<string | null>(null)
   // How far in the reader is, so the button says where it will take them. The shelf card already
   // showed "11% complete" while this screen offered a bare "Continue Reading" — the same reader,
   // the same book, one of the two screens keeping it to itself.
   const [continuePct, setContinuePct] = useState<number | null>(null)
+  /**
+   * The edition id whose session data has already been loaded once. The focus
+   * refresh below uses it to tell "the screen just came back into view" apart
+   * from "the initial load has not finished yet", which is the difference
+   * between a useful refetch and a duplicate one.
+   */
+  const progressLoadedForRef = useRef<string | null>(null)
   const [showAllChapters, setShowAllChapters] = useState(false)
   // True when the page is rendering a minimal view built from the offline
   // SQLite cache because the server was unreachable. Used to hide
@@ -49,10 +81,26 @@ export default function BookDetailScreen() {
   // Bump to force a refetch when the user presses Retry (P1-4).
   const [reloadTick, setReloadTick] = useState(0)
 
+  /**
+   * The public book. Deliberately NOT keyed on `isAuthenticated`.
+   *
+   * It used to be, and the session-dependent follow-ups lived inside this
+   * `.then`. That made a guest's first book open fetch `GET /books/{slug}`
+   * twice: `ReaderSessionGate` mints an anonymous session the moment the reader
+   * mounts, `isAuthenticated` flips false→true GLOBALLY, and this screen is
+   * still mounted underneath (the reader is pushed, not replaced) — so it
+   * re-fetched the same public book at the exact moment the gate was fetching
+   * it for the reader. `readerSessionGate.ts` freezes `isAuthenticated` for the
+   * reader's own lifetime; nothing freezes it for the screens behind it.
+   *
+   * The book does not change when a session appears, so a session appearing is
+   * not a reason to re-fetch it. Only what actually depends on the session
+   * moves, into the effect below.
+   */
   useEffect(() => {
     if (!slug) return
     let cancelled = false
-    setLoading(true)
+    setBookLoading(true)
     setFetchError(null)
     setOfflineMode(false)
     const api = createBooksApi(language)
@@ -64,32 +112,6 @@ export default function BookDetailScreen() {
           setCached(await isBookFullyCached(b.id))
         } catch (err) {
           console.warn('isBookFullyCached failed:', err)
-        }
-        if (isAuthenticated) {
-          // Library + progress are non-fatal for the detail page — if they
-          // fail we still render the book, just without the saved/continue
-          // state. We log the error instead of swallowing silently (P1-4/P3-2).
-          try {
-            const lib = await libraryApi.getLibrary()
-            if (!cancelled) setInLibrary(lib.some(item => item.editionId === b.id))
-          } catch (err) {
-            console.warn('getLibrary failed on book detail:', err)
-          }
-          try {
-            const p = await readingProgressApi.getProgress(b.id)
-            // Not `p?.chapterSlug` alone: a PDF read in Original layout is
-            // chapterless, its position is a `page:<N>` locator, and looking
-            // only at the slug made every half-read PDF report "never opened".
-            // `my-books/[id].tsx` already carries this fallback; the catalog
-            // screen did not.
-            if (!cancelled) {
-              const slug = resumeChapterSlug(p?.chapterSlug, p?.locator, b.chapters)
-              if (slug) setContinueSlug(slug)
-              setContinuePct(storedBookPercent(p))
-            }
-          } catch (err) {
-            console.warn('getProgress failed on book detail:', err)
-          }
         }
       })
       .catch(async (e) => {
@@ -149,11 +171,125 @@ export default function BookDetailScreen() {
         }
       })
       .finally(() => {
-        if (!cancelled) setLoading(false)
+        if (!cancelled) setBookLoading(false)
       })
 
     return () => { cancelled = true }
-  }, [slug, isAuthenticated, language, reloadTick])
+  }, [slug, language, reloadTick])
+
+  /**
+   * Everything that only makes sense once there is a session: is this book on
+   * the shelf, and how far in is the reader. Keyed on the book id and on
+   * `isAuthenticated`, so a session arriving mid-life (the guest mint above)
+   * refreshes exactly this and nothing else.
+   *
+   * Skipped in offline mode: `book` there is a stub assembled from the SQLite
+   * cache because the server was unreachable, and these are the two calls that
+   * cannot be made.
+   */
+  useEffect(() => {
+    const editionId = book?.id
+    // No book yet: `bookLoading` is still holding the skeleton, so there is
+    // nothing to release and nothing to fetch.
+    if (!editionId) return
+    if (!isAuthenticated || offlineMode) {
+      // Nothing will be fetched, so the question is already answered — and the
+      // focus refresh below is still armed (offline it re-reads local progress).
+      progressLoadedForRef.current = editionId
+      setSessionLoading(false)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      // Library + progress are non-fatal for the detail page — if they fail we
+      // still render the book, just without the saved/continue state. We log
+      // the error instead of swallowing silently (P1-4/P3-2).
+      try {
+        const lib = await libraryApi.getLibrary()
+        if (!cancelled) setInLibrary(lib.some(item => item.editionId === editionId))
+      } catch (err) {
+        console.warn('getLibrary failed on book detail:', err)
+      }
+      try {
+        const p = await readingProgressApi.getProgress(editionId)
+        // Not `p?.chapterSlug` alone: a PDF read in Original layout is
+        // chapterless, its position is a `page:<N>` locator, and looking
+        // only at the slug made every half-read PDF report "never opened".
+        // `my-books/[id].tsx` already carries this fallback; the catalog
+        // screen did not.
+        if (!cancelled) {
+          const resume = resumeChapterSlug(p?.chapterSlug, p?.locator, book?.chapters)
+          if (resume) setContinueSlug(resume)
+          setContinuePct(storedBookPercent(p))
+        }
+      } catch (err) {
+        console.warn('getProgress failed on book detail:', err)
+      }
+      if (!cancelled) {
+        // Whatever happened, the question "has the session data landed" is now
+        // answered — drop the skeleton. Marking the id lets the focus refresh
+        // below tell a re-entry apart from this first pass.
+        progressLoadedForRef.current = editionId
+        setSessionLoading(false)
+      }
+    })()
+    return () => { cancelled = true }
+    // `book?.chapters` is read inside but deliberately not a dep: it is fixed
+    // for a given edition id, and listing the array would re-run this on every
+    // book object identity change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [book?.id, isAuthenticated, offlineMode])
+
+  /**
+   * Re-read the progress when this screen comes back into view.
+   *
+   * The reader is pushed and left with `router.back()`, so this screen is never
+   * unmounted and neither effect above re-runs — none of their deps change. QA
+   * read a chapter, backed out, and met "Start Reading" and the pre-reader
+   * percentage on a book they had just moved through. The write side was fine;
+   * only the read was stale. Same fix, same shape, as `my-books/[id].tsx`.
+   *
+   * Only the progress, not the book: a book's own fields do not change by
+   * reading it.
+   *
+   * `progressLoadedForRef` is the guard against racing the initial load. This
+   * callback's identity changes when the book id lands, which re-runs it while
+   * still focused — at that moment the effect above has not answered yet, the
+   * ref does not match, and this returns rather than firing a second
+   * `GET /me/progress/{id}`. It only starts doing work on a genuine re-focus.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      const editionId = book?.id
+      if (!editionId || progressLoadedForRef.current !== editionId) return
+      let cancelled = false
+      if (offlineMode) {
+        // Offline the reader still writes progress locally, so the same
+        // staleness applies — it is just answered from AsyncStorage. Mirrors
+        // the offline branch of the load effect, which sets the slug only.
+        getLocalProgress(editionId)
+          .then(local => {
+            if (cancelled || !local?.chapterSlug) return
+            setContinueSlug(local.chapterSlug)
+          })
+          .catch(() => {})
+        return () => { cancelled = true }
+      }
+      if (!isAuthenticated) return
+      readingProgressApi.getProgress(editionId)
+        .then(p => {
+          if (cancelled || !p) return
+          const resume = resumeChapterSlug(p.chapterSlug, p.locator, book?.chapters)
+          if (resume) setContinueSlug(resume)
+          setContinuePct(storedBookPercent(p))
+        })
+        // Offline, or the request failed: keep whatever the screen already
+        // shows rather than blanking a good value with a failed refresh.
+        .catch(() => {})
+      return () => { cancelled = true }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [book?.id, isAuthenticated, offlineMode]),
+  )
 
   const dl = book ? downloads.get(book.id) : undefined
   const isDownloading = dl?.status === 'downloading'
@@ -396,13 +532,13 @@ export default function BookDetailScreen() {
           </TouchableOpacity>
         </View>
 
-        <AddToCollectionSheet
+        {collectionSheetMounted && <AddToCollectionSheet
           visible={collectionSheetOpen}
           bookId={book.id}
           bookType="savedbook"
           onClose={() => setCollectionSheetOpen(false)}
           onAdded={(name) => toast.show({ message: t('library.actions.addedToCollection').replace('{{name}}', name), variant: 'success' })}
-        />
+        />}
 
         <Text style={[styles.sectionTitle, { color: colors.text }]}>Chapters</Text>
         {(showAllChapters ? book.chapters : book.chapters.slice(0, 10)).map((ch) => (

--- a/apps/mobile/app/my-books/[id].tsx
+++ b/apps/mobile/app/my-books/[id].tsx
@@ -15,6 +15,7 @@ import { LoadingScreen } from '../../src/components/ui/LoadingScreen'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { trackBookOpened } from '../../src/lib/analytics'
 import { AddToCollectionSheet } from '../../src/components/library/AddToCollectionSheet'
+import { useSheetMount } from '../../src/hooks/useSheetMount'
 
 export default function UserBookDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>()
@@ -31,6 +32,8 @@ export default function UserBookDetailScreen() {
   const [deleting, setDeleting] = useState(false)
   const [enriching, setEnriching] = useState(false)
   const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
+  // Same reason as everywhere else this sheet appears — see useSheetMount.
+  const collectionSheetMounted = useSheetMount(collectionSheetOpen)
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const unmountedRef = useRef(false)
 
@@ -526,13 +529,13 @@ export default function UserBookDetailScreen() {
           </View>
         )}
 
-        <AddToCollectionSheet
+        {collectionSheetMounted && <AddToCollectionSheet
           visible={collectionSheetOpen}
           bookId={isReady ? book.id : null}
           bookType="userbook"
           onClose={() => setCollectionSheetOpen(false)}
           onAdded={(name) => showToast({ message: t('library.actions.addedToCollection').replace('{{name}}', name), variant: 'success' })}
-        />
+        />}
 
         {/* Chapter list */}
         {isReady && book.chapters.length > 0 && (

--- a/apps/mobile/src/components/TranslationSheet.tsx
+++ b/apps/mobile/src/components/TranslationSheet.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { View, Text, Modal, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
-import { translationApi } from '@textstack/shared'
 import { useTheme } from '../context/ThemeContext'
 import { useLanguage } from '../context/LanguageContext'
 import { useNativeLanguage } from '../context/NativeLanguageContext'
@@ -11,6 +10,7 @@ import { LanguageList } from './LanguageList'
 import { getLanguage } from '../data/languages'
 import { fonts } from '../theme/typography'
 import { trackTranslationUsed } from '../lib/analytics'
+import { cachedTranslate } from '../lib/translateCache'
 
 interface TranslationSheetProps {
   visible: boolean
@@ -66,9 +66,14 @@ export function TranslationSheet({ visible, text, onClose, onSpeak, fromLang: fr
     setError('')
     setTranslated('')
     trackTranslationUsed({ fromLang, toLang: translationTarget, kind: text.includes(' ') ? 'selection' : 'word' })
-    translationApi.translate(text, fromLang, translationTarget)
-      .then((res: any) => {
-        setTranslated(res.translatedText || res.translation || '')
+    // `cachedTranslate`, not `translationApi.translate`. This sheet is opened
+    // from the selection toolbar, which has ALREADY fetched and memoized the
+    // gloss for exactly this text — going direct re-bought a paid
+    // `gpt-4.1-nano` call for a string the process was holding in memory, and
+    // never wrote its own answer back for the next reader of the same word.
+    cachedTranslate(text, fromLang, translationTarget)
+      .then(({ translation }) => {
+        setTranslated(translation)
       })
       .catch(() => setError('Translation failed'))
       .finally(() => setLoading(false))

--- a/apps/mobile/src/components/library/BookList.tsx
+++ b/apps/mobile/src/components/library/BookList.tsx
@@ -13,6 +13,7 @@ import { useLanguage } from '../../context/LanguageContext'
 import { useToast } from '../../context/ToastContext'
 import { fonts } from '../../theme/typography'
 import { AddToCollectionSheet } from './AddToCollectionSheet'
+import { useSheetMount } from '../../hooks/useSheetMount'
 import { BookStatusBadge } from './BookStatusBadge'
 import { GeneratedCover } from './GeneratedCover'
 import { useBookActions } from '../../hooks/useBookActions'
@@ -69,6 +70,8 @@ export function BookList({
 
   const { showSavedActions, showUploadActions } = useBookActions()
   const [collectionTarget, setCollectionTarget] = useState<LibraryEntry | null>(null)
+  // Same reason as everywhere else this sheet appears — see useSheetMount.
+  const collectionSheetMounted = useSheetMount(!!collectionTarget)
 
   const handleAction = (e: LibraryEntry) => {
     if (e.kind === 'saved') {
@@ -273,13 +276,13 @@ export function BookList({
         columnWrapperStyle={viewMode === 'grid' ? { gap: 10 } : undefined}
         renderItem={({ item }) => renderEntry(item)}
       />
-      <AddToCollectionSheet
+      {collectionSheetMounted && <AddToCollectionSheet
         visible={!!collectionTarget}
         bookId={targetId}
         bookType={collectionTarget?.kind === 'upload' ? 'userbook' : 'savedbook'}
         onClose={() => setCollectionTarget(null)}
         onAdded={(name) => showToast({ message: t('library.actions.addedToCollection').replace('{{name}}', name), variant: 'success' })}
-      />
+      />}
     </>
   )
 }

--- a/apps/mobile/src/hooks/useSheetMount.ts
+++ b/apps/mobile/src/hooks/useSheetMount.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Don't mount a sheet until it has been opened once.
+ *
+ * `<Modal visible={false}>` draws nothing, which reads like "it costs nothing".
+ * It is not: the component AROUND the Modal mounts with its parent and its
+ * hooks run immediately. Every screen that rendered `AddToCollectionSheet` or
+ * `LibraryViewSheet` unconditionally therefore fired
+ * `GET /me/library/collections` on open, from `useCollections`. On the public
+ * book-detail screen — reachable signed out — that is a 401 on every single
+ * open, because `useCollections` caches successes only; and it drags
+ * `authFetch` into `onUnauthorized` → `handleTerminalAuthFailure()` on a screen
+ * that never needed a session at all.
+ *
+ * Latched rather than a plain `open && <Sheet/>`: unmounting on close would
+ * kill the slide-out animation the sheet was written for. After the first open
+ * the component stays mounted and `visible` alone drives it, exactly as before.
+ *
+ * @param open the sheet's own visibility flag
+ * @returns whether the sheet component should be rendered at all
+ */
+export function useSheetMount(open: boolean): boolean {
+  const [mounted, setMounted] = useState(open)
+  useEffect(() => {
+    if (open) setMounted(true)
+  }, [open])
+  return mounted
+}

--- a/apps/mobile/src/lib/translateCache.test.ts
+++ b/apps/mobile/src/lib/translateCache.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * `POST /translate` is a paid `gpt-4.1-nano` call on the most frequent action
+ * in the product (tap a word). These tests exist because the module used to
+ * memoize the RESULT and not the PROMISE: two callers in the same ~1s window
+ * both missed the cache and both were billed, while the file's own docblock
+ * claimed it "de-dupes the double translate per tap".
+ */
+
+const translate = vi.hoisted(() => vi.fn())
+vi.mock('@textstack/shared', () => ({ translationApi: { translate } }))
+
+/** A promise plus its resolvers, so a test can hold a call open. */
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+/**
+ * Fresh module per test. The cache and the in-flight map are module-level
+ * singletons on purpose (they are shared across the whole reader), so the only
+ * honest way to test a cold start is to re-import.
+ */
+async function freshModule() {
+  vi.resetModules()
+  return import('./translateCache')
+}
+
+beforeEach(() => {
+  translate.mockReset()
+})
+
+describe('cachedTranslate', () => {
+  it('N concurrent callers for the same word produce exactly ONE network call', async () => {
+    const { cachedTranslate } = await freshModule()
+    const gate = deferred<{ translatedText: string }>()
+    translate.mockReturnValue(gate.promise)
+
+    const callers = [
+      cachedTranslate('Wort', 'de', 'en'),
+      cachedTranslate('Wort', 'de', 'en'),
+      cachedTranslate('Wort', 'de', 'en'),
+      cachedTranslate('Wort', 'de', 'en'),
+    ]
+    gate.resolve({ translatedText: 'word' })
+
+    expect(await Promise.all(callers)).toEqual([
+      { translation: 'word', category: undefined },
+      { translation: 'word', category: undefined },
+      { translation: 'word', category: undefined },
+      { translation: 'word', category: undefined },
+    ])
+    expect(translate).toHaveBeenCalledTimes(1)
+  })
+
+  it('hands every joiner the same promise, not a copy', async () => {
+    const { cachedTranslate } = await freshModule()
+    const gate = deferred<{ translatedText: string }>()
+    translate.mockReturnValue(gate.promise)
+
+    const a = cachedTranslate('Haus', 'de', 'en')
+    const b = cachedTranslate('Haus', 'de', 'en')
+    gate.resolve({ translatedText: 'house' })
+    await Promise.all([a, b])
+
+    expect(translate).toHaveBeenCalledTimes(1)
+  })
+
+  it('keys the dedupe the same way the cache does — different words still both go out', async () => {
+    const { cachedTranslate } = await freshModule()
+    translate.mockImplementation(async (text: string) => ({ translatedText: `${text}!` }))
+
+    await Promise.all([
+      cachedTranslate('eins', 'de', 'en'),
+      cachedTranslate('zwei', 'de', 'en'),
+      cachedTranslate('eins', 'de', 'uk'), // same word, different target
+    ])
+
+    expect(translate).toHaveBeenCalledTimes(3)
+  })
+
+  it('normalises case and surrounding whitespace, so those join instead of paying', async () => {
+    const { cachedTranslate } = await freshModule()
+    const gate = deferred<{ translatedText: string }>()
+    translate.mockReturnValue(gate.promise)
+
+    const callers = [
+      cachedTranslate('Wort', 'de', 'en'),
+      cachedTranslate('  wort ', 'de', 'en'),
+    ]
+    gate.resolve({ translatedText: 'word' })
+    await Promise.all(callers)
+
+    expect(translate).toHaveBeenCalledTimes(1)
+  })
+
+  it('carries the backend save-recommendation category through to every joiner', async () => {
+    const { cachedTranslate } = await freshModule()
+    const gate = deferred<{ translatedText: string; category: string }>()
+    translate.mockReturnValue(gate.promise)
+
+    const a = cachedTranslate('Schadenfreude', 'de', 'en')
+    const b = cachedTranslate('Schadenfreude', 'de', 'en')
+    gate.resolve({ translatedText: 'schadenfreude', category: 'rare' })
+
+    expect(await a).toEqual({ translation: 'schadenfreude', category: 'rare' })
+    expect(await b).toEqual({ translation: 'schadenfreude', category: 'rare' })
+    expect(translate).toHaveBeenCalledTimes(1)
+  })
+
+  it('memoizes the result — a later caller is free', async () => {
+    const { cachedTranslate, peekTranslation } = await freshModule()
+    translate.mockResolvedValue({ translatedText: 'word' })
+
+    await cachedTranslate('Wort', 'de', 'en')
+    await cachedTranslate('Wort', 'de', 'en')
+
+    expect(translate).toHaveBeenCalledTimes(1)
+    expect(peekTranslation('Wort', 'de', 'en')).toEqual({ translation: 'word', category: undefined })
+  })
+
+  it('releases the slot on REJECT — a leaked slot would wedge translation for the whole process', async () => {
+    // The classic version of this bug: evict only in the success path, and one
+    // failed translate (offline, or the /translate rate limit) keeps the slot
+    // forever. Every later tap on that word would be handed the same stale
+    // rejection, and the gloss would never come back until the app restarted.
+    const { cachedTranslate } = await freshModule()
+    translate.mockRejectedValueOnce(new Error('429'))
+
+    await expect(cachedTranslate('Wort', 'de', 'en')).rejects.toThrow('429')
+
+    translate.mockResolvedValueOnce({ translatedText: 'word' })
+    await expect(cachedTranslate('Wort', 'de', 'en')).resolves.toEqual({ translation: 'word', category: undefined })
+    expect(translate).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives concurrent joiners the SAME rejection, and still only calls once', async () => {
+    const { cachedTranslate } = await freshModule()
+    const gate = deferred<never>()
+    translate.mockReturnValue(gate.promise)
+
+    const a = cachedTranslate('Wort', 'de', 'en')
+    const b = cachedTranslate('Wort', 'de', 'en')
+    gate.reject(new Error('offline'))
+
+    await expect(a).rejects.toThrow('offline')
+    await expect(b).rejects.toThrow('offline')
+    expect(translate).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not memoize an empty translation, so the next tap retries', async () => {
+    const { cachedTranslate, peekTranslation } = await freshModule()
+    translate.mockResolvedValue({ translatedText: '' })
+
+    await cachedTranslate('Wort', 'de', 'en')
+    expect(peekTranslation('Wort', 'de', 'en')).toBeUndefined()
+
+    translate.mockResolvedValue({ translatedText: 'word' })
+    expect(await cachedTranslate('Wort', 'de', 'en')).toEqual({ translation: 'word', category: undefined })
+    expect(translate).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not leak an in-flight entry per word — a long reading session stays bounded', async () => {
+    // Not a memory-size assertion; the observable proxy is that after a word
+    // has settled, the very next call for it must be served from `cache`
+    // without touching the network, which can only happen if the slot was
+    // both released AND evicted.
+    const { cachedTranslate } = await freshModule()
+    translate.mockImplementation(async (text: string) => ({ translatedText: `${text}-en` }))
+
+    for (const w of ['ein', 'zwei', 'drei']) {
+      await Promise.all([cachedTranslate(w, 'de', 'en'), cachedTranslate(w, 'de', 'en')])
+    }
+    for (const w of ['ein', 'zwei', 'drei']) {
+      await cachedTranslate(w, 'de', 'en')
+    }
+
+    expect(translate).toHaveBeenCalledTimes(3)
+  })
+})

--- a/apps/mobile/src/lib/translateCache.ts
+++ b/apps/mobile/src/lib/translateCache.ts
@@ -1,16 +1,40 @@
 import { translationApi } from '@textstack/shared'
+import { createSingleFlight, type SingleFlight } from './singleFlight'
 
 export type SaveCategory = 'common' | 'learnable' | 'rare'
 export type CachedTranslation = { translation: string; category?: SaveCategory }
 
 // In-memory translation cache shared by the reader's selection toolbar, the
-// vocab save path, and the gloss backfill. Wins:
+// vocab save path, the Translate sheet, and the gloss backfill. Wins:
 //   1. Re-tapping a word is instant (no network round-trip).
 //   2. De-dupes the double translate per tap.
 //   3. Carries the backend's single-word frequency "category" so the toolbar
 //      can recommend (not gate) saving.
 // Session-scoped; the backend file cache covers cross-session reuse.
 const cache = new Map<string, CachedTranslation>()
+
+/**
+ * In-flight calls, keyed exactly like `cache`.
+ *
+ * Point 2 above was a claim this file could not keep. It memoized the RESULT
+ * and nothing else, so two callers inside the same ~1s window both read
+ * `cache.get(k) === undefined`, both called the API, and both were billed:
+ * `/translate` is OpenAI `gpt-4.1-nano`, on the most frequent action in the
+ * product. The server-side file cache does not save you either — the second
+ * request reads a cache entry the first one has not written yet.
+ *
+ * `createSingleFlight` is REUSED rather than reimplemented. Its one job is
+ * "N callers, one call, everyone gets the same promise, and the slot is
+ * released on BOTH settlements", which is precisely the rule needed here, and
+ * it is the version of that rule this repo already has tests for. The only
+ * thing it lacks is a key, and a key is a `Map` — cheaper and far less
+ * dangerous than a second hand-rolled promise-tracking implementation whose
+ * release-on-reject path would have to be got right all over again.
+ *
+ * Entries are evicted once the call settles, so the map never outgrows the
+ * words actually in flight (the resolved values live in `cache`).
+ */
+const inFlight = new Map<string, SingleFlight<CachedTranslation>>()
 
 const keyOf = (text: string, from: string, to: string) =>
   `${from}|${to}|${text.trim().toLowerCase()}`
@@ -25,8 +49,30 @@ export async function cachedTranslate(text: string, from: string, to: string): P
   const k = keyOf(text, from, to)
   const hit = cache.get(k)
   if (hit !== undefined) return hit
-  const res = await translationApi.translate(text, from, to) as { translatedText?: string; translation?: string; category?: SaveCategory }
-  const out: CachedTranslation = { translation: res.translatedText || res.translation || '', category: res.category }
-  if (out.translation) cache.set(k, out)
-  return out
+
+  let slot = inFlight.get(k)
+  if (!slot) {
+    slot = createSingleFlight<CachedTranslation>()
+    inFlight.set(k, slot)
+  }
+  const claimed = slot
+  const call = claimed.run(async () => {
+    const res = await translationApi.translate(text, from, to) as { translatedText?: string; translation?: string; category?: SaveCategory }
+    const out: CachedTranslation = { translation: res.translatedText || res.translation || '', category: res.category }
+    if (out.translation) cache.set(k, out)
+    return out
+  })
+
+  // Evict on BOTH settlements, for the same reason `singleFlight` releases on
+  // both: a slot left behind after a failure would hand every later caller the
+  // one stale rejection, and translation would stay broken for the rest of the
+  // process. `run` has already cleared its own slot by the time this runs
+  // (it settles `call` from inside its own handlers), so `isInFlight` is the
+  // honest test for "nobody re-entered while we were settling".
+  const evict = () => {
+    if (!claimed.isInFlight && inFlight.get(k) === claimed) inFlight.delete(k)
+  }
+  call.then(evict, evict)
+
+  return call
 }


### PR DESCRIPTION
Four kinds of wasted request found by the QA-005 pass (#560) with a logging proxy. One spends money.

## `POST /translate` fired twice per word tap

`gpt-4.1-nano`, doubled, on the most frequent action in the product.

The reason a duplicate cost anything: `translateCache` memoized the **result**, never the promise, so two callers inside one round trip both saw a miss and both paid. Its own docblock claimed it *"de-dupes the double translate per tap"* — it could not; there was no in-flight map. The server cannot help either: it reads a file cache the first request has not written yet.

Now keyed over `createSingleFlight`, rather than a second promise-tracker. That utility already gets release-on-**both**-settlements right and already has tests for it; writing another would have meant getting that right a second time, in a file that had already lied about doing it once.

`TranslationSheet` bypassed the cache outright — every Translate press re-bought a gloss the toolbar was holding in memory, and never wrote the result back.

## `GET /books/{slug}` fired twice on reader open — this one is ours

A regression from #554. `ReaderSessionGate` mints a guest, `isAuthenticated` flips **globally**, and the book detail screen still mounted underneath refetches the same public book at the instant the gate mounts the reader with its own fetch. `readerSessionGate.ts` documents freezing that flag for the reader's lifetime; nothing froze it for the screens *behind* the reader.

The effect is split: the public fetch keys on the slug, the session-dependent follow-ups on the session.

**That needed more than a dep change.** `setLoading(false)` used to run after library+progress had already been awaited, so the skeleton covered both round trips. Splitting naively paints the hero one RTT early and an in-progress book flashes "Start Reading" before flipping. `loading` is now derived from a one-way `sessionLoading` latch — seeded `true` for an account so behaviour is unchanged, `false` for a guest so the book paints as soon as it arrives and a mid-flight mint refreshes without throwing the screen back to a skeleton. A failed load still reaches the error screen rather than hanging on a skeleton waiting for follow-ups that will never run.

## A 401 on every book detail open

`AddToCollectionSheet` was mounted unconditionally. A `Modal` with `visible={false}` draws nothing, but its hooks still run, and `useCollections` caches only successes — so a signed-out reader took the same 401 every single time, and dragged `authFetch` into `handleTerminalAuthFailure()` on a screen that never needed a session.

**Four sites, not the one reported.** Fixing only `LibraryViewSheet` would have changed nothing observable on the library tab: the 60 s module cache would simply have served `BookList`'s identical request instead. Extracted as `useSheetMount` — latched rather than `open && <Sheet/>`, so the slide-out animation the sheets were written for still plays.

## Book detail kept its pre-reader progress

The file **already imported `useFocusEffect` and `useCallback` and used neither** — the refetch was planned and never written. The reader is pushed, the screen never unmounts, no dep changes. Copied the fix already made on `my-books/[id].tsx` for the identical symptom, including its "keep the previous value on failure rather than blanking it" behaviour, plus a guard so first focus does not duplicate the initial load.

## Deliberately not done

The reader bridge posts the tap and Android's own `selectionchange` as two messages, and their exact-match dedupe fails when they differ by one character.

**The dedupe above does not make that pair free** — different text means different cache keys, so both are still billed. It kills every *same-key* duplicate, which is real and provable, but not this one.

The likely cause is `WORD_RE` carrying a **straight** apostrophe while the extraction pipeline's typography step writes curly ones, so a tap on `don’t` resolves `don` and Android resolves `don’t`. But the guard that looks obvious re-breaks drag-to-extend — fixed directly above it and verified on a device after a report of *"I selected a sentence and it read one word"*. Measure both dispatched strings on a dev build first, then fix the confirmed difference. Guessing there costs the word-selection gesture.

Also found while reading it, unfixed: the drag branch sets `_lastDispatchedText` but never resets `_lastDispatchWasTap`, so after tap → drag-extend → collapse the toolbar is not torn down.

## Tests

`translateCache.test.ts`, 10 tests. Shown failing against the unfixed cache — **6 of 10 red**, including "N concurrent callers produce exactly one network call" (got 4). The four that pass either way assert the result cache, which already worked.

**Everything else here is held by review.** `vitest.config.ts` collects `src/lib/**` only; `app/` has no test harness at all. Stating that rather than implying coverage.

## Correction to the brief this was written from

`reloadTick` was reported as dead state with an unwired Retry. It is not — `setReloadTick` is called from the Retry button on the error screen. A grep for `reloadTick` misses it because the setter capitalises the `R`. Left untouched.

## Rollback

`git revert`. No schema, no config, no flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZDSrvtAjiqUz82FPQdZpz