### PR TITLE
A page that hands you a working connect key

### DIFF
--- a/apps/web/src/api/mcpKeys.ts
+++ b/apps/web/src/api/mcpKeys.ts
@@ -1,0 +1,63 @@
+import { authFetch } from './client'
+
+/**
+ * Connect keys — the credential a reader pastes into Claude or ChatGPT so it can reach their books.
+ *
+ * The remote MCP endpoint is stateless and reads a bearer per request, so before this the only thing
+ * it could take was a 60-minute access token minted for the local transport. A connector configured
+ * with one stopped working inside the hour.
+ */
+
+export interface McpKey {
+  id: string
+  name: string
+  /** The clear-text head of the key. Enough to match a row against a config file, useless alone. */
+  prefix: string
+  createdAt: string
+  /**
+   * Null until the key has authenticated a request; written at most hourly, so it means "recently"
+   * rather than "exactly then". This is the field that answers "is the connector I just set up
+   * actually talking to us".
+   */
+  lastUsedAt: string | null
+  revokedAt: string | null
+}
+
+/** The only response that ever carries the key itself. It is unrecoverable afterwards. */
+export interface CreatedMcpKey extends Omit<McpKey, 'lastUsedAt' | 'revokedAt'> {
+  key: string
+}
+
+export async function listMcpKeys(): Promise<McpKey[]> {
+  const res = await authFetch<{ items: McpKey[] }>('/me/mcp/keys')
+  return res.items
+}
+
+export async function createMcpKey(name: string): Promise<CreatedMcpKey> {
+  return authFetch<CreatedMcpKey>('/me/mcp/keys', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  })
+}
+
+export async function revokeMcpKey(id: string): Promise<void> {
+  await authFetch<void>(`/me/mcp/keys/${id}`, { method: 'DELETE' })
+}
+
+/**
+ * A connector config with the key already in it, ready to paste. Two shapes because the clients
+ * differ: Claude Desktop takes a JSON file, ChatGPT and claude.ai take a URL plus a header in their
+ * own connector form.
+ */
+export function claudeDesktopConfig(key: string): string {
+  return `{
+  "mcpServers": {
+    "textstack": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://textstack.app/mcp",
+               "--header", "Authorization: Bearer ${key}"]
+    }
+  }
+}`
+}

