### PR TITLE
release(mcp): TextStack.Mcp 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **MCP** — TextStack.Mcp 1.1.0 on NuGet: the tool ships the uploaded-library and write-back tools — backend · [details](docs/changelog-archive/2026-H2.md#2026-09-08-mcp-the-book-opens-to-your-assistant-and-the-conclusions-come-back)
 - **Library** — searching your own library answered 500 on every call and always had, behind an empty-looking result — backend · [details](docs/changelog-archive/2026-H2.md#2026-09-08-mcp-the-book-opens-to-your-assistant-and-the-conclusions-come-back)
 - **MCP** — your uploaded books open to your assistant, and its conclusions come back into the book — backend, web · [details](docs/changelog-archive/2026-H2.md#2026-09-08-mcp-the-book-opens-to-your-assistant-and-the-conclusions-come-back)
 - **Docs** — ADR-015 records the position model, and QA-001 finally crosses a chapter boundary — docs · [details](docs/changelog-archive/2026-H2.md#2026-09-07-docs-adr-015-and-the-scenario-that-was-never-in-qa-001)

--- a/backend/src/Ai/TextStack.Ai.Mcp/TextStack.Ai.Mcp.csproj
+++ b/backend/src/Ai/TextStack.Ai.Mcp/TextStack.Ai.Mcp.csproj
@@ -11,17 +11,18 @@
        `textstack-mcp`. Users: `dotnet tool install -g TextStack.Mcp` (or
        `dnx textstack-mcp` on .NET 10). The tool defaults to stdio mode, which
        is exactly what a local Claude Desktop / Cursor stdio client needs.
-       Owner publishes: dotnet nuget push bin/Release/TextStack.Mcp.1.0.0.nupkg.
+       Owner publishes by pushing an `mcp-v*` tag; publish-mcp-nuget.yml packs and
+       pushes via Trusted Publishing (OIDC), so no API key is stored anywhere.
        ════════════════════════════════════════════════════════════════════════ -->
   <PropertyGroup>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>textstack-mcp</ToolCommandName>
     <PackageId>TextStack.Mcp</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <!-- Run on .NET 10 AND future majors — don't pin users to one runtime. -->
     <RollForward>Major</RollForward>
     <Authors>TextStack</Authors>
-    <Description>TextStack MCP server — query your TextStack reading library from Claude Desktop / Cursor / any MCP client. Search books, read chapters, ask grounded questions, and manage your highlights and vocabulary over stdio or remote HTTP.</Description>
+    <Description>TextStack MCP server — work with your TextStack reading library from Claude Desktop / Cursor / any MCP client. Search and read both the public catalog and the books you uploaded, ask grounded questions, manage highlights and vocabulary — and write conclusions back into a book so they are still there when you return. Speaks stdio or remote HTTP.</Description>
     <PackageTags>mcp;modelcontextprotocol;ai;textstack;reading</PackageTags>
     <RepositoryUrl>https://github.com/mrviduus/textstack</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
The seven tools added in #576 are in the server but not in the **published** tool. Anyone who installed `TextStack.Mcp` from NuGet is still on 1.0.1 and cannot reach a book they uploaded.

Minor bump: everything 1.0.1 exposed still works the same way, this only adds.

## What changes

- `<Version>` 1.0.1 → 1.1.0
- The package `Description` is rewritten. It matters more than it looks — it is the one line a person reads before installing, and it described only the catalog half ("search books, read chapters, manage highlights and vocabulary"). It now says what this release is for: both halves of the library, and writing conclusions back into a book.
- The README needed nothing: #576 already updated it to all fourteen tools. It is packed into the nupkg, so it is also the nuget.org page.

## Verified against the packed artifact, not the source

A NuGet version can never be overwritten or deleted, so this was checked on the thing that would actually be published:

| check | result |
|---|---|
| `dotnet pack -c Release` | `TextStack.Mcp.1.1.0.nupkg` |
| nuspec | id `TextStack.Mcp`, version `1.1.0`, `DotnetTool`, AGPL-3.0-or-later, icon + readme present |
| README **inside** the package | 14 tool rows, including `search_my_library`, `get_my_book`, `get_my_chapter` |
| installed from a local folder to a scratch `--tool-path`, then spoke MCP to it | `serverInfo` **1.1.0.0**, `tools/list` returns all **14** by name |

## Why a PR and not a push to main

The `mcp-v1.1.0` tag is what publishes, and publishing is irreversible. The tag should point at a commit CI has already agreed with.

After merge: `git tag mcp-v1.1.0 <merge sha> && git push origin mcp-v1.1.0` → `publish-mcp-nuget.yml` packs and pushes via Trusted Publishing (OIDC), no stored key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rgEMvYYi4Egj99dVtvm6E
