### PR TITLE
fix(sentry): stop reporting from developer machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Sentry** — a laptop's stale API key had been filing production-looking incidents for a month — backend, mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-11-sentry-a-developer-machine-is-not-an-incident)
 - **Genres** — opening any genre on the phone showed nothing, because the endpoint never sent the authors both clients read — backend, mobile, shared · [details](docs/changelog-archive/2026-H2.md#2026-09-11-genres-a-field-two-clients-used-and-the-server-never-sent)
 - **Tutor** — the exercise it plans is now the card you actually get, not a badge over one flashcard — backend, web, mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-11-tutor-the-planned-exercise-becomes-the-card)
 - **Tutor** — the planner was being told to call a tool deleted months ago, on every run — backend · [details](docs/changelog-archive/2026-H2.md#2026-09-11-tutor-an-instruction-that-could-not-be-obeyed)

--- a/apps/mobile/src/lib/sentry.ts
+++ b/apps/mobile/src/lib/sentry.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-native'
 import Constants from 'expo-constants'
 import * as Updates from 'expo-updates'
+import { sentryEnabled } from './sentryEnabled'
 import { scrubEvent, scrubUrl } from './sentryScrub'
 
 /**
@@ -24,12 +25,14 @@ import { scrubEvent, scrubUrl } from './sentryScrub'
  * DSN is supplied through `EXPO_PUBLIC_SENTRY_DSN`.
  */
 
-export const isSentryEnabled = (): boolean => !!process.env.EXPO_PUBLIC_SENTRY_DSN
+/** See {@link sentryEnabled} — the rule lives in its own module so it can be tested. */
+export const isSentryEnabled = (): boolean =>
+  sentryEnabled(process.env.EXPO_PUBLIC_SENTRY_DSN, __DEV__, process.env.EXPO_PUBLIC_SENTRY_IN_DEV)
 
 export function initSentry(): void {
   const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN
   // No DSN, no SDK. Same contract as the backend: absent config is not an error.
-  if (!dsn) return
+  if (!dsn || !isSentryEnabled()) return
 
   Sentry.init({
     dsn,

--- a/apps/mobile/src/lib/sentryEnabled.test.ts
+++ b/apps/mobile/src/lib/sentryEnabled.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { sentryEnabled } from './sentryEnabled'
+
+/**
+ * Whether the app reports to Sentry at all.
+ *
+ * <p>This exists because dev noise is not harmless. A stale OpenAI key in a local `.env` put 141
+ * `invalid_api_key` events into this account over a month; they sat at the top of the feed, and on
+ * 2026-09-11 they were read as a production outage and chased as one. The rule now matches the
+ * backend's (`SentryBootstrap.Resolve`).</p>
+ */
+describe('sentryEnabled', () => {
+  const dsn = 'https://k@o.ingest.sentry.io/1'
+
+  it('reports in a release build with a DSN', () => {
+    expect(sentryEnabled(dsn, false, undefined)).toBe(true)
+  })
+
+  it('reports nothing in development, even with a DSN configured', () => {
+    // The DSN legitimately stays configured — the point is that having it costs nothing on a laptop.
+    expect(sentryEnabled(dsn, true, undefined)).toBe(false)
+  })
+
+  it('opts back in for working on the integration itself', () => {
+    expect(sentryEnabled(dsn, true, 'true')).toBe(true)
+  })
+
+  it('treats any value other than "true" as off', () => {
+    // A half-set flag must not quietly re-enable the thing this rule exists to stop.
+    for (const flag of ['1', 'yes', 'TRUE', '']) expect(sentryEnabled(dsn, true, flag)).toBe(false)
+  })
+
+  it('stays off with no DSN, opt-in or not', () => {
+    expect(sentryEnabled(undefined, false, undefined)).toBe(false)
+    expect(sentryEnabled(undefined, true, 'true')).toBe(false)
+    expect(sentryEnabled('', false, undefined)).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/sentryEnabled.ts
+++ b/apps/mobile/src/lib/sentryEnabled.ts
@@ -1,0 +1,23 @@
+/**
+ * Whether this process should report to Sentry at all.
+ *
+ * <p>Its own module, importing nothing, because `sentry.ts` pulls in `@sentry/react-native` and
+ * through it React Native's Flow-typed entry point — which the test runner cannot parse. The rule is
+ * the part worth testing, so it lives where a test can reach it.</p>
+ *
+ * <p>Two conditions, mirroring the backend's `SentryBootstrap.Resolve`: a DSN must be configured,
+ * and a development run reports nothing. Dev noise is not a tidiness problem — a stale OpenAI key in
+ * a local `.env` put 141 `invalid_api_key` events into this account over a month, they sat at the
+ * top of the feed, and they were eventually read as a production outage and chased as one. An error
+ * tracker is only worth having if everything in it is real.</p>
+ *
+ * <p>The DSN deliberately stays configured locally: the point is that having it costs nothing, not
+ * that it must be deleted and re-pasted. `EXPO_PUBLIC_SENTRY_IN_DEV=true` opts back in, for working
+ * on this integration itself — the one case that actually wants dev events.</p>
+ */
+export function sentryEnabled(dsn: string | undefined, isDev: boolean, inDevFlag: string | undefined): boolean {
+  if (!dsn) return false
+  if (!isDev) return true
+  // Exactly "true": a half-set flag ("1", "yes") must not quietly re-enable what this rule stops.
+  return inDevFlag === 'true'
+}

--- a/backend/src/Infrastructure/Telemetry/SentrySettings.cs
+++ b/backend/src/Infrastructure/Telemetry/SentrySettings.cs
@@ -38,6 +38,18 @@ public static class SentryBootstrap
             return null;
 
         var isDevelopment = string.Equals(environmentName, "Development", StringComparison.OrdinalIgnoreCase);
+
+        // A developer machine does not belong in the error tracker. This is not tidiness: a stale
+        // OpenAI key in a local `.env` put 141 `invalid_api_key` events into the account over a
+        // month, they sat at the top of the feed, and on 2026-09-11 they were read as a production
+        // outage and chased as one. Dev noise in an error tracker is how a real error gets lost —
+        // and every one of those events was indistinguishable from the real thing at a glance.
+        //
+        // The DSN stays in the local `.env` on purpose: the point is that having it configured is
+        // harmless, not that it must be deleted and re-pasted. Set `Sentry:EnableInDevelopment=true`
+        // to work ON this integration locally, which is the only case that wants the events.
+        if (isDevelopment && !configuration.GetValue("Sentry:EnableInDevelopment", false))
+            return null;
         var configured = configuration.GetValue<double?>("Sentry:TracesSampleRate");
         var rate = configured ?? (isDevelopment ? 1.0 : DefaultProductionTracesSampleRate);
         rate = Math.Clamp(rate, 0.0, 1.0);

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,35 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-11-sentry-a-developer-machine-is-not-an-incident"></a>
+
+## Sentry — a developer machine is not an incident — backend, mobile — 2026-09-11
+
+Three issues sat at the top of the feed: `HTTP 401 invalid_api_key` on `/explain` and the tutor,
+**141 events over a month**, last seen six hours earlier. They were read as a production outage and
+chased as one — twice, with two wrong diagnoses on the way.
+
+They were not production. `environment: Development`, `url: http://localhost/explain`, and the key in
+the message ended `…vXgA` — the same last six characters as the stale key in this machine's local
+`.env`. Production was fine the whole time: a live call to `/api/translate` on a guaranteed
+cache-miss and a live `/api/explain` both returned real answers from OpenAI in seconds.
+
+So the local runs of an API — every rebuild, every integration-test pass — were writing into the
+account that exists to tell us when production breaks. The events were indistinguishable from real
+ones at a glance, which is the whole problem: an error tracker is only worth having if everything in
+it is real.
+
+`SentryBootstrap.Resolve` now returns null for `Development`, which is the existing no-op contract —
+the hosts never engage the SDK at all. The mobile app applies the same rule. The DSN deliberately
+stays in the local `.env`: the point is that having it configured is harmless, not that it must be
+deleted and re-pasted. `Sentry:EnableInDevelopment` (and `EXPO_PUBLIC_SENTRY_IN_DEV` on mobile) opts
+back in, for the one case that wants dev events — working on this integration itself.
+
+The mobile rule moved into its own importless module to be testable at all: `sentry.ts` pulls in
+`@sentry/react-native` and through it React Native's Flow-typed entry point, which the test runner
+cannot parse. Both sides pin that a half-set flag (`1`, `yes`, `TRUE`) does **not** count as opting
+in.
+
 <a id="2026-09-11-genres-a-field-two-clients-used-and-the-server-never-sent"></a>
 
 ## Genres — a field both clients used and the server never sent — backend, mobile, shared — 2026-09-11

--- a/tests/TextStack.UnitTests/SentryBootstrapTests.cs
+++ b/tests/TextStack.UnitTests/SentryBootstrapTests.cs
@@ -59,7 +59,12 @@ public class SentryBootstrapTests
     [Fact]
     public void Resolve_Development_DefaultsToFullSampling()
     {
-        var settings = SentryBootstrap.Resolve(Config(("SENTRY_DSN", "https://k@e.ingest.sentry.io/1")), "Development");
+        // Development reports nothing by default now, so the sampling rule is only reachable through
+        // the opt-in — the rule itself is unchanged: when you ARE looking at dev traces, you want all
+        // of them, not one in five.
+        var settings = SentryBootstrap.Resolve(
+            Config(("SENTRY_DSN", "https://k@e.ingest.sentry.io/1"), ("Sentry:EnableInDevelopment", "true")),
+            "Development");
 
         Assert.Equal(1.0, settings!.TracesSampleRate);
     }
@@ -101,4 +106,49 @@ public class SentryBootstrapTests
     [Fact]
     public void SampleRateFor_HttpRequest_UsesBaseRate() =>
         Assert.Equal(0.2, SentryBootstrap.SampleRateFor("GET /books", "http.server", 0.2));
+
+    // ---- Development is not reported ---------------------------------------------------------
+
+    [Fact]
+    public void Resolve_Development_ReturnsNull_EvenWithADsn()
+    {
+        // The local `.env` legitimately carries a DSN — the integration is developed against it. What
+        // must not happen is a developer machine writing into the account: a stale local OpenAI key
+        // put 141 `invalid_api_key` events there over a month, and they were eventually read as a
+        // production outage. Null here is what keeps the hosts from engaging the SDK at all.
+        var settings = SentryBootstrap.Resolve(
+            Config(("SENTRY_DSN", "https://key@example.ingest.sentry.io/1")), "Development");
+
+        Assert.Null(settings);
+    }
+
+    [Theory]
+    [InlineData("development")]
+    [InlineData("DEVELOPMENT")]
+    public void Resolve_Development_IsMatchedRegardlessOfCase(string environmentName) =>
+        Assert.Null(SentryBootstrap.Resolve(
+            Config(("SENTRY_DSN", "https://key@example.ingest.sentry.io/1")), environmentName));
+
+    [Fact]
+    public void Resolve_Development_WithExplicitOptIn_StillReports()
+    {
+        // The escape hatch exists so this integration can be worked on locally. Without it the only
+        // way to test a change to the Sentry wiring would be to ship it.
+        var settings = SentryBootstrap.Resolve(
+            Config(("SENTRY_DSN", "https://key@example.ingest.sentry.io/1"),
+                   ("Sentry:EnableInDevelopment", "true")), "Development");
+
+        Assert.NotNull(settings);
+        Assert.Equal("Development", settings.Environment);
+    }
+
+    [Fact]
+    public void Resolve_NonDevelopmentEnvironments_AreUnaffected()
+    {
+        // The change must cost nothing anywhere else — Staging and Production report exactly as before.
+        foreach (var env in new[] { "Staging", "Production", "production-like-thing" })
+            Assert.NotNull(SentryBootstrap.Resolve(
+                Config(("SENTRY_DSN", "https://key@example.ingest.sentry.io/1")), env));
+    }
 }
+


### PR DESCRIPTION
Three issues sat at the top of the feed — `HTTP 401 invalid_api_key` on `/explain` and the tutor, **141 events over a month**, last seen six hours earlier. They were read as a production outage and chased as one, through two wrong diagnoses before the evidence was actually looked at.

**They were not production.** `environment: Development`, `url: http://localhost/explain`, and the key in the message ends `…vXgA` — the same six characters as the stale key in this machine's local `.env`. Production was fine throughout, verified live rather than assumed:

- `POST /api/translate` on a guaranteed cache-miss → 200, a real model call
- `POST /api/explain` → 200 with a real explanation

So every local rebuild and every integration-test run was writing into the account whose only job is to say when production breaks — in events that look exactly like the real thing until you open one.

## The rule

`SentryBootstrap.Resolve` returns null for `Development`. That is the **existing** no-op contract, so the hosts never engage the SDK at all — stricter than initialising with an empty DSN, and the same path CI and forks already take. Mobile applies the same rule.

The DSN deliberately **stays** in the local `.env`. The point is that having it configured is harmless, not that it must be deleted and re-pasted before each run. `Sentry:EnableInDevelopment` (backend) and `EXPO_PUBLIC_SENTRY_IN_DEV` (mobile) opt back in — the one case that genuinely wants dev events is working on this integration itself, and without the hatch the only way to test a change to it would be to ship it.

## Notes

- The mobile predicate moved into its own importless module (`sentryEnabled.ts`). `sentry.ts` imports `@sentry/react-native`, which pulls React Native's Flow-typed entry point — vitest cannot parse it, which is why the mobile suite is scoped to `src/lib`. The rule is the part worth testing, so it now lives where a test can reach it.
- Both sides pin that a half-set flag (`1`, `yes`, `TRUE`) does **not** count as opting in.
- An existing test asserted Development gets full trace sampling; that rule is unchanged and now reached through the opt-in, so the test says so rather than being deleted.

## Verification

- unit 1259 (9 new) · mobile 374 (5 new) — pass
- `dotnet format --verify-no-changes`, `tsc --noEmit` — clean
- Non-Development environments explicitly asserted unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rgEMvYYi4Egj99dVtvm6E