--- a/apps/web/src/components/mcp/ConnectAssistant.tsx
+++ b/apps/web/src/components/mcp/ConnectAssistant.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useAuth } from '../../context/AuthContext'
+import { useTranslation } from '../../hooks/useTranslation'
+import {
+  listMcpKeys,
+  createMcpKey,
+  revokeMcpKey,
+  claudeDesktopConfig,
+  type McpKey,
+  type CreatedMcpKey,
+} from '../../api/mcpKeys'
+
+/**
+ * Create and manage the connect keys that let an outside assistant reach the reader's books.
+ *
+ * <p>This is the whole onboarding. Before it, connecting Claude meant installing a .NET CLI, running
+ * a device flow in a terminal, copying a JWT out of a cache file — and repeating within the hour,
+ * because the only credential the remote endpoint accepted expired in sixty minutes. Nobody away
+ * from a terminal could do it and nobody at all could do it from a phone, which is the honest
+ * explanation for zero conclusions ever coming back.</p>
+ *
+ * <p>The key is shown exactly once. The server keeps a SHA-256 and nothing else, so "copy it now" is
+ * a statement of fact rather than a nudge — hence the persistent panel rather than a toast.</p>
+ */
+export function ConnectAssistant() {
+  const { t } = useTranslation()
+  const { isAuthenticated, openAuthModal } = useAuth()
+
+  const [keys, setKeys] = useState<McpKey[]>([])
+  const [loading, setLoading] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [created, setCreated] = useState<CreatedMcpKey | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState<'key' | 'config' | null>(null)
+
+  // Deliberately does NOT clear `error` on success. The mount refresh and a user action overlap:
+  // a create that failed at 200ms would have its message wiped by a list that succeeded at 300ms,
+  // leaving a button that visibly did nothing. Each action clears the error it is about to replace.
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      setKeys(await listMcpKeys())
+    } catch {
+      setError(t('mcp.connect.loadFailed'))
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => {
+    if (isAuthenticated) void refresh()
+  }, [isAuthenticated, refresh])
+
+  const create = async () => {
+    setCreating(true)
+    setError(null)
+    try {
+      const key = await createMcpKey(defaultKeyName())
+      setCreated(key)
+      await refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('mcp.connect.createFailed'))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const revoke = async (id: string) => {
+    setError(null)
+    try {
+      await revokeMcpKey(id)
+      // A revoked key stops authenticating immediately; if the one on screen was just revoked, the
+      // panel must go with it rather than keep offering a dead string to copy.
+      if (created && created.id === id) setCreated(null)
+      await refresh()
+    } catch {
+      setError(t('mcp.connect.revokeFailed'))
+    }
+  }
+
+  const copy = async (text: string, which: 'key' | 'config') => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(which)
+      setTimeout(() => setCopied(null), 2000)
+    } catch {
+      /* clipboard unavailable — the value is selectable on screen either way */
+    }
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <section className="mcp-section mcp-connect">
+        <h2 className="mcp-section__heading">{t('mcp.connect.heading')}</h2>
+        <p className="mcp-section__lead">{t('mcp.connect.signInLead')}</p>
+        <button type="button" className="mcp-connect__btn" onClick={openAuthModal}>
+          {t('mcp.connect.signInCta')}
+        </button>
+      </section>
+    )
+  }
+
+  const live = keys.filter(k => !k.revokedAt)
+
+  return (
+    <section className="mcp-section mcp-connect">
+      <h2 className="mcp-section__heading">{t('mcp.connect.heading')}</h2>
+      <p className="mcp-section__lead">{t('mcp.connect.lead')}</p>
+
+      {error && <p className="mcp-connect__error" role="alert">{error}</p>}
+
+      {created && (
+        <div className="mcp-connect__fresh">
+          <p className="mcp-connect__once">{t('mcp.connect.shownOnce')}</p>
+
+          <div className="mcp-connect__keyrow">
+            <code className="mcp-connect__key">{created.key}</code>
+            <button type="button" className="mcp-connect__copy" onClick={() => copy(created.key, 'key')}>
+              {copied === 'key' ? t('mcp.copied') : t('mcp.copy')}
+            </button>
+          </div>
+
+          <p className="mcp-connect__configlabel">{t('mcp.connect.configLabel')}</p>
+          <div className="mcp-connect__keyrow">
+            <pre className="mcp-connect__config"><code>{claudeDesktopConfig(created.key)}</code></pre>
+            <button
+              type="button"
+              className="mcp-connect__copy"
+              onClick={() => copy(claudeDesktopConfig(created.key), 'config')}
+            >
+              {copied === 'config' ? t('mcp.copied') : t('mcp.copy')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <button type="button" className="mcp-connect__btn" onClick={create} disabled={creating}>
+        {creating ? t('mcp.connect.creating') : t('mcp.connect.createCta')}
+      </button>
+
+      {loading && live.length === 0 ? null : live.length === 0 ? (
+        <p className="mcp-connect__empty">{t('mcp.connect.empty')}</p>
+      ) : (
+        <ul className="mcp-connect__list">
+          {live.map(k => (
+            <li key={k.id} className="mcp-connect__item">
+              <div>
+                <span className="mcp-connect__name">{k.name}</span>
+                <code className="mcp-connect__prefix">{k.prefix}…</code>
+                <span className="mcp-connect__used">
+                  {k.lastUsedAt ? t('mcp.connect.usedRecently') : t('mcp.connect.neverUsed')}
+                </span>
+              </div>
+              <button type="button" className="mcp-connect__revoke" onClick={() => revoke(k.id)}>
+                {t('mcp.connect.revoke')}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+/**
+ * A label the reader can tell apart later without being asked to invent one now. Asking for a name
+ * before the key exists puts a form between them and the thing they came for; the list is editable
+ * only by revoking, so a date is the honest default.
+ */
+function defaultKeyName(): string {
+  return `Assistant · ${new Date().toISOString().slice(0, 10)}`
+}

--- a/apps/web/src/components/mcp/__tests__/ConnectAssistant.test.tsx
+++ b/apps/web/src/components/mcp/__tests__/ConnectAssistant.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+// vi.mock is hoisted above every top-level binding, so the fakes have to be created inside
+// vi.hoisted rather than as plain consts — otherwise the factory runs before they exist.
+const { auth, api } = vi.hoisted(() => ({
+  auth: { isAuthenticated: true, openAuthModal: () => {} },
+  api: { listMcpKeys: vi.fn(), createMcpKey: vi.fn(), revokeMcpKey: vi.fn() },
+}))
+
+vi.mock('../../../context/AuthContext', () => ({ useAuth: () => auth }))
+vi.mock('../../../api/mcpKeys', async () => {
+  const actual = await vi.importActual<typeof import('../../../api/mcpKeys')>('../../../api/mcpKeys')
+  return { ...actual, ...api }
+})
+
+import { ConnectAssistant } from '../ConnectAssistant'
+
+const KEY = 'tsk_abcdefghijklmnopqrstuvwxyz0123456789ABCDE'
+
+const listed = (over: Partial<{ id: string; lastUsedAt: string | null; revokedAt: string | null }> = {}) => ({
+  id: 'k1',
+  name: 'Assistant · 2026-09-10',
+  prefix: 'tsk_abcdef',
+  createdAt: '2026-09-10T00:00:00Z',
+  lastUsedAt: null,
+  revokedAt: null,
+  ...over,
+})
+
+beforeEach(() => {
+  auth.isAuthenticated = true
+  api.listMcpKeys.mockReset().mockResolvedValue([])
+  api.createMcpKey.mockReset()
+  api.revokeMcpKey.mockReset().mockResolvedValue(undefined)
+})
+afterEach(() => cleanup())
+
+describe('ConnectAssistant', () => {
+  it('asks a signed-out reader to sign in and never calls the API', async () => {
+    auth.isAuthenticated = false
+    render(<ConnectAssistant />)
+
+    expect(screen.getByText('mcp.connect.signInCta')).toBeTruthy()
+    // A key is per-account; listing before there is an account is a guaranteed 401.
+    expect(api.listMcpKeys).not.toHaveBeenCalled()
+  })
+
+  it('shows the secret exactly once, and only after it is created', async () => {
+    api.createMcpKey.mockResolvedValue({
+      id: 'k1', name: 'n', key: KEY, prefix: 'tsk_abcdef', createdAt: '2026-09-10T00:00:00Z',
+    })
+    api.listMcpKeys.mockResolvedValue([listed()])
+
+    render(<ConnectAssistant />)
+    // Nothing secret on screen before the reader asks for it.
+    await waitFor(() => expect(api.listMcpKeys).toHaveBeenCalled())
+    expect(screen.queryByText(KEY)).toBeNull()
+
+    fireEvent.click(screen.getByText('mcp.connect.createCta'))
+
+    await waitFor(() => expect(screen.getByText(KEY)).toBeTruthy())
+    // The server keeps only a hash, so the warning is a statement of fact and must be present.
+    expect(screen.getByText('mcp.connect.shownOnce')).toBeTruthy()
+  })
+
+  it('puts the key into a ready-to-paste connector config', async () => {
+    api.createMcpKey.mockResolvedValue({
+      id: 'k1', name: 'n', key: KEY, prefix: 'tsk_abcdef', createdAt: '2026-09-10T00:00:00Z',
+    })
+    api.listMcpKeys.mockResolvedValue([listed()])
+
+    render(<ConnectAssistant />)
+    fireEvent.click(screen.getByText('mcp.connect.createCta'))
+
+    // The whole point: copy from here, paste into the client. A config the reader has to hand-edit
+    // to insert the key is the terminal step this feature exists to remove.
+    const config = await screen.findByText(/mcpServers/)
+    expect(config.textContent).toContain(KEY)
+    expect(config.textContent).toContain('https://textstack.app/mcp')
+  })
+
+  it('stops showing a secret the moment its key is revoked', async () => {
+    api.createMcpKey.mockResolvedValue({
+      id: 'k1', name: 'n', key: KEY, prefix: 'tsk_abcdef', createdAt: '2026-09-10T00:00:00Z',
+    })
+    api.listMcpKeys.mockResolvedValue([listed()])
+
+    render(<ConnectAssistant />)
+    fireEvent.click(screen.getByText('mcp.connect.createCta'))
+    await waitFor(() => expect(screen.getByText(KEY)).toBeTruthy())
+
+    api.listMcpKeys.mockResolvedValue([])
+    fireEvent.click(screen.getByText('mcp.connect.revoke'))
+
+    // Leaving a revoked key on screen invites pasting a string that authenticates nothing.
+    await waitFor(() => expect(screen.queryByText(KEY)).toBeNull())
+    expect(api.revokeMcpKey).toHaveBeenCalledWith('k1')
+  })
+
+  it('hides revoked keys from the list but keeps live ones', async () => {
+    api.listMcpKeys.mockResolvedValue([
+      listed({ id: 'live' }),
+      listed({ id: 'dead', revokedAt: '2026-09-10T01:00:00Z' }),
+    ])
+
+    render(<ConnectAssistant />)
+    await waitFor(() => expect(screen.getAllByText('mcp.connect.revoke').length).toBe(1))
+  })
+
+  it('says whether a key has ever been used — the only signal that a connector works', async () => {
+    api.listMcpKeys.mockResolvedValue([listed({ lastUsedAt: null })])
+    render(<ConnectAssistant />)
+    await waitFor(() => expect(screen.getByText('mcp.connect.neverUsed')).toBeTruthy())
+
+    cleanup()
+    api.listMcpKeys.mockResolvedValue([listed({ lastUsedAt: '2026-09-10T02:00:00Z' })])
+    render(<ConnectAssistant />)
+    await waitFor(() => expect(screen.getByText('mcp.connect.usedRecently')).toBeTruthy())
+  })
+
+  it('surfaces a failed create instead of silently doing nothing', async () => {
+    api.listMcpKeys.mockResolvedValue([])
+    api.createMcpKey.mockRejectedValue(new Error('boom'))
+
+    render(<ConnectAssistant />)
+    fireEvent.click(screen.getByText('mcp.connect.createCta'))
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toBe('boom'))
+  })
+})

--- a/apps/web/src/locales/__tests__/__fixtures__/web-catalog.golden.json
+++ b/apps/web/src/locales/__tests__/__fixtures__/web-catalog.golden.json
@@ -1149,5 +1149,20 @@
   "vocabulary.weeklyBudget.label": "This week",
   "vocabulary.weeklyBudget.progress": "{used} / {budget}",
   "words.tabs.highlights": "Highlights",
-  "words.tabs.vocabulary": "Vocabulary"
+  "words.tabs.vocabulary": "Vocabulary",
+  "mcp.connect.heading": "Connect your assistant",
+  "mcp.connect.lead": "Create a key, paste it into Claude or ChatGPT once, and it can read the books you upload and write conclusions back. The key does not expire; revoke it here whenever you like.",
+  "mcp.connect.signInLead": "Sign in to create a key. It is tied to your account — that is what lets an assistant reach your library and nobody else's.",
+  "mcp.connect.signInCta": "Sign in",
+  "mcp.connect.createCta": "Create a key",
+  "mcp.connect.creating": "Creating…",
+  "mcp.connect.shownOnce": "Copy this now — it is shown once and cannot be recovered. We store only a hash of it.",
+  "mcp.connect.configLabel": "Claude Desktop — paste into claude_desktop_config.json",
+  "mcp.connect.empty": "No keys yet.",
+  "mcp.connect.revoke": "Revoke",
+  "mcp.connect.usedRecently": "used recently",
+  "mcp.connect.neverUsed": "never used",
+  "mcp.connect.loadFailed": "Could not load your keys.",
+  "mcp.connect.createFailed": "Could not create a key.",
+  "mcp.connect.revokeFailed": "Could not revoke that key."
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -442,6 +442,23 @@
     },
     "manifest": {
       "label": "Machine-readable manifest:"
+    },
+    "connect": {
+      "heading": "Connect your assistant",
+      "lead": "Create a key, paste it into Claude or ChatGPT once, and it can read the books you upload and write conclusions back. The key does not expire; revoke it here whenever you like.",
+      "signInLead": "Sign in to create a key. It is tied to your account — that is what lets an assistant reach your library and nobody else's.",
+      "signInCta": "Sign in",
+      "createCta": "Create a key",
+      "creating": "Creating…",
+      "shownOnce": "Copy this now — it is shown once and cannot be recovered. We store only a hash of it.",
+      "configLabel": "Claude Desktop — paste into claude_desktop_config.json",
+      "empty": "No keys yet.",
+      "revoke": "Revoke",
+      "usedRecently": "used recently",
+      "neverUsed": "never used",
+      "loadFailed": "Could not load your keys.",
+      "createFailed": "Could not create a key.",
+      "revokeFailed": "Could not revoke that key."
     }
   },
   "contact": {

--- a/apps/web/src/pages/McpLandingPage.css
+++ b/apps/web/src/pages/McpLandingPage.css
@@ -254,3 +254,57 @@
     min-width: 0;
   }
 }
+
+/* Connect key panel (2026-09-10). The key is shown exactly once — the server keeps only a hash — so
+   this is a panel that stays put rather than a toast that takes the value away with it. */
+.mcp-connect__error { color: var(--danger, #dc2626); font-size: 14px; margin: 8px 0; }
+.mcp-connect__fresh {
+  margin: 16px 0;
+  padding: 14px 16px;
+  border: 1px solid var(--accent, #2563eb);
+  border-radius: 8px;
+  background: rgba(37, 99, 235, 0.06);
+}
+.mcp-connect__once { margin: 0 0 10px; font-size: 13px; font-weight: 600; }
+.mcp-connect__keyrow { display: flex; gap: 8px; align-items: flex-start; margin-bottom: 12px; }
+.mcp-connect__key,
+.mcp-connect__config {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--surface-2, rgba(0, 0, 0, 0.05));
+}
+.mcp-connect__config { white-space: pre; margin: 0; }
+.mcp-connect__configlabel { margin: 0 0 6px; font-size: 12px; opacity: 0.75; }
+.mcp-connect__copy,
+.mcp-connect__btn,
+.mcp-connect__revoke {
+  flex-shrink: 0;
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: 13px;
+  padding: 8px 14px;
+  border: 1px solid var(--border, rgba(0, 0, 0, 0.15));
+  background: var(--surface, #fff);
+}
+.mcp-connect__btn { font-weight: 600; }
+.mcp-connect__btn:disabled { opacity: 0.6; cursor: default; }
+.mcp-connect__revoke { border-color: transparent; opacity: 0.7; }
+.mcp-connect__revoke:hover { opacity: 1; color: var(--danger, #dc2626); }
+.mcp-connect__empty { font-size: 13px; opacity: 0.7; margin-top: 12px; }
+.mcp-connect__list { list-style: none; padding: 0; margin: 16px 0 0; }
+.mcp-connect__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-top: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+}
+.mcp-connect__name { font-weight: 600; font-size: 14px; margin-right: 8px; }
+.mcp-connect__prefix { font-family: ui-monospace, monospace; font-size: 12px; opacity: 0.7; margin-right: 8px; }
+.mcp-connect__used { font-size: 12px; opacity: 0.6; }

--- a/apps/web/src/pages/McpLandingPage.tsx
+++ b/apps/web/src/pages/McpLandingPage.tsx
@@ -4,6 +4,7 @@ import { SeoHead } from '../components/SeoHead'
 import { Footer } from '../components/Footer'
 import { useTranslation } from '../hooks/useTranslation'
 import { useLanguage } from '../context/LanguageContext'
+import { ConnectAssistant } from '../components/mcp/ConnectAssistant'
 import './McpLandingPage.css'
 
 const REMOTE_SNIPPET = `https://textstack.app/mcp`
@@ -115,6 +116,8 @@ export function McpLandingPage() {
             </p>
           </div>
         </section>
+
+        <ConnectAssistant />
 
         <section className="mcp-section">
           <h2 className="mcp-section__heading">{t('mcp.local.heading')}</h2>

--- a/tests/TextStack.IntegrationTests/McpKeyEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/McpKeyEndpointTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// The connect key end to end, against a live API: mint → authenticate with it → revoke → refuse.
+///
+/// <para><b>Why this file exists at all.</b> <c>GuestActivityMiddleware</c> is dead code in this
+/// codebase — it reads a claim the pipeline never populates, so <c>users.LastActiveAt</c> has never
+/// been written outside guest creation. Nothing caught it because nobody wrote the test that asks
+/// "did the side effect actually happen". The connect key has the same shape: a middleware that
+/// resolves a bearer and stamps a column. So the last-used assertion below is not a nice-to-have —
+/// it is the specific test whose absence produced the last silent failure of exactly this kind.</para>
+///
+/// <para>Revocation is asserted from the other end too: a revoked key must stop authenticating in the
+/// same request, with no cached decision. The middleware checks <c>RevokedAt</c> inside the lookup
+/// query for that reason, and this is what proves it.</para>
+/// </summary>
+public class McpKeyEndpointTests : IClassFixture<LiveApiFixture>
+{
+    private readonly LiveApiFixture _fixture;
+
+    public McpKeyEndpointTests(LiveApiFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task ConnectKey_MintUseRevoke_AuthenticatesThenStopsDead()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var owner = await SignUpAsync(ct);
+        Assert.SkipWhen(owner is null, "registration unavailable");
+
+        // --- mint ---------------------------------------------------------------------------
+        var createReq = _fixture.CreateRequest(HttpMethod.Post, "/me/mcp/keys");
+        createReq.Headers.TryAddWithoutValidation("Authorization", $"Bearer {owner}");
+        createReq.Content = JsonContent.Create(new { name = "Integration probe" });
+
+        var createResp = await _fixture.Client.SendAsync(createReq, ct);
+        Assert.SkipWhen(IntegrationSkip.Unavailable(createResp), "/me/mcp/keys unavailable");
+        Assert.Equal(HttpStatusCode.OK, createResp.StatusCode);
+
+        var created = await createResp.Content.ReadFromJsonAsync<JsonElement>(ct);
+        var rawKey = created.GetProperty("key").GetString();
+        var keyId = created.GetProperty("id").GetString();
+
+        Assert.False(string.IsNullOrWhiteSpace(rawKey));
+        Assert.StartsWith("tsk_", rawKey, StringComparison.Ordinal);
+        // The clear-text head is stored for display and must genuinely be a prefix of the secret.
+        Assert.StartsWith(created.GetProperty("prefix").GetString()!, rawKey, StringComparison.Ordinal);
+
+        // --- it authenticates, and it is never echoed back -----------------------------------
+        var listed = await ListKeysAsync(rawKey!, ct);
+        Assert.Contains(listed.EnumerateArray(), k => k.GetProperty("id").GetString() == keyId);
+        // The SECRET is never echoed back. Not "no tsk_ anywhere" — the display prefix legitimately
+        // starts with it, which is the point of having a prefix at all.
+        Assert.DoesNotContain(rawKey!, listed.ToString(), StringComparison.Ordinal);
+
+        // --- the side effect actually happened -----------------------------------------------
+        // Written at most hourly, so a fresh key transitions null → set on its first use. This is
+        // the assertion GuestActivityMiddleware never had.
+        var mine = listed.EnumerateArray().First(k => k.GetProperty("id").GetString() == keyId);
+        var lastUsed = mine.GetProperty("lastUsedAt");
+        Assert.True(
+            lastUsed.ValueKind != JsonValueKind.Null,
+            "lastUsedAt is still null after the key authenticated a request — the stamp is not being written");
+
+        // --- revoke, and it stops dead --------------------------------------------------------
+        var revokeReq = _fixture.CreateRequest(HttpMethod.Delete, $"/me/mcp/keys/{keyId}");
+        revokeReq.Headers.TryAddWithoutValidation("Authorization", $"Bearer {owner}");
+        var revokeResp = await _fixture.Client.SendAsync(revokeReq, ct);
+        Assert.Equal(HttpStatusCode.NoContent, revokeResp.StatusCode);
+
+        var afterReq = _fixture.CreateRequest(HttpMethod.Get, "/me/mcp/keys");
+        afterReq.Headers.TryAddWithoutValidation("Authorization", $"Bearer {rawKey}");
+        var afterResp = await _fixture.Client.SendAsync(afterReq, ct);
+        Assert.Equal(HttpStatusCode.Unauthorized, afterResp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ConnectKey_Nonsense_IsUnauthorized_NotAnError()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Shaped like a key so the middleware takes the lookup branch, but matching no row. It must
+        // fall through unauthenticated and let the endpoint answer in its own shape — middleware
+        // that short-circuits here would give MCP a different failure envelope than every other
+        // caller of the same API.
+        var req = _fixture.CreateRequest(HttpMethod.Get, "/me/mcp/keys");
+        req.Headers.TryAddWithoutValidation("Authorization", "Bearer tsk_nosuchkeyatall_0000000000000000000");
+
+        var resp = await _fixture.Client.SendAsync(req, ct);
+        Assert.SkipWhen(IntegrationSkip.Unavailable(resp), "/me/mcp/keys unavailable");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ConnectKey_AnotherAccountsKey_CannotBeRevoked()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var mine = await SignUpAsync(ct);
+        var theirs = await SignUpAsync(ct);
+        Assert.SkipWhen(mine is null || theirs is null, "registration unavailable");
+
+        var createReq = _fixture.CreateRequest(HttpMethod.Post, "/me/mcp/keys");
+        createReq.Headers.TryAddWithoutValidation("Authorization", $"Bearer {mine}");
+        createReq.Content = JsonContent.Create(new { name = "Mine" });
+        var createResp = await _fixture.Client.SendAsync(createReq, ct);
+        Assert.SkipWhen(IntegrationSkip.Unavailable(createResp), "/me/mcp/keys unavailable");
+
+        var keyId = (await createResp.Content.ReadFromJsonAsync<JsonElement>(ct))
+            .GetProperty("id").GetString();
+
+        var revokeReq = _fixture.CreateRequest(HttpMethod.Delete, $"/me/mcp/keys/{keyId}");
+        revokeReq.Headers.TryAddWithoutValidation("Authorization", $"Bearer {theirs}");
+        var revokeResp = await _fixture.Client.SendAsync(revokeReq, ct);
+
+        // 404 rather than 403 on purpose: another account's key is not a key you are forbidden to
+        // revoke, it is a key that does not exist as far as you are concerned.
+        Assert.Equal(HttpStatusCode.NotFound, revokeResp.StatusCode);
+    }
+
+    private async Task<JsonElement> ListKeysAsync(string bearer, CancellationToken ct)
+    {
+        var req = _fixture.CreateRequest(HttpMethod.Get, "/me/mcp/keys");
+        req.Headers.TryAddWithoutValidation("Authorization", $"Bearer {bearer}");
+
+        var resp = await _fixture.Client.SendAsync(req, ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(ct);
+        return body.GetProperty("items");
+    }
+
+    /// <summary>
+    /// A fresh account per test — connect keys are per-user and revocation is permanent.
+    /// <para>
+    /// <c>X-Client: mobile</c> is load-bearing: without it <c>/auth/register</c> answers a web client
+    /// and puts the token in a Set-Cookie header, returning only <c>{ user, guestMergeSkipped }</c>
+    /// in the body. These tests need a bearer to send, not a cookie jar.
+    /// </para>
+    /// </summary>
+    private async Task<string?> SignUpAsync(CancellationToken ct)
+    {
+        var req = _fixture.CreateRequest(HttpMethod.Post, "/auth/register");
+        req.Headers.Add("X-Client", "mobile");
+        req.Content = JsonContent.Create(new
+        {
+            email = $"mcp-key-{Guid.NewGuid():N}@textstack.test",
+            password = "correct-horse-battery",
+            name = "Key Probe",
+        });
+
+        var resp = await _fixture.Client.SendAsync(req, ct);
+        if (IntegrationSkip.Unavailable(resp) || !resp.IsSuccessStatusCode) return null;
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(ct);
+        return body.GetProperty("accessToken").GetString();
+    }
+}


### PR DESCRIPTION
#596 shipped the connect-key routes with nothing in front of them, so a key could
only be minted with curl and `mcp_access_keys` stayed empty on production. This is
the missing half.

## Where it lives, and why

On the `/mcp` landing page, not in profile settings — that is where someone
already is when they want to connect.

Signed out it asks for sign-in and **never calls the API**: a key is per-account,
so listing without one is a guaranteed 401.

The key is shown **once**, in a panel that stays put rather than a toast, because
the server keeps only a SHA-256 and "copy it now" is a statement of fact. Under it
sits a `claude_desktop_config.json` with the key already substituted — a config the
reader has to hand-edit is the terminal step this whole feature exists to remove.
Revoking a key clears its panel: a dead string left on screen invites pasting
something that authenticates nothing.

Naming is skipped rather than asked. A date-stamped default beats putting a form
between the reader and the thing they came for.

## The tests found a defect rather than covering one

`refresh` cleared `error` on success, so a create that failed at 200ms had its
message wiped by the mount listing that succeeded at 300ms — a button that visibly
did nothing. Each action now clears the error it is about to replace; refresh
clears nothing.

## `McpKeyEndpointTests` — the one I owed twice

Mint → authenticate with the key → revoke → refuse, against a live API, plus
another account's key returning 404 rather than 403.

It asserts `lastUsedAt` actually transitions from null. **That assertion is the
point of the file:** `GuestActivityMiddleware` is dead code in this repo precisely
because nobody ever checked that its stamp was written, and the connect key is the
same shape — a middleware that resolves a bearer and stamps a column.

Run locally against a rebuilt container, 3/3. Writing it caught two things:
`/auth/register` returns the token in a **cookie** unless `X-Client: mobile` is
sent, and my first "the secret is never echoed" assertion was wrong because the
display prefix legitimately starts with `tsk_`.

## Verified

705 web tests, tsc clean, integration 3/3 locally against a live API.

## Still missing after this

No mobile screen — the web page exists, the phone has nothing, and the phone is
where the reading happens. That is gated on a question only the owner can answer:
whether the Claude and ChatGPT **mobile apps** accept custom MCP connectors at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rgEMvYYi4Egj99dVtvm6E