### PR TITLE
fix(genres): send the authors both clients were already reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Genres** — opening any genre on the phone showed nothing, because the endpoint never sent the authors both clients read — backend, mobile, shared · [details](docs/changelog-archive/2026-H2.md#2026-09-11-genres-a-field-two-clients-used-and-the-server-never-sent)
 - **Tutor** — the exercise it plans is now the card you actually get, not a badge over one flashcard — backend, web, mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-11-tutor-the-planned-exercise-becomes-the-card)
 - **Tutor** — the planner was being told to call a tool deleted months ago, on every run — backend · [details](docs/changelog-archive/2026-H2.md#2026-09-11-tutor-an-instruction-that-could-not-be-obeyed)
 - **Guests** — the middleware that keeps an active reader from being deleted had never run once — backend · [details](docs/changelog-archive/2026-H2.md#2026-09-11-guests-a-middleware-that-never-ran)

--- a/apps/mobile/app/genre/[slug].tsx
+++ b/apps/mobile/app/genre/[slug].tsx
@@ -117,7 +117,11 @@ export default function GenreScreen() {
                 <BookCard
                   key={ed.id}
                   title={ed.title}
-                  author={ed.authors.map(a => a.name).join(', ')}
+                  // `?? []` is not defensive noise: an OTA and an API deploy are separate events, so
+                  // this bundle can run against a server that predates authors being sent here. It
+                  // threw `Cannot read property 'map' of undefined` on every genre with books until
+                  // 2026-09-11, because the shared type promised a field the endpoint never sent.
+                  author={(ed.authors ?? []).map(a => a.name).join(', ')}
                   coverUrl={getStorageUrl(ed.coverPath)}
                   onPress={() => router.push(`/book/${ed.slug}`)}
                 />

--- a/backend/src/Api/Endpoints/GenresEndpoints.cs
+++ b/backend/src/Api/Endpoints/GenresEndpoints.cs
@@ -79,7 +79,18 @@ public static class GenresEndpoints
                         e.Slug,
                         e.Title,
                         e.Language,
-                        e.CoverPath
+                        e.CoverPath,
+                        // Same projection the book list uses (BookService), ordered the same way, so a
+                        // book's authors read identically wherever it appears.
+                        e.EditionAuthors
+                            .OrderBy(ea => ea.Order)
+                            .Select(ea => new Contracts.Books.BookAuthorDto(
+                                ea.Author.Id,
+                                ea.Author.Slug,
+                                ea.Author.Name,
+                                ea.Role.ToString()
+                            ))
+                            .ToList()
                     ))
                     .ToList()
             ))

--- a/backend/src/Contracts/Genres/GenreDtos.cs
+++ b/backend/src/Contracts/Genres/GenreDtos.cs
@@ -18,10 +18,21 @@ public record GenreDetailDto(
     List<GenreEditionDto> Editions
 );
 
