### PR TITLE
feat(mcp): open uploaded books to an assistant, and let its conclusions come back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **MCP** — your uploaded books open to your assistant, and its conclusions come back into the book — backend, web · [details](docs/changelog-archive/2026-H2.md#2026-09-08-mcp-the-book-opens-to-your-assistant-and-the-conclusions-come-back)
 - **Docs** — ADR-015 records the position model, and QA-001 finally crosses a chapter boundary — docs · [details](docs/changelog-archive/2026-H2.md#2026-09-07-docs-adr-015-and-the-scenario-that-was-never-in-qa-001)
 - **Library** — the shelf called Continue Reading can finally continue something — backend, shared · [details](docs/changelog-archive/2026-H2.md#2026-09-07-library-the-shelf-that-could-not-continue)
 - **Reader** — web joins the position model; a slug with a colon and a tab-close write both stop losing data — web · [details](docs/changelog-archive/2026-H2.md#2026-09-07-reader-web-joins-the-position-model)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Library** — searching your own library answered 500 on every call and always had, behind an empty-looking result — backend · [details](docs/changelog-archive/2026-H2.md#2026-09-08-mcp-the-book-opens-to-your-assistant-and-the-conclusions-come-back)
 - **MCP** — your uploaded books open to your assistant, and its conclusions come back into the book — backend, web · [details](docs/changelog-archive/2026-H2.md#2026-09-08-mcp-the-book-opens-to-your-assistant-and-the-conclusions-come-back)
 - **Docs** — ADR-015 records the position model, and QA-001 finally crosses a chapter boundary — docs · [details](docs/changelog-archive/2026-H2.md#2026-09-07-docs-adr-015-and-the-scenario-that-was-never-in-qa-001)
 - **Library** — the shelf called Continue Reading can finally continue something — backend, shared · [details](docs/changelog-archive/2026-H2.md#2026-09-07-library-the-shelf-that-could-not-continue)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,7 +500,9 @@ Supported formats: EPUB, PDF. Processing order: Spelling → Hyphenation → Typ
 
 ## MCP Server (`backend/src/Ai/TextStack.Ai.Mcp/`)
 
-Thin, stateless MCP↔HTTP bridge (Phase 8) — every tool call becomes an HTTP request to the public TextStack API (no DB/EF/OpenAI). 7 tools: `search_books`, `get_book`, `get_chapter` (public) + `list_my_highlights`, `list_my_vocabulary`, `ask_book`, `save_highlight` (Bearer).
+Thin, stateless MCP↔HTTP bridge (Phase 8) — every tool call becomes an HTTP request to the public TextStack API (no DB/EF/OpenAI). 14 tools. Public catalog: `search_books`, `get_book`, `get_chapter`. The user's own uploads (Bearer): `search_my_library`, `get_my_book`, `get_my_chapter`, `save_my_highlight`, `list_my_book_highlights` — keyed by `bookId` (`UserBook.Id`), which is NOT an `editionId` and does not work in the edition-scoped tools. Write-back, either book type (Bearer): `save_insight`, `get_my_insights` — conclusions from an outside assistant, keyed by chapter **slug** (`BookInsight`, table `book_insight`), one per (user, book, chapter) so a re-run replaces rather than accumulates. Everything else (Bearer): `list_my_highlights`, `list_my_vocabulary`, `ask_book`, `save_highlight`.
+
+The write-back exists because the reasoning happens in Claude/ChatGPT — where the reader already has a profile and a year of history — and only the **result** comes home. See `docs/05-features/mcp.md`.
 
 **Dual transport** (env `MCP_TRANSPORT`: `stdio` default | `http`; `--http` flag also selects http). Shared wiring (tool catalog handlers, typed `TextStackApiClient`) in `McpBridgeCore`; the two host builders in `McpHosts`.
 - **stdio** (local, single identity): `Host.CreateApplicationBuilder`, **logs→stderr** (stdout is JSON-RPC only — never `Console.Write*`), singleton DI, token from `TEXTSTACK_MCP_TOKEN` (static) or the device flow (`DeviceFlowTokenProvider`, AI-050). Byte-identical to the pre-049 server.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,8 @@ Context files: `apps/web/src/context/{Site,Auth,GuestLimits,NativeLanguage,Downl
 - Pages: `/:lang/library/my/:id` (detail), `/:lang/library/my/:id/read/:chapterSlug` (reader with `mode="userbook"`)
 - Metadata enrichment: `BookMetadataGenerator` (Worker) — Ollama fire-and-forget generates genre, year, description from title+author. Fields: Author, Genre, PublishedYear, TotalWordCount
 
+**`chapter_number` is an ordering key, not a display ordinal.** It is not consistently based and never has been: on production every edition starts at 0, but 4 uploaded books start at 2, and locally 5 editions start at 1. `BookDetailPage` renders `chapterNumber + 1` and `UserBookDetailPage` renders it raw, so both are right for the common case and wrong for the exceptions. Anything new that shows a chapter to a reader should show its **title** and use the number only to sort. (`BookInsightsSection` does.)
+
 **Book Upload Flow**:
 ```
 Upload EPUB/PDF → BookFile (stored) → IngestionJob (queued)
@@ -425,6 +427,18 @@ Test naming convention: `{MethodName}_{Scenario}_{ExpectedResult}`
 
 **E2E setup**: Global setup authenticates test user + admin, discovers books from API → `.test-data.json`. Auth state stored in `apps/web/e2e/.auth/`. Page object helpers in `apps/web/e2e/helpers/`.
 
+**Running the integration suite locally**: it trips its own rate limits at production values — a dozen classes seed a book by clipping one, and the GDPR-delete class calls account-delete four times. CI raises the knobs; do the same locally or you will read 429s as failures:
+
+```bash
+CLIP_PERMIT_LIMIT=200 ACCOUNT_DELETE_PERMIT_LIMIT=50 GUEST_SESSION_PERMIT_LIMIT=50 \
+  USER_LOGIN_PERMIT_LIMIT=100 RAG_ASK_PERMIT_LIMIT=200 \
+  docker compose up -d --no-deps --force-recreate api
+dotnet test tests/TextStack.IntegrationTests
+docker compose up -d --no-deps --force-recreate api   # back to production values
+```
+
+Also: the windows are 1–5 minutes, so **two overlapping runs throttle each other**. Run the suite once and read the result, rather than re-running to confirm a failure.
+
 **Test env vars**:
 - `ENABLE_TEST_AUTH=true` — enables test auth endpoints (needed for integration + E2E)
 - `ADMIN_EMAIL` / `ADMIN_PASSWORD` — needed for admin E2E
@@ -501,6 +515,10 @@ Supported formats: EPUB, PDF. Processing order: Spelling → Hyphenation → Typ
 ## MCP Server (`backend/src/Ai/TextStack.Ai.Mcp/`)
 
 Thin, stateless MCP↔HTTP bridge (Phase 8) — every tool call becomes an HTTP request to the public TextStack API (no DB/EF/OpenAI). 14 tools. Public catalog: `search_books`, `get_book`, `get_chapter`. The user's own uploads (Bearer): `search_my_library`, `get_my_book`, `get_my_chapter`, `save_my_highlight`, `list_my_book_highlights` — keyed by `bookId` (`UserBook.Id`), which is NOT an `editionId` and does not work in the edition-scoped tools. Write-back, either book type (Bearer): `save_insight`, `get_my_insights` — conclusions from an outside assistant, keyed by chapter **slug** (`BookInsight`, table `book_insight`), one per (user, book, chapter) so a re-run replaces rather than accumulates. Everything else (Bearer): `list_my_highlights`, `list_my_vocabulary`, `ask_book`, `save_highlight`.
+
+**Assistant write ceiling**: `HighlightsEndpoints.MaxAssistantHighlightsPerBook` (200) caps how many highlights one book may receive over MCP, counted by `anchor_json->>'source' = 'mcp'` — the field `SynthesizeAnchor` writes. A person highlighting in the reader is never counted and never capped. `POST /me/highlights` is additionally rate-limited by the `highlight-write` policy, which is the **only policy partitioned by user id rather than IP**: the MCP bridge reaches the API from one container address, so an IP key would let one looping client throttle every other MCP user.
+
+**On a PDF upload an MCP highlight is saved and listed but not painted.** The reader renders PDFs as the original document (ADR-012) and `PdfHighlightLayer` only draws `kind:"pdf"` anchors, which are page geometry the bridge cannot produce. `get_my_book` reports `rendersAsOriginalPdf` so the model can say so. Roughly half the uploaded library is PDF.
 
 The write-back exists because the reasoning happens in Claude/ChatGPT — where the reader already has a profile and a year of history — and only the **result** comes home. See `docs/05-features/mcp.md`.
 

--- a/apps/web/src/api/insights.ts
+++ b/apps/web/src/api/insights.ts
@@ -1,0 +1,40 @@
+import { authFetch } from './client'
+
+/**
+ * Insights — the conclusions an outside assistant wrote back into a book over MCP.
+ *
+ * TextStack does not host the conversation. The reasoning happens in Claude or
+ * ChatGPT, where the reader already has their profile and their history; what
+ * comes home is the result, hung on the book's spine. `chapterSlug` names the
+ * chapter it is about, or is null for the whole book — that null one is the
+ * конспект's overview.
+ *
+ * The server resolves each slug to its chapter number and title at read time and
+ * returns them in reading order, so the client renders the list as it comes.
+ */
+export interface BookInsight {
+  id: string
+  editionId: string | null
+  userBookId: string | null
+  chapterSlug: string | null
+  /** Null for a book-level insight, and for a slug that no longer resolves after a re-ingest. */
+  chapterNumber: number | null
+  chapterTitle: string | null
+  /** Markdown. */
+  text: string
+  /** What was being worked out. This is what makes an insight worth returning to. */
+  question: string | null
+  source: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** Everything already worked out about one book. Pass exactly one id. */
+export function getBookInsights(
+  target: { userBookId: string } | { editionId: string },
+): Promise<BookInsight[]> {
+  const query = 'userBookId' in target
+    ? `userBookId=${encodeURIComponent(target.userBookId)}`
+    : `editionId=${encodeURIComponent(target.editionId)}`
+  return authFetch<BookInsight[]>(`/me/insights?${query}`)
+}

--- a/apps/web/src/components/library/BookInsightsSection.tsx
+++ b/apps/web/src/components/library/BookInsightsSection.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { getBookInsights, type BookInsight } from '../../api/insights'
+import { useTranslation } from '../../hooks/useTranslation'
+
+/**
+ * "What you've worked out" — the conclusions an outside assistant wrote back into
+ * this book over MCP.
+ *
+ * This is the return path, and the reason the write-back is worth having: come
+ * back to a book a month later and read the twenty lines that matter instead of
+ * the four hundred pages. The server orders them — the book-level overview first,
+ * then chapters by number — so this renders the list as it arrives.
+ *
+ * Renders nothing at all when there is nothing yet. An empty state here would be
+ * a tutorial for a feature you can only reach by connecting an assistant, which
+ * belongs next to the connect prompt, not on every book page.
+ */
+interface Props {
+  /** Exactly one of these. */
+  userBookId?: string
+  editionId?: string
+}
+
+export function BookInsightsSection({ userBookId, editionId }: Props) {
+  const { t } = useTranslation()
+  const [insights, setInsights] = useState<BookInsight[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const target = userBookId ? { userBookId } : editionId ? { editionId } : null
+    if (!target) return
+
+    let cancelled = false
+    setLoading(true)
+    getBookInsights(target)
+      .then(rows => { if (!cancelled) setInsights(rows) })
+      // Silent: this is a supplementary panel and a failure here must never take
+      // the book page down with it. Same posture as BookStatsSection.
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [userBookId, editionId])
+
+  if (loading || insights.length === 0) return null
+
+  return (
+    <section className="book-insights" aria-label={t('library.insights.title')}>
+      <h2 className="book-insights__title">{t('library.insights.title')}</h2>
+      <p className="book-insights__lead">{t('library.insights.lead')}</p>
+
+      <ol className="book-insights__list">
+        {insights.map(insight => (
+          <li key={insight.id} className="book-insights__item">
+            {/* The TITLE, never the number. `chapterNumber` is what the server
+                orders by, but the two book types number differently — a catalog
+                page renders `chapterNumber + 1` while an upload renders it
+                as-is — so printing it here reads one off from the table of
+                contents on exactly one of them. The title identifies the chapter
+                to a reader anyway. */}
+            <div className="book-insights__scope">
+              {insight.chapterSlug === null
+                ? t('library.insights.wholeBook')
+                // The slug no longer resolves — a re-ingest renamed the chapter.
+                // The text is still worth having, so show it unplaced rather than
+                // dropping it.
+                : insight.chapterTitle ?? insight.chapterSlug}
+            </div>
+
+            {insight.question && (
+              <div className="book-insights__question">{insight.question}</div>
+            )}
+
+            {/* react-markdown does not parse raw HTML (no rehype-raw), so assistant
+                output cannot inject markup. No dangerouslySetInnerHTML anywhere. */}
+            <div className="book-insights__body">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{insight.text}</ReactMarkdown>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}

--- a/apps/web/src/components/library/DiscussWithAssistant.tsx
+++ b/apps/web/src/components/library/DiscussWithAssistant.tsx
@@ -1,0 +1,42 @@
+import { buildHandoffBrief, handoffUrl, type HandoffBook } from '../../lib/assistantHandoff'
+import { useTranslation } from '../../hooks/useTranslation'
+
+/**
+ * "Discuss with an assistant" — two links, not an integration.
+ *
+ * The reader picks Claude or ChatGPT; we open a new conversation there with an
+ * opening message already written. See `lib/assistantHandoff.ts` for why this is
+ * a link and what the brief does and does not carry.
+ *
+ * `target="_blank"` with `rel="noopener noreferrer"`: these are third-party
+ * origins and must not get a handle on this window.
+ */
+export function DiscussWithAssistant(props: HandoffBook) {
+  const { t } = useTranslation()
+  const brief = buildHandoffBrief(props)
+
+  return (
+    <div className="discuss-assistant">
+      <div className="discuss-assistant__label">{t('library.discuss.label')}</div>
+      <div className="discuss-assistant__actions">
+        <a
+          className="discuss-assistant__btn"
+          href={handoffUrl('claude', brief)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t('library.discuss.claude')}
+        </a>
+        <a
+          className="discuss-assistant__btn"
+          href={handoffUrl('chatgpt', brief)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t('library.discuss.chatgpt')}
+        </a>
+      </div>
+      <p className="discuss-assistant__hint">{t('library.discuss.hint')}</p>
+    </div>
+  )
+}

--- a/apps/web/src/lib/__tests__/assistantHandoff.test.ts
+++ b/apps/web/src/lib/__tests__/assistantHandoff.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { buildHandoffBrief, handoffUrl, MAX_BRIEF_CHARS } from '../assistantHandoff'
+
+/**
+ * The handoff is a LINK, and a link has a length limit that nothing else in the
+ * app has. These tests pin the two things that break silently: a brief that grows
+ * past what a URL can carry, and an identifier that names the wrong id space.
+ */
+describe('buildHandoffBrief', () => {
+  const book = {
+    title: 'Designing Data-Intensive Applications',
+    author: 'Martin Kleppmann',
+    bookId: '77777777-7777-7777-7777-777777777777',
+    progressPercent: 42.4,
+    chapterTitle: 'Replication',
+  }
+
+  it('names the book, the author and where the reader stopped', () => {
+    const brief = buildHandoffBrief(book)
+    expect(brief).toContain('Designing Data-Intensive Applications')
+    expect(brief).toContain('Martin Kleppmann')
+    expect(brief).toContain('42%')
+    expect(brief).toContain('Replication')
+  })
+
+  it('names an upload by bookId and points at the my-library tools', () => {
+    const brief = buildHandoffBrief(book)
+    expect(brief).toContain('bookId 77777777-7777-7777-7777-777777777777')
+    expect(brief).toContain('get_my_book')
+    // An upload has no editionId; offering one would send the assistant to a 404.
+    expect(brief).not.toContain('editionId')
+  })
+
+  it('names a catalog book by editionId and points at the catalog tools', () => {
+    const brief = buildHandoffBrief({
+      title: 'Dracula',
+      editionId: '33333333-3333-3333-3333-333333333333',
+    })
+    expect(brief).toContain('editionId 33333333-3333-3333-3333-333333333333')
+    expect(brief).toContain('get_book')
+    expect(brief).not.toContain('bookId')
+  })
+
+  it('asks the assistant to write conclusions back', () => {
+    // Without this line the conversation happens and nothing comes home, which is
+    // the entire failure mode the feature exists to fix.
+    expect(buildHandoffBrief(book)).toContain('save_insight')
+  })
+
+  it('omits progress when there is none rather than saying 0%', () => {
+    const brief = buildHandoffBrief({ title: 'Dracula', progressPercent: 0 })
+    expect(brief).not.toContain('%')
+  })
+
+  it('caps the brief, because it has to survive being a URL', () => {
+    const brief = buildHandoffBrief({
+      title: 'T'.repeat(5000),
+      author: 'A'.repeat(5000),
+      bookId: '77777777-7777-7777-7777-777777777777',
+    })
+    expect(brief.length).toBeLessThanOrEqual(MAX_BRIEF_CHARS)
+  })
+
+  it('keeps the encoded URL inside the safe ~2000-character floor', () => {
+    const url = handoffUrl('claude', buildHandoffBrief({
+      title: 'T'.repeat(5000),
+      bookId: '77777777-7777-7777-7777-777777777777',
+    }))
+    expect(url.length).toBeLessThanOrEqual(2000)
+  })
+})
+
+describe('handoffUrl', () => {
+  it('opens a NEW conversation on each service with the brief prefilled', () => {
+    expect(handoffUrl('claude', 'hello there')).toBe('https://claude.ai/new?q=hello%20there')
+    expect(handoffUrl('chatgpt', 'hello there')).toBe('https://chatgpt.com/?q=hello%20there')
+  })
+
+  it('encodes characters that would otherwise break the query', () => {
+    const url = handoffUrl('claude', 'a & b "quoted" #1')
+    expect(url).not.toContain(' ')
+    expect(url).not.toContain('"')
+    expect(url).toContain('%26')
+    expect(url).toContain('%23')
+  })
+})

--- a/apps/web/src/lib/assistantHandoff.ts
+++ b/apps/web/src/lib/assistantHandoff.ts
@@ -1,0 +1,90 @@
+/**
+ * "Discuss with an assistant" — the handoff out of TextStack and into a real chat.
+ *
+ * We are not building the chat. The reader's assistant already has their profile,
+ * their memory and a year of conversation, and none of that can be copied here.
+ * So the button is a LINK: it opens a new conversation in Claude or ChatGPT with
+ * an opening message already written.
+ *
+ * Two halves, deliberately independent:
+ *   • With the TextStack connector attached, the assistant can read the book and
+ *     write conclusions back (get_my_book / get_my_chapter / save_insight).
+ *   • Without it, this is still a real conversation about a real book — the reader
+ *     just carries the outcome back by hand.
+ * The brief says so, so a connected client uses the tools and an unconnected one
+ * does not sit there claiming it cannot help.
+ */
+
+/**
+ * How much of the brief we are willing to put in a URL.
+ *
+ * Browsers and the receiving apps both tolerate far more than this, but the safe
+ * floor across the chain (address bar, redirects, server logs) is about 2000
+ * characters for the whole URL — and percent-encoding roughly doubles spaces and
+ * punctuation. 1200 characters of message leaves room for the origin and the
+ * encoding overhead. This is why the brief is a BRIEF: the book does not travel
+ * in the link, the connector fetches it.
+ */
+export const MAX_BRIEF_CHARS = 1200
+
+export interface HandoffBook {
+  title: string
+  author?: string | null
+  /** UserBook id — what the MCP tools key on. Omitted for a catalog book. */
+  bookId?: string
+  /** Edition id for a catalog book. */
+  editionId?: string
+  /** 0–100, if known. */
+  progressPercent?: number | null
+  /** Where the reader stopped, if known. */
+  chapterTitle?: string | null
+}
+
+/** The opening message, written from the reader's side. */
+export function buildHandoffBrief(book: HandoffBook): string {
+  const lines: string[] = []
+
+  const author = book.author ? ` by ${book.author}` : ''
+  lines.push(`I'm reading "${book.title}"${author}.`)
+
+  const where: string[] = []
+  if (typeof book.progressPercent === 'number' && book.progressPercent > 0)
+    where.push(`about ${Math.round(book.progressPercent)}% in`)
+  if (book.chapterTitle) where.push(`currently at "${book.chapterTitle}"`)
+  if (where.length > 0) lines.push(`I'm ${where.join(', ')}.`)
+
+  lines.push('')
+  lines.push(
+    'Help me think it through: what I understood, what I did not, and what is worth marking. ' +
+    'Ask me questions rather than summarising at me.')
+
+  // The identifier and the tool names. A connected client acts on this; an
+  // unconnected one ignores it and the conversation still works.
+  const id = book.bookId
+    ? `bookId ${book.bookId}`
+    : book.editionId
+      ? `editionId ${book.editionId}`
+      : null
+  if (id) {
+    lines.push('')
+    lines.push(
+      `If you have the TextStack connector, this book is ${id}. ` +
+      (book.bookId
+        ? 'Read it with get_my_book and get_my_chapter, and check get_my_insights first in case we have discussed it before. '
+        : 'Read it with get_book and get_chapter, and check get_my_insights first in case we have discussed it before. ')
+      + 'When we are done, write the conclusions back with save_insight so I find them in the book later.')
+  }
+
+  const brief = lines.join('\n')
+  return brief.length <= MAX_BRIEF_CHARS ? brief : brief.slice(0, MAX_BRIEF_CHARS).trimEnd()
+}
+
+export type Assistant = 'claude' | 'chatgpt'
+
+/** The new-conversation URL for one assistant, with the brief prefilled. */
+export function handoffUrl(assistant: Assistant, brief: string): string {
+  const q = encodeURIComponent(brief)
+  return assistant === 'claude'
+    ? `https://claude.ai/new?q=${q}`
+    : `https://chatgpt.com/?q=${q}`
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -508,7 +508,7 @@
       "endpointLabel": "MCP endpoint URL",
       "transport": "Transport: Streamable HTTP.",
       "addServer": "In your client, choose \"add a custom MCP server\" (or \"connector\") and paste the endpoint URL above.",
-      "publicTools": "Public tools (search_books, get_book, get_chapter, ask_book) work without signing in.",
+      "publicTools": "Catalog tools (search_books, get_book, get_chapter) work without signing in. Your own uploads need sign-in.",
       "authNote": "The first user-scoped call (your highlights or vocabulary) returns a message like \"authentication required — open https://textstack.app/device and enter code XXXX-XXXX\". Open the device page, sign in, enter the code, then retry.",
       "deviceLink": "Open the device page"
     },
@@ -522,15 +522,22 @@
       "toolInstallLabel": "terminal"
     },
     "tools": {
-      "heading": "The 7 tools",
+      "heading": "The 14 tools",
       "lead": "What your AI assistant can do once connected:",
-      "searchBooks": "Search the public book library by query.",
+      "searchBooks": "Search the public book catalog by query.",
       "getBook": "Fetch a book's metadata and chapter list by slug.",
       "getChapter": "Fetch the full text of a single chapter.",
+      "searchMyLibrary": "Search the books you uploaded — your own library, not the public catalog (requires sign-in).",
+      "getMyBook": "Fetch one of your uploaded books: metadata and chapter list (requires sign-in).",
+      "getMyChapter": "Fetch the full text of one chapter of a book you uploaded (requires sign-in).",
+      "saveMyHighlight": "Highlight a passage in a book you uploaded (requires sign-in).",
+      "listMyBookHighlights": "List the highlights already in a book you uploaded (requires sign-in).",
       "listMyHighlights": "List your saved highlights (requires sign-in).",
       "saveHighlight": "Save a passage to your highlights (requires sign-in).",
       "listMyVocabulary": "List your saved vocabulary words (requires sign-in).",
-      "askBook": "Ask a question about a book and get a cited, grounded answer."
+      "askBook": "Ask a question about a book and get a cited, grounded answer.",
+      "saveInsight": "Write a conclusion back into a book — against one chapter, or the whole book (requires sign-in).",
+      "getMyInsights": "Read back everything already worked out about a book, in reading order (requires sign-in)."
     },
     "steps": {
       "heading": "Auth in 3 steps",
@@ -817,6 +824,17 @@
       "highlights": "Highlights",
       "pace": "Pace",
       "timeLeft": "Time left"
+    },
+    "insights": {
+      "title": "What you've worked out",
+      "lead": "Conclusions your assistant wrote back into this book. Read these instead of re-reading the book.",
+      "wholeBook": "This book"
+    },
+    "discuss": {
+      "label": "Talk this book over",
+      "claude": "Open in Claude",
+      "chatgpt": "Open in ChatGPT",
+      "hint": "Opens a new chat with an opening message about this book. Connect TextStack as a connector and your assistant can read the book and write its conclusions back here."
     },
     "bulk": {
       "select": "Select",

--- a/apps/web/src/pages/BookDetailPage.tsx
+++ b/apps/web/src/pages/BookDetailPage.tsx
@@ -23,6 +23,9 @@ import {
   generateThemeDescription,
 } from '../lib/bookSeo'
 import { ShareButtons } from '../components/ShareButtons'
+import { BookInsightsSection } from '../components/library/BookInsightsSection'
+import { DiscussWithAssistant } from '../components/library/DiscussWithAssistant'
+import { useAuth } from '../context/AuthContext'
 import { BookDetailHero } from '../components/BookDetailHero'
 import { AddToCollectionButton } from '../components/library/AddToCollectionButton'
 import { SimilarBooksRail } from '../components/book/SimilarBooksRail'
@@ -68,6 +71,7 @@ export function BookDetailPage() {
   const { t } = useTranslation()
   const { isDownloading, getProgress, startDownload } = useDownload()
   const { isInLibrary } = useLibrary()
+  const { isAuthenticated } = useAuth()
   const { site } = useSite()
   const canonicalOrigin = getCanonicalOrigin(site?.primaryDomain)
   const [book, setBook] = useState<BookDetail | null>(null)
@@ -348,6 +352,20 @@ export function BookDetailPage() {
           </>
         }
       />
+
+      {/* The same two panels as an uploaded book's page — a conclusion written
+          back over MCP can name either book type, so both have to show it or
+          catalog insights would be write-only. Behind isAuthenticated because
+          this page is also prerendered for crawlers, and an anonymous visit
+          firing a 401 is noise on the SEO path. */}
+      {isAuthenticated && <BookInsightsSection editionId={book.id} />}
+      {isAuthenticated && (
+        <DiscussWithAssistant
+          title={book.title}
+          author={book.authors.map(a => a.name).join(', ') || null}
+          editionId={book.id}
+        />
+      )}
 
       {/* Chapters */}
       <section className="book-tabs">

--- a/apps/web/src/pages/McpLandingPage.tsx
+++ b/apps/web/src/pages/McpLandingPage.tsx
@@ -73,10 +73,17 @@ export function McpLandingPage() {
     { name: 'search_books', desc: t('mcp.tools.searchBooks') },
     { name: 'get_book', desc: t('mcp.tools.getBook') },
     { name: 'get_chapter', desc: t('mcp.tools.getChapter') },
+    { name: 'search_my_library', desc: t('mcp.tools.searchMyLibrary') },
+    { name: 'get_my_book', desc: t('mcp.tools.getMyBook') },
+    { name: 'get_my_chapter', desc: t('mcp.tools.getMyChapter') },
+    { name: 'save_my_highlight', desc: t('mcp.tools.saveMyHighlight') },
+    { name: 'list_my_book_highlights', desc: t('mcp.tools.listMyBookHighlights') },
     { name: 'list_my_highlights', desc: t('mcp.tools.listMyHighlights') },
     { name: 'save_highlight', desc: t('mcp.tools.saveHighlight') },
     { name: 'list_my_vocabulary', desc: t('mcp.tools.listMyVocabulary') },
     { name: 'ask_book', desc: t('mcp.tools.askBook') },
+    { name: 'save_insight', desc: t('mcp.tools.saveInsight') },
+    { name: 'get_my_insights', desc: t('mcp.tools.getMyInsights') },
   ]
 
   return (

--- a/apps/web/src/pages/UserBookDetailPage.tsx
+++ b/apps/web/src/pages/UserBookDetailPage.tsx
@@ -8,6 +8,8 @@ import { Footer } from '../components/Footer'
 import { stringToColor } from '../utils/colors'
 import { ShareButtons } from '../components/ShareButtons'
 import { BookStatsSection } from '../components/library/BookStatsSection'
+import { BookInsightsSection } from '../components/library/BookInsightsSection'
+import { DiscussWithAssistant } from '../components/library/DiscussWithAssistant'
 import { emitDataChanges } from '../lib/dataEvents'
 import { AddToCollectionButton } from '../components/library/AddToCollectionButton'
 import { useTranslation } from '../hooks/useTranslation'
@@ -473,6 +475,26 @@ export function UserBookDetailPage() {
 
       {isReady && book && (
         <BookStatsSection bookId={book.id} />
+      )}
+
+      {/* Above the chapter list on purpose: coming back to a book, what you
+          already worked out is more use than the table of contents. */}
+      {isReady && book && (
+        <BookInsightsSection userBookId={book.id} />
+      )}
+
+      {/* Directly under the insights: the section shows what came back, this is
+          how you go and get more. */}
+      {isReady && book && (
+        <DiscussWithAssistant
+          title={book.title}
+          author={book.author}
+          bookId={book.id}
+          progressPercent={savedProgress?.percent ?? null}
+          chapterTitle={
+            book.chapters.find(c => c.slug === savedProgress?.chapterSlug)?.title ?? null
+          }
+        />
       )}
 
       {isReady && book.chapters.length > 0 && (

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -8324,3 +8324,34 @@ a.read-later__title:hover { text-decoration: underline; }
   max-width: 340px;
   margin: 0 auto;
 }
+
+/* "What you've worked out" — insights an outside assistant wrote back into the
+   book over MCP. Sits between the stats and the chapter list on the book page:
+   coming back to a book, what you already concluded beats the table of contents.
+   Styled as a quiet document, not a card grid — this is prose to be read. */
+.book-insights { margin: 24px 0; padding: 20px; background: var(--color-surface, #fff); border: 1px solid var(--color-border, #e0d8c8); border-radius: 12px; }
+.book-insights__title { margin: 0 0 4px; font-size: 18px; }
+.book-insights__lead { margin: 0 0 16px; font-size: 13px; color: var(--color-text-secondary, #666); }
+.book-insights__list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 20px; }
+.book-insights__item { padding-left: 14px; border-left: 3px solid var(--color-border, #e0d8c8); }
+.book-insights__scope { font-size: 12px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--color-text-secondary, #666); }
+/* The question is the provenance stamp — what you were trying to work out. It is
+   what makes the answer below worth returning to, so it reads as a heading. */
+.book-insights__question { margin-top: 2px; font-size: 15px; font-weight: 600; }
+.book-insights__body { margin-top: 8px; font-size: 15px; line-height: 1.6; }
+.book-insights__body > :first-child { margin-top: 0; }
+.book-insights__body > :last-child { margin-bottom: 0; }
+.book-insights__body ul, .book-insights__body ol { padding-left: 20px; }
+.book-insights__body code { font-size: 0.9em; padding: 1px 4px; border-radius: 4px; background: var(--color-bg-secondary, #f1f5f9); }
+.book-insights__body pre { overflow-x: auto; padding: 12px; border-radius: 8px; background: var(--color-bg-secondary, #f1f5f9); }
+.book-insights__body blockquote { margin: 8px 0; padding-left: 12px; border-left: 3px solid var(--color-border, #e0d8c8); color: var(--color-text-secondary, #666); }
+
+/* "Talk this book over" — the handoff into Claude / ChatGPT. A link, not an
+   integration: see lib/assistantHandoff.ts. Sits under the insights section, so
+   the page reads "here is what came back / here is how to get more". */
+.discuss-assistant { margin: 24px 0; padding: 16px 20px; background: var(--color-surface, #fff); border: 1px solid var(--color-border, #e0d8c8); border-radius: 12px; }
+.discuss-assistant__label { font-size: 14px; font-weight: 600; margin-bottom: 10px; }
+.discuss-assistant__actions { display: flex; flex-wrap: wrap; gap: 8px; }
+.discuss-assistant__btn { display: inline-flex; align-items: center; padding: 8px 14px; border: 1px solid var(--color-border, #e0d8c8); border-radius: 8px; font-size: 14px; text-decoration: none; color: inherit; background: var(--color-bg-secondary, #f1f5f9); }
+.discuss-assistant__btn:hover { border-color: var(--color-brand, #C4704B); }
+.discuss-assistant__hint { margin: 10px 0 0; font-size: 12px; line-height: 1.5; color: var(--color-text-secondary, #666); }

--- a/backend/src/Ai/TextStack.Ai.Mcp/Http/TextStackApiClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Mcp/Http/TextStackApiClient.cs
@@ -201,10 +201,16 @@ public sealed class TextStackApiClient
     /// <summary>
     /// <c>GET /me/library/search?q={query}&amp;tags={tags}</c> — Postgres FTS over the
     /// user's own uploads, one hit per book carrying its best-matching chapter.
-    /// Needs no RAG index. 401 → <see cref="McpUnauthorizedException"/>; other
-    /// non-success → empty list.
+    /// Needs no RAG index.
+    ///
+    /// <para>Returns <b>null</b> on failure, and an empty list only when the search really matched
+    /// nothing. The distinction is the whole point: this endpoint spent its life answering 500, and
+    /// mapping that to an empty list told the caller "you have no books about this" — a confident,
+    /// wrong answer that reads exactly like a true one.</para>
+    ///
+    /// <para>401 → <see cref="McpUnauthorizedException"/>.</para>
     /// </summary>
-    public async Task<IReadOnlyList<UserBookSearchHitJson>> SearchMyLibraryAsync(
+    public async Task<IReadOnlyList<UserBookSearchHitJson>?> SearchMyLibraryAsync(
         string query, string? tags, CancellationToken ct)
     {
         var url = $"/me/library/search?q={Uri.EscapeDataString(query)}";
@@ -223,7 +229,7 @@ public sealed class TextStackApiClient
             return result ?? [];
         }
 
-        return [];
+        return null;
     }
 
     /// <summary>
@@ -540,6 +546,10 @@ public sealed record ChapterNavJson(string? Slug, string Title);
 public sealed record HighlightJson(
     Guid Id,
     Guid? ChapterId,
+    // A highlight on an UPLOADED book carries its chapter here, not in ChapterId — the same
+    // edition/user-book split as everywhere else. Omitting it made every highlight listed off an
+    // upload report chapterId: null, so a model could not tell what it had already marked where.
+    Guid? UserChapterId,
     string Color,
     string SelectedText,
     string? NoteText,

--- a/backend/src/Ai/TextStack.Ai.Mcp/Http/TextStackApiClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Mcp/Http/TextStackApiClient.cs
@@ -190,6 +190,192 @@ public sealed class TextStackApiClient
         return null;
     }
 
+    // ── my library (Bearer) — the UPLOADED half of the library ───────────────────
+    //
+    // A user's own uploads are a different aggregate from the catalog: UserBook /
+    // UserChapter, their own tables, their own chunks. They have NO editionId and
+    // cannot be given one, so every tool below is keyed by `bookId` = UserBook.Id.
+    // Passing one of these ids to an edition-scoped tool (ask_book,
+    // list_my_highlights) is a 404 / an empty list, not a partial answer.
+
+    /// <summary>
+    /// <c>GET /me/library/search?q={query}&amp;tags={tags}</c> — Postgres FTS over the
+    /// user's own uploads, one hit per book carrying its best-matching chapter.
+    /// Needs no RAG index. 401 → <see cref="McpUnauthorizedException"/>; other
+    /// non-success → empty list.
+    /// </summary>
+    public async Task<IReadOnlyList<UserBookSearchHitJson>> SearchMyLibraryAsync(
+        string query, string? tags, CancellationToken ct)
+    {
+        var url = $"/me/library/search?q={Uri.EscapeDataString(query)}";
+        if (!string.IsNullOrWhiteSpace(tags))
+            url += $"&tags={Uri.EscapeDataString(tags)}";
+
+        using var request = await AuthorizedRequestAsync(HttpMethod.Get, url, ct);
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
+            throw new McpUnauthorizedException();
+
+        if (response.StatusCode is HttpStatusCode.OK)
+        {
+            var result = await response.Content.ReadFromJsonAsync<List<UserBookSearchHitJson>>(JsonOptions, ct);
+            return result ?? [];
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// <c>GET /me/books/{bookId}</c> — an upload's metadata and chapter list. The
+    /// chapter list carries each chapter's <c>id</c>, which is what
+    /// <c>save_my_highlight</c> needs. 401 → <see cref="McpUnauthorizedException"/>;
+    /// other non-success (incl. someone else's book → 404) → null.
+    /// </summary>
+    public async Task<UserBookDetailJson?> GetMyBookAsync(Guid bookId, CancellationToken ct)
+    {
+        using var request = await AuthorizedRequestAsync(HttpMethod.Get, $"/me/books/{bookId}", ct);
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
+            throw new McpUnauthorizedException();
+
+        if (response.StatusCode is HttpStatusCode.OK)
+            return await response.Content.ReadFromJsonAsync<UserBookDetailJson>(JsonOptions, ct);
+
+        return null;
+    }
+
+    /// <summary>
+    /// <c>GET /me/books/{bookId}/chapters/{chapterSlug}</c> — one chapter's HTML,
+    /// which the catalog strips and caps exactly as it does for <c>get_chapter</c>.
+    /// 401 → <see cref="McpUnauthorizedException"/>; other non-success → null.
+    /// </summary>
+    public async Task<UserChapterJson?> GetMyChapterAsync(Guid bookId, string chapterSlug, CancellationToken ct)
+    {
+        var url = $"/me/books/{bookId}/chapters/{Uri.EscapeDataString(chapterSlug)}";
+        using var request = await AuthorizedRequestAsync(HttpMethod.Get, url, ct);
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
+            throw new McpUnauthorizedException();
+
+        if (response.StatusCode is HttpStatusCode.OK)
+            return await response.Content.ReadFromJsonAsync<UserChapterJson>(JsonOptions, ct);
+
+        return null;
+    }
+
+    // ── my-library WRITES (Bearer) ───────────────────────────────────────────────
+
+    /// <summary>
+    /// <c>GET /me/highlights/userbook/{bookId}</c> — highlights on one of the user's uploads. A
+    /// different route from the edition one because they are different aggregates; passing a bookId
+    /// to <see cref="GetHighlightsAsync"/> would return an empty list rather than an error.
+    ///
+    /// <para>Returns <b>null</b> — not an empty list — when the book is not this user's (the endpoint
+    /// answers 404). The difference matters here in a way it does not for the other reads: an empty
+    /// list is a truthful answer to "what have I highlighted", so collapsing "not your book" into it
+    /// would let a wrong id read as a book with no marks. That is the same confusion this route
+    /// exists to avoid, arriving by a different door.</para>
+    ///
+    /// <para>401 → <see cref="McpUnauthorizedException"/>.</para>
+    /// </summary>
+    public async Task<IReadOnlyList<HighlightJson>?> GetUserBookHighlightsAsync(Guid bookId, CancellationToken ct)
+    {
+        using var request = await AuthorizedRequestAsync(HttpMethod.Get, $"/me/highlights/userbook/{bookId}", ct);
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
+            throw new McpUnauthorizedException();
+
+        if (response.StatusCode is HttpStatusCode.OK)
+        {
+            var result = await response.Content.ReadFromJsonAsync<List<HighlightJson>>(JsonOptions, ct);
+            return result ?? [];
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// <c>POST /me/highlights</c> for an UPLOADED book — same endpoint as
+    /// <see cref="SaveHighlightAsync"/>, the other side of its edition/user-book XOR. The API has
+    /// accepted this shape since user-book highlights shipped; only the MCP tool surface was missing.
+    /// A non-PDF upload requires <paramref name="userChapterId"/>, which <c>get_my_chapter</c> and
+    /// <c>get_my_book</c> supply. 401 → <see cref="McpUnauthorizedException"/>; other non-success → null.
+    /// </summary>
+    public async Task<HighlightJson?> SaveUserBookHighlightAsync(
+        Guid userBookId, Guid userChapterId, string anchorJson, string color, string selectedText,
+        string? noteText, CancellationToken ct)
+    {
+        using var request = await AuthorizedRequestAsync(HttpMethod.Post, "/me/highlights", ct);
+        request.Content = JsonContent.Create(
+            new CreateUserBookHighlightJson(userBookId, userChapterId, anchorJson, color, selectedText, noteText),
+            options: JsonOptions);
+
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
+            throw new McpUnauthorizedException();
+
+        if (response.StatusCode is HttpStatusCode.Created or HttpStatusCode.OK)
+            return await response.Content.ReadFromJsonAsync<HighlightJson>(JsonOptions, ct);
+
+        return null;
+    }
+
+    // ── insights (Bearer) — conclusions written back into a book ─────────────────
+
+    /// <summary>
+    /// <c>GET /me/insights?userBookId=…|editionId=…</c> — everything already worked out about this
+    /// book, in reading order. This is the continuity: a later session reads it and does not redo
+    /// work. 401 → <see cref="McpUnauthorizedException"/>; other non-success → empty.
+    /// </summary>
+    public async Task<IReadOnlyList<BookInsightJson>> GetInsightsAsync(
+        Guid? editionId, Guid? userBookId, CancellationToken ct)
+    {
+        var url = editionId is { } e ? $"/me/insights?editionId={e}" : $"/me/insights?userBookId={userBookId}";
+
+        using var request = await AuthorizedRequestAsync(HttpMethod.Get, url, ct);
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
+            throw new McpUnauthorizedException();
+
+        if (response.StatusCode is HttpStatusCode.OK)
+        {
+            var result = await response.Content.ReadFromJsonAsync<List<BookInsightJson>>(JsonOptions, ct);
+            return result ?? [];
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// <c>POST /me/insights</c> — save one conclusion against a chapter slug, or against the whole
+    /// book when <paramref name="chapterSlug"/> is null. Saving over an existing one REPLACES it.
+    /// 401 → <see cref="McpUnauthorizedException"/>; other non-success → null.
+    /// </summary>
+    public async Task<BookInsightJson?> SaveInsightAsync(
+        Guid? editionId, Guid? userBookId, string? chapterSlug, string text, string? question,
+        CancellationToken ct)
+    {
+        using var request = await AuthorizedRequestAsync(HttpMethod.Post, "/me/insights", ct);
+        request.Content = JsonContent.Create(
+            new SaveInsightJson(editionId, userBookId, chapterSlug, text, question), options: JsonOptions);
+
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
+            throw new McpUnauthorizedException();
+
+        if (response.StatusCode is HttpStatusCode.Created or HttpStatusCode.OK)
+            return await response.Content.ReadFromJsonAsync<BookInsightJson>(JsonOptions, ct);
+
+        return null;
+    }
+
     // ── ask_book (Bearer) ────────────────────────────────────────────────────────
 
     /// <summary>
@@ -385,3 +571,84 @@ public sealed record AskJson(
     bool Insufficient);
 
 public sealed record AskCitationJson(int Marker, int ChapterOrd, string Preview);
+
+// ── my-library DTOs (uploads). Mirror Contracts.UserBooks.*; deliberately a
+//    separate family from the catalog's Book*/Chapter* records above, because
+//    UserBook and Edition are separate aggregates and conflating the two is
+//    exactly the bug this surface exists to avoid. ─────────────────────────────
+
+// GET /me/library/search → UserBookSearchHitDto[]. `Id` is the UserBook id — the
+// only identifier an upload has. There is no editionId here, by construction.
+public sealed record UserBookSearchHitJson(
+    Guid Id,
+    string Title,
+    string? Author,
+    string? CoverPath,
+    string Language,
+    double Rank,
+    string? Excerpt,
+    string? ChapterSlug);
+
+// GET /me/books/{id} → UserBookDetailDto (subset we surface).
+public sealed record UserBookDetailJson(
+    Guid Id,
+    string Title,
+    string Slug,
+    string Language,
+    string? Author,
+    string? Description,
+    string? Genre,
+    int? PublishedYear,
+    int? TotalWordCount,
+    string Status,
+    IReadOnlyList<UserChapterSummaryJson>? Chapters);
+
+public sealed record UserChapterSummaryJson(
+    Guid Id, int ChapterNumber, string? Slug, string Title, int? WordCount);
+
+// GET /me/books/{id}/chapters/{slug} → UserChapterDto (subset).
+// Note `Previous`, not `Prev` — the user-book DTO spells it out where the
+// catalog's ChapterDto abbreviates.
+public sealed record UserChapterJson(
+    Guid Id,
+    int ChapterNumber,
+    string? Slug,
+    string Title,
+    string Html,
+    int? WordCount,
+    UserChapterNavJson? Previous,
+    UserChapterNavJson? Next);
+
+public sealed record UserChapterNavJson(int ChapterNumber, string? Slug, string Title);
+
+// POST /me/highlights request, user-book side of the XOR. EditionId / ChapterId are
+// simply absent (JsonOptions drops nulls) and the API's record defaults them to null.
+public sealed record CreateUserBookHighlightJson(
+    Guid UserBookId,
+    Guid UserChapterId,
+    string AnchorJson,
+    string Color,
+    string SelectedText,
+    string? NoteText);
+
+// GET /me/insights → BookInsightDto[]; also the POST response body.
+public sealed record BookInsightJson(
+    Guid Id,
+    Guid? EditionId,
+    Guid? UserBookId,
+    string? ChapterSlug,
+    int? ChapterNumber,
+    string? ChapterTitle,
+    string Text,
+    string? Question,
+    string Source,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);
+
+// POST /me/insights request → SaveInsightRequest.
+public sealed record SaveInsightJson(
+    Guid? EditionId,
+    Guid? UserBookId,
+    string? ChapterSlug,
+    string Text,
+    string? Question);

--- a/backend/src/Ai/TextStack.Ai.Mcp/Http/TextStackApiClient.cs
+++ b/backend/src/Ai/TextStack.Ai.Mcp/Http/TextStackApiClient.cs
@@ -330,9 +330,16 @@ public sealed class TextStackApiClient
     /// <summary>
     /// <c>GET /me/insights?userBookId=…|editionId=…</c> — everything already worked out about this
     /// book, in reading order. This is the continuity: a later session reads it and does not redo
-    /// work. 401 → <see cref="McpUnauthorizedException"/>; other non-success → empty.
+    /// work.
+    ///
+    /// <para>Returns <b>null</b> — not an empty list — when the book does not exist or is not this
+    /// user's, for the same reason <see cref="GetUserBookHighlightsAsync"/> does: an empty list is a
+    /// truthful answer to "what have I worked out about this book", so a wrong id must not be able
+    /// to borrow it.</para>
+    ///
+    /// <para>401 → <see cref="McpUnauthorizedException"/>.</para>
     /// </summary>
-    public async Task<IReadOnlyList<BookInsightJson>> GetInsightsAsync(
+    public async Task<IReadOnlyList<BookInsightJson>?> GetInsightsAsync(
         Guid? editionId, Guid? userBookId, CancellationToken ct)
     {
         var url = editionId is { } e ? $"/me/insights?editionId={e}" : $"/me/insights?userBookId={userBookId}";
@@ -349,7 +356,7 @@ public sealed class TextStackApiClient
             return result ?? [];
         }
 
-        return [];
+        return null;
     }
 
     /// <summary>
@@ -601,6 +608,10 @@ public sealed record UserBookDetailJson(
     int? PublishedYear,
     int? TotalWordCount,
     string Status,
+    // True when the upload is a PDF the reader renders as the original document
+    // (ADR-012). It changes what a highlight written from here can do — see
+    // BuildSaveMyHighlight — so it is surfaced rather than left in the DTO.
+    bool HasOriginalPdf,
     IReadOnlyList<UserChapterSummaryJson>? Chapters);
 
 public sealed record UserChapterSummaryJson(

--- a/backend/src/Ai/TextStack.Ai.Mcp/README.md
+++ b/backend/src/Ai/TextStack.Ai.Mcp/README.md
@@ -5,14 +5,21 @@ library to Claude Desktop, Cursor, or any [Model Context Protocol](https://model
 client. Ask your books questions, read chapters, and manage your highlights and
 vocabulary straight from your AI assistant.
 
-It exposes **7 tools**:
+It exposes **14 tools**:
 
 | Tool | What it does |
 |------|--------------|
-| `search_books` | Search the public book library by query |
+| `search_books` | Search the public book catalog by query |
 | `get_book` | Fetch a book's metadata and chapter list by slug |
 | `get_chapter` | Fetch the full text of a single chapter |
 | `ask_book` | Ask a question about a book and get a cited, grounded answer |
+| `search_my_library` | Search the books **you uploaded** (requires sign-in) |
+| `get_my_book` | Fetch one of your uploads: metadata + chapter list (requires sign-in) |
+| `get_my_chapter` | Fetch the full text of one chapter of your upload (requires sign-in) |
+| `save_my_highlight` | Highlight a passage in a book you uploaded (requires sign-in) |
+| `list_my_book_highlights` | List the highlights in a book you uploaded (requires sign-in) |
+| `save_insight` | Write a conclusion back into a book, against a chapter or the whole book (requires sign-in) |
+| `get_my_insights` | Read back everything already worked out about a book (requires sign-in) |
 | `list_my_highlights` | List your saved highlights (requires sign-in) |
 | `save_highlight` | Save a passage to your highlights (requires sign-in) |
 | `list_my_vocabulary` | List your saved vocabulary words (requires sign-in) |
@@ -50,8 +57,13 @@ Add to your `claude_desktop_config.json`:
 ```
 
 The server speaks MCP over **stdio** by default — exactly what a local desktop
-client needs. The public tools (`search_books`, `get_book`, `get_chapter`,
-`ask_book`) work without signing in.
+client needs. The catalog tools (`search_books`, `get_book`, `get_chapter`) work
+without signing in.
+
+Your own uploads are a separate half of the library, reached by the `*_my_*`
+tools and identified by a `bookId`. A `bookId` is not an `editionId`: passing one
+to `ask_book` or `list_my_highlights` returns nothing rather than an error, so
+keep the two apart.
 
 ## Auth (for your highlights / vocabulary)
 

--- a/backend/src/Ai/TextStack.Ai.Mcp/Tools/ArgReader.cs
+++ b/backend/src/Ai/TextStack.Ai.Mcp/Tools/ArgReader.cs
@@ -115,6 +115,29 @@ internal static class ArgReader
         return true;
     }
 
+    /// <summary>
+    /// Optional GUID. Absent → <paramref name="value"/> stays null (true); present-but-unparseable
+    /// → false. Used where a tool takes one of two mutually exclusive identifiers and has to check
+    /// the exclusivity itself, which JSON Schema cannot express in a form the SDK enforces anyway.
+    /// </summary>
+    public static bool TryOptionalGuid(
+        JsonElement obj, string name, out Guid? value, out string error)
+    {
+        value = null;
+        error = "";
+        if (!obj.TryGetProperty(name, out var el))
+            return true;
+
+        if (el.ValueKind != JsonValueKind.String || !Guid.TryParse(el.GetString(), out var g))
+        {
+            error = $"'{name}' must be a UUID.";
+            return false;
+        }
+
+        value = g;
+        return true;
+    }
+
     /// <summary>Optional string with a max length. Absent → null (true).</summary>
     public static bool TryOptionalString(
         JsonElement obj, string name, int max, out string? value, out string error)

--- a/backend/src/Ai/TextStack.Ai.Mcp/Tools/McpToolCatalog.cs
+++ b/backend/src/Ai/TextStack.Ai.Mcp/Tools/McpToolCatalog.cs
@@ -33,10 +33,17 @@ public sealed class McpToolCatalog
             BuildSearchBooks(api),
             BuildGetBook(api),
             BuildGetChapter(api),
+            BuildSearchMyLibrary(api),
+            BuildGetMyBook(api),
+            BuildGetMyChapter(api),
             BuildListMyHighlights(api),
             BuildListMyVocabulary(api),
             BuildAskBook(api),
             BuildSaveHighlight(api),
+            BuildSaveMyHighlight(api),
+            BuildListMyBookHighlights(api),
+            BuildSaveInsight(api),
+            BuildGetMyInsights(api),
         };
         _byName = tools.ToDictionary(t => t.Name, StringComparer.Ordinal);
     }
@@ -131,7 +138,7 @@ public sealed class McpToolCatalog
     private static McpToolDescriptor BuildSearchBooks(TextStackApiClient api) => new()
     {
         Name = "search_books",
-        Description = "Search the TextStack library for books and chapters matching a query.",
+        Description = "Search the PUBLIC TextStack catalog for books and chapters matching a query. This is the shared library of published books, NOT the user's own uploads — for those, use search_my_library.",
         InputSchema = SearchBooksSchema,
         Handler = (args, ct) =>
         {
@@ -248,6 +255,189 @@ public sealed class McpToolCatalog
                     slug = chapter.Slug,
                     title = chapter.Title,
                     prevSlug = chapter.Prev?.Slug,
+                    nextSlug = chapter.Next?.Slug,
+                    truncated,
+                    text,
+                };
+                return Text(JsonSerializer.Serialize(mapped));
+            });
+        },
+    };
+
+    // ── my library: search_my_library / get_my_book / get_my_chapter ────────────
+    //
+    // The user's OWN uploaded books. Separate from the three tools above in the
+    // only way that matters to a caller: an upload is identified by a `bookId`
+    // (UserBook.Id) and has NO editionId, because UserBook and Edition are
+    // separate aggregates with separate chapter and chunk tables. Feeding a
+    // bookId to ask_book or list_my_highlights yields a 404 or an empty list —
+    // so every description below says which identifier it returns and what that
+    // identifier is good for.
+    //
+    // All three are Bearer-scoped: the endpoints filter by user_id in SQL, so the
+    // bridge inherits the app's isolation rather than reimplementing it. None of
+    // them needs the RAG index — search is Postgres FTS over `search_vector`,
+    // built at upload, and get_my_chapter reads the stored chapter.
+
+    private static readonly JsonElement SearchMyLibrarySchema = JsonDocument.Parse(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "query": { "type": "string", "minLength": 2, "maxLength": 200 },
+            "tags": { "type": "string", "maxLength": 200 }
+          },
+          "required": ["query"],
+          "additionalProperties": false
+        }
+        """).RootElement;
+
+    private static McpToolDescriptor BuildSearchMyLibrary(TextStackApiClient api) => new()
+    {
+        Name = "search_my_library",
+        Description =
+            "Full-text search across the books the signed-in user has UPLOADED to TextStack "
+            + "(their private library, not the public catalog — requires authentication). "
+            + "Returns one hit per book with its bookId, title, author and the best-matching "
+            + "chapter slug and excerpt. Pass the bookId to get_my_book or get_my_chapter. "
+            + "A bookId is NOT an editionId and will not work with ask_book or list_my_highlights.",
+        InputSchema = SearchMyLibrarySchema,
+        Handler = (args, ct) =>
+        {
+            if (!ArgReader.TryObject(args, out var obj, out var err, "query", "tags")
+                || !ArgReader.TryRequiredString(obj, "query", 2, 200, out var query, out err)
+                || !ArgReader.TryOptionalString(obj, "tags", 200, out var tags, out err))
+                return Task.FromResult(Error(err));
+
+            return InvokeAsync("search_my_library", ct, async () =>
+            {
+                var hits = await api.SearchMyLibraryAsync(query, tags, ct);
+                var results = hits.Select(h => new
+                {
+                    // Stated on every row so a model holding a mixed result set
+                    // cannot lose track of which id space an id came from.
+                    source = "userbook",
+                    bookId = h.Id,
+                    title = h.Title,
+                    author = h.Author ?? "",
+                    language = h.Language,
+                    chapterSlug = h.ChapterSlug,
+                    // Carries <mark> around the matched terms, as search_books'
+                    // snippet carries <b> — left as sent.
+                    excerpt = h.Excerpt ?? "",
+                });
+                return Text(JsonSerializer.Serialize(new { results }));
+            });
+        },
+    };
+
+    private static readonly JsonElement GetMyBookSchema = JsonDocument.Parse(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "bookId": { "type": "string", "format": "uuid" }
+          },
+          "required": ["bookId"],
+          "additionalProperties": false
+        }
+        """).RootElement;
+
+    private static McpToolDescriptor BuildGetMyBook(TextStackApiClient api) => new()
+    {
+        Name = "get_my_book",
+        Description =
+            "Fetch one of the signed-in user's UPLOADED books by bookId (from search_my_library): "
+            + "its metadata and its full chapter list (requires authentication). Each chapter "
+            + "carries a chapterId and a slug — the slug goes to get_my_chapter, the chapterId to "
+            + "save_my_highlight.",
+        InputSchema = GetMyBookSchema,
+        Handler = (args, ct) =>
+        {
+            if (!ArgReader.TryObject(args, out var obj, out var err, "bookId")
+                || !ArgReader.TryRequiredGuid(obj, "bookId", out var bookId, out err))
+                return Task.FromResult(Error(err));
+
+            return InvokeAsync("get_my_book", ct, async () =>
+            {
+                var book = await api.GetMyBookAsync(bookId, ct);
+                if (book is null)
+                    return Error($"get_my_book: no uploaded book found with id '{bookId}'");
+
+                var mapped = new
+                {
+                    source = "userbook",
+                    bookId = book.Id,
+                    title = book.Title,
+                    slug = book.Slug,
+                    language = book.Language,
+                    author = book.Author ?? "",
+                    description = book.Description ?? "",
+                    genre = book.Genre,
+                    publishedYear = book.PublishedYear,
+                    totalWordCount = book.TotalWordCount,
+                    // Ready / Processing / Failed — a book still processing has no
+                    // chapters yet, and saying so beats an unexplained empty list.
+                    status = book.Status,
+                    chapters = (book.Chapters ?? []).Select(c => new
+                    {
+                        chapterId = c.Id,
+                        chapterNumber = c.ChapterNumber,
+                        slug = c.Slug,
+                        title = c.Title,
+                        wordCount = c.WordCount,
+                    }),
+                };
+                return Text(JsonSerializer.Serialize(mapped));
+            });
+        },
+    };
+
+    private static readonly JsonElement GetMyChapterSchema = JsonDocument.Parse(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "bookId": { "type": "string", "format": "uuid" },
+            "chapterSlug": { "type": "string", "minLength": 1, "maxLength": 300 }
+          },
+          "required": ["bookId", "chapterSlug"],
+          "additionalProperties": false
+        }
+        """).RootElement;
+
+    private static McpToolDescriptor BuildGetMyChapter(TextStackApiClient api) => new()
+    {
+        Name = "get_my_chapter",
+        Description =
+            "Fetch one chapter of a book the signed-in user UPLOADED: its plain text "
+            + "(HTML stripped, length-capped) plus its chapterId, number, title and prev/next "
+            + "slugs (requires authentication). The chapterId it returns is what save_my_highlight "
+            + "needs.",
+        InputSchema = GetMyChapterSchema,
+        Handler = (args, ct) =>
+        {
+            if (!ArgReader.TryObject(args, out var obj, out var err, "bookId", "chapterSlug")
+                || !ArgReader.TryRequiredGuid(obj, "bookId", out var bookId, out err)
+                || !ArgReader.TryRequiredString(obj, "chapterSlug", 1, 300, out var chapterSlug, out err))
+                return Task.FromResult(Error(err));
+
+            return InvokeAsync("get_my_chapter", ct, async () =>
+            {
+                var chapter = await api.GetMyChapterAsync(bookId, chapterSlug, ct);
+                if (chapter is null)
+                    return Error($"get_my_chapter: no chapter '{chapterSlug}' in uploaded book '{bookId}'");
+
+                var text = HtmlText.StripAndCap(chapter.Html, HtmlText.DefaultMaxChars, out var truncated);
+                var mapped = new
+                {
+                    source = "userbook",
+                    bookId,
+                    chapterId = chapter.Id,
+                    chapterNumber = chapter.ChapterNumber,
+                    slug = chapter.Slug,
+                    title = chapter.Title,
+                    prevSlug = chapter.Previous?.Slug,
                     nextSlug = chapter.Next?.Slug,
                     truncated,
                     text,
@@ -472,6 +662,262 @@ public sealed class McpToolCatalog
             });
         },
     };
+
+    // ── write-back: highlights and insights on the user's OWN books ─────────────
+    //
+    // This is the half that makes the whole surface worth having. The reasoning
+    // happens in the client — Claude, ChatGPT, wherever the reader already has a
+    // profile and a year of history. What comes back here is the RESULT, attached
+    // to the book so it is still there next month.
+    //
+    // Two shapes, because a conclusion is not always about one passage:
+    //   • a passage       → a highlight, which the reader already paints;
+    //   • a chapter, or   → an insight keyed by chapter slug;
+    //   • the whole book  → an insight with no chapter slug.
+    // A study конспект is the assembly of those in reading order, not a separate
+    // document — so re-running a pass refreshes it instead of duplicating it.
+
+    private static readonly JsonElement SaveMyHighlightSchema = JsonDocument.Parse(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "bookId": { "type": "string", "format": "uuid" },
+            "chapterId": { "type": "string", "format": "uuid" },
+            "selectedText": { "type": "string", "minLength": 1, "maxLength": 5000 },
+            "color": { "type": "string", "enum": ["yellow", "green", "blue", "pink"] },
+            "noteText": { "type": "string", "maxLength": 2000 }
+          },
+          "required": ["bookId", "chapterId", "selectedText"],
+          "additionalProperties": false
+        }
+        """).RootElement;
+
+    private static McpToolDescriptor BuildSaveMyHighlight(TextStackApiClient api) => new()
+    {
+        Name = "save_my_highlight",
+        Description =
+            "Highlight a passage in one of the books the user UPLOADED (WRITE on their own account — "
+            + "requires authentication). Pass the bookId, the chapterId of the chapter the passage is "
+            + "in (from get_my_book or get_my_chapter), and the exact text as it appears in that "
+            + "chapter — it is matched against the chapter text to place the highlight, so quote it "
+            + "verbatim. Optionally a color and a note. The highlight appears in the reader and in "
+            + "list_my_book_highlights. Highlight what is worth returning to, not every interesting "
+            + "line: a book marked end to end is a book with no marks.",
+        InputSchema = SaveMyHighlightSchema,
+        Handler = (args, ct) =>
+        {
+            if (!ArgReader.TryObject(args, out var obj, out var err, "bookId", "chapterId", "selectedText", "color", "noteText")
+                || !ArgReader.TryRequiredGuid(obj, "bookId", out var bookId, out err)
+                || !ArgReader.TryRequiredGuid(obj, "chapterId", out var chapterId, out err)
+                || !ArgReader.TryRequiredString(obj, "selectedText", 1, 5000, out var selectedText, out err)
+                || !ArgReader.TryOptionalString(obj, "noteText", 2000, out var noteText, out err)
+                || !TryReadColor(obj, out var color, out err))
+                return Task.FromResult(Error(err));
+
+            // Same synthesized W3C text-quote anchor as the catalog write: no DOM
+            // here, so the reader re-anchors by `exact`.
+            var anchorJson = SynthesizeAnchor(chapterId, selectedText);
+
+            return InvokeAsync("save_my_highlight", ct, async () =>
+            {
+                var saved = await api.SaveUserBookHighlightAsync(
+                    bookId, chapterId, anchorJson, color, selectedText, noteText, ct);
+                if (saved is null)
+                    return Error("save_my_highlight failed: the book or chapter was not found, or the save was rejected");
+
+                var mapped = new
+                {
+                    id = saved.Id,
+                    source = "userbook",
+                    bookId,
+                    chapterId = saved.ChapterId ?? chapterId,
+                    color = saved.Color,
+                    selectedText = saved.SelectedText,
+                    noteText = saved.NoteText,
+                    createdAt = saved.CreatedAt,
+                    saved = true,
+                };
+                return Text(JsonSerializer.Serialize(mapped));
+            });
+        },
+    };
+
+    private static readonly JsonElement ListMyBookHighlightsSchema = JsonDocument.Parse(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "bookId": { "type": "string", "format": "uuid" }
+          },
+          "required": ["bookId"],
+          "additionalProperties": false
+        }
+        """).RootElement;
+
+    private static McpToolDescriptor BuildListMyBookHighlights(TextStackApiClient api) => new()
+    {
+        Name = "list_my_book_highlights",
+        Description =
+            "List the highlights already saved in one of the books the user UPLOADED, by bookId "
+            + "(requires authentication). Use it before highlighting to see what is already marked. "
+            + "For a book from the public catalog use list_my_highlights with its editionId instead.",
+        InputSchema = ListMyBookHighlightsSchema,
+        Handler = (args, ct) =>
+        {
+            if (!ArgReader.TryObject(args, out var obj, out var err, "bookId")
+                || !ArgReader.TryRequiredGuid(obj, "bookId", out var bookId, out err))
+                return Task.FromResult(Error(err));
+
+            return InvokeAsync("list_my_book_highlights", ct, async () =>
+            {
+                var highlights = await api.GetUserBookHighlightsAsync(bookId, ct);
+                if (highlights is null)
+                    return Error($"list_my_book_highlights: no uploaded book found with id '{bookId}'");
+
+                var mapped = highlights.Select(h => new
+                {
+                    id = h.Id,
+                    chapterId = h.ChapterId,
+                    color = h.Color,
+                    selectedText = h.SelectedText,
+                    noteText = h.NoteText,
+                    createdAt = h.CreatedAt,
+                });
+                return Text(JsonSerializer.Serialize(new { source = "userbook", bookId, highlights = mapped }));
+            });
+        },
+    };
+
+    // bookId XOR editionId: JSON Schema could express it with oneOf, but the SDK
+    // does not validate InputSchema at all, so the exclusivity is enforced in the
+    // handler either way (TryReadInsightTarget) and the schema stays readable.
+    private static readonly JsonElement SaveInsightSchema = JsonDocument.Parse(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "bookId": { "type": "string", "format": "uuid" },
+            "editionId": { "type": "string", "format": "uuid" },
+            "chapterSlug": { "type": "string", "maxLength": 300 },
+            "text": { "type": "string", "minLength": 1, "maxLength": 20000 },
+            "question": { "type": "string", "maxLength": 1000 }
+          },
+          "required": ["text"],
+          "additionalProperties": false
+        }
+        """).RootElement;
+
+    private static McpToolDescriptor BuildSaveInsight(TextStackApiClient api) => new()
+    {
+        Name = "save_insight",
+        Description =
+            "Write a conclusion back into a book so the reader finds it there later (WRITE on their "
+            + "own account — requires authentication). Give EITHER bookId (a book they uploaded) OR "
+            + "editionId (a catalog book). Pass chapterSlug when the conclusion is about one chapter, "
+            + "and leave it out when it is about the whole book — that book-level one is the конспект's "
+            + "overview. `text` is Markdown; `question` records what was being worked out, which is "
+            + "what makes it worth coming back to. Saving again for the same chapter REPLACES the "
+            + "previous one, so a second pass refreshes the notes rather than duplicating them.",
+        InputSchema = SaveInsightSchema,
+        Handler = (args, ct) =>
+        {
+            if (!ArgReader.TryObject(args, out var obj, out var err, "bookId", "editionId", "chapterSlug", "text", "question")
+                || !TryReadInsightTarget(obj, out var editionId, out var bookId, out err)
+                || !ArgReader.TryRequiredString(obj, "text", 1, 20000, out var text, out err)
+                || !ArgReader.TryOptionalString(obj, "chapterSlug", 300, out var chapterSlug, out err)
+                || !ArgReader.TryOptionalString(obj, "question", 1000, out var question, out err))
+                return Task.FromResult(Error(err));
+
+            return InvokeAsync("save_insight", ct, async () =>
+            {
+                var saved = await api.SaveInsightAsync(editionId, bookId, chapterSlug, text, question, ct);
+                if (saved is null)
+                    return Error("save_insight failed: the book was not found, or that chapter slug does not exist in it");
+
+                var mapped = new
+                {
+                    id = saved.Id,
+                    editionId = saved.EditionId,
+                    bookId = saved.UserBookId,
+                    chapterSlug = saved.ChapterSlug,
+                    question = saved.Question,
+                    updatedAt = saved.UpdatedAt,
+                    saved = true,
+                };
+                return Text(JsonSerializer.Serialize(mapped));
+            });
+        },
+    };
+
+    private static readonly JsonElement GetMyInsightsSchema = JsonDocument.Parse(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "bookId": { "type": "string", "format": "uuid" },
+            "editionId": { "type": "string", "format": "uuid" }
+          },
+          "required": [],
+          "additionalProperties": false
+        }
+        """).RootElement;
+
+    private static McpToolDescriptor BuildGetMyInsights(TextStackApiClient api) => new()
+    {
+        Name = "get_my_insights",
+        Description =
+            "Read back everything already worked out about a book and saved with save_insight, in "
+            + "reading order (requires authentication). Give EITHER bookId (an uploaded book) OR "
+            + "editionId (a catalog book). Call this FIRST when starting to work on a book the reader "
+            + "has discussed before — it is what stops the next session repeating the last one.",
+        InputSchema = GetMyInsightsSchema,
+        Handler = (args, ct) =>
+        {
+            if (!ArgReader.TryObject(args, out var obj, out var err, "bookId", "editionId")
+                || !TryReadInsightTarget(obj, out var editionId, out var bookId, out err))
+                return Task.FromResult(Error(err));
+
+            return InvokeAsync("get_my_insights", ct, async () =>
+            {
+                var insights = await api.GetInsightsAsync(editionId, bookId, ct);
+                var mapped = insights.Select(i => new
+                {
+                    id = i.Id,
+                    // null chapterSlug = about the whole book.
+                    chapterSlug = i.ChapterSlug,
+                    chapterNumber = i.ChapterNumber,
+                    chapterTitle = i.ChapterTitle,
+                    question = i.Question,
+                    text = i.Text,
+                    updatedAt = i.UpdatedAt,
+                });
+                return Text(JsonSerializer.Serialize(new { insights = mapped }));
+            });
+        },
+    };
+
+    // Exactly one of bookId / editionId. Both or neither is a caller error, and
+    // saying which is missing beats a 400 from three layers down.
+    private static bool TryReadInsightTarget(
+        JsonElement obj, out Guid? editionId, out Guid? bookId, out string error)
+    {
+        editionId = null;
+        if (!ArgReader.TryOptionalGuid(obj, "bookId", out bookId, out error))
+            return false;
+        if (!ArgReader.TryOptionalGuid(obj, "editionId", out editionId, out error))
+            return false;
+
+        if (bookId.HasValue == editionId.HasValue)
+        {
+            error = bookId.HasValue
+                ? "Pass either 'bookId' (an uploaded book) or 'editionId' (a catalog book), not both."
+                : "Pass either 'bookId' (an uploaded book) or 'editionId' (a catalog book).";
+            return false;
+        }
+
+        return true;
+    }
 
     // Optional color: absent → "yellow"; present must be one of the reader palette.
     private static bool TryReadColor(JsonElement obj, out string color, out string error)

--- a/backend/src/Ai/TextStack.Ai.Mcp/Tools/McpToolCatalog.cs
+++ b/backend/src/Ai/TextStack.Ai.Mcp/Tools/McpToolCatalog.cs
@@ -379,6 +379,13 @@ public sealed class McpToolCatalog
                     // Ready / Processing / Failed — a book still processing has no
                     // chapters yet, and saying so beats an unexplained empty list.
                     status = book.Status,
+                    // Half the uploaded library is PDF, and a PDF is read as the
+                    // original document (ADR-012), where a highlight is painted from
+                    // page geometry. A highlight written from here carries a text
+                    // quote instead, so on these books it is saved and listable but
+                    // does not appear over the page. Say so where the model can act
+                    // on it rather than letting it discover the gap by not seeing one.
+                    rendersAsOriginalPdf = book.HasOriginalPdf,
                     chapters = (book.Chapters ?? []).Select(c => new
                     {
                         chapterId = c.Id,
@@ -701,9 +708,12 @@ public sealed class McpToolCatalog
             + "requires authentication). Pass the bookId, the chapterId of the chapter the passage is "
             + "in (from get_my_book or get_my_chapter), and the exact text as it appears in that "
             + "chapter — it is matched against the chapter text to place the highlight, so quote it "
-            + "verbatim. Optionally a color and a note. The highlight appears in the reader and in "
-            + "list_my_book_highlights. Highlight what is worth returning to, not every interesting "
-            + "line: a book marked end to end is a book with no marks.",
+            + "verbatim. Optionally a color and a note. The highlight is listed by "
+            + "list_my_book_highlights and appears in the reader — EXCEPT on a book get_my_book "
+            + "reports as rendersAsOriginalPdf, where it is saved and listed but not drawn over the "
+            + "page, because a PDF highlight is placed by page geometry this tool cannot produce. "
+            + "Highlight what is worth returning to, not every interesting line: a book marked end "
+            + "to end is a book with no marks, and there is a hard limit of 200 per book.",
         InputSchema = SaveMyHighlightSchema,
         Handler = (args, ct) =>
         {
@@ -881,6 +891,11 @@ public sealed class McpToolCatalog
             return InvokeAsync("get_my_insights", ct, async () =>
             {
                 var insights = await api.GetInsightsAsync(editionId, bookId, ct);
+                if (insights is null)
+                    return Error(bookId is { } b
+                        ? $"get_my_insights: no uploaded book found with id '{b}'"
+                        : $"get_my_insights: no catalog book found with editionId '{editionId}'");
+
                 var mapped = insights.Select(i => new
                 {
                     id = i.Id,

--- a/backend/src/Ai/TextStack.Ai.Mcp/Tools/McpToolCatalog.cs
+++ b/backend/src/Ai/TextStack.Ai.Mcp/Tools/McpToolCatalog.cs
@@ -312,6 +312,9 @@ public sealed class McpToolCatalog
             return InvokeAsync("search_my_library", ct, async () =>
             {
                 var hits = await api.SearchMyLibraryAsync(query, tags, ct);
+                if (hits is null)
+                    return Error("search_my_library failed: the library search is unavailable");
+
                 var results = hits.Select(h => new
                 {
                     // Stated on every row so a model holding a mixed result set
@@ -788,7 +791,9 @@ public sealed class McpToolCatalog
                 var mapped = highlights.Select(h => new
                 {
                     id = h.Id,
-                    chapterId = h.ChapterId,
+                    // An upload's chapter arrives as userChapterId; report it under the name the
+                    // write tool takes, so listing and saving speak about the same thing.
+                    chapterId = h.UserChapterId ?? h.ChapterId,
                     color = h.Color,
                     selectedText = h.SelectedText,
                     noteText = h.NoteText,

--- a/backend/src/Api/Endpoints/HighlightsEndpoints.cs
+++ b/backend/src/Api/Endpoints/HighlightsEndpoints.cs
@@ -269,14 +269,14 @@ public static class HighlightsEndpoints
         // string operator compiles to LIKE and Postgres rejects LIKE on jsonb at execution time.
         if (IsAssistantAnchor(request.AnchorJson))
         {
-            var bookColumn = request.UserBookId != null ? "user_book_id" : "edition_id";
-            var bookId = request.UserBookId ?? request.EditionId!.Value;
-
+            // Two fixed statements rather than one with the column name interpolated in. Nothing
+            // user-supplied could ever have reached that interpolation — it was one of two literals —
+            // but a raw-SQL string that is assembled at all is a thing a reader has to prove safe,
+            // and EF1002 is right to say so. Every value here is a parameter.
             var alreadyPlaced = await db.Database
                 .SqlQueryRaw<int>(
-                    $@"SELECT COUNT(*)::int AS ""Value"" FROM highlights
-                       WHERE user_id = {{0}} AND {bookColumn} = {{1}} AND anchor_json->>'source' = {{2}}",
-                    userId.Value, bookId, McpAnchorSource)
+                    request.UserBookId != null ? CountAssistantHighlightsInUserBookSql : CountAssistantHighlightsInEditionSql,
+                    userId.Value, request.UserBookId ?? request.EditionId!.Value, McpAnchorSource)
                 .FirstAsync(ct);
 
             if (alreadyPlaced >= MaxAssistantHighlightsPerBook)
@@ -338,6 +338,20 @@ public static class HighlightsEndpoints
     /// symptom, until a book comes back unreadable.</para>
     /// </summary>
     public const string McpAnchorSource = "mcp";
+
+    // The column differs between the two halves of the edition/user-book XOR and a column name
+    // cannot be a parameter, so it is the statement that varies, not a string that gets built.
+    private const string CountAssistantHighlightsInUserBookSql =
+        """
+        SELECT COUNT(*)::int AS "Value" FROM highlights
+        WHERE user_id = {0} AND user_book_id = {1} AND anchor_json->>'source' = {2}
+        """;
+
+    private const string CountAssistantHighlightsInEditionSql =
+        """
+        SELECT COUNT(*)::int AS "Value" FROM highlights
+        WHERE user_id = {0} AND edition_id = {1} AND anchor_json->>'source' = {2}
+        """;
 
     /// <summary>
     /// Whether this anchor was written by an assistant over MCP — its top-level <c>source</c> is

--- a/backend/src/Api/Endpoints/HighlightsEndpoints.cs
+++ b/backend/src/Api/Endpoints/HighlightsEndpoints.cs
@@ -21,7 +21,8 @@ public static class HighlightsEndpoints
         group.MapPost("/review", MarkHighlightReviewed).WithName("MarkHighlightReviewed");
         group.MapGet("/userbook/{userBookId:guid}", GetUserBookHighlights).WithName("GetUserBookHighlights");
         group.MapGet("/{editionId:guid}", GetHighlights).WithName("GetHighlights");
-        group.MapPost("", CreateHighlight).WithName("CreateHighlight");
+        group.MapPost("", CreateHighlight).WithName("CreateHighlight")
+            .RequireRateLimiting("highlight-write");
         group.MapPut("/{id:guid}", UpdateHighlight).WithName("UpdateHighlight");
         group.MapDelete("/{id:guid}", DeleteHighlight).WithName("DeleteHighlight");
     }
@@ -259,6 +260,31 @@ public static class HighlightsEndpoints
             }
         }
 
+        // The assistant ceiling. Only MCP-authored anchors are counted, and only against the book
+        // being written to, so this is invisible to a person highlighting in the reader — including
+        // one whose book an assistant has also marked.
+        //
+        // Raw SQL because the predicate is a jsonb one (anchor_json->>'source'), and EF has no
+        // mapping for it: AnchorJson is a plain string property over a jsonb column, so any LINQ
+        // string operator compiles to LIKE and Postgres rejects LIKE on jsonb at execution time.
+        if (IsAssistantAnchor(request.AnchorJson))
+        {
+            var bookColumn = request.UserBookId != null ? "user_book_id" : "edition_id";
+            var bookId = request.UserBookId ?? request.EditionId!.Value;
+
+            var alreadyPlaced = await db.Database
+                .SqlQueryRaw<int>(
+                    $@"SELECT COUNT(*)::int AS ""Value"" FROM highlights
+                       WHERE user_id = {{0}} AND {bookColumn} = {{1}} AND anchor_json->>'source' = {{2}}",
+                    userId.Value, bookId, McpAnchorSource)
+                .FirstAsync(ct);
+
+            if (alreadyPlaced >= MaxAssistantHighlightsPerBook)
+                return Results.BadRequest(
+                    $"This book already has {alreadyPlaced} assistant-placed highlights, which is the "
+                    + $"limit of {MaxAssistantHighlightsPerBook}. Remove some before adding more.");
+        }
+
         var now = DateTimeOffset.UtcNow;
         var highlight = new Highlight
         {
@@ -282,6 +308,57 @@ public static class HighlightsEndpoints
         await db.SaveChangesAsync(ct);
 
         return Results.Created($"/me/highlights/{highlight.Id}", highlight.ToDto());
+    }
+
+    /// <summary>
+    /// How many highlights one assistant may place in a single book.
+    ///
+    /// <para>Not a resource limit — a highlight row is tiny. It is a legibility limit. An MCP client
+    /// told to "go through the book and mark what matters" can place a highlight per paragraph in a
+    /// single pass, and a book marked end to end is a book with no marks: the reader loses the thing
+    /// the feature was for. The tool description asks for restraint; this is what happens when the
+    /// asking does not work.</para>
+    ///
+    /// <para>Counted per book and only over MCP-written highlights, so a person who genuinely
+    /// highlights heavily is never affected by it.</para>
+    /// </summary>
+    public const int MaxAssistantHighlightsPerBook = 200;
+
+    /// <summary>
+    /// The value <c>SynthesizeAnchor</c> puts in the anchor's top-level <c>source</c> field for every
+    /// MCP-authored highlight (see <c>TextStack.Ai.Mcp/Tools/McpToolCatalog.cs</c>).
+    ///
+    /// <para>Read with the jsonb operator <c>-&gt;&gt;</c>, not a substring match. <c>anchor_json</c>
+    /// IS jsonb, so <c>LIKE</c> against it does not merely risk false positives — Postgres refuses it
+    /// outright. Reading the field also makes the check independent of how the JSON was spaced or
+    /// ordered by whichever serializer wrote it, which a substring match is not.</para>
+    ///
+    /// <para>Public so a test can assert the bridge still writes it. If the two drift apart the cap
+    /// below silently stops applying, which is the worst way for a limit to fail: no error, no
+    /// symptom, until a book comes back unreadable.</para>
+    /// </summary>
+    public const string McpAnchorSource = "mcp";
+
+    /// <summary>
+    /// Whether this anchor was written by an assistant over MCP — its top-level <c>source</c> is
+    /// <see cref="McpAnchorSource"/>. Reads the same field the SQL predicate above reads, so the
+    /// gate and the count cannot disagree about what they are counting.
+    /// </summary>
+    private static bool IsAssistantAnchor(string? anchorJson)
+    {
+        if (string.IsNullOrWhiteSpace(anchorJson)) return false;
+        try
+        {
+            using var doc = JsonDocument.Parse(anchorJson);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("source", out var source)
+                && source.ValueKind == JsonValueKind.String
+                && source.GetString() == McpAnchorSource;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     // A PDF page anchor is the opaque JSON {v,kind:"pdf",page,rects,exact}. We treat the anchor as

--- a/backend/src/Api/Endpoints/InsightsEndpoints.cs
+++ b/backend/src/Api/Endpoints/InsightsEndpoints.cs
@@ -61,6 +61,23 @@ public static class InsightsEndpoints
         if (userBookId.HasValue == editionId.HasValue)
             return Results.BadRequest("Provide exactly one of userBookId or editionId");
 
+        // Resolve the book before reading. The query below filters by user_id, so a
+        // stranger's book leaks nothing either way — but it answers with an empty
+        // list, and an empty list is a TRUTHFUL answer to "what have I worked out
+        // about this book". Collapsing "not your book" into it lets a wrong id read
+        // as a book you have never discussed. Same reason
+        // GET /me/highlights/userbook/{id} checks ownership first.
+        if (userBookId is { } bookId)
+        {
+            var owns = await db.UserBooks.AnyAsync(b => b.Id == bookId && b.UserId == userId.Value, ct);
+            if (!owns) return Results.NotFound("User book not found");
+        }
+        else
+        {
+            var exists = await db.Editions.AnyAsync(e => e.Id == editionId!.Value, ct);
+            if (!exists) return Results.NotFound("Edition not found");
+        }
+
         var rows = await db.BookInsights
             .Where(i => i.UserId == userId.Value
                 && (userBookId.HasValue ? i.UserBookId == userBookId : i.EditionId == editionId))

--- a/backend/src/Api/Endpoints/InsightsEndpoints.cs
+++ b/backend/src/Api/Endpoints/InsightsEndpoints.cs
@@ -1,0 +1,213 @@
+using Api.Extensions;
+using Api.Sites;
+using Application.Auth;
+using Application.Common.Interfaces;
+using Contracts.Insights;
+using Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Endpoints;
+
+/// <summary>
+/// Insights — the conclusions an outside assistant writes back into a book.
+///
+/// <para>The reasoning happens in Claude or ChatGPT, where the reader already has their profile and
+/// their history. What comes home is the result, and it lands on the book's spine: a chapter slug, or
+/// null for the whole book. See <see cref="BookInsight"/> for why a catalog beats a transcript and
+/// why the key is a slug.</para>
+///
+/// <list type="bullet">
+///   <item><c>GET  /me/insights?userBookId=…</c> or <c>?editionId=…</c> — everything already worked
+///   out about that book, in reading order, with each chapter slug resolved to its number and title
+///   so the client can lay it out.</item>
+///   <item><c>POST /me/insights</c> — save one. An existing insight for the same
+///   (user, book, chapter) is REPLACED, so running the pass again refreshes the конспект rather than
+///   duplicating it.</item>
+/// </list>
+///
+/// <para>One flat group rather than a user-book route plus a catalog twin, because the entity's
+/// edition/user-book XOR is the same distinction the route prefix would encode, and encoding it twice
+/// is how the two halves drift.</para>
+/// </summary>
+public static class InsightsEndpoints
+{
+    /// <summary>
+    /// Cap on one insight's Markdown. Generous for a chapter's worth of conclusions and small enough
+    /// that a caller pasting a chapter back at us cannot turn the table into a document store.
+    /// </summary>
+    public const int MaxTextLength = 20_000;
+
+    public static void MapInsightsEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/me/insights").WithTags("Insights");
+
+        group.MapGet("", GetInsights).WithName("GetInsights");
+        group.MapPost("", SaveInsight).WithName("SaveInsight")
+            .RequireRateLimiting("insights");
+    }
+
+    private static async Task<IResult> GetInsights(
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        [FromQuery] Guid? userBookId,
+        [FromQuery] Guid? editionId,
+        CancellationToken ct = default)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        if (userBookId.HasValue == editionId.HasValue)
+            return Results.BadRequest("Provide exactly one of userBookId or editionId");
+
+        var rows = await db.BookInsights
+            .Where(i => i.UserId == userId.Value
+                && (userBookId.HasValue ? i.UserBookId == userBookId : i.EditionId == editionId))
+            .ToListAsync(ct);
+
+        if (rows.Count == 0) return Results.Ok(Array.Empty<BookInsightDto>());
+
+        // Resolve slugs to chapter number + title in ONE query, so the client can order by reading
+        // position. Done at read time rather than stored: a re-ingestion renumbers chapters, and a
+        // number frozen at write time would quietly point at the wrong one.
+        var slugs = rows.Where(r => r.ChapterSlug != null).Select(r => r.ChapterSlug!).Distinct().ToList();
+        var chapters = new Dictionary<string, (int Number, string Title)>(StringComparer.Ordinal);
+        if (slugs.Count > 0)
+        {
+            if (userBookId.HasValue)
+            {
+                var found = await db.UserChapters
+                    .Where(c => c.UserBookId == userBookId.Value && c.Slug != null && slugs.Contains(c.Slug))
+                    .Select(c => new { c.Slug, c.ChapterNumber, c.Title })
+                    .ToListAsync(ct);
+                foreach (var c in found) chapters[c.Slug!] = (c.ChapterNumber, c.Title);
+            }
+            else
+            {
+                var found = await db.Chapters
+                    .Where(c => c.EditionId == editionId!.Value && c.Slug != null && slugs.Contains(c.Slug))
+                    .Select(c => new { c.Slug, c.ChapterNumber, c.Title })
+                    .ToListAsync(ct);
+                foreach (var c in found) chapters[c.Slug!] = (c.ChapterNumber, c.Title);
+            }
+        }
+
+        var dtos = rows
+            .Select(r =>
+            {
+                var resolved = r.ChapterSlug is { } s && chapters.TryGetValue(s, out var c)
+                    ? c
+                    : ((int Number, string Title)?)null;
+                return new BookInsightDto(
+                    r.Id, r.EditionId, r.UserBookId, r.ChapterSlug,
+                    resolved?.Number, resolved?.Title,
+                    r.Text, r.Question, r.Source, r.CreatedAt, r.UpdatedAt);
+            })
+            // Reading order: the book-level overview first, then chapters by number. An insight whose
+            // slug no longer resolves keeps its text and sorts to the end rather than vanishing.
+            .OrderBy(d => d.ChapterSlug == null ? 0 : 1)
+            .ThenBy(d => d.ChapterNumber ?? int.MaxValue)
+            .ThenBy(d => d.CreatedAt)
+            .ToList();
+
+        return Results.Ok(dtos);
+    }
+
+    private static async Task<IResult> SaveInsight(
+        [FromBody] SaveInsightRequest request,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetUserId(authService);
+        if (userId == null) return Results.Unauthorized();
+
+        if (request.UserBookId.HasValue == request.EditionId.HasValue)
+            return Results.BadRequest("Provide exactly one of userBookId or editionId");
+
+        if (string.IsNullOrWhiteSpace(request.Text))
+            return Results.BadRequest("Text is required");
+        if (request.Text.Length > MaxTextLength)
+            return Results.BadRequest($"Text must be at most {MaxTextLength} characters");
+
+        // Normalize "" → null so a caller that means "about the whole book" cannot end up with two
+        // different book-level rows, one keyed on null and one on the empty string.
+        var chapterSlug = string.IsNullOrWhiteSpace(request.ChapterSlug) ? null : request.ChapterSlug.Trim();
+        if (chapterSlug is { Length: > 300 })
+            return Results.BadRequest("ChapterSlug must be at most 300 characters");
+
+        if (request.UserBookId is { } bookId)
+        {
+            var owns = await db.UserBooks.AnyAsync(b => b.Id == bookId && b.UserId == userId.Value, ct);
+            if (!owns) return Results.NotFound("User book not found");
+
+            // A slug that names no chapter is refused. The insight would still be readable, but it
+            // would never place in the конспект — and the usual cause is a hallucinated slug, which
+            // is worth telling the caller about while it can still fix it.
+            if (chapterSlug is not null)
+            {
+                var chapterExists = await db.UserChapters
+                    .AnyAsync(c => c.UserBookId == bookId && c.Slug == chapterSlug, ct);
+                if (!chapterExists) return Results.NotFound($"No chapter '{chapterSlug}' in this book");
+            }
+        }
+        else
+        {
+            var editionId = request.EditionId!.Value;
+            var exists = await db.Editions.AnyAsync(e => e.Id == editionId, ct);
+            if (!exists) return Results.NotFound("Edition not found");
+
+            if (chapterSlug is not null)
+            {
+                var chapterExists = await db.Chapters
+                    .AnyAsync(c => c.EditionId == editionId && c.Slug == chapterSlug, ct);
+                if (!chapterExists) return Results.NotFound($"No chapter '{chapterSlug}' in this book");
+            }
+        }
+
+        var now = DateTimeOffset.UtcNow;
+
+        // Upsert: one insight per (user, book, chapter). See BookInsight for why replace, not append.
+        var existing = await db.BookInsights.FirstOrDefaultAsync(
+            i => i.UserId == userId.Value
+                && i.UserBookId == request.UserBookId
+                && i.EditionId == request.EditionId
+                && i.ChapterSlug == chapterSlug,
+            ct);
+
+        if (existing is not null)
+        {
+            existing.Text = request.Text;
+            existing.Question = request.Question;
+            existing.UpdatedAt = now;
+            await db.SaveChangesAsync(ct);
+            return Results.Ok(ToDto(existing));
+        }
+
+        var insight = new BookInsight
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId.Value,
+            SiteId = httpContext.GetSiteId(),
+            EditionId = request.EditionId,
+            UserBookId = request.UserBookId,
+            ChapterSlug = chapterSlug,
+            Text = request.Text,
+            Question = request.Question,
+            Source = "mcp",
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        db.BookInsights.Add(insight);
+        await db.SaveChangesAsync(ct);
+
+        return Results.Created($"/me/insights/{insight.Id}", ToDto(insight));
+    }
+
+    private static BookInsightDto ToDto(BookInsight i) => new(
+        i.Id, i.EditionId, i.UserBookId, i.ChapterSlug, null, null,
+        i.Text, i.Question, i.Source, i.CreatedAt, i.UpdatedAt);
+}

--- a/backend/src/Api/Extensions/ServiceCollectionExtensions.RateLimiting.cs
+++ b/backend/src/Api/Extensions/ServiceCollectionExtensions.RateLimiting.cs
@@ -137,6 +137,33 @@ public static partial class ServiceCollectionExtensions
                     QueueLimit = 0,
                 });
             });
+            // Highlight writes (POST /me/highlights) — the one policy in this file NOT partitioned
+            // by IP, and deliberately so. This endpoint is reached both by a person in the reader and
+            // by an MCP client, and the MCP bridge talks to the API over the internal docker network:
+            // every assistant write in the deployment arrives from the one container address. Keyed
+            // by IP, a single looping client would throttle every other MCP user with it, while a
+            // person behind a shared NAT could be throttled by a stranger. The account is what owns
+            // the rows being written, so the account is the partition.
+            //
+            // The ceiling that stops a book being marked to illegibility is a COUNT, not a rate —
+            // HighlightsEndpoints.MaxAssistantHighlightsPerBook. This is only the loop guard: high
+            // enough that a person highlighting hard, or a client syncing an offline queue after a
+            // flight, never meets it.
+            options.AddPolicy("highlight-write", httpContext =>
+            {
+                var auth = httpContext.RequestServices.GetRequiredService<Application.Auth.AuthService>();
+                // Pure JWT validation, no database call — safe on the limiter's hot path. Falls back
+                // to the IP when there is no usable token; the endpoint answers 401 anyway.
+                var key = httpContext.GetUserId(auth)?.ToString()
+                    ?? httpContext.Connection.RemoteIpAddress?.ToString()
+                    ?? "unknown";
+                return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+                {
+                    Window = TimeSpan.FromMinutes(1),
+                    PermitLimit = 120,
+                    QueueLimit = 0,
+                });
+            });
             // Insights (POST /me/insights) — the write-back an outside assistant makes after a
             // reading session. Cheap for us (one row, no inference), so the cap is not about cost:
             // it is about a runaway agent loop rewriting a book's конспект thousands of times. 60/min

--- a/backend/src/Api/Extensions/ServiceCollectionExtensions.RateLimiting.cs
+++ b/backend/src/Api/Extensions/ServiceCollectionExtensions.RateLimiting.cs
@@ -137,6 +137,21 @@ public static partial class ServiceCollectionExtensions
                     QueueLimit = 0,
                 });
             });
+            // Insights (POST /me/insights) — the write-back an outside assistant makes after a
+            // reading session. Cheap for us (one row, no inference), so the cap is not about cost:
+            // it is about a runaway agent loop rewriting a book's конспект thousands of times. 60/min
+            // clears a model working chapter by chapter through a long book in one pass and stops a
+            // loop dead.
+            options.AddPolicy("insights", httpContext =>
+            {
+                var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+                return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+                {
+                    Window = TimeSpan.FromMinutes(1),
+                    PermitLimit = 60,
+                    QueueLimit = 0,
+                });
+            });
             // User book upload — per-IP cap, mirrors the clip zone. Uploads are heavier
             // (file ingestion) so the same conservative bucket applies.
             options.AddPolicy("user-upload", httpContext =>

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -333,6 +333,7 @@ app.MapProfileEndpoints();
 app.MapAccountEndpoints();
 app.MapUserDataEndpoints();
 app.MapHighlightsEndpoints();
+app.MapInsightsEndpoints();
 app.MapTranslationEndpoints();
 app.MapExplainEndpoints();
 app.MapDictionaryEndpoints();

--- a/backend/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/backend/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -68,6 +68,7 @@ public interface IAppDbContext
     DbSet<DriftCentroid> DriftCentroids { get; }
     DbSet<PodcastGenerationJob> PodcastGenerationJobs { get; }
     DbSet<BookConversation> BookConversations { get; }
+    DbSet<BookInsight> BookInsights { get; }
     DbSet<ConversationMessage> ConversationMessages { get; }
     /// <summary>Per-user RAG chunks. Exposed here (not only on the concrete context) because
     /// guest-merge has to re-parent them: UserId is denormalized off UserBook and has no FK to User,

--- a/backend/src/Application/UserBooks/UserBookSearchService.cs
+++ b/backend/src/Application/UserBooks/UserBookSearchService.cs
@@ -21,19 +21,25 @@ public class UserBookSearchService(IAppDbContext db)
         // websearch_to_tsquery handles user-typed query strings safely (quoted phrases, OR, -negation).
         // ts_headline returns excerpt with <mark>...</mark> around hits for direct UI rendering.
         var hasTagFilter = tagsArray.Length > 0;
+        // Column aliases are snake_case, and that is load-bearing. The context is built with
+        // UseSnakeCaseNamingConvention, and the convention applies to the SqlQueryRaw row type too:
+        // EF looks for `chapter_slug`, not `ChapterSlug`. Aliased in PascalCase the query throws
+        // "The required column 'chapter_slug' was not present in the results of a 'FromSql'
+        // operation" on every single call — which is what it did, silently, because the only caller
+        // renders an empty result on failure.
         var sql = $@"
             SELECT
-                ub.id AS ""Id"",
-                ub.title AS ""Title"",
-                ub.author AS ""Author"",
-                ub.cover_path AS ""CoverPath"",
-                ub.language AS ""Language"",
-                MAX(ts_rank(uc.search_vector, q))::float8 AS ""Rank"",
+                ub.id AS id,
+                ub.title AS title,
+                ub.author AS author,
+                ub.cover_path AS cover_path,
+                ub.language AS language,
+                MAX(ts_rank(uc.search_vector, q))::float8 AS rank,
                 (array_agg(
                     ts_headline('english', uc.plain_text, q, 'StartSel=<mark>,StopSel=</mark>,MaxFragments=1,MinWords=15,MaxWords=30,ShortWord=2')
                     ORDER BY ts_rank(uc.search_vector, q) DESC
-                ))[1] AS ""Excerpt"",
-                (array_agg(uc.slug ORDER BY ts_rank(uc.search_vector, q) DESC))[1] AS ""ChapterSlug""
+                ))[1] AS excerpt,
+                (array_agg(uc.slug ORDER BY ts_rank(uc.search_vector, q) DESC))[1] AS chapter_slug
             FROM user_books ub
             JOIN user_chapters uc ON uc.user_book_id = ub.id
             CROSS JOIN websearch_to_tsquery('english', {{0}}) q
@@ -41,7 +47,7 @@ public class UserBookSearchService(IAppDbContext db)
               AND uc.search_vector @@ q
               {(hasTagFilter ? "AND ub.tags @> {2}" : string.Empty)}
             GROUP BY ub.id
-            ORDER BY ""Rank"" DESC
+            ORDER BY rank DESC
             LIMIT {MaxResults};
         ";
 

--- a/backend/src/Contracts/Insights/InsightDtos.cs
+++ b/backend/src/Contracts/Insights/InsightDtos.cs
@@ -1,0 +1,40 @@
+namespace Contracts.Insights;
+
+/// <summary>
+/// A conclusion written back into a book. See <c>Domain.Entities.BookInsight</c> for why these are
+/// a catalog keyed by chapter slug rather than a stored conversation.
+/// </summary>
+/// <param name="ChapterSlug">The chapter this is about; null = the whole book.</param>
+/// <param name="ChapterNumber">
+/// Resolved from the slug at read time so the client can lay the insights out in reading order.
+/// Null for a book-level insight, and also for a chapter slug that no longer resolves — a
+/// re-ingestion that renamed a chapter leaves the insight readable but unplaced, which is the right
+/// failure: the text is still worth having.
+/// </param>
+/// <param name="ChapterTitle">Likewise resolved at read time; null when the slug no longer resolves.</param>
+public record BookInsightDto(
+    Guid Id,
+    Guid? EditionId,
+    Guid? UserBookId,
+    string? ChapterSlug,
+    int? ChapterNumber,
+    string? ChapterTitle,
+    string Text,
+    string? Question,
+    string Source,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt
+);
+
+/// <summary>
+/// Save (upsert) one insight. Exactly one of <paramref name="EditionId"/> / <paramref name="UserBookId"/>.
+/// A save to an existing (user, book, chapter) REPLACES it — that is what keeps a re-run's конспект
+/// current instead of duplicated.
+/// </summary>
+public record SaveInsightRequest(
+    Guid? EditionId,
+    Guid? UserBookId,
+    string? ChapterSlug,
+    string Text,
+    string? Question = null
+);

--- a/backend/src/Contracts/Mcp/McpManifest.cs
+++ b/backend/src/Contracts/Mcp/McpManifest.cs
@@ -24,21 +24,46 @@ public sealed record McpManifestAuth(string Type, string HowTo);
 public sealed record McpToolDescriptor(string Name, string Description);
 
 /// <summary>
-/// The advertised 7-tool surface, VERBATIM from the runtime
-/// <c>McpToolCatalog</c> (the source of truth in the Mcp project). The API cannot
-/// reference the Mcp executable, so the pairs are mirrored here; a drift test in
+/// The advertised tool surface, VERBATIM from the runtime <c>McpToolCatalog</c>
+/// (the source of truth in the Mcp project). The API cannot reference the Mcp
+/// executable, so the pairs are mirrored here; a drift test in
 /// <c>TextStack.Ai.Mcp.Tests</c> fails if these diverge from the catalog.
 ///
-/// Order matches the catalog's surface: search/read tools, then the WRITE tool
-/// <c>save_highlight</c>, then <c>ask_book</c>.
+/// Order matches the catalog's: the public catalog tools, then the user's own
+/// uploaded library, then their highlights and vocabulary, then <c>ask_book</c>
+/// and the WRITE tool <c>save_highlight</c>.
+///
+/// Two search tools is deliberate, not duplication. The catalog and a user's
+/// uploads are separate aggregates with separate identifiers — a catalog book has
+/// an <c>editionId</c>, an upload has a <c>bookId</c>, and neither works in the
+/// other's tools. The descriptions carry that distinction because the tool name
+/// alone does not.
 /// </summary>
 public static class McpManifestCatalog
 {
     public static IReadOnlyList<McpToolDescriptor> Tools { get; } =
     [
-        new("search_books", "Search the TextStack library for books and chapters matching a query."),
+        new("search_books",
+            "Search the PUBLIC TextStack catalog for books and chapters matching a query. "
+            + "This is the shared library of published books, NOT the user's own uploads — for those, use search_my_library."),
         new("get_book", "Fetch a catalog book by slug: its editionId (for ask_book), metadata, authors, genres, and chapter list."),
         new("get_chapter", "Fetch a chapter's plain text (HTML stripped, length-capped) plus its number, title, and prev/next slugs."),
+        new("search_my_library",
+            "Full-text search across the books the signed-in user has UPLOADED to TextStack "
+            + "(their private library, not the public catalog — requires authentication). "
+            + "Returns one hit per book with its bookId, title, author and the best-matching "
+            + "chapter slug and excerpt. Pass the bookId to get_my_book or get_my_chapter. "
+            + "A bookId is NOT an editionId and will not work with ask_book or list_my_highlights."),
+        new("get_my_book",
+            "Fetch one of the signed-in user's UPLOADED books by bookId (from search_my_library): "
+            + "its metadata and its full chapter list (requires authentication). Each chapter "
+            + "carries a chapterId and a slug — the slug goes to get_my_chapter, the chapterId to "
+            + "save_my_highlight."),
+        new("get_my_chapter",
+            "Fetch one chapter of a book the signed-in user UPLOADED: its plain text "
+            + "(HTML stripped, length-capped) plus its chapterId, number, title and prev/next "
+            + "slugs (requires authentication). The chapterId it returns is what save_my_highlight "
+            + "needs."),
         new("list_my_highlights", "List the signed-in user's highlights for a given edition (requires authentication)."),
         new("list_my_vocabulary", "List the signed-in user's saved vocabulary words, optionally filtered by SRS stage or search (requires authentication)."),
         new("save_highlight",
@@ -47,5 +72,30 @@ public static class McpManifestCatalog
             + "and chapterId (from get_book), the exact selected text, and optionally a color "
             + "and a note. The highlight is stored and listable via list_my_highlights."),
         new("ask_book", "Ask a question about a book the user is reading; spoiler-safe (answers only from chapters already read). Requires authentication."),
+        new("save_my_highlight",
+            "Highlight a passage in one of the books the user UPLOADED (WRITE on their own account — "
+            + "requires authentication). Pass the bookId, the chapterId of the chapter the passage is "
+            + "in (from get_my_book or get_my_chapter), and the exact text as it appears in that "
+            + "chapter — it is matched against the chapter text to place the highlight, so quote it "
+            + "verbatim. Optionally a color and a note. The highlight appears in the reader and in "
+            + "list_my_book_highlights. Highlight what is worth returning to, not every interesting "
+            + "line: a book marked end to end is a book with no marks."),
+        new("list_my_book_highlights",
+            "List the highlights already saved in one of the books the user UPLOADED, by bookId "
+            + "(requires authentication). Use it before highlighting to see what is already marked. "
+            + "For a book from the public catalog use list_my_highlights with its editionId instead."),
+        new("save_insight",
+            "Write a conclusion back into a book so the reader finds it there later (WRITE on their "
+            + "own account — requires authentication). Give EITHER bookId (a book they uploaded) OR "
+            + "editionId (a catalog book). Pass chapterSlug when the conclusion is about one chapter, "
+            + "and leave it out when it is about the whole book — that book-level one is the конспект's "
+            + "overview. `text` is Markdown; `question` records what was being worked out, which is "
+            + "what makes it worth coming back to. Saving again for the same chapter REPLACES the "
+            + "previous one, so a second pass refreshes the notes rather than duplicating them."),
+        new("get_my_insights",
+            "Read back everything already worked out about a book and saved with save_insight, in "
+            + "reading order (requires authentication). Give EITHER bookId (an uploaded book) OR "
+            + "editionId (a catalog book). Call this FIRST when starting to work on a book the reader "
+            + "has discussed before — it is what stops the next session repeating the last one."),
     ];
 }

--- a/backend/src/Contracts/Mcp/McpManifest.cs
+++ b/backend/src/Contracts/Mcp/McpManifest.cs
@@ -77,9 +77,12 @@ public static class McpManifestCatalog
             + "requires authentication). Pass the bookId, the chapterId of the chapter the passage is "
             + "in (from get_my_book or get_my_chapter), and the exact text as it appears in that "
             + "chapter — it is matched against the chapter text to place the highlight, so quote it "
-            + "verbatim. Optionally a color and a note. The highlight appears in the reader and in "
-            + "list_my_book_highlights. Highlight what is worth returning to, not every interesting "
-            + "line: a book marked end to end is a book with no marks."),
+            + "verbatim. Optionally a color and a note. The highlight is listed by "
+            + "list_my_book_highlights and appears in the reader — EXCEPT on a book get_my_book "
+            + "reports as rendersAsOriginalPdf, where it is saved and listed but not drawn over the "
+            + "page, because a PDF highlight is placed by page geometry this tool cannot produce. "
+            + "Highlight what is worth returning to, not every interesting line: a book marked end "
+            + "to end is a book with no marks, and there is a hard limit of 200 per book."),
         new("list_my_book_highlights",
             "List the highlights already saved in one of the books the user UPLOADED, by bookId "
             + "(requires authentication). Use it before highlighting to see what is already marked. "

--- a/backend/src/Domain/Entities/BookInsight.cs
+++ b/backend/src/Domain/Entities/BookInsight.cs
@@ -1,0 +1,77 @@
+namespace Domain.Entities;
+
+/// <summary>
+/// A conclusion about a book, written back into the book.
+///
+/// <para>The reasoning happens somewhere else — Claude, ChatGPT, whatever the reader already keeps
+/// their profile and their year of history in. We do not try to be that. What we are is the book, its
+/// markup, and the memory of having read it, so the only thing that has to come home is the
+/// <b>result</b>: what was worked out, and about which part of the book.</para>
+///
+/// <para><b>A catalog, not a transcript.</b> A transcript is ordered by time and is useless to come
+/// back to — the conclusion you want is in the fortieth message. A book already has a spine, and
+/// every other piece of user markup already hangs on it (highlights, bookmarks, progress). So an
+/// insight hangs on it too: <see cref="ChapterSlug"/> names the chapter it is about, or is
+/// <c>null</c> for the whole book. A study конспект is then not a frozen document but an assembly of
+/// these in reading order — run the pass again and it is current.</para>
+///
+/// <para><b>Keyed by slug, not chapter id.</b> Re-ingestion deletes and recreates every chapter, so
+/// the Guids change and anything holding one comes unstuck. The slug is regenerated from the title
+/// and survives while the title does. Same lesson as the reading position (ADR-015); the same lesson
+/// is why <see cref="Highlight"/> stores a text anchor.</para>
+///
+/// <para><b>One insight per target.</b> <c>(UserId, book, ChapterSlug)</c> is unique — a save
+/// replaces. That is what makes "run it again and the конспект is updated" literally true, and it is
+/// also the ceiling that stops one agent pass from burying the book under two hundred notes. It
+/// costs history, deliberately: this is a конспект, not a log. <see cref="UpdatedAt"/> carries
+/// freshness, and a writer that wants to add rather than replace reads the existing text first.</para>
+///
+/// <para>Exactly one of <see cref="EditionId"/> (a catalog book) or <see cref="UserBookId"/> (the
+/// user's own upload) is set — enforced by a DB CHECK, the same shape as
+/// <see cref="BookConversation"/>. Site-scoped (<see cref="ISiteScoped"/>) like the other per-user
+/// AI tables. Plain POCO; EF mapping in AppDbContext.Insights.cs.</para>
+///
+/// <para>Deliberately NOT <see cref="BookConversation"/>: that is a chat container with a rolling
+/// summary and a summarized-through watermark, and we decided not to keep the chat. Deliberately not
+/// <c>Note</c> either: its API was never wired up and it is hard-bound to an edition.</para>
+/// </summary>
+public class BookInsight : ISiteScoped
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public Guid SiteId { get; set; }
+
+    /// <summary>The catalog edition this is about — null iff this is about an upload.</summary>
+    public Guid? EditionId { get; set; }
+
+    /// <summary>The user's uploaded book this is about — null iff this is about a catalog book.</summary>
+    public Guid? UserBookId { get; set; }
+
+    /// <summary>
+    /// The chapter this is about, by slug. <c>null</c> means the insight is about the whole book —
+    /// which is what a study конспект's overview is.
+    /// </summary>
+    public string? ChapterSlug { get; set; }
+
+    /// <summary>The conclusion itself, as Markdown.</summary>
+    public string Text { get; set; } = "";
+
+    /// <summary>
+    /// The question this answers, when there was one. This is the provenance stamp that gives coming
+    /// back its meaning — "this is what I was trying to work out" — without storing the conversation
+    /// it came from. Null for an unprompted summary.
+    /// </summary>
+    public string? Question { get; set; }
+
+    /// <summary>Where it came from: <c>"mcp"</c> today; the app itself later.</summary>
+    public string Source { get; set; } = "mcp";
+
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    // Navigation
+    public User User { get; set; } = null!;
+    public Site Site { get; set; } = null!;
+    public Edition? Edition { get; set; }
+    public UserBook? UserBook { get; set; }
+}

--- a/backend/src/Infrastructure/Migrations/20260908004841_AddBookInsight.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260908004841_AddBookInsight.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260908004841_AddBookInsight")]
+    partial class AddBookInsight
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260908004841_AddBookInsight.cs
+++ b/backend/src/Infrastructure/Migrations/20260908004841_AddBookInsight.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBookInsight : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "book_insight",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    site_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    edition_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    user_book_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    chapter_slug = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+                    text = table.Column<string>(type: "text", nullable: false),
+                    question = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    source = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "mcp"),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_book_insight", x => x.id);
+                    table.CheckConstraint("ck_book_insight_target", "(edition_id IS NOT NULL AND user_book_id IS NULL) OR (edition_id IS NULL AND user_book_id IS NOT NULL)");
+                    table.ForeignKey(
+                        name: "fk_book_insight_editions_edition_id",
+                        column: x => x.edition_id,
+                        principalTable: "editions",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_book_insight_sites_site_id",
+                        column: x => x.site_id,
+                        principalTable: "sites",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_book_insight_user_books_user_book_id",
+                        column: x => x.user_book_id,
+                        principalTable: "user_books",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_book_insight_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_book_insight_edition_id",
+                table: "book_insight",
+                column: "edition_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_book_insight_site_id",
+                table: "book_insight",
+                column: "site_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_book_insight_user_book_id",
+                table: "book_insight",
+                column: "user_book_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_book_insight_user_id_edition_id_chapter_slug",
+                table: "book_insight",
+                columns: new[] { "user_id", "edition_id", "chapter_slug" },
+                unique: true,
+                filter: "edition_id IS NOT NULL")
+                .Annotation("Npgsql:NullsDistinct", false);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_book_insight_user_id_user_book_id_chapter_slug",
+                table: "book_insight",
+                columns: new[] { "user_id", "user_book_id", "chapter_slug" },
+                unique: true,
+                filter: "user_book_id IS NOT NULL")
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "book_insight");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.Insights.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.Insights.cs
@@ -1,0 +1,74 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Persistence;
+
+/// <summary>
+/// <see cref="BookInsight"/> (table <c>book_insight</c>) — conclusions written back into a book by an
+/// outside assistant over MCP. snake_case names come from the global convention (OnConfiguring).
+/// Mirrors the <see cref="BookConversation"/> mapping: XOR CHECK on the book target, ISiteScoped
+/// filter, cascade FKs.
+/// </summary>
+public partial class AppDbContext
+{
+    // Instance (not static): the query filter closes over _currentSite.
+    private void ConfigureInsights(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<BookInsight>(e =>
+        {
+            e.ToTable("book_insight", t =>
+                // Exactly one of edition_id / user_book_id is set (an insight is about one book).
+                t.HasCheckConstraint(
+                    "ck_book_insight_target",
+                    "(edition_id IS NOT NULL AND user_book_id IS NULL) OR (edition_id IS NULL AND user_book_id IS NOT NULL)"));
+
+            e.Property(x => x.Text).HasColumnType("text");
+            e.Property(x => x.Question).HasMaxLength(1000);
+            e.Property(x => x.Source).HasMaxLength(32).HasDefaultValue("mcp");
+            e.Property(x => x.ChapterSlug).HasMaxLength(300);
+
+            // One insight per user + book + chapter, so a re-run replaces rather than accumulates
+            // (see the entity docs).
+            //
+            // AreNullsDistinct(false) is load-bearing, not tidiness. By default Postgres treats NULLs
+            // in a unique index as distinct from each other, and chapter_slug IS NULL is the
+            // book-level insight — the конспект's overview, the single row most likely to be
+            // rewritten. Left default, that one row would be the only one the constraint did not
+            // protect, and it would silently accumulate a duplicate per pass. Requires PG15+; we are
+            // on 16.
+            //
+            // The two indexes are filtered so the NULL side of the edition/user_book XOR cannot
+            // collide across the other book type's rows.
+            e.HasIndex("UserId", "EditionId", "ChapterSlug")
+                .IsUnique()
+                .AreNullsDistinct(false)
+                .HasFilter("edition_id IS NOT NULL");
+            e.HasIndex("UserId", "UserBookId", "ChapterSlug")
+                .IsUnique()
+                .AreNullsDistinct(false)
+                .HasFilter("user_book_id IS NOT NULL");
+
+            e.HasOne(x => x.User)
+                .WithMany()
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(x => x.Site)
+                .WithMany()
+                .HasForeignKey(x => x.SiteId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(x => x.Edition)
+                .WithMany()
+                .HasForeignKey(x => x.EditionId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(x => x.UserBook)
+                .WithMany()
+                .HasForeignKey(x => x.UserBookId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasQueryFilter(x => x.SiteId == _currentSite.Id);
+        });
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -111,6 +111,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
     public DbSet<DriftCentroid> DriftCentroids => Set<DriftCentroid>();
     public DbSet<PodcastGenerationJob> PodcastGenerationJobs => Set<PodcastGenerationJob>();
     public DbSet<BookConversation> BookConversations => Set<BookConversation>();
+    public DbSet<BookInsight> BookInsights => Set<BookInsight>();
     public DbSet<ConversationMessage> ConversationMessages => Set<ConversationMessage>();
 
     // Phase 4 RAG. Intentionally not on IAppDbContext — retrieval uses raw Npgsql.
@@ -138,6 +139,7 @@ public partial class AppDbContext : DbContext, IAppDbContext
         ConfigureAgents(modelBuilder);
         ConfigurePodcasts(modelBuilder);
         ConfigureBookChat(modelBuilder);
+        ConfigureInsights(modelBuilder);
         ConfigureRag(modelBuilder);
     }
 

--- a/docs/05-features/mcp.md
+++ b/docs/05-features/mcp.md
@@ -29,7 +29,7 @@ means your uploads.
 | `search_my_library` | Full-text search across the books **you uploaded**. Returns one hit per book with its `bookId` and best-matching chapter. Needs no RAG index. | User |
 | `get_my_book` | Fetch one of your uploads by `bookId`: metadata + full chapter list, each chapter carrying its `chapterId`. | User |
 | `get_my_chapter` | Fetch one chapter of your upload as plain text, plus its `chapterId` and prev/next slugs. | User |
-| `save_my_highlight` | Highlight a passage in a book you uploaded. Matched against the chapter text, so the quote must be verbatim. | User |
+| `save_my_highlight` | Highlight a passage in a book you uploaded. Matched against the chapter text, so the quote must be verbatim. Capped at 200 per book. | User |
 | `list_my_book_highlights` | List the highlights already in a book you uploaded. | User |
 | `save_insight` | Write a conclusion back into a book — against a `chapterSlug`, or against the whole book when omitted. Saving again for the same chapter replaces it. | User |
 | `get_my_insights` | Read back everything already worked out about a book, in reading order. | User |
@@ -46,6 +46,23 @@ A typical catalog chain is `search_books → get_book` (to get the `editionId` /
 chapter ids) `→ get_chapter` / `ask_book` / `save_highlight`. The chain for your
 own uploads is `search_my_library → get_my_book` (to get the chapter ids)
 `→ get_my_chapter`.
+
+## Limits on what an assistant may write
+
+**200 highlights per book.** Not a resource limit — a highlight row is tiny. A client told to "go
+through the book and mark what matters" can place one per paragraph in a single pass, and a book
+marked end to end is a book with no marks. The cap counts only highlights written over MCP
+(`anchor_json->>'source' = 'mcp'`), so a person who highlights heavily is never affected, including
+on a book an assistant has also marked.
+
+**On a PDF, a highlight is saved but not painted.** The reader shows PDFs as the original document
+(ADR-012), where a highlight is drawn from page geometry an MCP client cannot produce. The highlight
+is stored, listed by `list_my_book_highlights`, and shown on the Highlights page — it just does not
+appear over the page. `get_my_book` reports `rendersAsOriginalPdf` so the assistant can say so
+instead of leaving you looking for a mark that is not there. About half the uploaded library is PDF.
+
+**Insights are capped by shape, not by count**: one per (you, book, chapter), because a save
+replaces. There is no way to accumulate them.
 
 ## Writing conclusions back into a book
 

--- a/docs/05-features/mcp.md
+++ b/docs/05-features/mcp.md
@@ -8,25 +8,71 @@ reading, and manage your own highlights and vocabulary — all from the chat.
 This is the canonical reference. The [package README](https://www.nuget.org/packages/TextStack.Mcp)
 and the [landing page](https://textstack.app/en/mcp) point here.
 
-## The 7 tools
+## The 14 tools
 
-The server exposes 7 tools. The public ones need no auth; the user-scoped ones
+The server exposes 14 tools. The public ones need no auth; the user-scoped ones
 require you to be signed in (see [Authentication](#authentication)).
+
+**Two halves, two identifiers.** The public catalog is made of `Edition`s and is
+addressed by `editionId`. The books you uploaded are `UserBook`s — a separate
+aggregate, with its own chapter and chunk tables — and are addressed by `bookId`.
+An upload has no `editionId` and cannot be given one. Passing a `bookId` to
+`ask_book` is a 404, and to `list_my_highlights` an empty list, which reads like
+an empty library rather than a wrong id. The tool names carry the split: `_my_`
+means your uploads.
 
 | Tool | What it does | Auth |
 |------|--------------|------|
 | `search_books` | Search the public library for books and chapters matching a query. | Public |
 | `get_book` | Fetch a catalog book by slug: its `editionId` (for `ask_book`), metadata, authors, genres, and chapter list. | Public |
 | `get_chapter` | Fetch a chapter's plain text (HTML stripped, length-capped) plus its number, title, and prev/next slugs. | Public |
+| `search_my_library` | Full-text search across the books **you uploaded**. Returns one hit per book with its `bookId` and best-matching chapter. Needs no RAG index. | User |
+| `get_my_book` | Fetch one of your uploads by `bookId`: metadata + full chapter list, each chapter carrying its `chapterId`. | User |
+| `get_my_chapter` | Fetch one chapter of your upload as plain text, plus its `chapterId` and prev/next slugs. | User |
+| `save_my_highlight` | Highlight a passage in a book you uploaded. Matched against the chapter text, so the quote must be verbatim. | User |
+| `list_my_book_highlights` | List the highlights already in a book you uploaded. | User |
+| `save_insight` | Write a conclusion back into a book — against a `chapterSlug`, or against the whole book when omitted. Saving again for the same chapter replaces it. | User |
+| `get_my_insights` | Read back everything already worked out about a book, in reading order. | User |
 | `list_my_highlights` | List your highlights for a given edition. | User |
 | `list_my_vocabulary` | List your saved vocabulary words, optionally filtered by SRS stage or search. | User |
 | `ask_book` | Ask a question about a book you're reading; spoiler-safe (answers only from chapters you've already read). | User |
 | `save_highlight` | Save a passage (text + optional color/note) to your highlights for a catalog book chapter. | User |
 
-All 7 tools are always listed regardless of whether you're signed in — only a
+All 14 tools are always listed regardless of whether you're signed in — only a
 user-scoped *call* fails with a clean "authentication required" message when no
-token is available. A typical chain is `search_books → get_book` (to get the
-`editionId` / chapter ids) `→ get_chapter` / `ask_book` / `save_highlight`.
+token is available.
+
+A typical catalog chain is `search_books → get_book` (to get the `editionId` /
+chapter ids) `→ get_chapter` / `ask_book` / `save_highlight`. The chain for your
+own uploads is `search_my_library → get_my_book` (to get the chapter ids)
+`→ get_my_chapter`.
+
+## Writing conclusions back into a book
+
+TextStack does not try to be your chat. Your assistant already has your profile,
+your memory, and a year of conversation; a copy of that is not something we can
+build, and competing with it is not the point. **The reasoning happens there. The
+result comes back here.**
+
+So after a session — "what did I understand, what didn't I, what's worth marking"
+— the assistant writes the outcome into the book, and it is still there next
+month:
+
+- a passage → `save_my_highlight`, which the reader paints like any other highlight;
+- a chapter → `save_insight` with a `chapterSlug`;
+- the whole book → `save_insight` with no `chapterSlug`.
+
+A study конспект is then not a separate frozen document but the assembly of those
+in reading order. Run the pass again and it is current, because one insight is
+kept per (you, book, chapter) and a save replaces.
+
+The key is the chapter **slug**, not its id: re-ingesting a book deletes and
+recreates every chapter, so anything holding a `chapterId` comes unstuck. Same
+reason the reading position is a text anchor (ADR-015).
+
+`get_my_insights` is the other half, and the more important one — call it at the
+START of a session about a book that has been discussed before. It is what stops
+the next conversation repeating the last one.
 
 ## Quick start — Claude Desktop
 
@@ -117,7 +163,7 @@ Same stdio transport as the global tool.
 
 ## Authentication
 
-Public tools (`search_books`, `get_book`, `get_chapter`) need no auth. The
+Catalog tools (`search_books`, `get_book`, `get_chapter`) need no auth. The
 user-scoped tools use the **OAuth 2.0 Device Authorization Grant**
 ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)):
 
@@ -163,7 +209,7 @@ Before wiring up a client, confirm the tool speaks MCP. This sends
 ```
 
 Expect a response with `serverInfo` naming `textstack` and a `tools/list`
-result containing all 7 tools.
+result containing all 14 tools.
 
 ## Troubleshooting
 

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -67,6 +67,56 @@ running API — 14 tools listed, insight written, chapter title resolved on read
 first, both-identifiers refused, another user seeing nothing. 1,533 unit + 20 MCP-wire + 771 web
 tests green; 13 new integration tests against the live API.
 
+**Second pass over the gaps that shipped with it.** Four of the five things flagged as open turned
+out to be worth acting on, and checking them corrected two of my own claims.
+
+*The write ceiling.* `save_my_highlight` had a per-call limit and nothing else, so a client told to
+mark what matters could mark a book to illegibility. Now `HighlightsEndpoints` caps a book at **200
+assistant-placed highlights**, counted by `anchor_json->>'source' = 'mcp'` — the field the bridge
+already writes — so a person highlighting heavily is never counted, including on a book an assistant
+has also marked. Verified by seeding 200 rows: the 201st is refused, a human anchor on the same book
+still saves. The first attempt used `.Contains()`, which EF compiles to `LIKE`; `anchor_json` is
+jsonb and Postgres refuses `LIKE` against it outright, so that would have thrown on the first write
+past the gate. Reading the field is also independent of whitespace and key order, which a substring
+match is not, and a drift test now asserts both sides agree — the two live in different projects with
+an opaque column between them, and a cap that silently stops matching is the worst way for a limit to
+fail.
+
+`POST /me/highlights` also gains a rate limit, and it is the **only policy in the codebase partitioned
+by user id rather than IP**. The endpoint is reached both by a person in the reader and by the MCP
+bridge, which talks to the API over the internal docker network — so every assistant write in the
+deployment arrives from one container address, and an IP key would let one looping client throttle
+every other MCP user. Verified: user A throttled after 116 writes in a window, user B from the same
+IP in the same second still served.
+
+*"Not your book" versus "nothing here."* `GET /me/insights` filtered by `user_id` and so leaked
+nothing, but answered a stranger's book with `[]` — and an empty list is a truthful answer to "what
+have I worked out about this book", which lets a wrong id read as a fact. It checks the book first
+now, like `GET /me/highlights/userbook/{id}` does, and the bridge distinguishes the two.
+
+*A claim of mine that was wrong.* I reported that `save_my_highlight` could not reach a chapterless
+PDF upload. Production says otherwise: the two books with no chapters are **failed ingests**, not
+chapterless PDFs, and every readable book has chapters. But checking it found the real version of the
+problem, which is worse and affects **half the library** — 36 of 75 uploads are PDFs, the reader shows
+a PDF as the original document (ADR-012), and `PdfHighlightLayer` only paints `kind:"pdf"` anchors.
+A text-anchored highlight from MCP is therefore saved, listed, and shown on the Highlights page, but
+never drawn over the page. `get_my_book` now reports `rendersAsOriginalPdf` and the tool description
+says what happens, so the model can tell you rather than leaving you hunting for a mark that was never
+going to appear.
+
+*And one that was understated.* I called `chapter_number` "0-based for editions, 1-based for user
+chapters". It is neither: production has every edition starting at 0 but **four uploaded books
+starting at 2**, and locally five editions start at 1. It is an ordering key that was never a display
+ordinal, `BookDetailPage` renders `chapterNumber + 1` and `UserBookDetailPage` renders it raw, and
+both are wrong for the exceptions. Written down in `CLAUDE.md` rather than papered over with a
+migration nobody asked for.
+
+*The one left alone.* The integration suite trips its own rate limits locally, because CI raises
+`CLIP_PERMIT_LIMIT` and friends and a developer's `.env` does not. Putting the raised values in
+`.env.example` would weaken production for anyone who copies it, so `CLAUDE.md` now carries the
+command instead — along with the sharper trap: the windows are minutes long, so re-running a suite to
+confirm a failure is what causes the next one.
+
 **Deliberately not in this work:** semantic retrieval and the indexing tools (they matter for 3 books
 until indexing is decided); bulk indexing, whose cost is not embeddings — a quarter of a cent per
 book — but the PDF vision parse at $0.00586 a page; the fate of our own Book Chat, which is a focus

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -111,6 +111,32 @@ ordinal, `BookDetailPage` renders `chapterNumber + 1` and `UserBookDetailPage` r
 both are wrong for the exceptions. Written down in `CLAUDE.md` rather than papered over with a
 migration nobody asked for.
 
+**And then the feature was pointed at a real uploaded book, which is when it broke.** Everything up
+to this point was exercised against canned JSON and a catalog book, because the local database had no
+uploads. Clipping an article to make one turned `search_my_library` up empty on a book that plainly
+contained the search term.
+
+`GET /me/library/search` was answering **500 on every call, and always had been.** Its raw SQL aliases
+its columns in PascalCase, the context is built with `UseSnakeCaseNamingConvention`, and that
+convention applies to the `SqlQueryRaw` row type too — so EF asked for `chapter_slug`, was handed
+`"ChapterSlug"`, and threw before reading a row. Nobody had noticed because the only caller is the web
+Library page's search box, which renders an empty result on failure: a library search that finds
+nothing looks exactly like a library search that failed. So the colleague's bug report was righter
+than it knew — the endpoint their spec called step 1, and called done, has never returned a result.
+Aliases are snake_case now, both SQL branches, with an integration test that asserts a 200, because
+only real SQL against a real database can catch it.
+
+The bridge was making it worse in its own way: `SearchMyLibraryAsync` mapped any non-2xx to an empty
+list, so a 500 reached the model as "you have no books about this" — the same confident-and-wrong
+answer this work fixed twice elsewhere and left standing here. Failure and emptiness are separate
+answers now.
+
+Two smaller things the same run found. `list_my_book_highlights` reported `chapterId: null` for every
+highlight on an upload, because an upload's chapter lives in `userChapterId` — so a model could not
+tell what it had marked where, which is most of the point of listing them before marking more. And
+`get_my_book` is where `rendersAsOriginalPdf` had to go, since that is the call a model makes before
+writing anything.
+
 *The one left alone.* The integration suite trips its own rate limits locally, because CI raises
 `CLIP_PERMIT_LIMIT` and friends and a developer's `.env` does not. Putting the raised values in
 `.env.example` would weaken production for anyone who copies it, so `CLAUDE.md` now carries the

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,75 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-08-mcp-the-book-opens-to-your-assistant-and-the-conclusions-come-back"></a>
+
+## MCP — the book opens to your assistant, and the conclusions come back — backend, web — 2026-09-08
+
+A colleague filed a small bug: MCP could not reach a book the user had uploaded. It was real, and the
+fix it proposed was not buildable. Chasing why produced a bigger answer about what TextStack is.
+
+**The bug, and why the spec could not be followed.** Step one of the spec — add a library-search
+endpoint — was already done: `GET /me/library/search` has existed, scoped by `user_id` in SQL, and
+the web already uses it. Step two asked the tool to return an `editionId` for each hit. **An upload
+does not have one and cannot be given one.** `UserBook` and `Edition` are separate aggregates with
+separate chapter and chunk tables, and the non-polymorphism is documented on the entity itself. Built
+as written, every id would 404 in `ask_book` and return a silent empty list from
+`list_my_highlights` — a wrong id that reads like an empty library. The identifier is `bookId`, and
+the tool descriptions now say so in as many words.
+
+**Why "I connected Claude Code and got nothing" was not a prompt problem.** Reconnaissance on
+production: 75 uploaded books, **3 indexed**; 1,423 catalog editions, **4** with chunks. An
+unindexed book returns `insufficient` *without calling the LLM*. `ask_book` was answering correctly
+about a corpus that was 96% empty. Cost was never the constraint — every conversational feature
+together has spent five cents; $4.14 of the $4.25 total is PDF vision parsing.
+
+**Six tools for the uploaded half, needing no index at all.** `search_my_library` (Postgres FTS over
+`user_chapters.search_vector`, built at upload), `get_my_book`, `get_my_chapter`,
+`save_my_highlight`, `list_my_book_highlights`. Measured on production: **73 of 75 books have
+chapters and 72 have real text**, so this works on essentially the whole library today, with no
+embeddings and no vision parse. `search_books`' description now says PUBLIC catalog and names its
+counterpart, because two search tools whose names differ by `_my_` is not enough for a model under
+pressure.
+
+**And then the part that is not a bug fix.** We are not building the chat. A reader's assistant
+already holds their profile, their memory and a year of conversation; that cannot be copied here and
+competing with it from an empty corpus is not a plan. So: **the reasoning happens there, the result
+comes home.** New entity `BookInsight` (table `book_insight`) plus `save_insight` / `get_my_insights`
+and `GET|POST /me/insights`. A conclusion hangs on the book's spine — a chapter slug, or nothing for
+the whole book — the way every other piece of user markup already does.
+
+A catalog, not a transcript: a transcript is ordered by time and useless to return to, because the
+conclusion you want is in the fortieth message. A study конспект is therefore an *assembly* of these
+in reading order rather than a frozen document, which is why one insight is kept per
+(user, book, chapter) and a save replaces. That upsert has a Postgres trap in it: by default NULLs in
+a unique index are distinct from one another, and `chapter_slug IS NULL` is the book-level
+overview — the single row most likely to be rewritten, and so the only one a default index would
+fail to protect. The index is `NULLS NOT DISTINCT`, and an integration test says so.
+
+The key is the **slug**, not the chapter id: re-ingestion deletes and recreates every chapter, so a
+`chapterId` comes unstuck. The same lesson as [ADR-015](../01-architecture/adr/ADR-015-reader-position-is-logical.md),
+learned the same week. Chapter number and title are resolved from the slug **at read time**, so a
+re-ingest that renumbers chapters cannot leave a stale ordinal behind, and a slug that no longer
+resolves keeps its text and sorts last rather than vanishing.
+
+**On the book page**, a "What you've worked out" section renders those conclusions above the chapter
+list — coming back to a book, what you already concluded beats the table of contents — and a "Talk
+this book over" pair of links opens a new Claude or ChatGPT conversation with a brief already
+written. That is a link, not an integration, and it is capped at 1,200 characters because a URL is
+about 2,000 and percent-encoding eats the rest; the book does not travel in the link, the connector
+fetches it. Without a connector it is still a real conversation about a real book — the reader just
+carries the outcome back by hand.
+
+Verified live, not only in tests: the whole loop through the actual stdio MCP server against a
+running API — 14 tools listed, insight written, chapter title resolved on read-back, book-level entry
+first, both-identifiers refused, another user seeing nothing. 1,533 unit + 20 MCP-wire + 771 web
+tests green; 13 new integration tests against the live API.
+
+**Deliberately not in this work:** semantic retrieval and the indexing tools (they matter for 3 books
+until indexing is decided); bulk indexing, whose cost is not embeddings — a quarter of a cent per
+book — but the PDF vision parse at $0.00586 a page; the fate of our own Book Chat, which is a focus
+decision and should not be smuggled inside a bug fix.
+
 <a id="2026-09-07-docs-adr-015-and-the-scenario-that-was-never-in-qa-001"></a>
 
 ## Docs — ADR-015, and the scenario that was never in QA-001 — docs — 2026-09-07

--- a/tests/TextStack.Ai.Mcp.Tests/McpManifestDriftTests.cs
+++ b/tests/TextStack.Ai.Mcp.Tests/McpManifestDriftTests.cs
@@ -54,9 +54,9 @@ public class McpManifestDriftTests
     }
 
     [Fact]
-    public void Manifest_AdvertisesAllSevenTools()
+    public void Manifest_AdvertisesTheWholeToolSurface()
     {
-        Assert.Equal(7, McpManifestCatalog.Tools.Count);
+        Assert.Equal(14, McpManifestCatalog.Tools.Count);
     }
 
     private sealed class NoTokenProvider : IMcpTokenProvider

--- a/tests/TextStack.Ai.Mcp.Tests/McpOverTheWireTests.cs
+++ b/tests/TextStack.Ai.Mcp.Tests/McpOverTheWireTests.cs
@@ -241,10 +241,10 @@ public class McpOverTheWireTests : IAsyncLifetime
         Assert.Equal("textstack", client.ServerInfo.Name);
     }
 
-    // ── 9. protocol: tools/list → exactly 7 ───────────────────────────────────────
+    // ── 9. protocol: tools/list → exactly the advertised surface ─────────────────
 
     [Fact]
-    public async Task ListTools_OverWire_ReturnsExactlySevenExpectedTools()
+    public async Task ListTools_OverWire_ReturnsExactlyTheExpectedTools()
     {
         await using var client = await _harness.ConnectAsync(bearer: null, Ct);
 
@@ -252,7 +252,7 @@ public class McpOverTheWireTests : IAsyncLifetime
 
         var names = tools.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
         Assert.Equal(
-            ["ask_book", "get_book", "get_chapter", "list_my_highlights", "list_my_vocabulary", "save_highlight", "search_books"],
+            ["ask_book", "get_book", "get_chapter", "get_my_book", "get_my_chapter", "get_my_insights", "list_my_book_highlights", "list_my_highlights", "list_my_vocabulary", "save_highlight", "save_insight", "save_my_highlight", "search_books", "search_my_library"],
             names);
     }
 
@@ -315,7 +315,7 @@ public class McpOverTheWireTests : IAsyncLifetime
         await using var client = await _harness.ConnectAsync(McpServerHarness.TestJwt, Ct);
 
         var tools = await client.ListToolsAsync(cancellationToken: Ct);
-        Assert.Equal(7, tools.Count);
+        Assert.Equal(14, tools.Count);
 
         var chapter = await CallAsync(client, "get_chapter", Args(("slug", "dracula"), ("chapterSlug", "ch-1")));
         Assert.NotEqual(true, chapter.IsError);
@@ -336,5 +336,83 @@ public class McpOverTheWireTests : IAsyncLifetime
         // All three user-scoped calls forwarded the same session bearer.
         Assert.Equal($"Bearer {McpServerHarness.TestJwt}", _harness.Stub.Last("save_highlight")!.Authorization);
         Assert.Equal($"Bearer {McpServerHarness.TestJwt}", _harness.Stub.Last("ask_book")!.Authorization);
+    }
+
+    // ── 14. one-session e2e over the UPLOADED half: search → book → chapter ───────
+
+    [Fact]
+    public async Task OneSession_OverWire_MyLibraryChain_SearchToBookToChapter()
+    {
+        // The chain a client actually walks to work with a user's own upload, in
+        // one session: find the book, list its chapters, read one. Every step is
+        // keyed by bookId; nothing in the chain produces or consumes an editionId.
+        await using var client = await _harness.ConnectAsync(McpServerHarness.TestJwt, Ct);
+
+        var found = await CallAsync(client, "search_my_library", Args(("query", "quorum")));
+        Assert.NotEqual(true, found.IsError);
+        var hit = Json(found).GetProperty("results").EnumerateArray().Single();
+        Assert.Equal("userbook", hit.GetProperty("source").GetString());
+        var bookId = hit.GetProperty("bookId").GetString()!;
+        Assert.Equal(StubBackend.UserBookId, bookId);
+
+        var book = await CallAsync(client, "get_my_book", Args(("bookId", bookId)));
+        Assert.NotEqual(true, book.IsError);
+        var chapter = Json(book).GetProperty("chapters").EnumerateArray().Single();
+        Assert.Equal(StubBackend.UserChapterId, chapter.GetProperty("chapterId").GetString());
+
+        var read = await CallAsync(client, "get_my_chapter", Args(
+            ("bookId", bookId),
+            ("chapterSlug", chapter.GetProperty("slug").GetString())));
+        Assert.NotEqual(true, read.IsError);
+        Assert.Contains("Replication means keeping a copy", Json(read).GetProperty("text").GetString());
+
+        // The chain never mentions an editionId — an upload does not have one, and
+        // a plausible-looking id here is worse than none.
+        Assert.DoesNotContain("editionId", TextOf(found));
+        Assert.DoesNotContain("editionId", TextOf(book));
+        Assert.DoesNotContain("editionId", TextOf(read));
+
+        Assert.Equal($"Bearer {McpServerHarness.TestJwt}", _harness.Stub.Last("search_my_library")!.Authorization);
+        Assert.Equal($"Bearer {McpServerHarness.TestJwt}", _harness.Stub.Last("get_my_chapter")!.Authorization);
+    }
+
+    // ── 15. one-session e2e: the write-back loop ─────────────────────────────────
+
+    [Fact]
+    public async Task OneSession_OverWire_WriteBack_HighlightThenInsightThenReadBack()
+    {
+        // The point of the whole surface: an outside assistant finishes a reading
+        // session by marking a passage and writing its conclusion into the book, and
+        // the NEXT session reads that back instead of starting over.
+        await using var client = await _harness.ConnectAsync(McpServerHarness.TestJwt, Ct);
+
+        var highlighted = await CallAsync(client, "save_my_highlight", Args(
+            ("bookId", StubBackend.UserBookId),
+            ("chapterId", StubBackend.UserChapterId),
+            ("selectedText", "a quorum of replicas"),
+            ("color", "blue")));
+        Assert.NotEqual(true, highlighted.IsError);
+
+        // It went down the user-book side of the API's XOR, not the edition side.
+        var sent = JsonDocument.Parse(_harness.Stub.Last("save_highlight")!.Body).RootElement;
+        Assert.Equal(StubBackend.UserBookId, sent.GetProperty("userBookId").GetString());
+        Assert.False(sent.TryGetProperty("editionId", out _));
+
+        var saved = await CallAsync(client, "save_insight", Args(
+            ("bookId", StubBackend.UserBookId),
+            ("chapterSlug", "replication"),
+            ("text", "Quorums are about overlap, not majorities."),
+            ("question", "why w + r > n?")));
+        Assert.NotEqual(true, saved.IsError);
+        Assert.True(Json(saved).GetProperty("saved").GetBoolean());
+
+        // A later session picks the book back up and finds the work already done.
+        var back = await CallAsync(client, "get_my_insights", Args(("bookId", StubBackend.UserBookId)));
+        Assert.NotEqual(true, back.IsError);
+        var items = Json(back).GetProperty("insights").EnumerateArray().ToArray();
+        Assert.Equal(2, items.Length);
+        Assert.Contains(items, i => i.GetProperty("chapterTitle").GetString() == "Replication");
+
+        Assert.Equal($"Bearer {McpServerHarness.TestJwt}", _harness.Stub.Last("save_insight")!.Authorization);
     }
 }

--- a/tests/TextStack.Ai.Mcp.Tests/McpStdioSmokeTests.cs
+++ b/tests/TextStack.Ai.Mcp.Tests/McpStdioSmokeTests.cs
@@ -20,7 +20,7 @@ namespace TextStack.Ai.Mcp.Tests;
 public class McpStdioSmokeTests
 {
     [Fact]
-    public async Task Stdio_SubprocessServer_InitializeAndListToolsReturnsSeven()
+    public async Task Stdio_SubprocessServer_InitializeAndListToolsReturnsWholeSurface()
     {
         var ct = TestContext.Current.CancellationToken;
 
@@ -53,7 +53,7 @@ public class McpStdioSmokeTests
         Assert.Equal("textstack", client.ServerInfo.Name);
 
         var tools = await client.ListToolsAsync(cancellationToken: ct);
-        Assert.Equal(7, tools.Count);
+        Assert.Equal(14, tools.Count);
     }
 
     // The MCP project is a ProjectReference, so its DLL is built into the test

--- a/tests/TextStack.Ai.Mcp.Tests/StubBackend.cs
+++ b/tests/TextStack.Ai.Mcp.Tests/StubBackend.cs
@@ -324,6 +324,7 @@ public sealed class StubBackend : IAsyncDisposable
           "totalWordCount": 210000,
           "status": "Ready",
           "errorMessage": null,
+          "hasOriginalPdf": false,
           "chapters": [
             { "id": "88888888-8888-8888-8888-888888888888", "chapterNumber": 5, "slug": "replication", "title": "Replication", "wordCount": 14200, "sourceStartPage": 151 }
           ],

--- a/tests/TextStack.Ai.Mcp.Tests/StubBackend.cs
+++ b/tests/TextStack.Ai.Mcp.Tests/StubBackend.cs
@@ -22,6 +22,13 @@ public sealed class StubBackend : IAsyncDisposable
     public const string GoodEdition = "33333333-3333-3333-3333-333333333333";
     public const string SpoilerEdition = "55555555-5555-5555-5555-555555555555";
     public const string ChapterId = "44444444-4444-4444-4444-444444444444";
+
+    // An UPLOADED book (UserBook) and one of its chapters. Deliberately different
+    // ids from the catalog edition above: the my-library tools must never hand
+    // back an editionId, and a shared constant would hide that if they did.
+    public const string UserBookId = "77777777-7777-7777-7777-777777777777";
+    public const string UserChapterId = "88888888-8888-8888-8888-888888888888";
+    public const string InsightId = "99999999-9999-9999-9999-999999999999";
     public const string NewHighlightId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
     private readonly WebApplication _app;
@@ -92,6 +99,30 @@ public sealed class StubBackend : IAsyncDisposable
             await WriteJsonAsync(ctx, ChapterBody);
         });
 
+        // GET /me/library/search → 401 if no bearer, else canned upload hits.
+        _app.MapGet("/me/library/search", async ctx =>
+        {
+            await RecordAsync("search_my_library", ctx);
+            if (!HasBearer(ctx)) { ctx.Response.StatusCode = StatusCodes.Status401Unauthorized; return; }
+            await WriteJsonAsync(ctx, MyLibrarySearchBody);
+        });
+
+        // GET /me/books/{id} → 401 if no bearer, else UserBookDetail incl. chapters.
+        _app.MapGet("/me/books/{id}", async ctx =>
+        {
+            await RecordAsync("get_my_book", ctx);
+            if (!HasBearer(ctx)) { ctx.Response.StatusCode = StatusCodes.Status401Unauthorized; return; }
+            await WriteJsonAsync(ctx, MyBookBody);
+        });
+
+        // GET /me/books/{id}/chapters/{slug} → 401 if no bearer, else UserChapter.
+        _app.MapGet("/me/books/{id}/chapters/{slug}", async ctx =>
+        {
+            await RecordAsync("get_my_chapter", ctx);
+            if (!HasBearer(ctx)) { ctx.Response.StatusCode = StatusCodes.Status401Unauthorized; return; }
+            await WriteJsonAsync(ctx, MyChapterBody);
+        });
+
         // GET /me/highlights/{editionId} → 401 if no bearer, else canned list.
         _app.MapGet("/me/highlights/{editionId}", async ctx =>
         {
@@ -114,6 +145,30 @@ public sealed class StubBackend : IAsyncDisposable
             await RecordAsync("save_highlight", ctx);
             if (!HasBearer(ctx)) { ctx.Response.StatusCode = StatusCodes.Status401Unauthorized; return; }
             await WriteJsonAsync(ctx, CreatedHighlightBody, StatusCodes.Status201Created);
+        });
+
+        // GET /me/highlights/userbook/{id} → 401 if no bearer, else canned list.
+        _app.MapGet("/me/highlights/userbook/{id}", async ctx =>
+        {
+            await RecordAsync("list_my_book_highlights", ctx);
+            if (!HasBearer(ctx)) { ctx.Response.StatusCode = StatusCodes.Status401Unauthorized; return; }
+            await WriteJsonAsync(ctx, UserBookHighlightsBody);
+        });
+
+        // GET /me/insights?userBookId=|editionId= → 401 if no bearer, else canned list.
+        _app.MapGet("/me/insights", async ctx =>
+        {
+            await RecordAsync("get_my_insights", ctx);
+            if (!HasBearer(ctx)) { ctx.Response.StatusCode = StatusCodes.Status401Unauthorized; return; }
+            await WriteJsonAsync(ctx, InsightsBody);
+        });
+
+        // POST /me/insights → 401 if no bearer, else 201 BookInsightDto.
+        _app.MapPost("/me/insights", async ctx =>
+        {
+            await RecordAsync("save_insight", ctx);
+            if (!HasBearer(ctx)) { ctx.Response.StatusCode = StatusCodes.Status401Unauthorized; return; }
+            await WriteJsonAsync(ctx, SavedInsightBody, StatusCodes.Status201Created);
         });
 
         // POST /books/{editionId}/ask → 401 if no bearer; spoiler edition → Insufficient.
@@ -238,6 +293,58 @@ public sealed class StubBackend : IAsyncDisposable
         }
         """;
 
+    private const string MyLibrarySearchBody =
+        """
+        [
+          {
+            "id": "77777777-7777-7777-7777-777777777777",
+            "title": "Designing Data-Intensive Applications",
+            "author": "Martin Kleppmann",
+            "coverPath": null,
+            "language": "en",
+            "rank": 0.42,
+            "excerpt": "a <mark>quorum</mark> of replicas must acknowledge",
+            "chapterSlug": "replication"
+          }
+        ]
+        """;
+
+    private const string MyBookBody =
+        """
+        {
+          "id": "77777777-7777-7777-7777-777777777777",
+          "title": "Designing Data-Intensive Applications",
+          "slug": "designing-data-intensive-applications",
+          "language": "en",
+          "author": "Martin Kleppmann",
+          "description": "The big ideas behind reliable systems.",
+          "coverPath": null,
+          "genre": "Computing",
+          "publishedYear": 2017,
+          "totalWordCount": 210000,
+          "status": "Ready",
+          "errorMessage": null,
+          "chapters": [
+            { "id": "88888888-8888-8888-8888-888888888888", "chapterNumber": 5, "slug": "replication", "title": "Replication", "wordCount": 14200, "sourceStartPage": 151 }
+          ],
+          "toc": null
+        }
+        """;
+
+    private const string MyChapterBody =
+        """
+        {
+          "id": "88888888-8888-8888-8888-888888888888",
+          "chapterNumber": 5,
+          "slug": "replication",
+          "title": "Replication",
+          "html": "<p>Replication means keeping a <b>copy</b> of the same data.</p>",
+          "wordCount": 10,
+          "previous": null,
+          "next": { "chapterNumber": 6, "slug": "partitioning", "title": "Partitioning" }
+        }
+        """;
+
     private const string HighlightsBody =
         """
         [
@@ -271,6 +378,66 @@ public sealed class StubBackend : IAsyncDisposable
               "createdAt": "2026-01-01T00:00:00+00:00", "updatedAt": "2026-01-01T00:00:00+00:00"
             }
           ]
+        }
+        """;
+
+    private const string UserBookHighlightsBody =
+        """
+        [
+          {
+            "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "editionId": null, "chapterId": null,
+            "userBookId": "77777777-7777-7777-7777-777777777777",
+            "userChapterId": "88888888-8888-8888-8888-888888888888",
+            "anchorJson": "{}", "color": "blue",
+            "selectedText": "a quorum of replicas", "noteText": "the core trade-off",
+            "version": 1,
+            "createdAt": "2026-01-01T00:00:00+00:00",
+            "updatedAt": "2026-01-01T00:00:00+00:00"
+          }
+        ]
+        """;
+
+    private const string InsightsBody =
+        """
+        [
+          {
+            "id": "99999999-9999-9999-9999-999999999999",
+            "editionId": null,
+            "userBookId": "77777777-7777-7777-7777-777777777777",
+            "chapterSlug": null, "chapterNumber": null, "chapterTitle": null,
+            "text": "The book's argument in one paragraph.",
+            "question": "what is this book actually about?",
+            "source": "mcp",
+            "createdAt": "2026-01-01T00:00:00+00:00",
+            "updatedAt": "2026-01-02T00:00:00+00:00"
+          },
+          {
+            "id": "aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa",
+            "editionId": null,
+            "userBookId": "77777777-7777-7777-7777-777777777777",
+            "chapterSlug": "replication", "chapterNumber": 5, "chapterTitle": "Replication",
+            "text": "Quorums are about overlap, not majorities.",
+            "question": "why w + r > n?",
+            "source": "mcp",
+            "createdAt": "2026-01-01T00:00:00+00:00",
+            "updatedAt": "2026-01-02T00:00:00+00:00"
+          }
+        ]
+        """;
+
+    private const string SavedInsightBody =
+        """
+        {
+          "id": "99999999-9999-9999-9999-999999999999",
+          "editionId": null,
+          "userBookId": "77777777-7777-7777-7777-777777777777",
+          "chapterSlug": "replication", "chapterNumber": null, "chapterTitle": null,
+          "text": "Quorums are about overlap, not majorities.",
+          "question": "why w + r > n?",
+          "source": "mcp",
+          "createdAt": "2026-01-01T00:00:00+00:00",
+          "updatedAt": "2026-01-02T00:00:00+00:00"
         }
         """;
 

--- a/tests/TextStack.AiEvals/CapturingDb.cs
+++ b/tests/TextStack.AiEvals/CapturingDb.cs
@@ -103,6 +103,7 @@ internal sealed class CapturingDb : IAppDbContext
     public DbSet<DriftCentroid> DriftCentroids => throw new NotSupportedException();
     public DbSet<PodcastGenerationJob> PodcastGenerationJobs => throw new NotSupportedException();
     public DbSet<BookConversation> BookConversations => throw new NotSupportedException();
+    public DbSet<BookInsight> BookInsights => throw new NotSupportedException();
     public DbSet<ConversationMessage> ConversationMessages => throw new NotSupportedException();
     public DbSet<UserChapterChunk> UserChapterChunks => throw new NotSupportedException();
 }

--- a/tests/TextStack.IntegrationTests/InsightsEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/InsightsEndpointTests.cs
@@ -1,0 +1,328 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// <c>/me/insights</c> — the conclusions an outside assistant writes back into a book.
+///
+/// <para>Four properties are load-bearing and none of them is visible from a unit test, because
+/// every one of them lives in Postgres:</para>
+/// <list type="number">
+///   <item><b>Upsert.</b> One insight per (user, book, chapter), so a second pass over a book
+///   refreshes the конспект instead of duplicating it.</item>
+///   <item><b>Upsert of the BOOK-LEVEL one.</b> Its chapter_slug is NULL, and Postgres treats NULLs
+///   in a unique index as distinct unless the index says otherwise — so the overview, the single row
+///   most likely to be rewritten, is exactly the row a default index would fail to protect. The
+///   mapping sets NULLS NOT DISTINCT; this asserts it took.</item>
+///   <item><b>Chapter resolution at read time.</b> The slug is resolved to a number and title on the
+///   way out, so a re-ingest that renumbers chapters cannot leave a stale ordinal behind.</item>
+///   <item><b>Isolation.</b> Another user asking about the same book gets nothing.</item>
+/// </list>
+///
+/// <para>Requires: docker compose up, and ENABLE_TEST_AUTH=true for the authenticated half.
+/// Skips (does not fail) when either is unavailable, like the rest of this suite.</para>
+/// </summary>
+public class InsightsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixture<AuthenticatedApiFixture>
+{
+    private readonly LiveApiFixture _fixture;
+    private readonly AuthenticatedApiFixture _auth;
+
+    public InsightsEndpointTests(LiveApiFixture fixture, AuthenticatedApiFixture auth)
+    {
+        _fixture = fixture;
+        _auth = auth;
+    }
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>An edition with at least one slugged chapter, or null when the DB has none seeded.</summary>
+    private async Task<(Guid EditionId, string ChapterSlug)?> FindSeededChapterAsync()
+    {
+        var listReq = _fixture.CreateRequest(HttpMethod.Get, "/books?limit=1");
+        var listResp = await _fixture.Client.SendAsync(listReq, Ct);
+        if (!listResp.IsSuccessStatusCode) return null;
+
+        var list = await listResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: Ct);
+        if (!list.TryGetProperty("items", out var items) || items.GetArrayLength() == 0) return null;
+        var slug = items[0].GetProperty("slug").GetString();
+
+        var bookReq = _fixture.CreateRequest(HttpMethod.Get, $"/books/{slug}");
+        var bookResp = await _fixture.Client.SendAsync(bookReq, Ct);
+        if (!bookResp.IsSuccessStatusCode) return null;
+
+        var book = await bookResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: Ct);
+        var editionId = book.GetProperty("id").GetGuid();
+        if (!book.TryGetProperty("chapters", out var chapters)) return null;
+
+        foreach (var c in chapters.EnumerateArray())
+        {
+            if (c.TryGetProperty("slug", out var s) && s.ValueKind == JsonValueKind.String)
+                return (editionId, s.GetString()!);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Saves and returns the row. Accepts 201 or 200, deliberately: whether the FIRST save of a run
+    /// creates or replaces depends on whether a previous run left a row behind, and this suite runs
+    /// against a live database as the same test user. 201-vs-200 is therefore a fact about the
+    /// database's history, not about the feature. What the feature promises — one row per
+    /// (user, book, chapter) — is asserted on the id.
+    /// </summary>
+    private async Task<JsonElement> SaveAsync(object body)
+    {
+        var req = _auth.CreateRequest(HttpMethod.Post, "/me/insights");
+        req.Content = JsonContent.Create(body);
+        var resp = await _auth.Client.SendAsync(req, Ct);
+        Assert.True(
+            resp.StatusCode is HttpStatusCode.Created or HttpStatusCode.OK,
+            $"save returned {(int)resp.StatusCode}");
+        return await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: Ct);
+    }
+
+    /// <summary>Saves and requires a REPLACE (200) — used for the second write of a pair.</summary>
+    private async Task<JsonElement> ResaveAsync(object body)
+    {
+        var req = _auth.CreateRequest(HttpMethod.Post, "/me/insights");
+        req.Content = JsonContent.Create(body);
+        var resp = await _auth.Client.SendAsync(req, Ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: Ct);
+    }
+
+    // ── unauthenticated ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetInsights_WithoutAuth_Returns401()
+    {
+        var req = _fixture.CreateRequest(HttpMethod.Get, $"/me/insights?editionId={Guid.NewGuid()}");
+        var resp = await _fixture.Client.SendAsync(req, Ct);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SaveInsight_WithoutAuth_Returns401()
+    {
+        var req = _fixture.CreateRequest(HttpMethod.Post, "/me/insights");
+        req.Content = JsonContent.Create(new { editionId = Guid.NewGuid(), text = "x" });
+        var resp = await _fixture.Client.SendAsync(req, Ct);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    // ── the XOR ─────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(true, true)]    // both targets
+    [InlineData(false, false)]  // neither
+    public async Task SaveInsight_NotExactlyOneTarget_Returns400(bool edition, bool userBook)
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+
+        var req = _auth.CreateRequest(HttpMethod.Post, "/me/insights");
+        req.Content = JsonContent.Create(new
+        {
+            editionId = edition ? Guid.NewGuid() : (Guid?)null,
+            userBookId = userBook ? Guid.NewGuid() : (Guid?)null,
+            text = "x",
+        });
+        var resp = await _auth.Client.SendAsync(req, Ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public async Task GetInsights_NotExactlyOneTarget_Returns400(bool edition, bool userBook)
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+
+        var query = (edition, userBook) switch
+        {
+            (true, true) => $"?editionId={Guid.NewGuid()}&userBookId={Guid.NewGuid()}",
+            _ => "",
+        };
+        var req = _auth.CreateRequest(HttpMethod.Get, $"/me/insights{query}");
+        var resp = await _auth.Client.SendAsync(req, Ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // ── validation ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveInsight_UnknownEdition_Returns404()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+
+        var req = _auth.CreateRequest(HttpMethod.Post, "/me/insights");
+        req.Content = JsonContent.Create(new { editionId = Guid.NewGuid(), text = "x" });
+        var resp = await _auth.Client.SendAsync(req, Ct);
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SaveInsight_ChapterSlugThatDoesNotExist_Returns404()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+        var seed = await FindSeededChapterAsync();
+        Assert.SkipWhen(seed is null, "no seeded book with a slugged chapter");
+
+        var req = _auth.CreateRequest(HttpMethod.Post, "/me/insights");
+        req.Content = JsonContent.Create(new
+        {
+            editionId = seed!.Value.EditionId,
+            chapterSlug = "no-such-chapter-anywhere",
+            text = "x",
+        });
+        var resp = await _auth.Client.SendAsync(req, Ct);
+
+        // A hallucinated slug is refused while the caller can still fix it, rather
+        // than stored as an insight that never places in the конспект.
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SaveInsight_EmptyText_Returns400()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+        var seed = await FindSeededChapterAsync();
+        Assert.SkipWhen(seed is null, "no seeded book with a slugged chapter");
+
+        var req = _auth.CreateRequest(HttpMethod.Post, "/me/insights");
+        req.Content = JsonContent.Create(new { editionId = seed!.Value.EditionId, text = "   " });
+        var resp = await _auth.Client.SendAsync(req, Ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SaveInsight_OversizedText_Returns400()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+        var seed = await FindSeededChapterAsync();
+        Assert.SkipWhen(seed is null, "no seeded book with a slugged chapter");
+
+        var req = _auth.CreateRequest(HttpMethod.Post, "/me/insights");
+        req.Content = JsonContent.Create(new
+        {
+            editionId = seed!.Value.EditionId,
+            text = new string('x', 20_001),
+        });
+        var resp = await _auth.Client.SendAsync(req, Ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // ── upsert + read-back ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveInsight_SameChapterTwice_ReplacesInsteadOfDuplicating()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+        var seed = await FindSeededChapterAsync();
+        Assert.SkipWhen(seed is null, "no seeded book with a slugged chapter");
+        var (editionId, chapterSlug) = seed!.Value;
+
+        var first = await SaveAsync(
+            new { editionId, chapterSlug, text = "First pass.", question = "what is going on here?" });
+
+        var second = await ResaveAsync(
+            new { editionId, chapterSlug, text = "Second pass, rewritten." });
+
+        Assert.Equal(first.GetProperty("id").GetGuid(), second.GetProperty("id").GetGuid());
+        Assert.Equal("Second pass, rewritten.", second.GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public async Task SaveInsight_BookLevelTwice_AlsoReplaces_NullsAreNotDistinct()
+    {
+        // The regression this exists for: with a default unique index, chapter_slug
+        // IS NULL rows do not collide, so the конспект's overview — the row rewritten
+        // most often — would be the only one that silently accumulated duplicates.
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+        var seed = await FindSeededChapterAsync();
+        Assert.SkipWhen(seed is null, "no seeded book with a slugged chapter");
+        var editionId = seed!.Value.EditionId;
+
+        var first = await SaveAsync(new { editionId, text = "Overview, first pass." });
+        var second = await ResaveAsync(new { editionId, text = "Overview, second pass." });
+
+        Assert.Equal(first.GetProperty("id").GetGuid(), second.GetProperty("id").GetGuid());
+    }
+
+    [Fact]
+    public async Task GetInsights_ResolvesChapterPlacement_AndPutsTheOverviewFirst()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+        var seed = await FindSeededChapterAsync();
+        Assert.SkipWhen(seed is null, "no seeded book with a slugged chapter");
+        var (editionId, chapterSlug) = seed!.Value;
+
+        await SaveAsync(new { editionId, text = "The book in one paragraph." });
+        await SaveAsync(new { editionId, chapterSlug, text = "About this chapter." });
+
+        var req = _auth.CreateRequest(HttpMethod.Get, $"/me/insights?editionId={editionId}");
+        var resp = await _auth.Client.SendAsync(req, Ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var rows = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: Ct);
+        var items = rows.EnumerateArray().ToArray();
+        Assert.True(items.Length >= 2);
+
+        // Reading order: the whole-book overview leads.
+        Assert.Equal(JsonValueKind.Null, items[0].GetProperty("chapterSlug").ValueKind);
+
+        // The chapter one carries a number and a title resolved from the slug at
+        // read time — not a number frozen when it was written.
+        var chapterRow = items.Single(i => i.GetProperty("chapterSlug").GetString() == chapterSlug);
+        Assert.Equal(JsonValueKind.Number, chapterRow.GetProperty("chapterNumber").ValueKind);
+        Assert.False(string.IsNullOrWhiteSpace(chapterRow.GetProperty("chapterTitle").GetString()));
+    }
+
+    // ── isolation ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetInsights_AnotherUser_SeesNothing()
+    {
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+        var seed = await FindSeededChapterAsync();
+        Assert.SkipWhen(seed is null, "no seeded book with a slugged chapter");
+        var editionId = seed!.Value.EditionId;
+
+        await SaveAsync(new { editionId, text = "Only this user's conclusion." });
+
+        // A second identity. Registration, not a guest session: the guest policy is 3
+        // per 5 minutes per IP, so a guest here skips this test on any run that has
+        // minted one — and this is the assertion in this file least worth skipping.
+        // Registration is the same knob family with an order of magnitude more room.
+        var registerReq = _fixture.CreateRequest(HttpMethod.Post, "/auth/register");
+        registerReq.Content = JsonContent.Create(new
+        {
+            email = $"insight-isolation-{Guid.NewGuid():N}@example.test",
+            password = "Test12345!",
+            name = "Insight Isolation",
+        });
+        var otherUser = await _fixture.Client.SendAsync(registerReq, Ct);
+        Assert.SkipWhen(otherUser.StatusCode == HttpStatusCode.TooManyRequests,
+            "user-login rate limited (RateLimits:UserLoginPermitLimit)");
+        Assert.True(otherUser.IsSuccessStatusCode, $"register returned {(int)otherUser.StatusCode}");
+
+        var cookie = string.Join("; ", otherUser.Headers.GetValues("Set-Cookie")
+            .Select(c => c.Split(';')[0].Trim()));
+
+        var otherReq = _fixture.CreateRequest(HttpMethod.Get, $"/me/insights?editionId={editionId}");
+        otherReq.Headers.Add("Cookie", cookie);
+        var otherResp = await _fixture.Client.SendAsync(otherReq, Ct);
+
+        Assert.Equal(HttpStatusCode.OK, otherResp.StatusCode);
+        var rows = await otherResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: Ct);
+        Assert.Empty(rows.EnumerateArray());
+    }
+}

--- a/tests/TextStack.IntegrationTests/InsightsEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/InsightsEndpointTests.cs
@@ -345,3 +345,46 @@ public class InsightsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtur
         Assert.Empty(rows.EnumerateArray());
     }
 }
+
+/// <summary>
+/// <c>GET /me/library/search</c> — the library full-text search.
+///
+/// <para>One test, for one reason. The endpoint's raw SQL aliased its columns in PascalCase while
+/// the context is built with <c>UseSnakeCaseNamingConvention</c>, which applies to the
+/// <c>SqlQueryRaw</c> row type as well — so EF asked for <c>chapter_slug</c>, got
+/// <c>"ChapterSlug"</c>, and threw on <b>every</b> call. It answered 500 for its whole life and
+/// nobody noticed, because the web caller renders an empty result on failure and an empty library
+/// search looks exactly like a library with nothing matching.</para>
+///
+/// <para>No unit test can catch this: it is only wrong once real SQL meets a real database. This
+/// asserts the shape of the answer, not its contents, so it holds on any seeded database.</para>
+/// </summary>
+public class UserLibrarySearchEndpointTests(LiveApiFixture fixture, AuthenticatedApiFixture auth)
+    : IClassFixture<LiveApiFixture>, IClassFixture<AuthenticatedApiFixture>
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Theory]
+    [InlineData("q=quorum")]
+    [InlineData("q=quorum&tags=nonexistent-tag")] // the other SQL branch — it is built separately
+    public async Task SearchLibrary_Authenticated_Returns200AndAJsonArray(string query)
+    {
+        Assert.SkipUnless(auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+
+        var req = auth.CreateRequest(HttpMethod.Get, $"/me/library/search?{query}");
+        var resp = await auth.Client.SendAsync(req, Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: Ct);
+        Assert.Equal(JsonValueKind.Array, body.ValueKind);
+    }
+
+    [Fact]
+    public async Task SearchLibrary_WithoutAuth_Returns401()
+    {
+        var req = fixture.CreateRequest(HttpMethod.Get, "/me/library/search?q=quorum");
+        var resp = await fixture.Client.SendAsync(req, Ct);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+}

--- a/tests/TextStack.IntegrationTests/InsightsEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/InsightsEndpointTests.cs
@@ -286,6 +286,23 @@ public class InsightsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtur
         Assert.False(string.IsNullOrWhiteSpace(chapterRow.GetProperty("chapterTitle").GetString()));
     }
 
+    [Fact]
+    public async Task GetInsights_UnknownBook_Returns404_NotAnEmptyList()
+    {
+        // The read filters by user_id, so a stranger's book leaks nothing either way.
+        // But an empty list is a truthful answer to "what have I worked out about this
+        // book", and letting a wrong id borrow that answer is how a mistake reads as a
+        // fact. Mirrors GET /me/highlights/userbook/{id}.
+        Assert.SkipUnless(_auth.IsAuthenticated, "test-login unavailable (ENABLE_TEST_AUTH)");
+
+        foreach (var query in new[] { $"userBookId={Guid.NewGuid()}", $"editionId={Guid.NewGuid()}" })
+        {
+            var req = _auth.CreateRequest(HttpMethod.Get, $"/me/insights?{query}");
+            var resp = await _auth.Client.SendAsync(req, Ct);
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+    }
+
     // ── isolation ───────────────────────────────────────────────────────────────
 
     [Fact]
@@ -317,6 +334,8 @@ public class InsightsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtur
         var cookie = string.Join("; ", otherUser.Headers.GetValues("Set-Cookie")
             .Select(c => c.Split(';')[0].Trim()));
 
+        // A catalog edition exists for everyone, so this is the read succeeding and
+        // returning nothing — isolation, not a 404 standing in for it.
         var otherReq = _fixture.CreateRequest(HttpMethod.Get, $"/me/insights?editionId={editionId}");
         otherReq.Headers.Add("Cookie", cookie);
         var otherResp = await _fixture.Client.SendAsync(otherReq, Ct);

--- a/tests/TextStack.IntegrationTests/McpManifestEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/McpManifestEndpointTests.cs
@@ -20,10 +20,17 @@ public class McpManifestEndpointTests : IClassFixture<LiveApiFixture>
         "search_books",
         "get_book",
         "get_chapter",
+        "search_my_library",
+        "get_my_book",
+        "get_my_chapter",
         "list_my_highlights",
         "list_my_vocabulary",
         "save_highlight",
         "ask_book",
+        "save_my_highlight",
+        "list_my_book_highlights",
+        "save_insight",
+        "get_my_insights",
     ];
 
     public McpManifestEndpointTests(LiveApiFixture fixture)
@@ -62,7 +69,7 @@ public class McpManifestEndpointTests : IClassFixture<LiveApiFixture>
     }
 
     [Fact]
-    public async Task GetManifest_ListsSevenExpectedTools()
+    public async Task GetManifest_ListsTheExpectedTools()
     {
         var request = _fixture.CreateRequest(HttpMethod.Get, "/mcp/manifest");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
@@ -73,7 +80,7 @@ public class McpManifestEndpointTests : IClassFixture<LiveApiFixture>
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(manifest);
-        Assert.Equal(7, manifest.Tools.Count);
+        Assert.Equal(14, manifest.Tools.Count);
 
         var names = manifest.Tools.Select(t => t.Name).ToHashSet();
         Assert.Equal(ExpectedToolNames.ToHashSet(), names);

--- a/tests/TextStack.UnitTests/AssistantHighlightCeilingTests.cs
+++ b/tests/TextStack.UnitTests/AssistantHighlightCeilingTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Text.Json;
+using Api.Endpoints;
+using TextStack.Ai.Mcp;
+using TextStack.Ai.Mcp.Auth;
+using TextStack.Ai.Mcp.Http;
+using TextStack.Ai.Mcp.Tools;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// The seam that makes the assistant highlight ceiling work.
+///
+/// <para><c>HighlightsEndpoints</c> caps how many highlights an assistant may place in one book
+/// (<see cref="HighlightsEndpoints.MaxAssistantHighlightsPerBook"/>) by counting rows whose anchor
+/// has <c>source = </c><see cref="HighlightsEndpoints.McpAnchorSource"/>. Nothing in the type system
+/// connects that field to the JSON the MCP bridge actually writes: they live in different projects,
+/// and between them sits an opaque jsonb column the endpoint owns no schema for.</para>
+///
+/// <para>So if <c>SynthesizeAnchor</c> ever renames the field or changes its value, the cap matches
+/// nothing and silently stops applying. There is no error and no symptom — until a book comes back
+/// marked end to end. This assembly is the one place that can see both sides.</para>
+/// </summary>
+public class AssistantHighlightCeilingTests
+{
+    private sealed class CapturingHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        public string? LastRequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            return response;
+        }
+    }
+
+    private const string Book = "77777777-7777-7777-7777-777777777777";
+    private const string Chapter = "88888888-8888-8888-8888-888888888888";
+    private const string Edition = "33333333-3333-3333-3333-333333333333";
+
+    private const string SavedBody =
+        """
+        {
+          "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "editionId": null, "chapterId": null,
+          "userBookId": "77777777-7777-7777-7777-777777777777",
+          "userChapterId": "88888888-8888-8888-8888-888888888888",
+          "anchorJson": "{}", "color": "yellow",
+          "selectedText": "x", "noteText": null, "version": 1,
+          "createdAt": "2026-01-01T00:00:00+00:00",
+          "updatedAt": "2026-01-01T00:00:00+00:00"
+        }
+        """;
+
+    private static async Task<string> AnchorWrittenByAsync(string tool, string args)
+    {
+        var handler = new CapturingHandler(
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(SavedBody, System.Text.Encoding.UTF8, "application/json"),
+            });
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.example/") };
+        var options = new McpBridgeOptions
+        {
+            ApiBaseUrl = "https://api.example",
+            SiteHost = "textstack.test",
+            McpToken = "tok",
+        };
+        var catalog = new McpToolCatalog(new TextStackApiClient(http, options, new StaticEnvTokenProvider(options)));
+
+        await catalog.CallAsync(tool, JsonDocument.Parse(args).RootElement, CancellationToken.None);
+
+        var sent = JsonDocument.Parse(handler.LastRequestBody!).RootElement;
+        return sent.GetProperty("anchorJson").GetString()!;
+    }
+
+    [Theory]
+    [InlineData("save_my_highlight",
+        $$"""{"bookId":"{{Book}}","chapterId":"{{Chapter}}","selectedText":"a quorum of replicas"}""")]
+    [InlineData("save_highlight",
+        $$"""{"editionId":"{{Edition}}","chapterId":"{{Chapter}}","selectedText":"the dead travel fast"}""")]
+    public async Task EveryAssistantWrite_CarriesTheSourceTheCapCountsOn(string tool, string args)
+    {
+        var anchor = await AnchorWrittenByAsync(tool, args);
+
+        // Read the field, exactly as `anchor_json->>'source'` does — not a substring
+        // of the serialized text, which would pass even if the value moved into a
+        // nested object the SQL predicate cannot see.
+        using var doc = JsonDocument.Parse(anchor);
+        Assert.Equal(
+            HighlightsEndpoints.McpAnchorSource,
+            doc.RootElement.GetProperty("source").GetString());
+    }
+
+    [Fact]
+    public void AReaderAnchor_HasNoSource_SoAPersonIsNeverCapped()
+    {
+        // The shape the web reader stores: prefix/exact/suffix plus offsets, no source.
+        // The cap must be invisible to it, including on a book an assistant has also
+        // marked — which is the whole reason it counts by source and not by row.
+        const string readerAnchor =
+            """{"prefix":"and then ","exact":"the dead travel fast","suffix":" said he","startOffset":812,"endOffset":832}""";
+
+        using var doc = JsonDocument.Parse(readerAnchor);
+        Assert.False(doc.RootElement.TryGetProperty("source", out _));
+    }
+
+    [Fact]
+    public void TheCeiling_IsAboveAnyPlausibleDeliberatePass()
+    {
+        // A guard on the guard: this is a legibility stop for a runaway loop, not a
+        // taste limit. Tightening it to something a thorough pass over a long book
+        // could hit would turn a safety net into a product decision made by accident.
+        Assert.True(HighlightsEndpoints.MaxAssistantHighlightsPerBook >= 100);
+    }
+}

--- a/tests/TextStack.UnitTests/Fakes/FakeAppDbContext.cs
+++ b/tests/TextStack.UnitTests/Fakes/FakeAppDbContext.cs
@@ -97,6 +97,7 @@ internal sealed class FakeAppDbContext : IAppDbContext
     public DbSet<TutorSession> TutorSessions => throw new NotSupportedException();
     public DbSet<PodcastGenerationJob> PodcastGenerationJobs => throw new NotSupportedException();
     public DbSet<BookConversation> BookConversations => throw new NotSupportedException();
+    public DbSet<BookInsight> BookInsights => throw new NotSupportedException();
     public DbSet<ConversationMessage> ConversationMessages => throw new NotSupportedException();
     public DbSet<UserChapterChunk> UserChapterChunks => throw new NotSupportedException();
 }

--- a/tests/TextStack.UnitTests/McpMyLibraryToolsTests.cs
+++ b/tests/TextStack.UnitTests/McpMyLibraryToolsTests.cs
@@ -161,6 +161,34 @@ public class McpMyLibraryToolsTests
     }
 
     [Fact]
+    public async Task SearchMyLibrary_UpstreamFailure_IsAnError_NotAnEmptyLibrary()
+    {
+        // This endpoint really did answer 500 on every call (a snake_case mismatch in
+        // its raw SQL), and mapping that to {"results":[]} told the caller "you have
+        // no books about this" — indistinguishable from the truth, and wrong.
+        var (catalog, _) = BuildCatalog(Json("", HttpStatusCode.InternalServerError));
+
+        var result = await catalog.CallAsync(
+            "search_my_library", Args("""{"query":"quorum"}"""), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("unavailable", TextOf(result));
+    }
+
+    [Fact]
+    public async Task SearchMyLibrary_NoMatches_IsStillAnEmptyResult_NotAnError()
+    {
+        // The other side of it: nothing found is a real answer and must stay one.
+        var (catalog, _) = BuildCatalog(Json("[]"));
+
+        var result = await catalog.CallAsync(
+            "search_my_library", Args("""{"query":"quorum"}"""), CancellationToken.None);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Empty(Body(result).GetProperty("results").EnumerateArray());
+    }
+
+    [Fact]
     public async Task SearchMyLibrary_NullToken_ReturnsAuthRequired_NeverHitsHttp()
     {
         var (catalog, handler) = BuildCatalog(Json("[]"), token: null);
@@ -517,6 +545,9 @@ public class McpMyLibraryToolsTests
 
         var first = Assert.Single(Body(result).GetProperty("highlights").EnumerateArray());
         Assert.Equal("a quorum of replicas", first.GetProperty("selectedText").GetString());
+        // The chapter of an upload's highlight lives in userChapterId. Reported under the
+        // name save_my_highlight accepts, so "what is already marked, and where" is answerable.
+        Assert.Equal(Chapter, first.GetProperty("chapterId").GetString());
     }
 
     [Fact]

--- a/tests/TextStack.UnitTests/McpMyLibraryToolsTests.cs
+++ b/tests/TextStack.UnitTests/McpMyLibraryToolsTests.cs
@@ -202,6 +202,7 @@ public class McpMyLibraryToolsTests
           "totalWordCount": 210000,
           "status": "Ready",
           "errorMessage": null,
+          "hasOriginalPdf": true,
           "chapters": [
             { "id": "88888888-8888-8888-8888-888888888888", "chapterNumber": 5, "slug": "replication", "title": "Replication", "wordCount": 14200, "sourceStartPage": 151 }
           ],
@@ -231,6 +232,32 @@ public class McpMyLibraryToolsTests
         var chapter = Assert.Single(body.GetProperty("chapters").EnumerateArray());
         Assert.Equal(Chapter, chapter.GetProperty("chapterId").GetString());
         Assert.Equal("replication", chapter.GetProperty("slug").GetString());
+    }
+
+    [Fact]
+    public async Task GetMyBook_ReportsWhenTheBookRendersAsAnOriginalPdf()
+    {
+        // Half the uploaded library is PDF, and on a PDF the reader paints highlights
+        // from page geometry this bridge cannot produce. A text-anchored highlight is
+        // still saved and still listed — it just never appears over the page. The
+        // model has to be told that here, because the alternative is discovering it
+        // by not seeing a mark it believes it made.
+        var (catalog, _) = BuildCatalog(Json(BookBody));
+
+        var result = await catalog.CallAsync(
+            "get_my_book", Args($$"""{"bookId":"{{Book}}"}"""), CancellationToken.None);
+
+        Assert.True(Body(result).GetProperty("rendersAsOriginalPdf").GetBoolean());
+    }
+
+    [Fact]
+    public void SaveMyHighlight_Description_WarnsAboutOriginalPdfBooks()
+    {
+        var (catalog, _) = BuildCatalog(Json("{}"));
+        var description = catalog.ListTools().Single(t => t.Name == "save_my_highlight").Description;
+
+        Assert.Contains("rendersAsOriginalPdf", description);
+        Assert.Contains("200 per book", description);
     }
 
     [Fact]
@@ -651,6 +678,22 @@ public class McpMyLibraryToolsTests
             "get_my_insights", Args($$"""{"editionId":"{{edition}}"}"""), CancellationToken.None);
 
         Assert.Equal($"/me/insights?editionId={edition}", handler.LastRequest!.RequestUri!.PathAndQuery);
+    }
+
+    [Theory]
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777"}""", "no uploaded book found")]
+    [InlineData("""{"editionId":"33333333-3333-3333-3333-333333333333"}""", "no catalog book found")]
+    public async Task GetMyInsights_UnknownBook_SaysSo_RatherThanReturningEmpty(string args, string expected)
+    {
+        // Same trap as list_my_book_highlights: "you have not discussed this book" and
+        // "that is not your book" are different answers, and only one of them is worth
+        // acting on.
+        var (catalog, _) = BuildCatalog(Json("", HttpStatusCode.NotFound));
+
+        var result = await catalog.CallAsync("get_my_insights", Args(args), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains(expected, TextOf(result));
     }
 
     [Fact]

--- a/tests/TextStack.UnitTests/McpMyLibraryToolsTests.cs
+++ b/tests/TextStack.UnitTests/McpMyLibraryToolsTests.cs
@@ -1,0 +1,682 @@
+using System.Net;
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using TextStack.Ai.Mcp;
+using TextStack.Ai.Mcp.Auth;
+using TextStack.Ai.Mcp.Http;
+using TextStack.Ai.Mcp.Tools;
+
+namespace TextStack.UnitTests;
+
+/// <summary>
+/// The my-library MCP tools — <c>search_my_library</c>, <c>get_my_book</c>,
+/// <c>get_my_chapter</c> — which open a user's OWN uploads to an MCP client. The
+/// catalog tools could already be reached; uploads could not, and that gap is the
+/// whole reason these exist.
+///
+/// The assertion this file exists for is the identifier. An upload is a
+/// <c>UserBook</c>: a different aggregate from <c>Edition</c>, with its own
+/// chapter and chunk tables and NO editionId. A tool that returned an
+/// <c>editionId</c> for an upload would hand the model an id that 404s in
+/// <c>ask_book</c> and silently returns an empty list from
+/// <c>list_my_highlights</c> — a failure that looks like an empty library rather
+/// than a wrong id. So every output here is keyed by <c>bookId</c> and says
+/// <c>source: "userbook"</c>, and the tests below check exactly that.
+///
+/// Same fake-HTTP harness as <see cref="McpReadToolsTests"/>: CI-safe, no network.
+/// </summary>
+public class McpMyLibraryToolsTests
+{
+    private const string SiteHost = "textstack.test";
+    private const string Book = "77777777-7777-7777-7777-777777777777";
+    private const string Chapter = "88888888-8888-8888-8888-888888888888";
+
+    private sealed class CapturingHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        // Read here: the client disposes the request (and its content) once SendAsync
+        // returns, so reading it off LastRequest afterwards throws.
+        public string? LastRequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            if (request.Content is not null)
+                LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            return response;
+        }
+    }
+
+    private static (McpToolCatalog catalog, CapturingHandler handler) BuildCatalog(
+        HttpResponseMessage response, string? token = "tok-123")
+    {
+        var handler = new CapturingHandler(response);
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.example/") };
+        var options = new McpBridgeOptions { ApiBaseUrl = "https://api.example", SiteHost = SiteHost, McpToken = token };
+        var api = new TextStackApiClient(http, options, new StaticEnvTokenProvider(options));
+        return (new McpToolCatalog(api), handler);
+    }
+
+    private static HttpResponseMessage Json(string body, HttpStatusCode status = HttpStatusCode.OK) =>
+        new(status) { Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json") };
+
+    private static JsonElement Args(string json) => JsonDocument.Parse(json).RootElement;
+
+    private static string TextOf(CallToolResult result) => ((TextContentBlock)result.Content[0]).Text;
+
+    private static JsonElement Body(CallToolResult result) => JsonDocument.Parse(TextOf(result)).RootElement;
+
+    private static string? BearerOf(HttpRequestMessage req) => req.Headers.Authorization?.ToString();
+
+    // ── search_my_library ───────────────────────────────────────────────────────
+
+    private const string SearchBody =
+        """
+        [
+          {
+            "id": "77777777-7777-7777-7777-777777777777",
+            "title": "Designing Data-Intensive Applications",
+            "author": "Martin Kleppmann",
+            "coverPath": "/storage/x.jpg",
+            "language": "en",
+            "rank": 0.42,
+            "excerpt": "a <mark>quorum</mark> of replicas must acknowledge",
+            "chapterSlug": "replication"
+          }
+        ]
+        """;
+
+    [Fact]
+    public async Task SearchMyLibrary_IssuesAuthorizedGet_MapsBookIdAndChapterHit()
+    {
+        var (catalog, handler) = BuildCatalog(Json(SearchBody));
+
+        var result = await catalog.CallAsync(
+            "search_my_library", Args("""{"query":"quorum"}"""), CancellationToken.None);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
+        Assert.Equal("/me/library/search?q=quorum", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal(SiteHost, handler.LastRequest.Headers.Host);
+        Assert.Equal("Bearer tok-123", BearerOf(handler.LastRequest));
+
+        var hit = Assert.Single(Body(result).GetProperty("results").EnumerateArray());
+        Assert.Equal("userbook", hit.GetProperty("source").GetString());
+        Assert.Equal(Book, hit.GetProperty("bookId").GetString());
+        Assert.Equal("replication", hit.GetProperty("chapterSlug").GetString());
+        Assert.Contains("quorum", hit.GetProperty("excerpt").GetString()!);
+    }
+
+    [Fact]
+    public async Task SearchMyLibrary_NeverEmitsAnEditionId()
+    {
+        // The bug this surface was reported for: an upload has no editionId, so
+        // inventing one would hand the model an id that 404s in ask_book.
+        var (catalog, _) = BuildCatalog(Json(SearchBody));
+
+        var result = await catalog.CallAsync(
+            "search_my_library", Args("""{"query":"quorum"}"""), CancellationToken.None);
+
+        Assert.DoesNotContain("editionId", TextOf(result));
+    }
+
+    [Fact]
+    public async Task SearchMyLibrary_Tags_ArePassedThroughAsQueryParam()
+    {
+        var (catalog, handler) = BuildCatalog(Json("[]"));
+
+        await catalog.CallAsync(
+            "search_my_library", Args("""{"query":"quorum","tags":"systems,work"}"""), CancellationToken.None);
+
+        Assert.Equal("/me/library/search?q=quorum&tags=systems%2Cwork",
+            handler.LastRequest!.RequestUri!.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task SearchMyLibrary_NoTags_OmitsTheParam()
+    {
+        var (catalog, handler) = BuildCatalog(Json("[]"));
+
+        await catalog.CallAsync("search_my_library", Args("""{"query":"quorum"}"""), CancellationToken.None);
+
+        Assert.DoesNotContain("tags=", handler.LastRequest!.RequestUri!.PathAndQuery);
+    }
+
+    [Theory]
+    [InlineData("""{}""")]                                // missing query
+    [InlineData("""{"query":"q"}""")]                     // shorter than minLength 2
+    [InlineData("""{"query":123}""")]                     // wrong type
+    [InlineData("""{"query":"quorum","x":1}""")]          // extra prop
+    [InlineData("""{"query":"quorum","tags":7}""")]       // tags wrong type
+    public async Task SearchMyLibrary_InvalidArgs_ReturnsToolError_NeverHitsHttp(string args)
+    {
+        var (catalog, handler) = BuildCatalog(Json("[]"));
+
+        var result = await catalog.CallAsync("search_my_library", Args(args), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Null(handler.LastRequest);
+    }
+
+    [Fact]
+    public async Task SearchMyLibrary_NullToken_ReturnsAuthRequired_NeverHitsHttp()
+    {
+        var (catalog, handler) = BuildCatalog(Json("[]"), token: null);
+
+        var result = await catalog.CallAsync(
+            "search_my_library", Args("""{"query":"quorum"}"""), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("authentication required", TextOf(result));
+        Assert.Null(handler.LastRequest);
+    }
+
+    [Fact]
+    public async Task SearchMyLibrary_Api401_ReturnsAuthRequired()
+    {
+        var (catalog, _) = BuildCatalog(Json("", HttpStatusCode.Unauthorized));
+
+        var result = await catalog.CallAsync(
+            "search_my_library", Args("""{"query":"quorum"}"""), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("authentication required", TextOf(result));
+    }
+
+    // ── get_my_book ─────────────────────────────────────────────────────────────
+
+    private const string BookBody =
+        """
+        {
+          "id": "77777777-7777-7777-7777-777777777777",
+          "title": "Designing Data-Intensive Applications",
+          "slug": "designing-data-intensive-applications",
+          "language": "en",
+          "author": "Martin Kleppmann",
+          "description": "The big ideas behind reliable systems.",
+          "coverPath": null,
+          "genre": "Computing",
+          "publishedYear": 2017,
+          "totalWordCount": 210000,
+          "status": "Ready",
+          "errorMessage": null,
+          "chapters": [
+            { "id": "88888888-8888-8888-8888-888888888888", "chapterNumber": 5, "slug": "replication", "title": "Replication", "wordCount": 14200, "sourceStartPage": 151 }
+          ],
+          "toc": null
+        }
+        """;
+
+    [Fact]
+    public async Task GetMyBook_IssuesAuthorizedGet_MapsChaptersWithChapterId()
+    {
+        var (catalog, handler) = BuildCatalog(Json(BookBody));
+
+        var result = await catalog.CallAsync(
+            "get_my_book", Args($$"""{"bookId":"{{Book}}"}"""), CancellationToken.None);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Equal($"/me/books/{Book}", handler.LastRequest!.RequestUri!.PathAndQuery);
+        Assert.Equal("Bearer tok-123", BearerOf(handler.LastRequest));
+
+        var body = Body(result);
+        Assert.Equal("userbook", body.GetProperty("source").GetString());
+        Assert.Equal(Book, body.GetProperty("bookId").GetString());
+        Assert.Equal("Ready", body.GetProperty("status").GetString());
+
+        // chapterId is the whole point: save_my_highlight needs it and nothing
+        // else on this surface supplies it.
+        var chapter = Assert.Single(body.GetProperty("chapters").EnumerateArray());
+        Assert.Equal(Chapter, chapter.GetProperty("chapterId").GetString());
+        Assert.Equal("replication", chapter.GetProperty("slug").GetString());
+    }
+
+    [Fact]
+    public async Task GetMyBook_NotFound_ReturnsToolError()
+    {
+        // Someone else's book is a 404 (the endpoint filters by user_id), so this
+        // is also the isolation path seen from the bridge.
+        var (catalog, _) = BuildCatalog(Json("", HttpStatusCode.NotFound));
+
+        var result = await catalog.CallAsync(
+            "get_my_book", Args($$"""{"bookId":"{{Book}}"}"""), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("no uploaded book found", TextOf(result));
+    }
+
+    [Theory]
+    [InlineData("""{}""")]
+    [InlineData("""{"bookId":"not-a-guid"}""")]
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777","x":1}""")]
+    public async Task GetMyBook_InvalidArgs_ReturnsToolError_NeverHitsHttp(string args)
+    {
+        var (catalog, handler) = BuildCatalog(Json("{}"));
+
+        var result = await catalog.CallAsync("get_my_book", Args(args), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Null(handler.LastRequest);
+    }
+
+    [Fact]
+    public async Task GetMyBook_NullToken_ReturnsAuthRequired_NeverHitsHttp()
+    {
+        var (catalog, handler) = BuildCatalog(Json("{}"), token: null);
+
+        var result = await catalog.CallAsync(
+            "get_my_book", Args($$"""{"bookId":"{{Book}}"}"""), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("authentication required", TextOf(result));
+        Assert.Null(handler.LastRequest);
+    }
+
+    // ── get_my_chapter ──────────────────────────────────────────────────────────
+
+    private const string ChapterBody =
+        """
+        {
+          "id": "88888888-8888-8888-8888-888888888888",
+          "chapterNumber": 5,
+          "slug": "replication",
+          "title": "Replication",
+          "html": "<p>Replication means keeping a <b>copy</b> of the same data &amp; more.</p>",
+          "wordCount": 11,
+          "previous": { "chapterNumber": 4, "slug": "encoding", "title": "Encoding and Evolution" },
+          "next": { "chapterNumber": 6, "slug": "partitioning", "title": "Partitioning" }
+        }
+        """;
+
+    [Fact]
+    public async Task GetMyChapter_IssuesAuthorizedGet_StripsHtml_MapsNavAndChapterId()
+    {
+        var (catalog, handler) = BuildCatalog(Json(ChapterBody));
+
+        var result = await catalog.CallAsync(
+            "get_my_chapter",
+            Args($$"""{"bookId":"{{Book}}","chapterSlug":"replication"}"""),
+            CancellationToken.None);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Equal($"/me/books/{Book}/chapters/replication", handler.LastRequest!.RequestUri!.PathAndQuery);
+        Assert.Equal("Bearer tok-123", BearerOf(handler.LastRequest));
+
+        var body = Body(result);
+        Assert.Equal(Chapter, body.GetProperty("chapterId").GetString());
+        Assert.Equal(Book, body.GetProperty("bookId").GetString());
+        Assert.Equal("encoding", body.GetProperty("prevSlug").GetString());
+        Assert.Equal("partitioning", body.GetProperty("nextSlug").GetString());
+        Assert.False(body.GetProperty("truncated").GetBoolean());
+
+        var text = body.GetProperty("text").GetString()!;
+        Assert.DoesNotContain("<b>", text);
+        Assert.Contains("copy", text);
+        Assert.Contains("&", text); // entity decoded, not left as &amp;
+    }
+
+    [Fact]
+    public async Task GetMyChapter_NotFound_ReturnsToolError()
+    {
+        var (catalog, _) = BuildCatalog(Json("", HttpStatusCode.NotFound));
+
+        var result = await catalog.CallAsync(
+            "get_my_chapter",
+            Args($$"""{"bookId":"{{Book}}","chapterSlug":"nope"}"""),
+            CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("no chapter 'nope'", TextOf(result));
+    }
+
+    [Theory]
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777"}""")]  // missing slug
+    [InlineData("""{"chapterSlug":"replication"}""")]                      // missing bookId
+    [InlineData("""{"bookId":"nope","chapterSlug":"replication"}""")]      // bad guid
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777","chapterSlug":"r","x":1}""")]
+    public async Task GetMyChapter_InvalidArgs_ReturnsToolError_NeverHitsHttp(string args)
+    {
+        var (catalog, handler) = BuildCatalog(Json("{}"));
+
+        var result = await catalog.CallAsync("get_my_chapter", Args(args), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Null(handler.LastRequest);
+    }
+
+    [Fact]
+    public async Task GetMyChapter_NullToken_ReturnsAuthRequired_NeverHitsHttp()
+    {
+        var (catalog, handler) = BuildCatalog(Json("{}"), token: null);
+
+        var result = await catalog.CallAsync(
+            "get_my_chapter",
+            Args($$"""{"bookId":"{{Book}}","chapterSlug":"replication"}"""),
+            CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("authentication required", TextOf(result));
+        Assert.Null(handler.LastRequest);
+    }
+
+    // ── save_my_highlight (WRITE) ───────────────────────────────────────────────
+
+    private const string SavedHighlightBody =
+        """
+        {
+          "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "editionId": null, "chapterId": null,
+          "userBookId": "77777777-7777-7777-7777-777777777777",
+          "userChapterId": "88888888-8888-8888-8888-888888888888",
+          "anchorJson": "{}", "color": "blue",
+          "selectedText": "a quorum of replicas", "noteText": "the core trade-off",
+          "version": 1,
+          "createdAt": "2026-01-01T00:00:00+00:00",
+          "updatedAt": "2026-01-01T00:00:00+00:00"
+        }
+        """;
+
+    [Fact]
+    public async Task SaveMyHighlight_PostsUserBookSideOfTheXor_NotTheEditionSide()
+    {
+        // The API's CreateHighlightRequest is an XOR: editionId+chapterId, or
+        // userBookId+userChapterId. Sending an upload down the edition side is a 404
+        // on a chapter that exists — which is the failure this whole surface is for.
+        var (catalog, handler) = BuildCatalog(Json(SavedHighlightBody, HttpStatusCode.Created));
+
+        var result = await catalog.CallAsync(
+            "save_my_highlight",
+            Args($$"""
+            {"bookId":"{{Book}}","chapterId":"{{Chapter}}",
+             "selectedText":"a quorum of replicas","color":"blue","noteText":"the core trade-off"}
+            """),
+            CancellationToken.None);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
+        Assert.Equal("/me/highlights", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("Bearer tok-123", BearerOf(handler.LastRequest));
+
+        var sent = JsonDocument.Parse(handler.LastRequestBody!).RootElement;
+        Assert.Equal(Book, sent.GetProperty("userBookId").GetString());
+        Assert.Equal(Chapter, sent.GetProperty("userChapterId").GetString());
+        Assert.False(sent.TryGetProperty("editionId", out _));
+        Assert.False(sent.TryGetProperty("chapterId", out _));
+        Assert.Equal("blue", sent.GetProperty("color").GetString());
+
+        Assert.True(Body(result).GetProperty("saved").GetBoolean());
+    }
+
+    [Fact]
+    public async Task SaveMyHighlight_SynthesizesTextQuoteAnchor_FromTheExactText()
+    {
+        // No DOM on this side of the bridge, so the anchor is built from the quote
+        // and the reader re-anchors by `exact`.
+        var (catalog, handler) = BuildCatalog(Json(SavedHighlightBody, HttpStatusCode.Created));
+
+        await catalog.CallAsync(
+            "save_my_highlight",
+            Args($$"""{"bookId":"{{Book}}","chapterId":"{{Chapter}}","selectedText":"a quorum of replicas"}"""),
+            CancellationToken.None);
+
+        var sent = JsonDocument.Parse(handler.LastRequestBody!).RootElement;
+        var anchor = JsonDocument.Parse(sent.GetProperty("anchorJson").GetString()!).RootElement;
+        Assert.Equal("a quorum of replicas", anchor.GetProperty("exact").GetString());
+        Assert.Equal("mcp", anchor.GetProperty("source").GetString());
+        Assert.Equal(Chapter, anchor.GetProperty("chapterId").GetString());
+    }
+
+    [Fact]
+    public async Task SaveMyHighlight_DefaultsToYellow_WhenNoColorGiven()
+    {
+        var (catalog, handler) = BuildCatalog(Json(SavedHighlightBody, HttpStatusCode.Created));
+
+        await catalog.CallAsync(
+            "save_my_highlight",
+            Args($$"""{"bookId":"{{Book}}","chapterId":"{{Chapter}}","selectedText":"a quorum"}"""),
+            CancellationToken.None);
+
+        var sent = JsonDocument.Parse(handler.LastRequestBody!).RootElement;
+        Assert.Equal("yellow", sent.GetProperty("color").GetString());
+    }
+
+    [Theory]
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777","selectedText":"x"}""")]
+    [InlineData("""{"chapterId":"88888888-8888-8888-8888-888888888888","selectedText":"x"}""")]
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777","chapterId":"88888888-8888-8888-8888-888888888888"}""")]
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777","chapterId":"88888888-8888-8888-8888-888888888888","selectedText":"x","color":"orange"}""")]
+    public async Task SaveMyHighlight_InvalidArgs_NeverWrites(string args)
+    {
+        // A rejected WRITE must not reach the API at all.
+        var (catalog, handler) = BuildCatalog(Json("{}"));
+
+        var result = await catalog.CallAsync("save_my_highlight", Args(args), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Null(handler.LastRequest);
+    }
+
+    [Fact]
+    public async Task SaveMyHighlight_NullToken_NeverWrites()
+    {
+        var (catalog, handler) = BuildCatalog(Json("{}"), token: null);
+
+        var result = await catalog.CallAsync(
+            "save_my_highlight",
+            Args($$"""{"bookId":"{{Book}}","chapterId":"{{Chapter}}","selectedText":"x"}"""),
+            CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("authentication required", TextOf(result));
+        Assert.Null(handler.LastRequest);
+    }
+
+    // ── list_my_book_highlights ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListMyBookHighlights_UsesTheUserBookRoute_NotTheEditionRoute()
+    {
+        // /me/highlights/{editionId} would answer 200 with [] for a bookId — an empty
+        // list that reads like "nothing highlighted" rather than "wrong route".
+        var (catalog, handler) = BuildCatalog(Json($"[{SavedHighlightBody}]"));
+
+        var result = await catalog.CallAsync(
+            "list_my_book_highlights", Args($$"""{"bookId":"{{Book}}"}"""), CancellationToken.None);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Equal($"/me/highlights/userbook/{Book}", handler.LastRequest!.RequestUri!.PathAndQuery);
+
+        var first = Assert.Single(Body(result).GetProperty("highlights").EnumerateArray());
+        Assert.Equal("a quorum of replicas", first.GetProperty("selectedText").GetString());
+    }
+
+    [Fact]
+    public async Task ListMyBookHighlights_NotYourBook_SaysSo_RatherThanReturningEmpty()
+    {
+        // The endpoint answers 404 for a book that is not yours. An empty list is a
+        // TRUTHFUL answer to "what have I highlighted", so collapsing 404 into it
+        // would make a wrong bookId read as a book with no marks — which is exactly
+        // the failure this whole surface exists to remove.
+        var (catalog, _) = BuildCatalog(Json("", HttpStatusCode.NotFound));
+
+        var result = await catalog.CallAsync(
+            "list_my_book_highlights", Args($$"""{"bookId":"{{Book}}"}"""), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("no uploaded book found", TextOf(result));
+    }
+
+    // ── save_insight ────────────────────────────────────────────────────────────
+
+    private const string SavedInsightBody =
+        """
+        {
+          "id": "99999999-9999-9999-9999-999999999999",
+          "editionId": null,
+          "userBookId": "77777777-7777-7777-7777-777777777777",
+          "chapterSlug": "replication", "chapterNumber": null, "chapterTitle": null,
+          "text": "Quorums are about overlap, not majorities.",
+          "question": "why w + r > n?",
+          "source": "mcp",
+          "createdAt": "2026-01-01T00:00:00+00:00",
+          "updatedAt": "2026-01-02T00:00:00+00:00"
+        }
+        """;
+
+    [Fact]
+    public async Task SaveInsight_PostsChapterScopedInsight_WithItsQuestion()
+    {
+        var (catalog, handler) = BuildCatalog(Json(SavedInsightBody, HttpStatusCode.Created));
+
+        var result = await catalog.CallAsync(
+            "save_insight",
+            Args($$"""
+            {"bookId":"{{Book}}","chapterSlug":"replication",
+             "text":"Quorums are about overlap, not majorities.","question":"why w + r > n?"}
+            """),
+            CancellationToken.None);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
+        Assert.Equal("/me/insights", handler.LastRequest.RequestUri!.PathAndQuery);
+
+        var sent = JsonDocument.Parse(handler.LastRequestBody!).RootElement;
+        Assert.Equal(Book, sent.GetProperty("userBookId").GetString());
+        Assert.Equal("replication", sent.GetProperty("chapterSlug").GetString());
+        Assert.Equal("why w + r > n?", sent.GetProperty("question").GetString());
+        Assert.False(sent.TryGetProperty("editionId", out _));
+
+        Assert.True(Body(result).GetProperty("saved").GetBoolean());
+    }
+
+    [Fact]
+    public async Task SaveInsight_NoChapterSlug_MeansTheWholeBook()
+    {
+        // The book-level insight IS the конспект's overview, so its absence of a
+        // chapter must survive the wire rather than becoming an empty string.
+        var (catalog, handler) = BuildCatalog(Json(SavedInsightBody, HttpStatusCode.Created));
+
+        await catalog.CallAsync(
+            "save_insight",
+            Args($$"""{"bookId":"{{Book}}","text":"The book's argument in one paragraph."}"""),
+            CancellationToken.None);
+
+        var sent = JsonDocument.Parse(handler.LastRequestBody!).RootElement;
+        Assert.False(sent.TryGetProperty("chapterSlug", out _));
+    }
+
+    [Theory]
+    [InlineData("""{"text":"x"}""")]                                          // neither target
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777","editionId":"33333333-3333-3333-3333-333333333333","text":"x"}""")] // both
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777"}""")]     // no text
+    [InlineData("""{"bookId":"77777777-7777-7777-7777-777777777777","text":"x","x":1}""")]
+    public async Task SaveInsight_InvalidTargetOrArgs_NeverWrites(string args)
+    {
+        var (catalog, handler) = BuildCatalog(Json("{}"));
+
+        var result = await catalog.CallAsync("save_insight", Args(args), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Null(handler.LastRequest);
+    }
+
+    [Fact]
+    public async Task SaveInsight_BothTargets_SaysWhichToPick()
+    {
+        var (catalog, _) = BuildCatalog(Json("{}"));
+
+        var result = await catalog.CallAsync(
+            "save_insight",
+            Args($$"""{"bookId":"{{Book}}","editionId":"33333333-3333-3333-3333-333333333333","text":"x"}"""),
+            CancellationToken.None);
+
+        Assert.Contains("not both", TextOf(result));
+    }
+
+    // ── get_my_insights ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetMyInsights_ByBookId_MapsChapterPlacementAndQuestion()
+    {
+        const string body =
+            """
+            [
+              {
+                "id": "99999999-9999-9999-9999-999999999999",
+                "editionId": null, "userBookId": "77777777-7777-7777-7777-777777777777",
+                "chapterSlug": null, "chapterNumber": null, "chapterTitle": null,
+                "text": "The book's argument in one paragraph.",
+                "question": "what is this book actually about?",
+                "source": "mcp",
+                "createdAt": "2026-01-01T00:00:00+00:00",
+                "updatedAt": "2026-01-02T00:00:00+00:00"
+              },
+              {
+                "id": "aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa",
+                "editionId": null, "userBookId": "77777777-7777-7777-7777-777777777777",
+                "chapterSlug": "replication", "chapterNumber": 5, "chapterTitle": "Replication",
+                "text": "Quorums are about overlap, not majorities.",
+                "question": "why w + r > n?",
+                "source": "mcp",
+                "createdAt": "2026-01-01T00:00:00+00:00",
+                "updatedAt": "2026-01-02T00:00:00+00:00"
+              }
+            ]
+            """;
+        var (catalog, handler) = BuildCatalog(Json(body));
+
+        var result = await catalog.CallAsync(
+            "get_my_insights", Args($$"""{"bookId":"{{Book}}"}"""), CancellationToken.None);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Equal($"/me/insights?userBookId={Book}", handler.LastRequest!.RequestUri!.PathAndQuery);
+
+        var items = Body(result).GetProperty("insights").EnumerateArray().ToArray();
+        Assert.Equal(2, items.Length);
+        // Book-level first — it is the overview, and the server orders it that way.
+        Assert.Equal(JsonValueKind.Null, items[0].GetProperty("chapterSlug").ValueKind);
+        Assert.Equal("Replication", items[1].GetProperty("chapterTitle").GetString());
+        Assert.Equal("why w + r > n?", items[1].GetProperty("question").GetString());
+    }
+
+    [Fact]
+    public async Task GetMyInsights_ByEditionId_UsesTheEditionQueryParam()
+    {
+        const string edition = "33333333-3333-3333-3333-333333333333";
+        var (catalog, handler) = BuildCatalog(Json("[]"));
+
+        await catalog.CallAsync(
+            "get_my_insights", Args($$"""{"editionId":"{{edition}}"}"""), CancellationToken.None);
+
+        Assert.Equal($"/me/insights?editionId={edition}", handler.LastRequest!.RequestUri!.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task GetMyInsights_NoTarget_ReturnsToolError_NeverHitsHttp()
+    {
+        var (catalog, handler) = BuildCatalog(Json("[]"));
+
+        var result = await catalog.CallAsync("get_my_insights", Args("{}"), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Null(handler.LastRequest);
+    }
+
+    // ── the two search tools must stay distinguishable ──────────────────────────
+
+    [Fact]
+    public void SearchDescriptions_NameWhichHalfOfTheLibraryTheySearch()
+    {
+        // Two tools whose names differ by "_my_" is not enough for a model to pick
+        // correctly under pressure; the descriptions have to say it.
+        var (catalog, _) = BuildCatalog(Json("{}"));
+        var byName = catalog.ListTools().ToDictionary(t => t.Name);
+
+        Assert.Contains("PUBLIC", byName["search_books"].Description);
+        Assert.Contains("search_my_library", byName["search_books"].Description);
+        Assert.Contains("UPLOADED", byName["search_my_library"].Description);
+        Assert.Contains("NOT an editionId", byName["search_my_library"].Description);
+    }
+}

--- a/tests/TextStack.UnitTests/McpReadToolsTests.cs
+++ b/tests/TextStack.UnitTests/McpReadToolsTests.cs
@@ -74,17 +74,17 @@ public class McpReadToolsTests
 
     private const string Edition = "33333333-3333-3333-3333-333333333333";
 
-    // ── tools/list: all 7 exposed with correct schemas (6 reads + save_highlight) ─
+    // ── tools/list: the whole surface, with correct schemas ──────────────────────
 
     [Fact]
-    public void ListTools_ExposesAllSevenTools()
+    public void ListTools_ExposesTheWholeSurface()
     {
         var (catalog, _) = BuildCatalog(Json("{}"));
 
         var names = catalog.ListTools().Select(t => t.Name).OrderBy(n => n).ToArray();
 
         Assert.Equal(
-            ["ask_book", "get_book", "get_chapter", "list_my_highlights", "list_my_vocabulary", "save_highlight", "search_books"],
+            ["ask_book", "get_book", "get_chapter", "get_my_book", "get_my_chapter", "get_my_insights", "list_my_book_highlights", "list_my_highlights", "list_my_vocabulary", "save_highlight", "save_insight", "save_my_highlight", "search_books", "search_my_library"],
             names);
     }
 
@@ -115,6 +115,11 @@ public class McpReadToolsTests
         Assert.Equal(["editionId"], Required(byName["list_my_highlights"]));
         Assert.Empty(Required(byName["list_my_vocabulary"]));
         Assert.Equal(["editionId", "question"], Required(byName["ask_book"]));
+        // The my-library tools are keyed by bookId — never editionId. The schema is
+        // where that distinction is enforced, so it is asserted here.
+        Assert.Equal(["query"], Required(byName["search_my_library"]));
+        Assert.Equal(["bookId"], Required(byName["get_my_book"]));
+        Assert.Equal(["bookId", "chapterSlug"], Required(byName["get_my_chapter"]));
     }
 
     [Fact]

--- a/tests/TextStack.UnitTests/McpServerTests.cs
+++ b/tests/TextStack.UnitTests/McpServerTests.cs
@@ -74,7 +74,11 @@ public class McpServerTests
         var tools = catalog.ListTools();
 
         var tool = Assert.Single(tools, t => t.Name == "search_books");
-        Assert.Equal("Search the TextStack library for books and chapters matching a query.", tool.Description);
+        // Names the half of the library it searches, and points at the other tool.
+        // Two search tools that both say "the TextStack library" is how a model
+        // ends up searching the catalog for a book the user uploaded.
+        Assert.StartsWith("Search the PUBLIC TextStack catalog", tool.Description);
+        Assert.Contains("search_my_library", tool.Description);
 
         var schema = tool.InputSchema;
         Assert.Equal("object", schema.GetProperty("type").GetString());


### PR DESCRIPTION
A colleague reported that MCP could not reach a book the user had uploaded. The bug was real. The fix it proposed was not buildable, and chasing why produced a larger answer about what TextStack is — plus a production bug in a user-facing feature that has been broken since it shipped.

## The reported bug, and why the spec could not be followed

Step 1 of the spec (add a library-search endpoint) was already done. Step 2 asked the tool to return an `editionId` per hit. **An upload does not have one and cannot be given one** — `UserBook` and `Edition` are separate aggregates with separate chapter and chunk tables, and the non-polymorphism is documented on the entity itself. Built as written, every id would 404 in `ask_book` and return a silent empty list from `list_my_highlights`: a wrong id that reads like an empty library. The identifier is `bookId`, and the descriptions and schemas now say so.

## Why "I connected Claude Code and got nothing" was not a prompt problem

Reconnaissance on production: 75 uploaded books, **3 indexed**; 1,423 catalog editions, **4** with chunks. An unindexed book returns `insufficient` *without calling the LLM*. `ask_book` was answering correctly about a corpus that was 96% empty. Cost was never the constraint — every conversational feature together has spent five cents; $4.14 of the $4.25 total is PDF vision parsing.

## What this adds

**Six tools for the uploaded half, needing no index at all.** `search_my_library` (Postgres FTS over `user_chapters.search_vector`, built at upload), `get_my_book`, `get_my_chapter`, `save_my_highlight`, `list_my_book_highlights`. Measured on production: **73 of 75 books have chapters and 72 have real text**, so this works on essentially the whole library today, with no embeddings and no vision parse.

**Write-back — the part that is not a bug fix.** We are not building the chat: a reader's assistant already holds their profile and a year of history, and that cannot be copied here. The reasoning happens there, the result comes home. New entity `BookInsight` + `save_insight` / `get_my_insights` + `GET|POST /me/insights`. A conclusion hangs on the book's spine — a chapter slug, or nothing for the whole book — the way every other piece of user markup already does, so a конспект is an assembly in reading order rather than a frozen document.

**On the web**, both book pages gain a "What you've worked out" section above the chapter list and a "Talk this book over" pair of links that open a new Claude or ChatGPT conversation with a brief prefilled. A link, not an integration, capped at 1200 characters because a URL is about 2000 and encoding eats the rest.

## Two things that are load-bearing and easy to miss

- **One insight per (user, book, chapter)**, so a second pass refreshes rather than duplicates. Postgres treats NULLs in a unique index as distinct by default, and `chapter_slug IS NULL` is the book-level overview — the row rewritten most often, and so the only one a default index would fail to protect. `NULLS NOT DISTINCT`, with an integration test on it.
- **The key is the slug, not the chapter id**: re-ingestion recreates every chapter. Same lesson as ADR-015. Number and title are resolved from the slug at *read* time, so a re-ingest cannot leave a stale ordinal behind.

## A production bug found on the way

Pointing the new tools at a real uploaded book — the first time anything here met one, since the local database had none — turned up empty on a book that plainly contained the search term.

**`GET /me/library/search` has been answering 500 on every call for its whole life.** Its raw SQL aliases columns in PascalCase; the context is built with `UseSnakeCaseNamingConvention`, and that convention applies to the `SqlQueryRaw` row type too, so EF asked for `chapter_slug`, got `"ChapterSlug"`, and threw before reading a row. Nobody noticed because the only caller is the web Library page's search box, which renders an empty result on failure — and a library search that finds nothing looks exactly like one that failed. The colleague's report was righter than it knew: the endpoint their spec called step 1, and called done, has never returned a result.

Fixed on both SQL branches, with an integration test asserting a 200. No unit test can catch this; it is only wrong once real SQL meets a real database.

## Ceilings on what an assistant may write

- **200 highlights per book**, counted by `anchor_json->>'source' = 'mcp'` — the field the bridge already writes — so a person highlighting heavily is never counted, including on a book an assistant has also marked. The first cut used `.Contains()`, which EF compiles to `LIKE`; `anchor_json` is jsonb and Postgres refuses `LIKE` against it, so that would have thrown on the first write past the gate. A drift test asserts both sides agree: they sit in different projects with an opaque column between them, and a cap that silently stops matching is the worst way for a limit to fail.
- **`POST /me/highlights` is rate-limited per user id, not per IP** — the only such policy here. The bridge reaches the API over the internal docker network, so every assistant write arrives from one container address; an IP key would let one looping client throttle every other MCP user.

## Corrections to my own findings

- I reported that `save_my_highlight` could not reach a chapterless PDF upload. Production says otherwise — the two books with no chapters are **failed ingests**. But the real version is worse and hits half the library: 36 of 75 uploads are PDFs, the reader renders a PDF as the original document (ADR-012), and `PdfHighlightLayer` paints only `kind:"pdf"` anchors. An MCP highlight there is saved, listed, and on the Highlights page, but never drawn over the page. `get_my_book` now reports `rendersAsOriginalPdf`.
- I called `chapter_number` "0-based for editions, 1-based for user chapters". It is neither: production has every edition at 0 but four uploads starting at 2, and locally five editions start at 1. It is an ordering key that was never a display ordinal. Written down in `CLAUDE.md` rather than migrated.

## Verification

Verified live through the actual stdio MCP server against a running API, against both a catalog book and a **real clipped upload**: 14 tools listed, search → book → chapter → highlight → list → two insights → read back, chapter title resolved, overview first, both-identifiers refused, another user seeing nothing. Both book pages browser-checked in light and dark — which caught two defects: the handoff buttons used two CSS custom properties that do not exist (unreadable in dark mode), and printing the chapter number read one off the table of contents.

- 1543 unit + 20 MCP-wire + 771 web tests green
- Integration: 198 passed, 59 skipped, 0 failed (with CI's rate-limit knobs)
- `dotnet format` clean; web `tsc` clean

## Not in this work

Semantic retrieval and the indexing tools (they matter for 3 books until indexing is decided); bulk indexing, whose cost is not embeddings — a quarter of a cent per book — but the PDF vision parse at $0.00586 a page; the fate of our own Book Chat, which is a focus decision and should not be smuggled inside a bug fix; the mobile reader-exit placement of the handoff button, which would need a priority decision against the two prompts already competing for that moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rgEMvYYi4Egj99dVtvm6E
