### PR TITLE
docs(vocab,qa): the review-mode field is residue, and three scenario defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Vocabulary** — Blitz runs Blitz, after a mode set in one mount effect lost to the default read in the next — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-06-vocabulary-blitz-runs-blitz-and-four-smaller-things-a-qa)
+- **Mobile** — one word tap buys one translation instead of two, and the screen behind the reader stops refetching — mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-06-mobile-one-word-tap-buys-one-translation-not-two-and-the)
+- **QA** — the guest loop walked on a device with a traffic log, and the step that guards the data loss could not reach it — docs · [details](docs/changelog-archive/2026-H2.md#2026-09-06-qa-the-guest-loop-walked-on-a-device-with-a-traffic-log)
 - **Dictionary** — a word tap survives the dictionary API being down, and fails in 3s instead of 10 when it cannot — backend · [details](docs/changelog-archive/2026-H2.md#2026-09-06-dictionary-an-upstream-outage-stops-being-an-outage)
 - **Guest** — a reader finishes the loop — read, save a word, review it — with no account, and registering keeps every bit of it — mobile, backend · [details](docs/changelog-archive/2026-H2.md#2026-09-06-guest-the-whole-loop-without-an-account)
 - **Mobile** — a reader with no account gets an invitation, not a red error, and a Save button that is actually there — mobile, web · [details](docs/changelog-archive/2026-H2.md#2026-09-05-mobile-an-invitation-not-a-red-error)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,11 +222,12 @@ Upload EPUB/PDF → BookFile (stored) → IngestionJob (queued)
 **Vocabulary SRS**: Spaced repetition vocabulary builder integrated into the reader.
 - **Entity**: `VocabularyWord` — word, translation, definition, sentence, bookTitle, distractors (JSON), hint (LLM-generated), SRS fields (stage, interval, consecutiveCorrect, nextReviewAt)
 - **Review entity**: `VocabularyReview` — tracks each answer (isCorrect, responseTimeMs, reviewMode)
-- **5 SRS stages**: New(0) → Recognition(1) → Recall(2) → Context(3) → Mastered(4). Logic in `Application/Vocabulary/SrsEngine.cs`
-- **2 review modes**: `multiple_choice` (all stages, Blitz + Context Cloze), `classic` (flashcard with self-assessment). Typing mode removed.
+- **5 SRS stages**: New(0) → Recognition(1) → Recall(2) → Context(3) → Mastered(4). Logic in `backend/src/Vocabulary/TextStack.Vocabulary/SrsEngine.cs`
+- **One card shape on the wire**: `ReviewCardBuilder` emits `multiple_choice` for every card. `SrsEngine.GetReviewMode` still returns `"context"` for stages 3-4 with a sentence, but the builder gives those MC options and rewrites the mode — context cloze *is* MC, with the sentence as the prompt. Typed recall is gone. `ReviewCardDto.reviewMode` is therefore vestigial and no client reads it (see the comment on the field in `packages/shared/src/types/api.ts`).
+- **Review style is a client choice**, not a server one: `ReviewMode = 'blitz' | 'classic'` (`packages/shared/src/vocabularyConstants.ts`) — Blitz renders the MC card, Flashcards renders self-assessment. Persisted per client (`apps/mobile/src/lib/reviewMode.ts`, web `localStorage['practiceMode']`).
 - **MC distractors + hint + explanation**: Ollama LLM (`gemma4:e2b`) generates 5 distractors + hint + 2-3 sentence explanation (in native language) per word at save time. Stored in `Distractors` (JSON), `Hint` (varchar 500), `Explanation` (varchar 1000). Fallback: random words from user's vocab pool + hardcoded list. Generator: `Vocabulary/TextStack.Vocabulary/DistractorGenerator.cs`
 - **Ollama**: Docker service (`ollama/ollama`), config: `Ollama:BaseUrl`, `Ollama:Model`, `Ollama:TimeoutSeconds` (default 30s). Fire-and-forget generation via `IServiceScopeFactory` after word save
-- **MC fallback cascade**: definition → translation → blank sentence (if LLM distractors exist) → downgrade to context/typed_recall
+- **MC prompt cascade** (client-side, `MultipleChoiceCard`): blank sentence → definition → translation. No downgrade path — there is nothing left to downgrade to
 - **Frontend**: `VocabularyPage.tsx` (word list, filters, search, stats), `VocabularyReviewPage.tsx` (review session), components in `components/vocabulary/`
 - **API**: `POST /me/vocabulary/words` (save), `GET /me/vocabulary/words` (list), `DELETE /me/vocabulary/words/{id}`, `PUT /me/vocabulary/words/{id}`, `GET /me/vocabulary/review` (queue), `POST /me/vocabulary/review` (submit), `GET /me/vocabulary/stats`
 
@@ -344,8 +345,8 @@ Upload EPUB/PDF → BookFile (stored) → IngestionJob (queued)
 | Reading Hooks | `apps/web/src/hooks/useReadingSession.ts` |
 | Achievements | `backend/src/Application/ReadingTracking/AchievementChecker.cs` |
 | Vocabulary API | `backend/src/Api/Endpoints/VocabularyEndpoints.cs` |
-| Vocabulary SRS | `backend/src/Application/Vocabulary/SrsEngine.cs` |
-| Distractor Gen | `backend/src/Api/Endpoints/DistractorGenerator.cs` |
+| Vocabulary SRS | `backend/src/Vocabulary/TextStack.Vocabulary/SrsEngine.cs`, `ReviewCardBuilder.cs` |
+| Distractor Gen | `backend/src/Vocabulary/TextStack.Vocabulary/DistractorGenerator.cs` |
 | Vocabulary Page | `apps/web/src/pages/VocabularyPage.tsx` |
 | Vocab Review | `apps/web/src/pages/VocabularyReviewPage.tsx` |
 | Vocab Components | `apps/web/src/components/vocabulary/` |

--- a/docs/02-system/database.md
+++ b/docs/02-system/database.md
@@ -199,7 +199,7 @@ All services: API :8080 | Web :5173 | Admin :81 | DB :5432
 │   └──────────────────┘                                                      │
 │                                                                             │
 │   SRS: New(0) → Recognition(1) → Recall(2) → Context(3) → Mastered(4)     │
-│   Modes: multiple_choice | typed_recall | context                           │
+│   Review modes stored: multiple_choice | context (+ practice_ prefix)      │
 │   Distractors: Ollama gemma4:e2b generates 5 plausible wrong answers       │
 └─────────────────────────────────────────────────────────────────────────────┘
 
@@ -716,7 +716,11 @@ id                 UUID PRIMARY KEY
 vocabulary_word_id UUID NOT NULL → vocabulary_words(id) CASCADE
 user_id            UUID NOT NULL → users(id) CASCADE
 site_id            UUID NOT NULL → sites(id)
-review_mode        VARCHAR NOT NULL  -- "multiple_choice" | "typed_recall" | "context"
+review_mode        VARCHAR NOT NULL  -- "multiple_choice" | "context", each also with a
+                                     -- "practice_" prefix. Written from SrsEngine.GetReviewMode,
+                                     -- so "context" appears here even though the card DTO never
+                                     -- carries it (ReviewCardBuilder rewrites it to MC). Typed
+                                     -- recall was removed; old rows may still hold "typed_recall".
 is_correct         BOOLEAN NOT NULL
 response_time_ms   INT NOT NULL
 stage_before       INT NOT NULL

--- a/docs/05-features/vocabulary-srs.md
+++ b/docs/05-features/vocabulary-srs.md
@@ -14,27 +14,45 @@ Review page → GET /me/vocabulary/review → SRS queue (due words)
 
 ## SRS Stages
 
-| Stage | Name | Review Mode | Interval |
-|-------|------|------------|----------|
-| 0 | New | multiple_choice | immediate |
-| 1 | Recognition | multiple_choice | 1 day |
-| 2 | Recall | typed_recall | 3 days |
-| 3 | Context | context (fill-in-blank) | 7 days |
-| 4 | Mastered | typed_recall or context | 14d → 60d (2x multiplier) |
+| Stage | Name | `GetReviewMode` returns | Card the reader gets | Interval |
+|-------|------|------------------------|----------------------|----------|
+| 0 | New | multiple_choice | MC | immediate |
+| 1 | Recognition | multiple_choice | MC | 1 day |
+| 2 | Recall | multiple_choice | MC | 3 days |
+| 3 | Context | context *if the word has a sentence*, else multiple_choice | MC, prompted by the cloze sentence | 7 days |
+| 4 | Mastered | same as stage 3 | same as stage 3 | 14d → 60d (2x multiplier) |
 
 **Promotion**: Stage 0 needs 1 correct, stages 1-3 need 2 consecutive correct to advance.
-**Demotion**: Wrong answer drops 1 stage (mastered drops to recall, not context).
+**Demotion**: Wrong answer drops 1 stage (mastered drops to recall, not context); stages 0-1 stay
+put and retry in 12h.
+**Auto-retire**: three consecutive correct at Mastered with an interval ≥14d retires the word from
+the queue. A reader tap unretires it at stage 3.
 
-Logic: `backend/src/Application/Vocabulary/SrsEngine.cs`
+Logic: `backend/src/Vocabulary/TextStack.Vocabulary/SrsEngine.cs`
 
 ## Review Modes
 
-1. **multiple_choice** — Show definition/translation, pick correct word from 4 options
-2. **typed_recall** — Show definition/translation, type the word
-3. **context** — Show sentence with blank, type the missing word
+**The server emits one card shape.** `ReviewCardBuilder` builds four MC options for every card,
+including the context-cloze ones, and rewrites their mode to `multiple_choice` on the way out —
+so `ReviewCardDto.reviewMode` is always `"multiple_choice"` over the wire. Typed recall was removed;
+`context` survives only as a *prompt* (the sentence with the word blanked) and as a value written to
+`vocabulary_reviews.review_mode`, which is computed straight from `SrsEngine.GetReviewMode` and does
+still record `context`. See the comment on the field in `packages/shared/src/types/api.ts`.
 
-### MC Fallback Cascade
-When building MC prompt: definition → translation → blank sentence (if LLM distractors exist) → downgrade to context/typed_recall.
+**The review style is the client's choice**, and shares none of those names:
+`ReviewMode = 'blitz' | 'classic'` (`packages/shared/src/vocabularyConstants.ts`).
+
+1. **blitz** — the MC card: prompt plus four options.
+2. **classic** — flashcard, self-assessed (Forgot / Almost / Knew). The default.
+
+Persisted per client: `apps/mobile/src/lib/reviewMode.ts` (AsyncStorage) and web
+`localStorage['practiceMode']`. Derive it from route params as a plain value and hand *that* to
+`startSession` — reading hook state during startup is how #558 shipped, where Blitz was selected and
+Flashcards ran every time.
+
+### MC prompt cascade
+`MultipleChoiceCard` renders `blankSentence || definition || translation`. There is no downgrade path
+— there is no longer another mode to downgrade to.
 
 ## Ollama LLM Distractors
 
@@ -89,9 +107,9 @@ docker compose exec ollama ollama pull gemma4:e2b
 |------|---------|
 | `pages/VocabularyPage.tsx` | Word list, filters, stats cards |
 | `pages/VocabularyReviewPage.tsx` | Review session orchestrator |
-| `components/vocabulary/MultipleChoiceCard.tsx` | MC quiz card |
-| `components/vocabulary/TypedRecallCard.tsx` | Type-the-word card |
-| `components/vocabulary/ContextCard.tsx` | Fill-in-the-blank card |
+| `components/vocabulary/MultipleChoiceCard.tsx` | MC quiz card (Blitz) — also renders the context cloze |
+| `components/vocabulary/FlashCard.tsx` | Self-assessed flashcard (Classic) |
+| `components/vocabulary/NewWordCard.tsx` | First sight of a word before its first review |
 | `components/vocabulary/ReviewFeedback.tsx` | Correct/wrong feedback + stage change |
 | `components/vocabulary/SessionSummary.tsx` | End-of-session stats |
 | `hooks/useVocabulary.ts` | Word CRUD + filtering |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ answers "what happened" and nothing answered "what is half-finished right now".
 | **Book Chat** | Streaming, persistent history, per-chapter summaries, page citations for PDFs. Web + mobile at parity. |
 | **Observability** | OpenTelemetry → Aspire, plus Sentry on API + Worker with LLM/provider-routing spans. Mobile Sentry is **armed** since 2026-09-03 — project `textstack-mobile` in the `textstack` org, DSN supplied as an EAS environment variable (`EXPO_PUBLIC_SENTRY_DSN`, production + preview) rather than a repo file, so it reaches OTA bundles as well as store builds. |
 | **Entitlements** | `UserTier { Guest, Free, Supporter, Staff }`, config-driven quotas — now including `AiEnabled` and `DailyEnrichmentCap`, enforced server-side by `RequireAiAccount()` (403 `account_required`). |
-| **Guest sessions** | Web and mobile both mint an anonymous `User` row on demand; the read → save → review loop works with no account, and registering promotes that row in place. [ADR-014](01-architecture/adr/ADR-014-guest-sessions.md). |
+| **Guest sessions** | Web and mobile both mint an anonymous `User` row on demand; the read → save → review loop works with no account, and registering promotes that row in place. [ADR-014](01-architecture/adr/ADR-014-guest-sessions.md). Walked end to end on Android on 2026-09-06 with every request logged ([QA-005 report](qa/reports/2026-09-06-android-guest-loop.md)): promotion-in-place proven by the account's `createdAt` matching the guest mint, both AI walls firing zero requests, and the book still opening when the mint is rate-limited. |
 | **SEO / SSG** | Prerendered pages, sitemap, IndexNow. Four incidents since 2026-08-11 ([dead five weeks](incidents/2026-08-11-ssg-dead-five-weeks.md), [deploy wiped a running rebuild](incidents/2026-08-31-deploy-wiped-a-running-ssg-rebuild.md), [worker lost its output path](incidents/2026-09-01-ssg-worker-lost-its-output-path.md), [a prompt stranded the swap](incidents/2026-09-02-corepack-prompt-stranded-the-ssg.md)), each invisible from outside because humans get the SPA and it renders fine. Now watched three ways: the deploy refuses to promote a rebuild that lost its files, `/health/ready` reports rebuild age and failure, and the health check asks a crawler's question every five minutes. |
 | **Mobile** | Android on Play Internal Testing (`versionCode 24`). OTA via `expo-updates`, published automatically on merge — and refused automatically when the runtime fingerprint has moved. |
 | **Build & deps** | One Node version in `.nvmrc` (24.20.0), enforced across CI, four Dockerfiles and the deploy runner. One pnpm workspace with a version catalog — the JS answer to `Directory.Packages.props`. Weekly dependency refresh by pull request. |
@@ -82,6 +82,21 @@ someone's memory.
 - **PDF highlights have no context and never will.** Reflow highlights store ~30 characters either side
   in their anchor, so they gained context retroactively. A PDF-rect anchor carries only `exact`; those
   render as the passage alone. Capturing surrounding text at PDF-highlight time is the open follow-up.
+- **A word tap can still dispatch two messages one character apart.** The reader bridge sends the tap
+  and Android's own `selectionchange`; the exact-match dedupe only collapses identical strings, and
+  the single-flight added in #561 keys on the text, so a pair differing by one character is still two
+  translations. Suspected cause: `WORD_RE` carries a straight apostrophe while extraction writes curly
+  ones — but the obvious guard re-breaks drag-to-extend, fixed directly above it. Measure both
+  dispatched strings before changing anything.
+- **`ReviewCardDto.reviewMode` is a dead field.** No client reads it, and one of its two declared
+  values (`'context'`) cannot reach the wire — `ReviewCardBuilder` rewrites every context card to
+  `multiple_choice`. Same shape as `selfAssessment` below. Documented on the field in
+  `packages/shared/src/types/api.ts`; removing it touches two DTO copies plus the server contract and
+  needs its own slice.
+- **Four QA accounts and their guest rows sit on production** — `qa-guest-{a,b,c,d}-20260906@textstack.app`,
+  created during the QA-005 pass, plus several abandoned guest rows that `GuestCleanupWorker` will not
+  prune because they hold vocabulary. The findings they were created for are closed (#561, #562), so
+  they can go.
 - **`selfAssessment` is captured and discarded.** The three-button card ("Forgot / Almost / Knew") sends
   the choice, `SubmitReviewRequest` accepts it, and no server code reads it — so "Almost" differs from
   "Knew" only in the boolean derived from it. Either make the middle button mean something, or drop it.

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,182 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-06-vocabulary-blitz-runs-blitz-and-four-smaller-things-a-qa"></a>
+
+## Vocabulary — Blitz runs Blitz, and four smaller things a QA pass found — mobile — 2026-09-06
+
+`aca11d9c` (#562), closing #558 and #559 from the QA-005 run.
+
+**#558 was not a race. It failed every time.** `app/vocabulary/review.tsx` had two mount effects.
+The first dispatched `setReviewMode('blitz')` from the route param. The second called
+`startSession(batchSize, review.reviewMode, …)` — and `review.reviewMode` there is the
+mount-render closure value, still the hook default `'classic'`. `startSession` dispatches the mode
+it is handed. Two dispatches, one React batch, the later one wins. The comment sitting above that
+call asserted the opposite of what happened.
+
+So **Blitz was unreachable from the entry point entirely** — including from `ClusterBonusCard`,
+which hard-codes `reviewMode=blitz` in the URL it pushes. It worked only from the end-of-session
+toggle, a separate event in a separate render, which is exactly how a mode nobody could select
+survived to production looking selectable: the sheet showed Blitz checked, and remembered it.
+
+Web has always done this correctly (`apps/web/src/pages/VocabularyReviewPage.tsx`): derive the
+starting mode from the params as a **plain value** and hand that value to `startSession`, never
+reading hook state during startup. One writer, no batch to lose. The same rule now lives in
+`apps/mobile/src/lib/reviewMode.ts` — extracted to `src/lib` rather than left in the screen because
+mobile's `vitest.config.ts` collects only that directory. **A rule that lives in a screen is a rule
+that cannot be tested, which is how this shipped.** `reviewModeFromParam` is total and deliberately
+case-sensitive: `?reviewMode=Blitz` is a caller bug, and silently repairing it hides the caller.
+
+The choice also did not survive a cold start. It lived in `useState`, so "it persists across
+reopening the sheet" only ever meant "the tab stayed mounted"; killing the app reverted to
+Flashcards. It is now in AsyncStorage under `vocab.reviewMode.v1`, matching what web keeps in
+`localStorage['practiceMode']`, and a storage failure falls back to the default rather than breaking
+a screen.
+
+Worth stating because the names collide: this choice is `ReviewMode = 'blitz' | 'classic'`, a
+**client** concept. The server's `ReviewCardDto.reviewMode` is unrelated, is read by no client, and
+is documented as vestigial on the field itself in `packages/shared/src/types/api.ts`.
+
+**#559, fixed second on purpose.** `ReviewFeedback` ran a dictionary lookup for every card without a
+stored definition, then — in `classic` mode — returned the *mini* feedback branch, which has no
+definition slot. The fetched value is only ever read in the blitz layout. QA measured two lookups
+fired and discarded per session, ~3 s each against the dictionary upstream that was down that day.
+The ordering was deliberate: until Blitz was reachable, the branch that *can* show a definition could
+not be verified at all, so fixing #559 first would have meant shipping an unobserved fix.
+
+**Three pieces of friction on the guest→account path**, all on work that shipped a week earlier:
+
+- **"Create free account" opened the auth screen on the *Sign in* tab.** The screen read no route
+  params at all. It now takes an optional `mode` param as a `useState` **initializer**, not a syncing
+  effect — a sync would yank a user back to Register after they deliberately tapped Sign in. The
+  other twelve callers pass nothing and still land on Sign in.
+- **"Password must be at least 8 characters" stayed red at 14 characters.** The validation was
+  correct; `setError('')` only ran on the next submit and `onChangeText` cleared nothing. The same
+  defect was in `reset-password.tsx`, which is the screen a user meets straight after a reset email.
+- **A guest's Profile advertised "Upload space 0 B / 50.0 MB"** for a capability guests do not have.
+  `profile.tsx` destructured four capabilities from the tier and not `canUpload` — the one governing
+  that row was the one the screen never read.
+
+<a id="2026-09-06-mobile-one-word-tap-buys-one-translation-not-two-and-the"></a>
+
+## Mobile — one word tap buys one translation, not two, and the screen behind the reader stops refetching — mobile — 2026-09-06
+
+`37758fa9` (#561). Four kinds of wasted request, found by running QA-005 through a logging proxy.
+One of them spends money on the most frequent action in the product.
+
+**`translateCache` memoized the result and never the promise.** Two callers inside one round trip
+both read `cache.get(k) === undefined`, both called `/translate`, and both were billed — that is
+OpenAI `gpt-4.1-nano`, twice per word tap. The file's own docblock claimed it "de-dupes the double
+translate per tap"; it could not, because there was no in-flight map. The server-side file cache does
+not save you either: the second request reads an entry the first has not written yet.
+
+The fix is a `Map` of keys over `createSingleFlight` rather than a second promise tracker.
+`createSingleFlight` already does the one job needed here — N callers, one call, everyone gets the
+same promise, slot released on **both** settlements — and it is the version of that rule this repo
+already has tests for. A hand-rolled tracker would have meant getting the release-on-reject path
+right a second time, in a file that had already lied about doing it once. Slots are evicted on
+settle, so the map never outgrows the words actually in flight.
+
+`TranslationSheet` bypassed the cache outright, so every Translate press re-bought a gloss the
+toolbar was already holding in memory.
+
+**`GET /books/{slug}` fired twice on reader open, and that one is ours** — a regression from the
+guest work (#554). `ReaderSessionGate` mints a guest, `isAuthenticated` flips false→true *globally*,
+and the book detail screen still mounted underneath refetches at the instant the gate mounts the
+reader. `readerSessionGate.ts` documents freezing that flag for the reader's lifetime; nothing froze
+it for the screens behind. The effect is now split: the public fetch keys on the slug, the
+session-dependent follow-ups (library membership, progress) key on the session.
+
+The split cost more than a dependency change. `setLoading(false)` used to run after
+library + progress, so one skeleton covered both round trips; splitting naively paints the hero one
+RTT early and an in-progress book flashes "Start Reading" before its progress lands. `loading` is now
+derived from a one-way `sessionLoading` latch — seeded `true` for an account so nothing changes,
+`false` for a guest so the book paints at once and a mid-flight mint refreshes without throwing up a
+skeleton.
+
+**`AddToCollectionSheet` was mounted unconditionally on four screens.** A `<Modal visible={false}>`
+draws nothing, which reads like it costs nothing; the component around it mounts with its parent and
+its hooks run immediately, so `useCollections` fired `GET /me/library/collections` on every open.
+`useCollections` caches successes only, so on the public book-detail screen — reachable signed out —
+that is a **401 on every single open, forever**, and it drags `authFetch` into
+`handleTerminalAuthFailure()` on a screen that never needed a session. Two of the four screens were
+not in the QA report: fixing only the reported one would have changed nothing observable, because the
+60 s module cache would have served the neighbour's request instead. `useSheetMount` latches rather
+than unmounting on close, so the slide-out animation the sheet was written for still runs.
+
+**Book detail kept its pre-reader progress** — "Start Reading" with no progress row immediately after
+leaving the reader, correct on the next visit. The file already imported `useFocusEffect` and
+`useCallback` and used neither: the refetch was planned and never written. Same fix as the one
+already made on `my-books/[id].tsx` for the same symptom.
+
+**Not done, deliberately.** The reader bridge dispatches the tap and Android's own `selectionchange`
+as two messages whose exact-match dedupe fails when they differ by one character. The single-flight
+above makes every *same-key* duplicate free but not that pair, since different text means different
+keys. The likely cause is `WORD_RE` carrying a straight apostrophe while the extraction pipeline
+writes curly ones — but the guard that looks obvious re-breaks drag-to-extend, fixed directly above
+it and verified on a device. Measure both dispatched strings first, then fix the confirmed
+difference.
+
+<a id="2026-09-06-qa-the-guest-loop-walked-on-a-device-with-a-traffic-log"></a>
+
+## QA — the guest loop, walked on a device with a traffic log — docs — 2026-09-06
+
+`e2b3dc6e` (#560). The full run is
+[`docs/qa/reports/2026-09-06-android-guest-loop.md`](../qa/reports/2026-09-06-android-guest-loop.md);
+the scenario is [QA-005](../qa/scenarios/QA-005-guest-loop.md).
+
+**The loop holds.** A reader with no account reads, taps a word, is asked their language in place,
+saves, reviews, and converts. The headline assertion is proven by data rather than by inspection:
+after registering, the account's `createdAt` is the timestamp of the guest mint, so the row was
+**promoted, not copied**. Signing in to an existing account returns 200 and merges both sets of
+words without overwriting the account's own native language. Librarian, Tutor and Ask-this-book each
+render their sign-in wall with **zero requests fired** — no paid inference before the wall. With the
+guest mint deliberately rate-limited, the book opened 68 ms after the 429: the gate cannot hide a
+book.
+
+**Why the numbers are checkable.** `EXPO_PUBLIC_API_URL` pointed at a ~30-line local node proxy over
+`adb reverse`, logging method, path, status, duration and whether an `Authorization` header was
+present; timings came from `screenrecord` at 10 fps measured by dark-pixel fraction. That is what
+turns "zero requests" and "auth=yes" into observations instead of assertions. It also caught a
+measurement error on the way: a 2.9 s blank frame before the reader, which looked like the gate
+spending its whole 3 s budget, re-measured at 0.5 s on the same AVD as the control — the 2.9 s
+belonged to the slower emulator image.
+
+**Two things from this run are worth more than the pass.**
+
+*§4b could not reach its own bug.* The step exists to prove that registering with an **expired**
+access token still merges — the failure mode that used to answer 200 and silently discard everything.
+The scenario said to go "straight to Profile". That screen's own `/me/books/quota` 401s and triggers
+`POST /auth/refresh-mobile` two and a half minutes before the register button is reachable, so the
+expired-token condition is destroyed on the way to the form. An hour of waiting proved nothing, and
+nothing on screen said so. Re-run through a route that makes no authenticated call — Discover → Ask
+the librarian → its sign-in wall → Register, measured at zero requests — with the token 21 minutes
+expired, the app refreshed proactively *before* registering (`packages/shared/src/api/tokenExpiry.ts`
+doing its job), and the word survived. The scenario was corrected in a follow-up: that route, plus
+the check that makes the run verifiable — confirm from the request log that no `refresh-mobile` has
+fired before pressing Create account.
+
+*A defect was filed and withdrawn, and the withdrawal is the finding.* The session-less Save was
+reported as silent — no request, no toast, no state change. The app in fact shows *"Saving words
+needs an account — this one wasn't kept"* for 3.6 s; the screenshots were taken 4–7 seconds after the
+tap. An empty screen was read as silence. Not sending the request is the design —
+`saveWordIntent` is explicit that an unauthenticated save "must never reach the API". The general
+rule is now in [`docs/qa/README.md`](../qa/README.md): **a toast is a short window; screenshot within
+a second of the action or record the screen, because a late screenshot cannot distinguish "no
+feedback" from "feedback you missed".**
+
+Two defects found while there, both unrelated to guests and both fixed the same day in #562: Blitz
+selected but Flashcards running (#558), and a dictionary lookup the classic branch cannot render
+(#559). Smaller findings — a double `/translate` per tap, a double book fetch, a 401 from a sheet
+mounted invisibly — went to #561.
+
+**What was not run, stated as such:** haptics (not observable on an emulator), landscape (the app is
+portrait-locked in `app.json`, so the case cannot occur — the scenario now says so), the two true
+interleave races (sign-in during an in-flight mint, sign-out during a profile fetch; both need two
+screens at once and adb drives one — only the post-conditions were verified), and real hardware. Four
+QA accounts and their guest rows were created on production and are listed in the report for
+deletion.
+
 <a id="2026-09-06-dictionary-an-upstream-outage-stops-being-an-outage"></a>
 
 ## Dictionary — an upstream outage stops being an outage — backend — 2026-09-06

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -7,8 +7,11 @@ Manual test scenarios for verifying reader functionality.
 ```
 docs/qa/
 ├── README.md           # This file
-└── scenarios/          # Individual test scenarios
-    └── *.md
+├── MOBILE-TEST-PLAN.md # The mobile e2e lane, as specified
+├── scenarios/          # Individual test scenarios — the steps
+│   └── *.md
+└── reports/            # What a given run actually found, dated
+    └── YYYY-MM-DD-*.md
 ```
 
 ## Running Tests
@@ -38,6 +41,24 @@ and the answer, not the flow: a breadcrumb per step is a trail nobody reads.
 
 `__DEV__` stays right for warnings aimed at whoever is running the dev client.
 
+## Observing a defect: a toast is a window, not a state
+
+**Screenshot within a second of the action, or record the screen.** A late screenshot cannot
+distinguish "no feedback" from "feedback you missed", and the two get written up identically.
+
+From the QA-005 run: a defect was filed saying that Save with no session did nothing at all — no
+request, no toast, no state change — and withdrawn on re-run. The toast lives 3.6 s; the screenshots
+were taken 4–7 seconds after the tap. An empty screen was read as silence, and the app had in fact
+said plainly that the word was not kept.
+
+The rule generalises past toasts to every transient: haptics, a spinner, a flash of feedback, an
+optimistic row that settles. If the evidence is a still frame, the still frame has to be inside the
+window. `adb shell screenrecord` costs nothing and answers "when", which a screenshot cannot.
+
+Corollary, from the same run: **a negative claim needs a positive instrument.** "Nothing was sent"
+is only worth writing down if a traffic log was watching. Otherwise say the step could not be
+verified.
+
 ## Scenario Format
 
 Each scenario includes:
@@ -54,3 +75,7 @@ Each scenario includes:
 | QA-002 | [Library Multilang Navigation](scenarios/QA-002-library-multilang-navigation.md) | Library, i18n |
 | QA-003 | [SSG Rebuild Admin](scenarios/QA-003-ssg-rebuild.md) | Admin, SSG |
 | QA-004 | [Bookmarks & Autosave](scenarios/QA-004-bookmarks-autosave.md) | Reader, Bookmarks |
+| QA-005 | [Guest Loop](scenarios/QA-005-guest-loop.md) | Auth, Reader, Vocabulary, Profile — Android only |
+
+Runs live in [`reports/`](reports/); the most recent is
+[2026-09-06 — QA-005 on the Android emulator](reports/2026-09-06-android-guest-loop.md).

--- a/docs/qa/scenarios/QA-005-guest-loop.md
+++ b/docs/qa/scenarios/QA-005-guest-loop.md
@@ -53,9 +53,10 @@ Read §7 first if anything behaves oddly — several failures below have a known
 - [ ] Have an unused email ready for §4 (registration).
 - [ ] Have a **second, existing** account with at least one saved vocabulary word for §5 (merge on
       login). The prod QA account is in the project memory note on mobile QA.
-- [ ] Ability to watch traffic (Charles, mitmproxy, or `adb logcat` filtered on the API host) for
-      §1 step 3 and §6. Without it, those two steps cannot be verified — say so in the results
-      rather than ticking them.
+- [ ] Ability to watch traffic (Charles, mitmproxy, or a small local proxy behind `adb reverse`) for
+      §1 step 3, **§4b** and §6. Without it, those steps cannot be verified — say so in the results
+      rather than ticking them. §4b in particular has no on-screen tell: the request log is the only
+      thing that distinguishes a real run from a wasted hour.
 
 ---
 
@@ -103,8 +104,11 @@ Read §7 first if anything behaves oddly — several failures below have a known
 **Device-only checks in this step:**
 - [ ] The language list **scrolls** inside the sheet. (A `FlatList` inside a `Modal` is a known
       React Native gesture pass-through hazard.)
-- [ ] The sheet is usable on a **small screen and in landscape** — `styles.sheet` has no
-      `maxHeight`. Try a long multi-word selection, which is the worst case.
+- [ ] The sheet is usable on a **small screen** — `styles.sheet` has no `maxHeight`. Try a long
+      multi-word selection, which is the worst case. Force one with
+      `adb shell wm size 720x1280 && adb shell wm density 280` (reset with `wm size reset`).
+      *Landscape is **not applicable**: `apps/mobile/app.json` sets `"orientation": "portrait"`, so
+      the app does not rotate — `settings put system user_rotation 1` changes nothing.*
 
 ---
 
@@ -142,16 +146,27 @@ Read §7 first if anything behaves oddly — several failures below have a known
 The bug this guards was invisible: registration answered *success* and silently discarded the data.
 It only appears when the access token has expired, which takes an hour.
 
-1. Fresh install, become a guest, save a word (§1–§3).
+1. Fresh install, become a guest, save a word (§1–§3). Note the mint time.
 2. **Kill the app** and leave it closed for **over an hour** (access tokens live 60 minutes).
-3. Reopen and go **straight** to Profile → Create free account. Do not open a book, do not tap
-   anything that would make a network call first — a call that 401s would refresh the token and
-   mask the bug.
+3. Reopen and reach the register form by a route that makes **no authenticated call**:
+   Discover → **Ask the librarian** → its sign-in wall → **Register**. Measured at zero requests.
+
+   **Not via Profile.** That screen fetches `/me/books/quota` itself, which 401s on the stale token
+   and fires `POST /auth/refresh-mobile` — about two and a half minutes before the register button
+   is reachable. The expired-token condition is destroyed on the way to the form, and nothing on
+   screen says so, so an hour of waiting proves nothing. This is how the first run of this step went
+   (D2).
 
 **Verify**:
+- [ ] **Before pressing Create account, confirm from the request log that no `refresh-mobile` has
+      fired.** Without that line the run is worthless — and it is not observable from the screen.
+      This check is the step; the rest is setup.
 - [ ] Registration succeeds **and the saved word is still there.**
+- [ ] The account's `createdAt` equals the guest mint time — proof the row was promoted, not copied.
 
-> If the word is gone, the merge did not fire. That is D1 and it is critical.
+> If the word is gone, the merge did not fire. That is critical.
+> A proactive `refresh-mobile` immediately before `register` (no 401 preceding it) is **correct** —
+> that is `packages/shared/src/api/tokenExpiry.ts` keeping an expired bearer off the merge call.
 
 ---
 
@@ -188,8 +203,14 @@ It only appears when the access token has expired, which takes an hour.
 
 ## 7. Failure modes with known non-obvious causes
 
-- [ ] **Airplane mode, previously-read book.** Turn on airplane mode and open a book whose chapters
-      are cached. The reader must open in about a second — **not** after a 3-second pause. The gate
+- [ ] **Airplane mode, downloaded book.** The book must have been through the explicit **Download
+      for Offline** action first. *Reading a chapter online does not make it available offline* —
+      a book you have merely read shows "This chapter isn't available offline", and the case then
+      fails for a reason that has nothing to do with the gate. Also stop any logging proxy:
+      `adb reverse` is a loopback forward through adbd and keeps working with the radio off, so
+      airplane mode alone does not take the app offline.
+      With a downloaded book, the reader must open in about a second — **not** after a 3-second
+      pause. The gate
       is designed to give up immediately when the network fails outright; spending the full budget
       means it is waiting on something it should not.
 - [ ] **Rate-limited first launch.** `POST /auth/guest` is limited per IP. If you install several
@@ -236,9 +257,9 @@ It only appears when the access token has expired, which takes an hour.
 | Date | Issue | Status |
 |------|-------|--------|
 | 2026-09-06 | ~~**D1** — word saved while rate-limited is silently discarded~~ | **Withdrawn** — tester error. The toast ("Saving words needs an account — this one wasn't kept") fires for 3.6 s; screenshots were taken after it expired |
-| 2026-09-06 | **D2** — §4b cannot reach its own bug via the Profile route; Profile refreshes the token first. Use Discover → Ask the librarian → Register instead, and check the log for no prior `refresh-mobile` | Open (scenario fix) |
-| 2026-09-06 | **D3** — Blitz review style is selected and persisted but the session still runs Flashcards | Open — [#558](https://github.com/mrviduus/textstack/issues/558) |
-| 2026-09-06 | **D4** — Flashcards mode fetches a dictionary definition it structurally cannot display | Open — [#559](https://github.com/mrviduus/textstack/issues/559) |
+| 2026-09-06 | **D2** — §4b cannot reach its own bug via the Profile route; Profile refreshes the token first | **Closed** — §4b above now routes through Discover → Ask the librarian → Register and requires the request log to show no prior `refresh-mobile` |
+| 2026-09-06 | **D3** — Blitz review style is selected and persisted but the session still runs Flashcards | **Fixed** — [#558](https://github.com/mrviduus/textstack/issues/558) in [#562](https://github.com/mrviduus/textstack/pull/562) |
+| 2026-09-06 | **D4** — Flashcards mode fetches a dictionary definition it structurally cannot display | **Fixed** — [#559](https://github.com/mrviduus/textstack/issues/559) in [#562](https://github.com/mrviduus/textstack/pull/562) |
 
 ---
 

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -307,6 +307,29 @@ export interface ReviewCardDto {
   word: string
   translation: string | null
   definition: string | null
+  /**
+   * Vestigial. **The client owns the review style; this field does not.**
+   *
+   * No runtime code reads it. Cards render from `options` / `correctOptionIndex` /
+   * `blankSentence`; the style a session runs in comes from the client
+   * (`apps/mobile/src/lib/reviewMode.ts`, added in #562, and
+   * `apps/web/src/pages/VocabularyReviewPage.tsx`), whose `ReviewMode` is
+   * `'blitz' | 'classic'` — a different vocabulary that only happens to share the
+   * name. The one place `'context'` is asserted is a unit test of the tutor's
+   * local card projection.
+   *
+   * `'context'` also cannot arrive over the wire. `SrsEngine.GetReviewMode` can
+   * return it for stages 3-4 with a sentence, but `ReviewCardBuilder` builds MC
+   * options for those cards and rewrites the mode to `'multiple_choice'` on the
+   * way out ("Context cloze uses MC UI"). Typed recall was removed; the branch
+   * that would have used the distinction went with it. Both clients still *write*
+   * `'context'` locally when the tutor synthesizes a flashcard from a plan item
+   * (`buildPlanCard`), purely because the field is required.
+   *
+   * Left in place deliberately: removing it is a code change across two DTO
+   * copies (this one and `apps/web/src/api/vocabulary.ts`), the server contract
+   * and the projections, and it belongs in its own slice. Do not build on it.
+   */
   reviewMode: 'multiple_choice' | 'context'
   blankSentence: string | null
   originalSentence: string | null


### PR DESCRIPTION
Closes the paperwork on #560, #561 and #562 — all three landed without a `CHANGELOG` line, against this repo's own rule — and corrects the docs the QA pass showed to be wrong.

## `ReviewCardDto.reviewMode` is documented as a live contract in two places and is neither

Verified in code rather than assumed, and the truth turned out stranger than "dead":

- **No client reads it.** But both clients *write* `'context'` for a tutor-synthesized flashcard (`apps/mobile/src/lib/agents.ts:163`, `apps/web/src/hooks/useTutorSession.ts:42`), purely to satisfy a required field.
- **On the DTO, `'context'` is unreachable.** `ReviewCardBuilder.cs:28` declares `options = null` per word; the branch that fills it (`:32`) runs only for `multiple_choice`; so the guard at `:81` is true for **every** context card and `:119` rewrites the mode. `SrsEngine` can return it; nothing downstream can emit it.
- **In the database it is alive.** `VocabularyReviewRecorder.cs:95` calls `GetReviewMode` **directly**, bypassing the builder, so `vocabulary_reviews.review_mode` really does store `context` — and `practice_context`.

So a reversed decision left residue in two places with **opposite truth values**. Recorded on the field. The type is untouched: removing it is a code change, and there are two declarations to reconcile — web keeps its own copy at `apps/web/src/api/vocabulary.ts:46`.

The decision itself, already made: **the client owns the review style.** `apps/mobile/src/lib/reviewMode.ts` (added in #562) and `VocabularyReviewPage.tsx` are where it actually lives.

## Docs corrected against the code, not against each other

- `CLAUDE.md` listed a **server** value and a **client** value as "2 review modes" — `classic` is not something `SrsEngine` can emit. It also pointed at two files that have moved.
- `docs/05-features/vocabulary-srs.md` documented `typed_recall` for stages the engine returns MC for, and two components that do not exist.
- **Both** described the MC prompt cascade as ending in "downgrade to context/typed_recall". There is no downgrade: `blankSentence || definition || translation || word`.
- `docs/02-system/database.md` said the `review_mode` column holds `typed_recall`.

The last two were not in the brief — they were found by checking rather than transcribing.

## The QA scenario had three defects of its own, all mine

- **§4b routed through Profile**, whose own `/me/books/quota` 401s and refreshes the token **two and a half minutes before** the register button is reachable. An hour of waiting spent proving nothing. Now routed through a screen that makes no authenticated call, with the log check that makes the run verifiable — otherwise nothing on screen says it was worthless.
- **A landscape case that cannot occur** — the app is portrait-locked in `app.json`.
- **"A book whose chapters are cached"** is satisfied only by the explicit *Download for Offline*; reading a chapter online does not cache it. The tester hit this and the case initially failed for the wrong reason.

## The method note the run earned

A toast is a short window: screenshot within a second of the action, or record the screen. A late screenshot cannot tell *"no feedback"* from *"feedback you missed"* — which is exactly how correct behaviour got filed as a defect and then withdrawn by the tester who filed it.

`docs/qa/README.md` also did not list QA-005 at all, and its structure block omitted `reports/`.

## STATUS

Three additions, no padding: the guest-sessions row now cites the QA-005 evidence, and three known-broken bullets — the two-message word-tap dedupe #561 deliberately left open, this vestigial field, and the four QA accounts still on production whose reason to exist is now closed.

## Verification

`tsc` clean on all three packages (the type file gained a comment only); shared 412, mobile 332. All three changelog anchors script-checked to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZDSrvtAjiqUz82FPQdZpz