+/// <summary>
+/// One book on a genre page.
+///
+/// <para><see cref="Authors"/> was missing until 2026-09-11, and both clients had already been
+/// written as if it were there: the mobile genre screen called <c>ed.authors.map(...)</c> and threw
+/// <c>Cannot read property 'map' of undefined</c> on every genre that has books, while the web page
+/// wrote <c>ed.authors || []</c> and so rendered its "Popular authors in …" section empty forever.
+/// Neither was caught by the compiler, because the shared TypeScript type declared these editions as
+/// the full <c>Edition</c> shape — a type that described something the endpoint never sent.</para>
+/// </summary>
 public record GenreEditionDto(
     Guid Id,
     string Slug,
     string Title,
     string Language,
-    string? CoverPath
+    string? CoverPath,
+    IReadOnlyList<Contracts.Books.BookAuthorDto> Authors
 );

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,36 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-11-genres-a-field-two-clients-used-and-the-server-never-sent"></a>
+
+## Genres — a field both clients used and the server never sent — backend, mobile, shared — 2026-09-11
+
+Sentry, on a reader's OnePlus: `TypeError: Cannot read property 'map' of undefined`, in `GenreScreen`.
+
+`GET /genres/{slug}` projected each book as id, slug, title, language, cover — **no authors at
+all**. The mobile genre screen called `ed.authors.map(a => a.name)`, so opening *any* genre that has
+books threw. It is caught rather than fatal, so what the reader saw was a screen that did not render
+instead of a crash — which is why it survived a year.
+
+The web page had the same field and the same absence, and wrote `ed.authors || []`. It did not throw;
+its "Popular authors in <genre>" section has simply been empty since it was written.
+
+**Why nothing caught it.** The shared TypeScript type declared these editions as the full `Edition`
+shape, and the endpoint sends a narrow projection. A type that describes something the server does
+not send is worse than no type: it moves the error from the compiler to the reader's phone. There is
+now a `ListedEdition` that says what genre and author pages actually receive — and the moment it
+landed, `tsc` pointed at the exact line Sentry had reported.
+
+The projection now sends authors, ordered by `EditionAuthor.Order`, using the same `BookAuthorDto`
+the book list uses so a book's authors read identically wherever it appears. Two broken things come
+back at once: the author under each card on the phone, and the web's dead section.
+
+`GenreEndpointTests` asserts the wire — every edition carries an `authors` **array**, and at least one
+book in the catalogue actually names someone, so the test cannot pass on a projection that sends
+empty arrays. It fails against the previous build and passes against this one. A unit test could not
+have caught this: the defect was in an EF projection, and the only question that matters is what
+reaches the client.
+
 <a id="2026-09-11-tutor-the-planned-exercise-becomes-the-card"></a>
 
 ## Tutor — the exercise it plans is now the card you get — backend, web, mobile — 2026-09-11

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -101,7 +101,8 @@ export interface AuthorDetail extends Author {
   seoRelevanceText: string | null
   seoThemesJson: string | null
   seoFaqsJson: string | null
-  editions: Edition[]
+  /** The same narrow shape a genre page gets — see {@link ListedEdition}. */
+  editions: ListedEdition[]
 }
 
 export interface Genre {
@@ -112,8 +113,31 @@ export interface Genre {
   bookCount: number
 }
 
+/**
+ * One book as a genre or author page lists it — NOT the full `Edition`.
+ *
+ * The endpoints project a narrow shape (`GenreEditionDto` / the author equivalent), and these two
+ * pages were typed as `Edition[]` anyway. The compiler therefore blessed `ed.authors.map(...)` on
+ * the mobile genre screen, which threw `Cannot read property 'map' of undefined` on every genre with
+ * books, and `ed.authors || []` on the web, which quietly rendered an empty "Popular authors"
+ * section for a year. A type that describes something the server does not send is worse than no type
+ * at all: it moves the error from the compiler to the reader's phone.
+ *
+ * `authors` is now genuinely sent for genres. It is declared optional here because a device can run
+ * a JS bundle older or newer than the server it is talking to — an OTA and an API deploy are
+ * separate events, and this is exactly the seam where that bites.
+ */
+export interface ListedEdition {
+  id: string
+  slug: string
+  title: string
+  language: string
+  coverPath: string | null
+  authors?: { id: string; slug: string; name: string; role: string }[]
+}
+
 export interface GenreDetail extends Genre {
-  editions: Edition[]
+  editions: ListedEdition[]
 }
 
 // Auth

--- a/tests/TextStack.IntegrationTests/GenreEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/GenreEndpointTests.cs
@@ -1,0 +1,92 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// <c>GET /genres/{slug}</c> — the shape a genre page is actually served.
+///
+/// <para>This exists because of a defect that survived a year of review, a compiler and two clients:
+/// the projection sent an edition with no <c>authors</c> at all, while the shared TypeScript type
+/// declared these as full editions. The mobile genre screen therefore called
+/// <c>ed.authors.map(...)</c> and threw on EVERY genre that has books; the web wrote
+/// <c>ed.authors || []</c> and rendered its "Popular authors" section empty forever. Nothing failed
+/// loudly, and nothing tested the wire.</para>
+///
+/// <para>A unit test could not have caught it — the bug was in an EF projection, and the only
+/// question that matters is what the endpoint puts on the wire.</para>
+/// </summary>
+public class GenreEndpointTests : IClassFixture<LiveApiFixture>
+{
+    private readonly LiveApiFixture _fixture;
+
+    public GenreEndpointTests(LiveApiFixture fixture) => _fixture = fixture;
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>The first genre that actually has published books, or null when none is seeded.</summary>
+    private async Task<JsonElement?> FirstGenreWithBooksAsync()
+    {
+        var listResp = await _fixture.Client.SendAsync(_fixture.CreateRequest(HttpMethod.Get, "/genres"), Ct);
+        if (!listResp.IsSuccessStatusCode) return null;
+
+        var list = await listResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: Ct);
+        var items = list.ValueKind == JsonValueKind.Array ? list
+            : list.TryGetProperty("items", out var inner) ? inner : default;
+        if (items.ValueKind != JsonValueKind.Array) return null;
+
+        foreach (var g in items.EnumerateArray())
+        {
+            if (g.TryGetProperty("bookCount", out var c) && c.GetInt32() == 0) continue;
+            var slug = g.GetProperty("slug").GetString();
+
+            var detail = await _fixture.Client.SendAsync(
+                _fixture.CreateRequest(HttpMethod.Get, $"/genres/{slug}"), Ct);
+            if (!detail.IsSuccessStatusCode) continue;
+
+            var body = await detail.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: Ct);
+            if (body.TryGetProperty("editions", out var eds) && eds.GetArrayLength() > 0)
+                return body;
+        }
+
+        return null;
+    }
+
+    [Fact]
+    public async Task GetGenre_EveryEdition_CarriesTheAuthorsBothClientsRender()
+    {
+        var genre = await FirstGenreWithBooksAsync();
+        Assert.SkipWhen(genre is null, "no seeded genre with published editions");
+
+        var editions = genre!.Value.GetProperty("editions").EnumerateArray().ToArray();
+
+        foreach (var ed in editions)
+        {
+            // Present, and an ARRAY. Absent is what threw on the phone; null would throw the same way.
+            Assert.True(ed.TryGetProperty("authors", out var authors),
+                $"edition '{ed.GetProperty("slug")}' has no authors field — the mobile genre screen maps over it");
+            Assert.Equal(JsonValueKind.Array, authors.ValueKind);
+        }
+
+        // At least one book in the catalogue must actually name an author, or the assertion above
+        // passes on a projection that sends empty arrays for everything — which is the same blank
+        // screen with a different cause.
+        Assert.Contains(editions, e => e.GetProperty("authors").GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public async Task GetGenre_AnAuthor_HasTheFieldsACardNeeds()
+    {
+        var genre = await FirstGenreWithBooksAsync();
+        Assert.SkipWhen(genre is null, "no seeded genre with published editions");
+
+        var author = genre!.Value.GetProperty("editions").EnumerateArray()
+            .SelectMany(e => e.GetProperty("authors").EnumerateArray())
+            .FirstOrDefault();
+        Assert.SkipWhen(author.ValueKind != JsonValueKind.Object, "no seeded edition has an author");
+
+        // `name` is what both clients print; `slug` is what a card would link to.
+        Assert.False(string.IsNullOrWhiteSpace(author.GetProperty("name").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(author.GetProperty("slug").GetString()));
+    }
+}


### PR DESCRIPTION
Sentry, from a reader's OnePlus, two minutes after an OTA: `TypeError: Cannot read property 'map' of undefined`, in `GenreScreen`. **Not from that OTA** — the defect is a year old and someone finally opened the screen.

## What was wrong

`GET /genres/{slug}` projected each book as `id, slug, title, language, coverPath` — **no `authors` at all**. The mobile genre screen calls `ed.authors.map(a => a.name)`, so opening *any* genre that has books threw. Verified on production before touching anything: `/genres/adventure` returns 127 editions, none with the field.

It is handled rather than fatal, so the reader got a screen that did not render instead of a crash — which is how it lasted a year with one Sentry event.

The web page has the same field and the same absence, written as `ed.authors || []`. It never threw; its **"Popular authors in <genre>" section has simply been empty since it was written**.

## Why the compiler blessed it

The shared type declared these editions as the full `Edition` shape while the endpoint sends a narrow projection. A type that describes something the server does not send is worse than no type at all — it moves the error from the compiler to the reader's phone.

There is now a `ListedEdition` describing what genre and author pages actually receive. The moment it landed, `tsc` pointed at exactly the line Sentry had reported:

```
apps/mobile/app/genre/[slug].tsx(120,27): error TS18048: 'ed.authors' is possibly 'undefined'.
```

The author endpoint returns the same narrow shape, so it is typed the same way — nothing reads `authors` there today, and now nothing can start to by accident.

## The fix

- **Server** sends authors, ordered by `EditionAuthor.Order`, via the same `BookAuthorDto` the book list uses, so a book's authors read identically wherever it appears.
- **Mobile** keeps a `?? []`, and the comment says why it is not defensive noise: an OTA and an API deploy are separate events, so a bundle can run against a server that predates the field.
- Two broken things come back at once — the author under each card on the phone, and the web's dead section.

## Verification

- `GenreEndpointTests` asserts the **wire**: every edition carries an `authors` array, and at least one book in the catalogue actually names someone — so it cannot pass on a projection that sends empty arrays for everything, which would be the same blank screen with a different cause. **Red against the previous build, green against this one**, checked by rebuilding the local API between runs.
- A unit test could not have caught this: the defect was in an EF projection, and the only question that matters is what reaches the client.
- Local payload after the change: `The Last of the Mohicans → ['James Fenimore Cooper']`.
- unit 1254 · integration 170 (51 skipped) · web 713 · mobile 369 — pass; `tsc` both apps clean; `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rgEMvYYi4Egj99dVtvm6E