### PR TITLE
feat(guests): say when a sign-in did not bring the reader's work across

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the archive; if it broke production, it belongs in `docs/incidents/`. See
 
 ## [Unreleased]
 
+- **Guests** — a sign-in that left your reading behind no longer tells you it was kept — web, mobile, shared · [details](docs/changelog-archive/2026-H2.md#2026-09-11-guests-the-reader-is-told-when-their-work-did-not-come-across)
 - **Sentry** — a laptop's stale API key had been filing production-looking incidents for a month — backend, mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-11-sentry-a-developer-machine-is-not-an-incident)
 - **Genres** — opening any genre on the phone showed nothing, because the endpoint never sent the authors both clients read — backend, mobile, shared · [details](docs/changelog-archive/2026-H2.md#2026-09-11-genres-a-field-two-clients-used-and-the-server-never-sent)
 - **Tutor** — the exercise it plans is now the card you actually get, not a badge over one flashcard — backend, web, mobile · [details](docs/changelog-archive/2026-H2.md#2026-09-11-tutor-the-planned-exercise-becomes-the-card)

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -10,6 +10,8 @@ import { GoogleSignin } from '@react-native-google-signin/google-signin'
 import Constants from 'expo-constants'
 import { useAuth } from '../../src/context/AuthContext'
 import { useTheme } from '../../src/context/ThemeContext'
+import { useToast } from '../../src/context/ToastContext'
+import { useLanguage } from '../../src/context/LanguageContext'
 import { fonts } from '../../src/theme/typography'
 import { trackLogin, trackSignUp } from '../../src/lib/analytics'
 
@@ -52,6 +54,24 @@ export default function LoginScreen() {
   const { colors } = useTheme()
   const router = useRouter()
   const { signInWithTokens } = useAuth()
+  const { show: showToast } = useToast()
+  const { t: translate } = useLanguage()
+
+  /**
+   * Says so when the sign-in did not bring the reader's earlier work across.
+   *
+   * <p>The server has reported this since guest sessions shipped and no client read it, so someone
+   * whose highlights and progress stayed on the abandoned guest row was simply landed in their new
+   * account as if nothing had happened. It is indistinguishable, from their side, from the data
+   * having been deleted — and silence is the one response that makes it look deliberate.</p>
+   *
+   * <p>Long, because it asks the reader to notice something rather than confirming what they just
+   * did. Not a blocking dialog: they ARE signed in, and there is nothing for them to decide here.</p>
+   */
+  const warnIfNothingCarried = (skipped: string | null | undefined) => {
+    if (!skipped) return
+    showToast({ message: translate('guest.progressNotCarried'), variant: 'error', duration: 9000 })
+  }
   const [loading, setLoading] = useState(false)
   // Which tab this screen opens on.
   //
@@ -115,11 +135,13 @@ export default function LoginScreen() {
       } else if (mode === 'register') {
         const result = await authApi.registerWithEmail(email.trim(), password, name.trim() || undefined)
         await signInWithTokens(result.accessToken, result.refreshToken, result.user)
+        warnIfNothingCarried(result.guestMergeSkipped)
         trackSignUp('email')
         landAfterAuth(result.user)
       } else {
         const result = await authApi.loginWithEmail(email.trim(), password)
         await signInWithTokens(result.accessToken, result.refreshToken, result.user)
+        warnIfNothingCarried(result.guestMergeSkipped)
         trackLogin('email')
         landAfterAuth(result.user)
       }
@@ -176,6 +198,7 @@ export default function LoginScreen() {
 
       const result = await authApi.loginWithGoogle(idToken)
       await signInWithTokens(result.accessToken, result.refreshToken, result.user)
+      warnIfNothingCarried(result.guestMergeSkipped)
       if (isFreshAccount(result.user.createdAt)) trackSignUp('google')
       else trackLogin('google')
       landAfterAuth(result.user)

--- a/apps/mobile/src/lib/__fixtures__/shared-catalog.golden.json
+++ b/apps/mobile/src/lib/__fixtures__/shared-catalog.golden.json
@@ -121,6 +121,7 @@
   "guest.createAccount": "Create free account",
   "guest.signOut": "Sign out",
   "guest.signOutCancel": "Keep reading",
+  "guest.progressNotCarried": "Signed in — but what you read before signing in stayed on the previous session and is not in this account.",
   "guest.signOutConfirm": "Sign out and lose it",
   "guest.signOutMessage": "You're reading as a guest, so this phone is the only key to your account — there's no email or password to get back in with. Sign out and your saved books, highlights, vocabulary and reading progress are gone for good, and we can't recover them for you either.",
   "guest.signOutTitle": "Sign out and lose everything?",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -64,6 +64,27 @@ function AuthSuccessToast() {
   return <Toast message={t('auth.progressSavedToast')} duration={4000} onClose={dismissAuthSuccessToast} />
 }
 
+/**
+ * The other half of the sentence above.
+ *
+ * The server has reported a skipped guest merge since guest sessions shipped, and no client read it
+ * — so a reader whose highlights and progress did NOT come across was shown "your progress was
+ * kept" all the same. The two are mutually exclusive in AuthContext; this one is deliberately the
+ * slower read, because it is the one that asks the reader to notice something.
+ */
+function GuestMergeSkippedToast() {
+  const { guestMergeSkipped, dismissGuestMergeSkipped } = useAuth()
+  const { t } = useTranslation()
+  if (!guestMergeSkipped) return null
+  return (
+    <Toast
+      message={t('guest.progressNotCarried')}
+      duration={9000}
+      onClose={dismissGuestMergeSkipped}
+    />
+  )
+}
+
 function LanguageRoutes() {
   const { lang } = useParams<{ lang: string }>()
   const location = useLocation()
@@ -81,6 +102,7 @@ function LanguageRoutes() {
     <LanguageProvider>
       {!isReaderPage && !isUserBookReaderPage && <Header />}
       <AuthSuccessToast />
+      <GuestMergeSkippedToast />
       {!isReaderPage && !isUserBookReaderPage && <GlobalDropZone />}
       <CommandPaletteProvider />
       <Suspense fallback={null}>

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { PERCENT_UNIT_BOOK, PROGRESS_LOCATOR_END, PROGRESS_LOCATOR_START } from '@textstack/shared'
-import type { ReadingProgressDto } from '@textstack/shared'
+import type { ReadingProgressDto, GuestMergeSkipReason } from '@textstack/shared'
 
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080'
 
@@ -17,6 +17,11 @@ export interface User {
 
 export interface AuthResponse {
   user: User
+  /**
+   * Set when the sign-in did NOT carry the reader's pre-sign-in work across — see
+   * `GuestMergeSkipReason` in the shared types. Absent on the ordinary path.
+   */
+  guestMergeSkipped?: GuestMergeSkipReason | null
 }
 
 async function authFetch<T>(path: string, options?: RequestInit): Promise<T> {

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -6,6 +6,8 @@ import {
   deleteAccount as deleteAccountApi,
   createGuestSession as createGuestSessionApi,
 } from '../api/auth'
+import type { GuestMergeSkipReason } from '@textstack/shared'
+import { authToastFor } from '../lib/authToast'
 import { flushLocalProgress } from '../lib/progressSync'
 import { trackLogin, trackSignUp } from '../lib/analytics'
 
@@ -32,6 +34,16 @@ interface AuthContextValue {
   /** Set to true after a successful register/login. Consumer shows toast then calls dismissAuthSuccessToast. */
   authSuccessToast: boolean
   dismissAuthSuccessToast: () => void
+  /**
+   * Set when the sign-in did NOT bring the reader's pre-sign-in work across.
+   *
+   * <p>Mutually exclusive with {@link authSuccessToast} on purpose: that one says "your progress is
+   * saved", which is precisely the sentence that must not be shown to someone whose progress was
+   * left behind. The server has reported this since guest sessions shipped; no client read it, so
+   * the reassurance was shown anyway.</p>
+   */
+  guestMergeSkipped: GuestMergeSkipReason | null
+  dismissGuestMergeSkipped: () => void
 }
 
 const AuthContext = createContext<AuthContextValue>({
@@ -54,6 +66,8 @@ const AuthContext = createContext<AuthContextValue>({
   deleteAccount: async () => {},
   authSuccessToast: false,
   dismissAuthSuccessToast: () => {},
+  guestMergeSkipped: null,
+  dismissGuestMergeSkipped: () => {},
 })
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID
@@ -68,6 +82,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [showAuthModal, setShowAuthModal] = useState(false)
   const [authSuccessToast, setAuthSuccessToast] = useState(false)
   const dismissAuthSuccessToast = useCallback(() => setAuthSuccessToast(false), [])
+  const [guestMergeSkipped, setGuestMergeSkipped] = useState<GuestMergeSkipReason | null>(null)
+  const dismissGuestMergeSkipped = useCallback(() => setGuestMergeSkipped(null), [])
 
   // Google callback - stable ref to avoid stale closures
   const handleGoogleCallback = useCallback(async (response: google.accounts.id.CredentialResponse) => {
@@ -76,8 +92,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const authResponse = await loginWithGoogle(response.credential)
       // Capture prev before setUser — if a real user logs in again (re-auth), no toast.
       setUser(prev => {
-        const wasGuestOrAnon = prev === null || prev.isGuest
-        if (wasGuestOrAnon) setAuthSuccessToast(true)
+        const toast = authToastFor(prev === null || prev.isGuest, authResponse.guestMergeSkipped)
+        if (toast === 'merge-skipped') setGuestMergeSkipped(authResponse.guestMergeSkipped!)
+        else if (toast === 'success') setAuthSuccessToast(true)
         return authResponse.user
       })
       setShowAuthModal(false)
@@ -226,15 +243,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const closeAuthModal = useCallback(() => setShowAuthModal(false), [])
 
   const authenticateAndClose = useCallback(async (
-    apiCall: () => Promise<{ user: User }>,
+    apiCall: () => Promise<{ user: User; guestMergeSkipped?: GuestMergeSkipReason | null }>,
     kind: 'login' | 'sign_up',
   ) => {
     const response = await apiCall()
     // Only show the "progress kept" reassurance when user actually transitioned from
     // anonymous/guest to real. A returning real user re-authenticating had nothing at risk.
     setUser(prev => {
-      const wasGuestOrAnon = prev === null || prev.isGuest
-      if (wasGuestOrAnon) setAuthSuccessToast(true)
+      const toast = authToastFor(prev === null || prev.isGuest, response.guestMergeSkipped)
+      if (toast === 'merge-skipped') setGuestMergeSkipped(response.guestMergeSkipped!)
+      else if (toast === 'success') setAuthSuccessToast(true)
       return response.user
     })
     setShowAuthModal(false)
@@ -325,6 +343,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         deleteAccount,
         authSuccessToast,
         dismissAuthSuccessToast,
+        guestMergeSkipped,
+        dismissGuestMergeSkipped,
       }}
     >
       {children}

--- a/apps/web/src/lib/authToast.test.ts
+++ b/apps/web/src/lib/authToast.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { authToastFor } from './authToast'
+
+describe('authToastFor', () => {
+  it('reassures a reader who just turned their guest session into an account', () => {
+    expect(authToastFor(true, null)).toBe('success')
+  })
+
+  it('says nothing to a returning reader who simply signed in again', () => {
+    // Nothing was at risk, so there is nothing to reassure them about.
+    expect(authToastFor(false, null)).toBe(null)
+  })
+
+  it('warns instead of reassuring when the merge was skipped', () => {
+    // The case this function exists for. Showing "your progress was kept" here is worse than
+    // showing nothing: it is the sentence that stops the reader looking for what went missing.
+    expect(authToastFor(true, 'merge_conflict')).toBe('merge-skipped')
+    expect(authToastFor(true, 'invalid_token')).toBe('merge-skipped')
+  })
+
+  it('warns even when the reader was not a guest a moment ago', () => {
+    // The server only reports a skip when a guest token WAS presented, so this combination means
+    // the local view of "were they a guest" disagrees with the server's. Trust the server: it is
+    // the side that knows whether anything was left behind.
+    expect(authToastFor(false, 'merge_conflict')).toBe('merge-skipped')
+  })
+})

--- a/apps/web/src/lib/authToast.ts
+++ b/apps/web/src/lib/authToast.ts
@@ -1,0 +1,24 @@
+import type { GuestMergeSkipReason } from '@textstack/shared'
+
+/**
+ * Which reassurance a completed sign-in has earned — at most one.
+ *
+ * <p>`success` is the existing "your reading progress and saved words were kept". It is shown only
+ * when the reader actually crossed from anonymous/guest into an account; a returning reader
+ * re-authenticating had nothing at risk and needs no reassurance.</p>
+ *
+ * <p>`merge-skipped` wins over it, and that precedence is the whole point of this function. The
+ * server has reported a skipped guest merge since guest sessions shipped, and no client read the
+ * field — so a reader whose highlights and progress stayed behind on an abandoned guest row was
+ * shown "your progress was kept" all the same. Of all the things to say in that moment, the false
+ * reassurance is the worst one, because it is the sentence that stops them looking.</p>
+ */
+export type AuthToast = 'success' | 'merge-skipped' | null
+
+export function authToastFor(
+  wasGuestOrAnonymous: boolean,
+  guestMergeSkipped: GuestMergeSkipReason | null | undefined,
+): AuthToast {
+  if (guestMergeSkipped) return 'merge-skipped'
+  return wasGuestOrAnonymous ? 'success' : null
+}

--- a/apps/web/src/locales/__tests__/__fixtures__/web-catalog.golden.json
+++ b/apps/web/src/locales/__tests__/__fixtures__/web-catalog.golden.json
@@ -246,6 +246,7 @@
   "guest.banner": "A free account keeps your books, highlights and vocabulary if you lose this phone — and lets you upload your own.",
   "guest.createAccount": "Create free account",
   "guest.signOut": "Sign out",
+  "guest.progressNotCarried": "Signed in — but what you read before signing in stayed on the previous session and is not in this account.",
   "guest.signOutCancel": "Keep reading",
   "guest.signOutConfirm": "Sign out and lose it",
   "guest.signOutMessage": "You're reading as a guest, so this phone is the only key to your account — there's no email or password to get back in with. Sign out and your saved books, highlights, vocabulary and reading progress are gone for good, and we can't recover them for you either.",

--- a/docs/changelog-archive/2026-H2.md
+++ b/docs/changelog-archive/2026-H2.md
@@ -3,6 +3,34 @@
 Full write-ups, newest first. The one-line index lives in [`../../CHANGELOG.md`](../../CHANGELOG.md);
 the incidents worth reading on their own are in [`../incidents/`](../incidents/README.md).
 
+<a id="2026-09-11-guests-the-reader-is-told-when-their-work-did-not-come-across"></a>
+
+## Guests — the reader is told when their work did not come across — web, mobile, shared — 2026-09-11
+
+A guest reads, highlights, saves words. They sign in. If the merge is abandoned — an expired guest
+token, or a unique-index collision on `reading_sessions` — the sign-in still succeeds, by design: a
+throw there would be a permanent sign-in outage, since the client re-presents the same guest token on
+every retry. The server says so in the response, as `guestMergeSkipped`.
+
+**No client had ever read that field.** So the reader landed in their new account with everything from
+before missing, and the web app showed them a toast saying *"Your reading progress and saved words
+were kept."* The one sentence that must not be said in that moment, because it is the sentence that
+stops them looking.
+
+Both clients read it now. Web shows the warning **instead of** the reassurance — the precedence is a
+pure function, `authToastFor`, so the mutual exclusion is a test rather than an ordering of two `if`s
+that someone will later reorder. Mobile shows it after any of its three sign-in paths (email,
+register, Google), on a long timer, as a toast rather than a dialog: they *are* signed in, and there
+is nothing for them to decide.
+
+One sentence, one key (`guest.progressNotCarried`), shared by both apps — web's catalogue merges the
+shared one, so a second local copy would have been two places to fix a wording nobody would keep in
+step.
+
+Both skip reasons say the same thing to the reader; they differ only for whoever reads the logs. And
+the message says what is true — the work stayed on the previous session — rather than claiming it was
+deleted or promising it can be recovered.
+
 <a id="2026-09-11-sentry-a-developer-machine-is-not-an-incident"></a>
 
 ## Sentry — a developer machine is not an incident — backend, mobile — 2026-09-11

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -104,7 +104,8 @@
     "signOutTitle": "Sign out and lose everything?",
     "signOutMessage": "You're reading as a guest, so this phone is the only key to your account — there's no email or password to get back in with. Sign out and your saved books, highlights, vocabulary and reading progress are gone for good, and we can't recover them for you either.",
     "signOutCancel": "Keep reading",
-    "signOutConfirm": "Sign out and lose it"
+"progressNotCarried": "Signed in — but what you read before signing in stayed on the previous session and is not in this account.",
+        "signOutConfirm": "Sign out and lose it"
   },
   "footer": {
     "privacy": "Privacy Policy",

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -151,14 +151,31 @@ export interface UserDto {
   nativeLanguage: string | null
 }
 
+/**
+ * Why a sign-in completed WITHOUT carrying the reader's pre-sign-in work across.
+ *
+ * Mirrors `AuthEndpoints.GuestMergeSkipReason`. Null/absent is the ordinary case, and by far the
+ * common one. Both values mean the same thing to the reader — what they did before signing in is
+ * not in this account — and they differ only for whoever reads the logs.
+ */
+export type GuestMergeSkipReason = 'invalid_token' | 'merge_conflict'
+
 export interface AuthResponse {
   user: UserDto
+  /**
+   * Set when the guest merge was abandoned. **Read it**: the server has reported this since guest
+   * sessions shipped and no client looked, so a reader whose highlights and progress stayed behind
+   * was shown "your progress is saved" — a reassurance that was false exactly when it mattered.
+   */
+  guestMergeSkipped?: GuestMergeSkipReason | null
 }
 
 export interface MobileAuthResponse {
   user: UserDto
   accessToken: string
   refreshToken: string
+  /** See {@link AuthResponse.guestMergeSkipped}. */
+  guestMergeSkipped?: GuestMergeSkipReason | null
 }
 
 // Reading Progress (matches backend ReadingProgressDto)


### PR DESCRIPTION
A guest reads, highlights, saves words. They sign in. If the merge is abandoned — an expired guest token, or the unique-index collision on `reading_sessions` that `GuestMergeConflictTests` exists for — the sign-in still succeeds **by design**: throwing there would be a permanent sign-in outage, because the client re-presents the same guest token on every retry. The server says what happened, in `guestMergeSkipped`.

**No client had ever read that field.** So the reader landed in their new account with everything from before missing, and web showed a toast saying *"Your reading progress and saved words were kept."*

That is the worst available sentence for that moment — not because it is rude, but because it is the one that stops them looking.

## What changed

- **Web** shows the warning **instead of** the reassurance. The precedence lives in a pure function, `authToastFor`, so the mutual exclusion is a test rather than an ordering of two `if`s that someone reorders later. Covered on all three inputs, including the case where the local "were they a guest" view disagrees with the server's — there, the server wins, because it is the side that knows whether anything was left behind.
- **Mobile** shows it after all three sign-in paths (email, register, Google), on a long timer, as a toast rather than a dialog: they *are* signed in, and there is nothing for them to decide.
- **One sentence, one key** (`guest.progressNotCarried`), shared. Web's catalogue merges the shared one, so a web-local copy would have been two places to fix a wording nobody would keep in step — I wrote the duplicate first and removed it.
- Both skip reasons read the same to the reader and differ only for whoever reads the logs, so the message does not expose them.
- The wording says what is true — the work stayed on the previous session — rather than claiming it was deleted or promising it can be recovered. It cannot: the guest row's only handle was the token.

## Verification

- web 717 (4 new) · mobile 374 · shared 452 · unit 1259 — pass
- `tsc --noEmit` both apps, `vite build`, `dotnet format --verify-no-changes` — clean
- Both golden catalogues hand-edited, as their guards require.

**Not verified on a device or in a browser**: producing this state means making a guest, colliding its reading sessions with an account's, and signing in. The precedence is unit-tested and the wiring is three call sites; the toast itself has not been seen by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rgEMvYYi4Egj99dVtvm6E