### PR TITLE
fix(mobile): Blitz runs Blitz, and four smaller things QA found

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -4,7 +4,7 @@ import {
   Alert, Platform, TextInput, KeyboardAvoidingView, ScrollView,
 } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
-import { useRouter } from 'expo-router'
+import { useLocalSearchParams, useRouter } from 'expo-router'
 import { authApi, type UserDto } from '@textstack/shared'
 import { GoogleSignin } from '@react-native-google-signin/google-signin'
 import Constants from 'expo-constants'
@@ -53,7 +53,20 @@ export default function LoginScreen() {
   const router = useRouter()
   const { signInWithTokens } = useAuth()
   const [loading, setLoading] = useState(false)
-  const [mode, setMode] = useState<Mode>('login')
+  // Which tab this screen opens on.
+  //
+  // It read no params at all, so "Create free account" on Profile — the one CTA
+  // whose whole job is turning a guest into an account — landed the reader on
+  // *Sign in*, with an empty password field and no account to put in it.
+  //
+  // A `useState` INITIALISER and deliberately not a `useEffect` that syncs on
+  // param change: the tabs below are the user's to switch, and a syncing effect
+  // would yank them back to Register the moment anything re-rendered after they
+  // tapped Sign in. The param decides the first frame and then has no further
+  // opinion. Everything other than `register` (including the twelve call sites
+  // that pass nothing) keeps landing on Sign in.
+  const params = useLocalSearchParams<{ mode?: string }>()
+  const [mode, setMode] = useState<Mode>(() => (params.mode === 'register' ? 'register' : 'login'))
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [name, setName] = useState('')
@@ -68,6 +81,15 @@ export default function LoginScreen() {
 
   const resetForm = () => { setEmail(''); setPassword(''); setName(''); setError(''); setForgotSent(false) }
   const switchMode = (m: Mode) => { resetForm(); setMode(m) }
+
+  // Editing retires the error the edit is answering.
+  //
+  // `setError('')` ran only on the next submit, and `onChangeText` cleared
+  // nothing — so "Password must be at least 8 characters." stayed red while the
+  // user typed the ninth, tenth and fourteenth. The form was telling them they
+  // were still wrong about something they had just fixed.
+  const changeEmail = (text: string) => { setEmail(text); if (error) setError('') }
+  const changePassword = (text: string) => { setPassword(text); if (error) setError('') }
 
   const handleEmailAuth = async () => {
     // Guard: the submit button is disabled while `loading`, but keyboard
@@ -299,7 +321,7 @@ export default function LoginScreen() {
               placeholder="Email"
               placeholderTextColor={colors.textSecondary}
               value={email}
-              onChangeText={setEmail}
+              onChangeText={changeEmail}
               keyboardType="email-address"
               autoCapitalize="none"
               autoCorrect={false}
@@ -321,7 +343,7 @@ export default function LoginScreen() {
                 placeholder="Password"
                 placeholderTextColor={colors.textSecondary}
                 value={password}
-                onChangeText={setPassword}
+                onChangeText={changePassword}
                 secureTextEntry
                 autoCapitalize="none"
                 autoCorrect={false}

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -90,7 +90,7 @@ export default function ProfileScreen() {
   // controls under them, `startEdit` and `pickAvatar`, stayed open to a guest.
   // (Named rather than quoted above: `capabilityLiterals.test.ts` greps source
   // text and cannot tell a comment from a branch. Correct — it stays dumb.)
-  const { isGuest, canEditIdentity, canDeleteAccount, canSyncAcrossDevices } = capabilitiesFor(user)
+  const { isGuest, canUpload, canEditIdentity, canDeleteAccount, canSyncAcrossDevices } = capabilitiesFor(user)
   const anon = isGuest && user ? getAnonymousReader(user.id) : null
   const anonSource = anon && user ? getAnonAvatarSource(user.id) : null
   const displayName = anon ? anon.name : (user?.name || user?.email || '')
@@ -340,8 +340,14 @@ export default function ProfileScreen() {
 
       <View style={styles.menu}>
         {/* Upload space lives here rather than mid-list on Library, where it
-            was an unlabelled bar between the upload button and the search box. */}
-        <StorageQuotaRow />
+            was an unlabelled bar between the upload button and the search box.
+
+            Behind `canUpload` because upload is account-only by product choice
+            (`src/lib/capabilities.ts`). Unconditional, this screen offered a
+            guest "0 B of 50 MB used" — an allowance they are not permitted to
+            spend, on the same screen that asks them to create an account. The
+            capability was already computed one line up and simply never read. */}
+        {canUpload && <StorageQuotaRow />}
 
         {MENU_ITEMS.map(item => (
           <TouchableOpacity
@@ -465,7 +471,9 @@ export default function ProfileScreen() {
             <Text style={[styles.guestBanner, { color: colors.textSecondary }]}>{t('guest.banner')}</Text>
             <TouchableOpacity
               style={[styles.guestCta, { backgroundColor: colors.primary }]}
-              onPress={() => router.push('/(auth)/login')}
+              // The button says "Create free account", so the screen it opens
+              // has to be the Register tab. It opened on Sign in.
+              onPress={() => router.push({ pathname: '/(auth)/login', params: { mode: 'register' } })}
               activeOpacity={0.85}
               accessibilityRole="button"
               accessibilityLabel={t('guest.createAccount')}

--- a/apps/mobile/app/(tabs)/vocabulary.tsx
+++ b/apps/mobile/app/(tabs)/vocabulary.tsx
@@ -22,6 +22,7 @@ import { VocabViewSheet } from '../../src/components/vocabulary/VocabViewSheet'
 import { VocabSummaryCard } from '../../src/components/vocabulary/VocabSummaryCard'
 import { buildContextSnippet } from '@textstack/shared'
 import { resolveListScreenState } from '../../src/lib/listScreenState'
+import { DEFAULT_REVIEW_MODE, loadReviewMode, saveReviewMode } from '../../src/lib/reviewMode'
 
 const STAGE_LABELS = ['New', 'Recognition', 'Recall', 'Context', 'Mastered']
 const STAGE_COLORS = ['#9CA3AF', '#3B82F6', '#F59E0B', '#8B5CF6', '#10B981']
@@ -64,7 +65,20 @@ export default function VocabularyScreen() {
   const [refreshing, setRefreshing] = useState(false)
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [total, setTotal] = useState(0)
-  const [reviewMode, setReviewMode] = useState<ReviewMode>('classic')
+  // Survives a cold start. It used to be plain `useState`, so "the setting
+  // persists" only meant "this tab stayed mounted" — kill the app and Blitz
+  // silently became Flashcards again, which reads as the app ignoring you.
+  // Web has persisted this since it shipped (`localStorage['practiceMode']`).
+  const [reviewMode, setReviewMode] = useState<ReviewMode>(DEFAULT_REVIEW_MODE)
+  useEffect(() => {
+    let cancelled = false
+    loadReviewMode().then(m => { if (!cancelled) setReviewMode(m) })
+    return () => { cancelled = true }
+  }, [])
+  const selectReviewMode = (next: ReviewMode) => {
+    setReviewMode(next)
+    void saveReviewMode(next)
+  }
   const [pendingItems, setPendingItems] = useState<PendingVocabWordDto[] | null>(null)
   const [pendingBusyId, setPendingBusyId] = useState<string | null>(null)
   const [lookupItems, setLookupItems] = useState<WordLookupDto[] | null>(null)
@@ -311,7 +325,7 @@ export default function VocabularyScreen() {
         sort={sort}
         sortOptions={SORT_OPTIONS}
         stats={stats}
-        onSelectReviewMode={m => setReviewMode(m as ReviewMode)}
+        onSelectReviewMode={selectReviewMode}
         onSelectSort={k => setSort(k as SortKey)}
         onOpenSettings={() => setSettingsOpen(true)}
         onClose={() => setViewSheetOpen(false)}

--- a/apps/mobile/app/reset-password.tsx
+++ b/apps/mobile/app/reset-password.tsx
@@ -92,7 +92,11 @@ export default function ResetPasswordScreen() {
                 placeholderTextColor={colors.textSecondary}
                 secureTextEntry
                 value={password}
-                onChangeText={setPassword}
+                // Same defect as the sign-in form: the length error cleared only
+                // on the next submit, so it stayed red while the user typed the
+                // characters that fixed it. This is the first screen after a
+                // reset email, so it is the worst place to look broken.
+                onChangeText={text => { setPassword(text); if (error) setError('') }}
                 autoFocus
                 autoCapitalize="none"
                 autoCorrect={false}

--- a/apps/mobile/app/vocabulary/review.tsx
+++ b/apps/mobile/app/vocabulary/review.tsx
@@ -9,6 +9,7 @@ import { useLanguage } from '../../src/context/LanguageContext'
 import { useTts } from '../../src/hooks/useTts'
 import { useHaptics } from '../../src/hooks/useHaptics'
 import { useVocabularyReview } from '../../src/hooks/useVocabularyReview'
+import { reviewModeFromParam } from '../../src/lib/reviewMode'
 import { LoadingScreen } from '../../src/components/ui/LoadingScreen'
 import { PressableScale } from '../../src/components/ui/PressableScale'
 import { MultipleChoiceCard } from '../../src/components/vocabulary/MultipleChoiceCard'
@@ -25,6 +26,10 @@ export default function VocabularyReviewScreen() {
   const params = useLocalSearchParams<{ limit?: string; reviewMode?: string; cluster?: string; practice?: string }>()
   const clusterId = typeof params.cluster === 'string' ? params.cluster : null
   const practiceMode = params.practice === '1' || params.practice === 'true'
+  // The mode this session starts in, as a plain value — the point being that it
+  // is NOT hook state. See `reviewModeFromParam` for the failure that made this
+  // necessary (#558); web derives it the same way and for the same reason.
+  const initialReviewMode = reviewModeFromParam(params.reviewMode)
 
   const [batchSize, setBatchSize] = useState(() => {
     const v = parseInt(params.limit || String(DEFAULT_BATCH_SIZE), 10)
@@ -47,26 +52,27 @@ export default function VocabularyReviewScreen() {
   const haptics = useHaptics()
   const sessionStartRef = useRef(Date.now())
 
-  // Init review mode from params
-  useEffect(() => {
-    if (params.reviewMode === 'classic' || params.reviewMode === 'blitz') {
-      review.setReviewMode(params.reviewMode)
-    }
-    // Intentionally only on mount — params shouldn't re-trigger.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // Start session
+  // Start session.
+  //
+  // There used to be a second mount effect above this one that dispatched
+  // `review.setReviewMode(params.reviewMode)`. It is gone, and its removal is
+  // the fix: `startSession`/`startClusterSession` already call `setReviewMode`
+  // with whatever they are handed, so there is now exactly one writer of the
+  // mode during startup and nothing for React's batching to resolve in the
+  // wrong order. What is passed is `initialReviewMode`, a value derived from
+  // the params above — deliberately not `review.reviewMode`, which at mount is
+  // the closure's copy of the hook default and never the param.
   useEffect(() => {
     sessionStartRef.current = Date.now()
     if (clusterId) {
-      review.startClusterSession(clusterId, review.reviewMode)
+      review.startClusterSession(clusterId, initialReviewMode)
     } else {
-      review.startSession(batchSize, review.reviewMode, practiceMode)
+      review.startSession(batchSize, initialReviewMode, practiceMode)
     }
-    // `review` is stable per-hook, review.reviewMode read at call time.
+    // `review` is stable per-hook; `initialReviewMode` is a plain string, so
+    // listing it is a value comparison and cannot loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [batchSize, clusterId, practiceMode])
+  }, [batchSize, clusterId, practiceMode, initialReviewMode])
 
   // Say the word when its card appears.
   //

--- a/apps/mobile/src/components/vocabulary/ReviewFeedback.tsx
+++ b/apps/mobile/src/components/vocabulary/ReviewFeedback.tsx
@@ -24,6 +24,13 @@ export function ReviewFeedback({ card, result, isCorrect, reviewMode, onSpeak, o
   const [fetchedDef, setFetchedDef] = useState<string | null>(null)
 
   useEffect(() => {
+    // Classic mode returns the mini branch below, and that branch has no
+    // definition slot — `fetchedDef` is read only in the blitz layout. So this
+    // lookup was a network round-trip whose result was structurally
+    // unreachable: QA measured two of them at ~3s each per card, against an
+    // upstream dictionary that is currently down (#559). Fetch only what the
+    // branch about to render can actually show.
+    if (reviewMode === 'classic') return
     if (card.definition || !language) return
     let cancelled = false
     // Reset any stale result from the previous card before the new lookup lands.
@@ -39,7 +46,7 @@ export function ReviewFeedback({ card, result, isCorrect, reviewMode, onSpeak, o
       if (!cancelled) console.warn('Dictionary lookup failed:', e)
     })
     return () => { cancelled = true }
-  }, [card.word, card.definition, language])
+  }, [card.word, card.definition, language, reviewMode])
 
   // Mini feedback for classic mode.
   // Previously the whole card was `alignItems: 'center'` which made the Next

--- a/apps/mobile/src/lib/reviewMode.test.ts
+++ b/apps/mobile/src/lib/reviewMode.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  DEFAULT_REVIEW_MODE,
+  isReviewMode,
+  reviewModeFromParam,
+  loadReviewMode,
+  saveReviewMode,
+} from './reviewMode'
+
+/**
+ * The regression under test is #558: `?reviewMode=blitz` started a Flashcards
+ * session, every time. The screen wiring that caused it is not testable here
+ * (vitest collects `src/lib/**` only), so the rule was moved out of the screen
+ * — and the case that must never regress is the first one below: a param that
+ * says `blitz` resolves to `blitz`, with no hook state anywhere in the answer.
+ */
+describe('reviewModeFromParam', () => {
+  const cases: [label: string, raw: unknown, expected: string][] = [
+    // The bug. Before the fix the session always ran 'classic' regardless.
+    ['blitz', 'blitz', 'blitz'],
+    ['classic', 'classic', 'classic'],
+    ['undefined (no param — Practice tapped with no mode)', undefined, 'classic'],
+    ['null', null, 'classic'],
+    ['empty string', '', 'classic'],
+    ['garbage', 'not-a-mode', 'classic'],
+    ['wrong case', 'Blitz', 'classic'],
+    ['uppercase', 'BLITZ', 'classic'],
+    ['whitespace-padded', ' blitz ', 'classic'],
+    // expo-router hands back string[] for a repeated param (?reviewMode=a&reviewMode=b).
+    ['string array', ['blitz'], 'classic'],
+    ['number', 1, 'classic'],
+    ['object', { mode: 'blitz' }, 'classic'],
+  ]
+
+  for (const [label, raw, expected] of cases) {
+    it(`${label} → ${expected}`, () => {
+      expect(reviewModeFromParam(raw)).toBe(expected)
+    })
+  }
+
+  it('never throws, whatever it is handed', () => {
+    for (const raw of [Symbol('x'), NaN, () => {}, [], {}]) {
+      expect(() => reviewModeFromParam(raw)).not.toThrow()
+    }
+  })
+
+  it('default matches the hook default so an absent param changes nothing', () => {
+    expect(DEFAULT_REVIEW_MODE).toBe('classic')
+    expect(reviewModeFromParam(undefined)).toBe(DEFAULT_REVIEW_MODE)
+  })
+})
+
+describe('isReviewMode', () => {
+  it('accepts exactly the two literals', () => {
+    expect(isReviewMode('blitz')).toBe(true)
+    expect(isReviewMode('classic')).toBe(true)
+    expect(isReviewMode('typed_recall')).toBe(false)
+    expect(isReviewMode(undefined)).toBe(false)
+  })
+})
+
+describe('persistence', () => {
+  beforeEach(() => {
+    ;(AsyncStorage as unknown as { __reset(): void }).__reset()
+  })
+
+  it('a cold start with nothing stored gets the default', async () => {
+    await expect(loadReviewMode()).resolves.toBe('classic')
+  })
+
+  it('round-trips blitz — the cold-start case that used to revert', async () => {
+    await saveReviewMode('blitz')
+    await expect(loadReviewMode()).resolves.toBe('blitz')
+  })
+
+  it('a corrupted stored value falls back instead of propagating', async () => {
+    await AsyncStorage.setItem('vocab.reviewMode.v1', '{"mode":"blitz"}')
+    await expect(loadReviewMode()).resolves.toBe('classic')
+  })
+})

--- a/apps/mobile/src/lib/reviewMode.ts
+++ b/apps/mobile/src/lib/reviewMode.ts
@@ -1,0 +1,72 @@
+/**
+ * Which review mode a session starts in.
+ *
+ * **The bug this exists to make impossible (#558).** `app/vocabulary/review.tsx`
+ * had two mount effects: one dispatched `setReviewMode(params.reviewMode)`, the
+ * next called `startSession(batch, review.reviewMode, …)` — and that
+ * `review.reviewMode` is the mount-render closure value, i.e. still the hook
+ * default `'classic'`. `startSession` then dispatches it too. Both dispatches
+ * land in one batch and the later one wins, so `?reviewMode=blitz` produced a
+ * Flashcards session 100% of the time. Not a race: the losing order was fixed.
+ *
+ * The rule, borrowed verbatim from web (`apps/web/src/pages/VocabularyReviewPage.tsx`):
+ * derive the starting mode from the params as a plain value and hand THAT to
+ * `startSession`. Never read hook state during startup. One writer, no batch to
+ * lose.
+ *
+ * Pure (`reviewModeFromParam`) plus two AsyncStorage helpers, because mobile's
+ * `vitest.config.ts` only collects `src/lib/**` — a rule that lives in a screen
+ * is a rule that cannot be tested, which is how the above shipped.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import type { ReviewMode } from '@textstack/shared'
+
+/** What a session runs when nothing says otherwise. Matches `useVocabularyReview`. */
+export const DEFAULT_REVIEW_MODE: ReviewMode = 'classic'
+
+export function isReviewMode(value: unknown): value is ReviewMode {
+  return value === 'blitz' || value === 'classic'
+}
+
+/**
+ * Route param → mode. Total: anything unrecognised (missing, garbage, wrong
+ * case, or the `string[]` expo-router hands back for a repeated param) falls to
+ * the default rather than throwing at a reader who tapped Practice.
+ *
+ * Deliberately case-sensitive. `?reviewMode=Blitz` is a caller bug, and
+ * silently repairing it hides the caller; the app itself only ever emits the
+ * lowercase literals.
+ */
+export function reviewModeFromParam(raw: unknown): ReviewMode {
+  return isReviewMode(raw) ? raw : DEFAULT_REVIEW_MODE
+}
+
+/**
+ * Where the chosen mode survives a cold start.
+ *
+ * `app/(tabs)/vocabulary.tsx` held the choice in `useState`, so "it persists"
+ * only meant "the tab stayed mounted" — killing the app silently reverted to
+ * Flashcards. Web has always persisted it (`localStorage['practiceMode']`,
+ * `apps/web/src/pages/VocabularyPage.tsx`); this is the same setting, keyed for
+ * AsyncStorage.
+ */
+const STORAGE_KEY = 'vocab.reviewMode.v1'
+
+export async function loadReviewMode(): Promise<ReviewMode> {
+  try {
+    return reviewModeFromParam(await AsyncStorage.getItem(STORAGE_KEY))
+  } catch {
+    // Storage unavailable is not worth a broken screen — a setting reverting to
+    // its default is the mildest possible failure.
+    return DEFAULT_REVIEW_MODE
+  }
+}
+
+export async function saveReviewMode(mode: ReviewMode): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, mode)
+  } catch {
+    // Fire-and-forget: the in-memory state is already correct for this session.
+  }
+}


### PR DESCRIPTION
From the QA-005 pass (#560). Two broken features with issues, three pieces of friction on the guest→account path built last week.

Closes #558. Closes #559.

## #558 — Blitz was selected, and Flashcards ran

**Not a race. It failed every time**, which is why it reproduced twice.

`review.tsx` dispatched `setReviewMode('blitz')` in one mount effect and, in the very next, called `startSession(batchSize, review.reviewMode, …)` — where `review.reviewMode` is the **mount-render closure value**, still the hook default `'classic'`. `startSession` then dispatched *that*. Two dispatches, one batch, the later one wins.

The comment sitting above it asserted the opposite of what happened: *"review.reviewMode read at call time"*. It is not read at call time; it is captured.

**So Blitz was unreachable from the entry point entirely** — including from `ClusterBonusCard`, which hard-codes `&reviewMode=blitz` and got Flashcards. It worked only from the end-of-session toggle, a separate event in a separate render. That is how a completely broken feature survived to production.

Web already does it right: derive the mode from the params as a plain value, pass **that** value, never read hook state during startup. Same here, with the derivation extracted to `src/lib/reviewMode.ts` so it can be tested — that directory is the only one vitest collects.

**The choice also did not survive a cold start.** It lived in `useState`, so "persists across reopening the sheet" was only the tab staying mounted; killing the app silently reverted to Flashcards. Now in AsyncStorage, matching what web keeps in `localStorage`. Without this, the setting would still feel unreliable after the fix.

## #559 — Flashcards fetched a definition it cannot display

`ReviewFeedback` ran a dictionary lookup for every card without a stored definition, but the `classic` branch returns the *mini* layout, which has no definition slot. The value is only ever read in the blitz branch. Two lookups fired and discarded per session, **3 s each** against the currently-dead upstream.

**Fixed after #558 on purpose:** until Blitz was reachable, the branch that *can* show a definition could not be exercised at all, so a fix here was unverifiable.

## Three on the conversion path

- **"Create free account" opened the auth screen on the Sign in tab.** The screen read no route params at all. Now an optional param used as the **`useState` initializer** — deliberately not a syncing effect, which would yank the user back to Register after they tapped Sign in on purpose. All twelve other callers pass nothing and still land on Sign in; checked individually.
- **The password error stayed red at 14 characters.** Validation was correct; `setError('')` ran only on the *next* submit and `onChangeText` cleared nothing. Same defect in `reset-password.tsx` — the screen a user meets straight after a reset email — fixed in the same pass.
- **A guest's Profile advertised 50 MB of upload space.** Upload is account-only by product choice, and `profile.tsx` destructured four capabilities from `capabilitiesFor(user)` — not `canUpload`, the one governing that row. It offered an allowance the user is not permitted to spend.

## Tests

`reviewMode.test.ts`, 18 cases including the cold-start round-trip. Shown failing against the pre-fix behaviour (`reviewModeFromParam` stubbed to return the hook default, which is exactly what the screen did):

```
FAIL  blitz → blitz                                    expected 'classic' to be 'blitz'
FAIL  round-trips blitz — the cold-start case          expected 'classic' to be 'blitz'
```

**Only the derivation is covered.** #559 and the three conversion fixes live in `app/**` and `src/components/**`, which vitest does not collect — held by review. And even for #558 the test proves the *rule*, not that `review.tsx` passes the value into `startSession`. That part is review plus a device.

Full run: 36 files, 322 tests, `tsc` exit 0, including `routeLiterals` and `capabilityLiterals` — the two grep guards these edits could have tripped.

## Found while there, not fixed

- `handlePracticeAnyway` re-derives the mode from the **original** param on restart, silently discarding a mode the user changed on the summary screen. Same class as #558, pointed the other way; rarer path.
- `ReviewFeedback` keeps `fetchedDef` across cards when the effect early-returns. Harmless today because classic never reads it — but if the mini branch ever gains a definition slot, it would show the previous card's text.

## Rollback

`git revert`. One new AsyncStorage key (`vocab.reviewMode.v1`); leaving it behind is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZDSrvtAjiqUz82FPQdZpz